### PR TITLE
adds CI for cutting releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,215 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*" # Run when tag matches v*, i.e. v1.0, v20.15.10
+
+env:
+  RELEASE_BIN: rover
+  RELEASE_DIR: artifacts
+  GITHUB_REF: "${{ github.ref }}"
+  WINDOWS_TARGET: x86_64-pc-windows-msvc
+  MACOS_TARGET: x86_64-apple-darwin
+  LINUX_TARGET: x86_64-unknown-linux-musl
+
+  # Space separated paths to include in the archive.
+  RELEASE_ADDS: README.md LICENSE
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            rust: stable
+          - build: macos
+            os: macos-latest
+            rust: stable
+          - build: windows
+            os: windows-latest
+            rust: stable
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Query version number
+        id: get_version
+        shell: bash
+        run: |
+          echo "using version tag ${GITHUB_REF:10}"
+          echo ::set-output name=version::"${GITHUB_REF:10}"
+
+      - name: Install Rust
+        if: matrix.rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+
+      - name: Install musl-tools (Linux)
+        if: matrix.build == 'linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install musl-tools -y
+
+      - name: Install p7zip (MacOS)
+        if: matrix.build == 'macos'
+        run: brew install p7zip
+
+      # We install gnu-tar because BSD tar is buggy on Github's MacOS machines. 
+      # https://github.com/actions/cache/issues/403
+      # This can be removed if that issue is ever closed
+      - name: Install GNU tar (MacOS)
+        if: matrix.build == 'macos'
+        run: |
+          brew install gnu-tar
+          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+
+      - name: Build (Linux)
+        if: matrix.build == 'linux'
+        run: |
+          rustup target add ${{ env.LINUX_TARGET }}
+          cargo build --release --target ${{ env.LINUX_TARGET }}
+          
+      - name: Build (MacOS)
+        if: matrix.build == 'macos'
+        run: cargo build --release
+        
+      - name: Build (Windows)
+        if: matrix.build == 'windows'
+        run: cargo build --release
+        env:
+          RUSTFLAGS: -Ctarget-feature=+crt-static
+        
+      - name: Compress binaries (Linux)
+        if: matrix.build == 'linux'
+        uses: svenstaro/upx-action@v1-release
+        with:
+          file: target/${{ env.LINUX_TARGET }}/release/${{ env.RELEASE_BIN }}
+
+      - name: Compress binaries (MacOS)
+        if: matrix.build == 'macos'
+        uses: svenstaro/upx-action@v1-release
+        with:
+          file: target/release/${{ env.RELEASE_BIN }}
+
+      - name: Compress binaries (Windows)
+        if: matrix.build == 'windows'
+        uses: svenstaro/upx-action@v1-release
+        with:
+          file: target/release/${{ env.RELEASE_BIN }}.exe
+
+      - name: Create artifact directory
+        shell: bash
+        run: mkdir ${{ env.RELEASE_DIR }} dist
+
+      - name: Create tarball (Linux)
+        if: matrix.build == 'linux'
+        run: |
+          mv ./target/${{ env.LINUX_TARGET }}/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
+          mv ${{ env.RELEASE_ADDS }} ./dist
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+
+      - name: Create tarball (Windows)
+        if: matrix.build == 'windows'
+        shell: bash
+        run: |
+          mv ./target/release/${{ env.RELEASE_BIN }}.exe ./dist/${{ env.RELEASE_BIN }}.exe
+          mv ${{ env.RELEASE_ADDS }} ./dist
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz
+
+      - name: Create tarball (MacOS)
+        if: matrix.build == 'macos'
+        run: |
+          mv ./target/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
+          mv ${{ env.RELEASE_ADDS }} ./dist
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+
+      - name: Upload Zip
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.build }}
+          path: ./${{ env.RELEASE_DIR }}
+
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query version number
+        id: get_version
+        shell: bash
+        run: |
+          echo "using version tag ${GITHUB_REF:10}"
+          echo ::set-output name=version::"${GITHUB_REF:10}"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Unzip binaries
+        shell: bash
+        run: |
+          tar -xzvf ./linux/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }} ./linux-cli && rm -rf dist
+          tar -xzvf ./windows/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }}.exe ./windows-cli.exe && rm -rf dist
+          tar -xzvf ./macos/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }} ./macos-cli && rm -rf dist
+
+      - name: Hash binaries
+        id: get_shas
+        shell: bash
+        run: |
+          echo ::set-output name=linux::"- __Linux__: $(sha256sum -b linux-cli | cut -d ' ' -f1)"
+          echo ::set-output name=windows::"- __Windows__: $(sha256sum -b windows-cli.exe | cut -d ' ' -f1)"
+          echo ::set-output name=macos::"- __MacOS__: $(sha256sum -b macos-cli | cut -d ' ' -f1)"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          release_name: ${{ steps.get_version.outputs.VERSION }}
+          prerelease: ${{ contains(steps.get_version.outputs.VERSION, 'alpha') || contains(steps.get_version.ouputs.VERSION, 'beta') || contains(steps.get_version.outputs.VERSION, 'rc')}}
+          body: |
+            <!---
+              paste the changelog entry here!
+            -->
+            ---
+            ### SHA256 of release binaries for validation:
+            ${{ steps.get_shas.outputs.LINUX }}
+            ${{ steps.get_shas.outputs.WINDOWS }}
+            ${{ steps.get_shas.outputs.MACOS }}    
+      
+      - name: Release Linux tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./linux/rover-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: rover-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+
+      - name: Release Windows tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./windows/rover-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: rover-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz
+
+      - name: Release MacOS tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./macos/rover-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: rover-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz


### PR DESCRIPTION
fixes #10

This is the first pass at adding GitHub actions for releasing `rover` and is largely based on the work found [here](https://github.com/cloudflare/wrangler/blob/master/.github/workflows/release.yml). 

**When is this action triggered?**

This action is triggered whenever a tag with a `v` prefix is pushed. For example, this action would be run if you ran `git tag -a v0.1.0 -m 0.1.0` or `git tag -a v0.1.0-rc.0 -m 0.1.0-rc.0` followed by `git push --tags`. It is important to note that there are actually _two_ actions being run in sequence here, `build` and `release`. These are separated into distinct steps so if something goes horribly wrong in the build step, no release artifacts are created.

**What happens after the build action is triggered?**

1) The version number is parsed from the tag.

1) Build dependencies are installed.

1) Release binaries are built for Linux (`x86_64-unknown-linux-musl`), MacOS (`x86_64-apple-darwin`), and Windows (`x86_64-pc-windows-msvc`).

1) The release binaries are tarballed and uploaded to the GitHub actions runner as artifacts.

1) The release action is started after the build step completes.

**What happens after the release action is triggered?**

1) The release tarballs from the build step are downloaded from the GitHub actions runner.

1) The release tarballs are unzipped and SHA256 hashes are computed.

1) A GitHub Release is created and named after the version parsed from the tag. The release includes the SHA-256 hashes computed in the previous step. In the future we may want this to automatically include entries from CHANGELOG.md, but for now that does not exist as we have not decided on the format for rover's changelog entries.

1) Each release tarball is uploaded to the GitHub Release as a release artifact.

**What _doesn't_ happen after the action is triggered?**

- The action does not (yet) publish to any registry (`cargo` or `npm`) and it does not push the assets to our distribution worker.

- The action does not (yet) build for ARM or any other target aside from the three main operating systems.

- The action does not (yet) automatically create the release with the complete entry from the changelog, the release must be modified _after_ the release has been created by the action.

**Footguns**

- If you try to be clever and create the release manually before the action runs so you can put in the changelog entry before the artifacts are uploaded, the action will fail because the release already exists. This is a design decision made by the GitHub actions team in `actions/create-release@v1` which may change in the future. For now, if something goes wrong and you have to re-run the release step, make sure to delete the current release.

**How do we know it works?**

I forked this repo and created a release with `git tag -a "v0.0.0" -m "0.0.0" && `git push --tags` and [this](https://github.com/EverlastingBugstopper/apollo-cli/releases/tag/v0.0.0) is what happened.