### PR TITLE
removes flaky profile test

### DIFF
--- a/crates/houston/tests/profile.rs
+++ b/crates/houston/tests/profile.rs
@@ -2,16 +2,6 @@ use houston as config;
 use std::env;
 
 #[test]
-fn it_lists_nothing_when_no_profiles() {
-    env::set_var("APOLLO_CONFIG_HOME", "./");
-    let profiles = config::Profile::list().expect("listing profiles failed");
-
-    assert!(profiles.is_empty());
-
-    config::clear().expect("clearing configuration failed");
-}
-
-#[test]
 fn it_lists_many_profiles() {
     env::set_var("APOLLO_CONFIG_HOME", "./");
     let cprofile_name = "corporate";


### PR DESCRIPTION
fixes #37 

we will add more configuration tests when we have per-project configuration. for now this removes a flaky test that relied on global state and would race the other test that relies on global state.