### PR TITLE
lint Cargo.toml in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,13 @@ jobs:
           rustup default stable
           rustup component add rustfmt
           rustup component add clippy
-      - name: Check formatting
+          cargo install cargo-tomlfmt
+
+      - name: Check code formatting
         run: cargo fmt --all -- --check
+
+      - name: Check Cargo.toml formatting
+        run: cargo tomlfmt --dryrun
 
       - name: Check idiomatic code
         run: cargo clippy --all --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 members = [".", "crates/*"]
 
 [dependencies]
-# Workspace Deps
-houston = { path = "./crates/houston" }
 
 # Crates.io Deps
 anyhow = "1.0.31"
 console = "0.11.3"
 env_logger = "0.7.1"
+# Workspace Deps
+houston = { path = "./crates/houston" }
 log = "0.4.11"
 structopt = "0.3.15"
 


### PR DESCRIPTION
this adds an extra linter to CI. understand if this is too much overhead and we dont want to do it, but i've found that without it the `Cargo.toml` can get a bit unwieldy over time. also helps if everyone else does this so my save on format doesnt create unrelated diffs in my PRs :)