### PR TITLE
adds dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "rust:cargo"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
once we merge this and add dependabot to this repo, it will automatically make PRs to bump dependency versions across all workspace crates. this should make our lives a bit easier and avoid the world where we need to take time every few months to audit all of our dependencies.