### PR TITLE
report anonymous usage data (telemetry)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,32 @@ rover is an open source project developed by [Apollo GraphQL](https://apollograp
 - One approval from a member of the Apollo tooling team.
   - The team consists of @jbaxleyiii, @ashleygwilliams, @JakeDawkins, and @EverlastingBugstopper.
   - PRs with changes in `docs/` automatically add @StephenBarlow as a reviewer. PRs are not blocked on this approval.
+
+## Adding new commands/subcommands
+
+When adding a new command or a subcommand, make sure that the field in the new command struct is named `command`. This enables automated anonymous usage collection.
+
+If you add arguments that are _not_ subcommands, the arguments you specify are automatically reported to Apollo's Telemetry backend, unless you specify that an argument should be ignored with `#[serde(skip_serializing)]`. *Make sure you add the `skip_serializing` attribute to any fields that may contain data that might contain data that is not anonymous (such as a username, graph name, or a file path)!*
+
+To verify that your new command works with the usage data capturing system, you can spin up a development server at `http://localhost:8787/telemetry` (or specify a different endpoint by settings `APOLLO_TELEMETRY_URL`) and make sure the `command` section of the request body looks correct. For example, the usage collection request body for the command `rover config profile show default --sensitive` looks like the following:
+
+```json
+{
+  "machine_id": "esd140f0-3f2d-12f5-a22a-d5231d7e1802",
+  "cli_version": "0.0.1",
+  "platform": {
+    "os": "linux",
+    "continuous_integration": null,
+  },
+  "command": {
+    "name": "config profile show",
+    "arguments": {
+      "sensitive": true
+    }
+  },
+  "session_id": "ead890f0-1f8a-43f2-a21e-a3721d7e1042",
+  "cwd_hash": "25b120fee6f41226b1db561ecb708ave187e6912fa33a2390f8e01ca94e89bb1",
+}
+```
+
+As you can see, `default` is omitted from `command.arguments` because it is a user-defined argument and might contain identifiable information, and has been labelled with the `#[serde(skip_serializing)]` attribute.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
 name = "sputnik"
 version = "0.0.0"
 dependencies = [
+ "assert_fs",
  "ci_info",
  "reqwest",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,10 +613,10 @@ dependencies = [
 name = "houston"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "directories",
  "log",
  "serde",
+ "thiserror",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ascii"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes",
  "fnv",
@@ -644,6 +644,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1337,8 +1338,12 @@ dependencies = [
  "log",
  "predicates",
  "rover-client",
+ "serde",
+ "serde_json",
  "serial_test",
+ "sputnik",
  "structopt",
+ "url",
 ]
 
 [[package]]
@@ -1368,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
+checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "ryu"
@@ -1778,6 +1783,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +195,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ci_info"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d240a3b5a8a7cb577fa8d595d8ec30828b252a58d477b4ae3309b9603204c3b5"
+dependencies = [
+ "envmnt",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "clap"
@@ -264,6 +284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +305,15 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "directories"
@@ -314,9 +349,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encode_unicode"
@@ -344,6 +379,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "envmnt"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
+dependencies = [
+ "fsio",
+ "indexmap",
 ]
 
 [[package]]
@@ -397,6 +442,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fsio"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -463,6 +514,16 @@ dependencies = [
  "pin-project",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -944,6 +1005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1072,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project"
@@ -1292,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 
 [[package]]
 name = "ryu"
@@ -1348,6 +1424,25 @@ checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -1416,6 +1511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer",
+ "cfg-if 0.1.10",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1545,22 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "sputnik"
+version = "0.0.0"
+dependencies = [
+ "ci_info",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "structopt",
+ "thiserror",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1669,6 +1793,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1867,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,22 @@ edition = "2018"
 members = [".", "crates/*"]
 
 [dependencies]
-# Workspace Deps
+
+# workspace deps
 houston = { path = "./crates/houston" }
 rover-client = { path = "./crates/rover-client" }
+sputnik = { path = "./crates/sputnik" }
 
-# Crates.io Deps
+# crates.io deps
 anyhow = "1.0.31"
 console = "0.12.0"
 env_logger = "0.7.1"
 log = "0.4.11"
+serde = "1.0"
+serde_json = "1.0"
 structopt = "0.3.15"
+url = "2.1.1"
+
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.31"
 directories = "3.0.1"
 log = "0.4.11"
 serde = { version = "1.0.112", features = ["derive"] }
 toml = "0.5.6"
+thiserror = "1.0"

--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+use std::io;
+
+/// HoustonProblem is the type of Error that occured.
+#[derive(Error, Debug)]
+pub enum HoustonProblem {
+    /// ConfigDirNotFound occurs when the default OS config can't be found.
+    #[error("Could not determine default OS config directory.")]
+    ConfigDirNotFound,
+
+    /// ProfileNotFound occurs when a profile with a specified name can't be found.
+    #[error("Profile {0} not found.")]
+    ProfileNotFound(String),
+
+    /// NoNonSensitiveConfigFound occurs when non-sensitive config can't be found for a profile.
+    #[error("No non-sensitive config found for profile {0}.")]
+    NoNonSensitiveConfigFound(String),
+
+    /// TomlSerialization occurs when a profile's configuration can't be serialized to a String.
+    #[error(transparent)]
+    TomlSerialization(#[from] toml::ser::Error),
+
+    /// TomlDeserialization occurs when a profile's configruation can't be deserialized from a String.
+    #[error(transparent)]
+    TomlDeserialization(#[from] toml::de::Error),
+
+    /// IOError occurs when any given std::io::Error arises.
+    #[error(transparent)]
+    IOError(#[from] io::Error),
+}

--- a/crates/houston/src/home.rs
+++ b/crates/houston/src/home.rs
@@ -1,18 +1,16 @@
-use anyhow::{Error, Result};
+use crate::HoustonProblem;
 use std::env;
 use std::path::PathBuf;
 
 /// Returns the value of an optional `APOLLO_CONFIG_HOME` environment variable
 /// or the default OS configuration directory. Returns an error if it cannot
 /// determine the default OS configuration directory.
-pub fn dir() -> Result<PathBuf> {
+pub fn dir() -> Result<PathBuf, HoustonProblem> {
     let dir = match env::var("APOLLO_CONFIG_HOME").ok() {
         Some(home) => PathBuf::from(&home),
         None => {
-            let error = Error::msg("Could not determine default OS config directory. Please set a location for rover to store configuration using the APOLLO_CONFIG_HOME config env var.");
-
             directories::ProjectDirs::from("com", "Apollo", "Rover")
-                .ok_or(error)?
+                .ok_or(HoustonProblem::ConfigDirNotFound)?
                 .config_dir()
                 .to_path_buf()
 

--- a/crates/houston/src/lib.rs
+++ b/crates/houston/src/lib.rs
@@ -2,17 +2,21 @@
 
 //! Utilites for configuring the rover CLI tool.
 
+mod error;
 mod home;
 mod profile;
 
+pub use error::HoustonProblem;
+pub use home::dir;
+
 /// Utilites for saving, loading, and deleting configuration profiles.
-use anyhow::Result;
 pub use profile::LoadOpts;
 pub use profile::Profile;
+
 use std::fs;
 
 /// Removes all configuration files from filesystem
-pub fn clear() -> Result<()> {
+pub fn clear() -> Result<(), HoustonProblem> {
     let profiles_dir = home::dir()?.join("profiles");
     let result = fs::remove_dir_all(profiles_dir);
     match result {

--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -1,5 +1,4 @@
-use crate::profile::Profile;
-use anyhow::Result;
+use crate::{profile::Profile, HoustonProblem};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -11,12 +10,12 @@ pub struct Sensitive {
 }
 
 impl Sensitive {
-    fn path(profile_name: &str) -> Result<PathBuf> {
+    fn path(profile_name: &str) -> Result<PathBuf, HoustonProblem> {
         Ok(Profile::dir(profile_name)?.join(".sensitive"))
     }
 
     /// Serializes to toml and saves to file system at `$APOLLO_CONFIG_HOME/<profile_name>/.sensitive`.
-    pub fn save(&self, profile_name: &str) -> Result<()> {
+    pub fn save(&self, profile_name: &str) -> Result<(), HoustonProblem> {
         let path = Sensitive::path(profile_name)?;
         let data = toml::to_string(self)?;
 
@@ -30,7 +29,7 @@ impl Sensitive {
     }
 
     /// Opens and deserializes `$APOLLO_CONFIG_HOME/<profile_name>/.sensitive`.
-    pub fn load(profile_name: &str) -> Result<Sensitive> {
+    pub fn load(profile_name: &str) -> Result<Sensitive, HoustonProblem> {
         let path = Sensitive::path(profile_name)?;
         let contents = &fs::read_to_string(path)?;
         Ok(toml::from_str(contents)?)

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sputnik"
+version = "0.0.0"
+authors = ["Apollo Developers <opensource@apollographql.com>"]
+edition = "2018"
+
+[dependencies]
+ci_info = { version = "0.11", features = ["serde-1"] }
+reqwest =  { version = "0.10", features = ["blocking"] }
+semver = { version = "0.11", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.9"
+structopt = "0.3"
+thiserror = "1.0"
+url = "2.1"
+uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -15,3 +15,6 @@ structopt = "0.3"
 thiserror = "1.0"
 url = "2.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+
+[dev-dependencies]
+assert_fs = "1.0"

--- a/crates/sputnik/README.md
+++ b/crates/sputnik/README.md
@@ -1,0 +1,25 @@
+# 🚀 Sputnik
+
+Sputnik is a crate to aid in the collection of anonymous usage data for CLIs built in Rust.
+
+## Overview
+
+Sputnik declares the `sputnik::Session` struct which is used to capture information about a single command execution. example:
+
+```sh
+body:
+  command:
+    name:      config profile list
+    arguments:
+  machine_id:  edd890f0-3f8d-43f5-a22e-d3731d7e5042
+  session_id:  a9d345b6-75f9-4bc1-9685-8475c6771610
+  cwd_hash:    52b120fee6f41776b6fb561ecb708cfe187e6922fa33a2399f8e01cb94e89bb0
+  platform:
+    os:                     macos
+    continuous_integration: null
+  cli_version: 0.0.0
+```
+
+When creating a new `sputnik::Session` with `Session::new`, you must provide a type that implements the `sputnik::Report` trait. This trait defines the functions that determine how to populate the `sputnik::Session` struct on every command, and how it is reported to the backend that captures your anonymous usage data.
+
+Finally, `sputnik::SputnikError` is an enum that defines all of the possible error variations that can occur in this crate, and should work with any error handling library you'd like to use it with.

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -1,0 +1,36 @@
+use thiserror::Error;
+
+use std::io;
+
+/// SputnikError is the type of Error that occured.
+#[derive(Error, Debug)]
+pub enum SputnikError {
+    /// IOError occurs when any given std::io::Error arises.
+    #[error(transparent)]
+    IOError(#[from] io::Error),
+
+    /// JSONError occurs when an error occurs when serializing/deserializing JSON.
+    #[error(transparent)]
+    JSONError(#[from] serde_json::Error),
+
+    /// HTTPError occurs when an error occurs while reporting anonymous usage data.
+    #[error("Could not report anonymous usage data.")]
+    HTTPError(#[from] reqwest::Error),
+
+    /// VersionParseError occurs when the version of the tool cannot be determined.
+    #[error("Could not parse the version of the tool.")]
+    VersionParseError(#[from] semver::SemVerError),
+
+    /// URLParseError occurs when the URL to POST the anonymous usage data cannot be parsed.
+    #[error("Could not parse telemetry URL.")]
+    URLParseError(#[from] url::ParseError),
+
+    /// ConfigError occurs when the configuration location of the globally persistent machine
+    /// identifier cannot be found.
+    #[error("Could not read the machine ID from config.")]
+    ConfigError,
+
+    /// CommandParseError occurs when serializing a command fails.
+    #[error("Could not parse command line arguments")]
+    CommandParseError,
+}

--- a/crates/sputnik/src/lib.rs
+++ b/crates/sputnik/src/lib.rs
@@ -1,0 +1,11 @@
+#![deny(missing_docs)]
+
+//! Utilities for reporting anonymous usage data for the rover CLI tool.
+
+mod error;
+mod report;
+mod session;
+
+pub use error::SputnikError;
+pub use report::Report;
+pub use session::{Command, Session};

--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -1,0 +1,62 @@
+use url::Url;
+use uuid::Uuid;
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::{Command, SputnikError};
+
+/// Report defines the behavior of how anonymous usage data is reported.
+pub trait Report {
+    /// converts the struct to a json blob.
+    fn serialize_command(&self) -> Result<Command, SputnikError>;
+
+    /// checks if a user has enabled anonymous usage data.
+    fn is_enabled(&self) -> bool;
+
+    /// returns the endpoint that the data should be posted to.
+    fn endpoint(&self) -> Result<Url, SputnikError>;
+
+    /// returns the name of the tool, this is used to construct
+    /// the User-Agent header.
+    fn tool_name(&self) -> String;
+
+    /// returns the version of the tool, this is used to construct
+    /// the User-Agent header
+    fn version(&self) -> String;
+
+    /// constructs a user agent for the tool. by default, it calls
+    /// self.tool_name() and self.version() to construct this.
+    fn user_agent(&self) -> String {
+        format!("{}/{}", self.tool_name(), self.version())
+    }
+
+    /// returns the location the tool stores a globally persistent
+    /// machine identifier
+    fn machine_id_config(&self) -> Result<PathBuf, SputnikError>;
+
+    /// returns the globally persistent machine identifier
+    /// and writes it if it does not exist
+    /// the default implemenation uses self.machine_id_config()
+    /// as the location the machine identifier is written to.
+    fn machine_id(&self) -> Result<Uuid, SputnikError> {
+        let config_path = self.machine_id_config()?;
+        if Path::exists(&config_path) {
+            if let Ok(contents) = fs::read_to_string(&config_path) {
+                if let Ok(machine_uuid) = Uuid::parse_str(&contents) {
+                    return Ok(machine_uuid);
+                }
+            }
+        }
+
+        write_machine_id(&config_path)
+    }
+}
+
+fn write_machine_id(path: &PathBuf) -> Result<Uuid, SputnikError> {
+    let machine_id = Uuid::new_v4();
+    let mut file = File::create(path)?;
+    file.write_all(machine_id.to_string().as_bytes())?;
+    Ok(machine_id)
+}

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -1,0 +1,136 @@
+use ci_info::types::Vendor as CiVendor;
+use reqwest::Url;
+use semver::Version;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use std::collections::HashMap;
+use std::env::{consts::OS, current_dir};
+use std::fmt::Debug;
+use std::time::Duration;
+
+use crate::{Report, SputnikError};
+
+/// The Session represents a usage of the CLI analogous to a web session
+/// It contains the "url" (command path + flags) but doesn't contain any
+/// values entered by the user. It also contains some identity information
+/// for the user
+#[derive(Debug, Serialize)]
+pub struct Session {
+    /// the command usage where information about the command is collected
+    command: Command,
+
+    /// Apollo generated machine ID. Stored globally at ~/.apollo/config.toml
+    machine_id: Uuid,
+
+    /// A unique session id
+    session_id: Uuid,
+
+    /// Directory hash. A hash of the current working directory
+    cwd_hash: String,
+
+    /// Information about the current architecture/platform
+    platform: Platform,
+
+    /// The current version of the CLI
+    cli_version: Version,
+
+    /// Where the telemetry data is being reported to
+    #[serde(skip_serializing)]
+    reporting_info: ReportingInfo,
+}
+
+/// Platform represents the platform the CLI is being run from
+#[derive(Debug, Serialize)]
+pub struct Platform {
+    /// the platform from which the command was run (i.e. linux, macOS, or windows)
+    os: String,
+
+    /// if we think this command is being run in CI
+    continuous_integration: Option<CiVendor>,
+}
+
+/// Command contains information about the command that was run
+#[derive(Serialize, Clone, Debug)]
+pub struct Command {
+    /// the name of the command that was run.
+    pub name: String,
+
+    /// the arguments that were run with the command.
+    pub arguments: HashMap<String, serde_json::Value>,
+}
+
+/// ReportingInfo represents information about where the telemetry data
+/// should be reported to
+#[derive(Debug)]
+struct ReportingInfo {
+    is_enabled: bool,
+    endpoint: Url,
+    user_agent: String,
+}
+
+impl Session {
+    /// creates a new Session containing info about the current command
+    /// being executed.
+    pub fn new<T: Report>(app: &T) -> Result<Session, SputnikError> {
+        let machine_id = app.machine_id()?;
+        let command = app.serialize_command()?;
+        let reporting_info = ReportingInfo {
+            is_enabled: app.is_enabled(),
+            endpoint: app.endpoint()?,
+            user_agent: app.user_agent(),
+        };
+        let session_id = Uuid::new_v4();
+        let cwd_hash = get_cwd_hash()?;
+
+        let continuous_integration = if ci_info::is_ci() {
+            ci_info::get().vendor
+        } else {
+            None
+        };
+
+        let platform = Platform {
+            os: OS.to_string(),
+            continuous_integration,
+        };
+
+        let cli_version = Version::parse(app.version().as_str())?;
+
+        Ok(Session {
+            command,
+            machine_id,
+            session_id,
+            cwd_hash,
+            platform,
+            cli_version,
+            reporting_info,
+        })
+    }
+
+    /// sends anonymous usage data to the endpoint defined in ReportingInfo.
+    pub fn report(&self) -> Result<(), SputnikError> {
+        if self.reporting_info.is_enabled {
+            // set timeout to 400 ms to prevent blocking for too long on reporting
+            let timeout = Duration::from_millis(4000);
+            let body = serde_json::to_string(&self)?;
+            reqwest::blocking::Client::new()
+                .post(self.reporting_info.endpoint.to_owned())
+                .body(body)
+                .header("User-Agent", &self.reporting_info.user_agent)
+                .header("Content-Type", "application/json")
+                .timeout(timeout)
+                .send()?;
+        }
+        Ok(())
+    }
+}
+
+/// returns sha256 digest of the directory the tool was executed from.
+fn get_cwd_hash() -> Result<String, SputnikError> {
+    let current_dir = current_dir()?;
+    let current_dir_string = current_dir.to_string_lossy();
+    let current_dir_bytes = current_dir_string.as_bytes();
+
+    Ok(format!("{:x}", Sha256::digest(current_dir_bytes)))
+}

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -52,7 +52,7 @@ pub struct Platform {
 }
 
 /// Command contains information about the command that was run
-#[derive(Serialize, Clone, Debug)]
+#[derive(PartialEq, Serialize, Clone, Debug)]
 pub struct Command {
     /// the name of the command that was run.
     pub name: String,

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -25,6 +25,9 @@ module.exports = {
             'usage/config/environment-variables',
             'usage/config/profiles',
           ],
+          Privacy: [
+            `privacy/index`,
+          ],
         },
       },
     },

--- a/docs/source/contributing/project-structure.md
+++ b/docs/source/contributing/project-structure.md
@@ -8,6 +8,7 @@ description: "Breaking down the structure of the Rover repository"
     - `src/bin/rover.rs`: the entry point for the CLI executable
     - `src/lib.rs`: all the logic used by the CLI
     - `src/logger.rs`: custom formatter for `env_logger`
+    - `src/telemetry.rs`: implements `sputnik::Report` for capturing and reporting anonymous usage data
     - `src/commands`: logic for the CLI commands
         - `src/commands/auth.rs`: the `rover auth` command  
 

--- a/docs/source/contributing/project-structure.md
+++ b/docs/source/contributing/project-structure.md
@@ -14,3 +14,4 @@ description: "Breaking down the structure of the Rover repository"
 - `crates`
     - `crates/houston`: logic related to configuring rover
     - `crates/apollo`: logic for querying apollo services
+    - `crates/sputnik`: logic for capturing anonymous usage data

--- a/docs/source/privacy/index.md
+++ b/docs/source/privacy/index.md
@@ -1,0 +1,20 @@
+---
+title: "Data collection"
+description: "Information about data collected by Rover"
+---
+
+By default, Rover collects some anonymous usage data to help better understand the needs of our users.
+
+To opt out of data collection, set the `APOLLO_TELEMETRY_DISABLED` environment variable to `1` in each environment where you use Rover.
+
+## Collected data
+
+Rover reports the following data each time you run a command:
+
+- The command that was run _(excluding any identifiable arguments such as file-system paths or profile names)_
+- The version of `rover` that was executed
+- A unique, anonymized **machine identifier**, which is the same for every command run on the same machine
+- A unique, anonymized **session identifier**, which is different for every command
+- The SHA-256 hash of the directory that `rover` was executed from
+- The operating system `rover` was executed on
+- The CI system `rover` was executed on, if any

--- a/docs/source/usage/config/environment-variables.md
+++ b/docs/source/usage/config/environment-variables.md
@@ -14,5 +14,7 @@ configuration.
 
 | Name               | Value                                              | Default                             | Notes                                                                                                                   |
 |--------------------|----------------------------------------------------|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| APOLLO_CONFIG_HOME | Path to where CLI configuration should be stored.  | Default OS Configuration directory. | More information in [Authentication - Configuration](./authentication#configuration).                  |
-| APOLLO_KEY         | An API Key generated from Apollo Studio.           | none                                | More information in [Authentication - Environment Variables](./authentication#environment-variables). |
+| `APOLLO_CONFIG_HOME` | Path to where CLI configuration is stored.  | Default OS Configuration directory. | More information in [Authentication - Configuration](./authentication#configuration).                  |
+| `APOLLO_KEY`         | An API Key generated from Apollo Studio.           | none                                | More information in [Authentication - Environment Variables](./authentication#environment-variables). |
+| `APOLLO_TELEMETRY_URL` | The URL where anonymous usage data is reported | [https://install.apollographql.com/telemetry](https://install.apollographql.com/telemetry) | More information in [Privacy](../../privacy). |
+| `APOLLO_TELEMETRY_DISABLED` | Set to `1` if you don't want Rover to collect anonymous usage data | none | |

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -1,12 +1,45 @@
 use anyhow::Result;
 use rover::*;
+use sputnik::Session;
 use structopt::StructOpt;
+
+use std::thread;
 
 fn main() -> Result<()> {
     logger::init();
+    let app = cli::Rover::from_args();
 
-    let cli = cli::Rover::from_args();
-    log::debug!("Command structure {:?}", cli);
-    cli.run()?;
+    // attempt to create a new `Session` to capture anonymous usage data
+    match Session::new(&app) {
+        // if successful, report the usage data in the background
+        Ok(session) => {
+            // kicks off the reporting on a background thread
+            let report_thread = thread::spawn(move || {
+                // log + ignore errors because it is not in the critical path
+                let _ = session.report().map_err(|e| {
+                    log::debug!("{:?}", e);
+                    e
+                });
+            });
+
+            // kicks off the app on the main thread
+            // don't return an error with ? quite yet
+            // since we still want to report the usage data
+            let app_result = app.run();
+
+            // makes sure the reporting finishes in the background
+            // before continuing.
+            // ignore errors because it is not in the critical path
+            let _ = report_thread.join();
+
+            // return result of app execution
+            // now that we have reported our usage data
+            app_result?
+        }
+
+        // otherwise just run the app without reporting
+        Err(_) => app.run()?,
+    }
+
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,15 +1,17 @@
-use crate::command;
 use anyhow::Result;
+use serde::Serialize;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+use crate::command;
+
+#[derive(Debug, Serialize, StructOpt)]
 #[structopt(name = "Rover", about = "✨🤖🐶 the new CLI for apollo")]
 pub struct Rover {
     #[structopt(subcommand)]
-    command: Command,
+    pub(crate) command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub enum Command {
     ///  ⚙️  Manage configuration
     Config(command::Config),

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -14,9 +14,9 @@ impl ApiKey {
     pub fn run(&self) -> Result<()> {
         let api_key = api_key_prompt()?;
         Profile::set_api_key(&self.profile_name, api_key)?;
-        Profile::get_api_key(&self.profile_name).map(|_| {
+        Ok(Profile::get_api_key(&self.profile_name).map(|_| {
             log::info!("Successfully saved API key.");
-        })
+        })?)
     }
 }
 

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -2,11 +2,13 @@ use anyhow::{Error, Result};
 use config::Profile;
 use console::{self, style};
 use houston as config;
+use serde::Serialize;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct ApiKey {
     #[structopt(long = "profile", default_value = "default")]
+    #[serde(skip_serializing)]
     profile_name: String,
 }
 

--- a/src/command/config/mod.rs
+++ b/src/command/config/mod.rs
@@ -3,15 +3,16 @@ mod profile;
 
 use anyhow::Result;
 use houston as config;
+use serde::Serialize;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct Config {
     #[structopt(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub enum Command {
     /// 🔑 Configure an account or graph API key
     ApiKey(api_key::ApiKey),

--- a/src/command/config/profile.rs
+++ b/src/command/config/profile.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
 use houston as config;
+use serde::Serialize;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct Profile {
     #[structopt(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub enum Command {
     /// 🎅 List all of your configuration profiles
     List,
@@ -18,16 +19,18 @@ pub enum Command {
     Delete(Delete),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct Show {
     #[structopt(default_value = "default")]
+    #[serde(skip_serializing)]
     name: String,
     #[structopt(long = "sensitive")]
     sensitive: bool,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct Delete {
+    #[serde(skip_serializing)]
     name: String,
 }
 

--- a/src/command/schema/fetch.rs
+++ b/src/command/schema/fetch.rs
@@ -2,17 +2,23 @@ use anyhow::Result;
 use houston as config;
 use rover_client::blocking::Client;
 use rover_client::query::schema::get;
+use serde::Serialize;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
     /// ID of the graph to fetch from Apollo Studio
     #[structopt(name = "GRAPH_NAME")]
+    #[serde(skip_serializing)]
     graph_name: String,
+
     /// The variant of the request graph from Apollo Studio
     #[structopt(long, default_value = "current")]
+    #[serde(skip_serializing)]
     variant: String,
+
     #[structopt(long = "profile", default_value = "default")]
+    #[serde(skip_serializing)]
     profile_name: String,
 }
 

--- a/src/command/schema/fetch.rs
+++ b/src/command/schema/fetch.rs
@@ -45,7 +45,7 @@ impl Fetch {
                 log::info!("{}", schema);
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 }

--- a/src/command/schema/mod.rs
+++ b/src/command/schema/mod.rs
@@ -1,15 +1,16 @@
 mod fetch;
 
 use anyhow::Result;
+use serde::Serialize;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub struct Schema {
     #[structopt(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, StructOpt)]
 pub enum Command {
     /// 🐶 Get a schema given an identifier
     Fetch(fetch::Fetch),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cli;
 pub mod command;
 pub mod logger;
+mod telemetry;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,116 @@
+use url::Url;
+
+use std::path::PathBuf;
+
+use crate::cli::Rover;
+use sputnik::{Command, Report, SputnikError};
+
+use std::collections::HashMap;
+
+const DEV_TELEMETRY_URL: &str = "http://localhost:8787/telemetry";
+const PROD_TELEMETRY_URL: &str = "https://install.apollographql.com/telemetry";
+
+fn get_command_from_args(mut raw_arguments: &mut serde_json::Value) -> Command {
+    let mut commands = Vec::new();
+    let mut arguments = HashMap::new();
+    let mut should_break = true;
+    loop {
+        let (command_name, leftover_arguments) = get_next_command(&mut raw_arguments);
+        if let Some(command_name) = command_name {
+            commands.push(command_name);
+            should_break = false;
+        }
+
+        if let Some(leftover_arguments) = leftover_arguments {
+            if let serde_json::Value::Object(object) = leftover_arguments {
+                for argument in object.iter() {
+                    let (key, value) = argument;
+                    arguments.insert(key.to_lowercase(), value.to_owned());
+                }
+            }
+        }
+
+        if should_break {
+            break;
+        } else {
+            should_break = true;
+        }
+    }
+
+    let name = commands.join(" ");
+    Command { name, arguments }
+}
+
+fn get_next_command(
+    raw_arguments: &mut serde_json::Value,
+) -> (Option<String>, Option<serde_json::Value>) {
+    let mut command_name = None;
+    let mut leftover_arguments = None;
+
+    if let Some(command_info) = raw_arguments.get("command") {
+        match command_info {
+            serde_json::Value::Object(object) => {
+                if let Some(item) = object.clone().iter_mut().next() {
+                    let (name, next) = item;
+                    command_name = Some(name.to_lowercase());
+                    *raw_arguments = next.to_owned();
+                }
+            }
+            serde_json::Value::String(string) => {
+                command_name = Some(string.to_lowercase());
+                *raw_arguments = serde_json::Value::Null;
+            }
+            serde_json::Value::Null => command_name = None,
+            _ => {
+                command_name = Some(format!("{:?}", command_info).to_lowercase());
+                *raw_arguments = serde_json::Value::Null;
+            }
+        }
+    } else {
+        leftover_arguments = Some(raw_arguments.clone());
+    }
+
+    (command_name, leftover_arguments)
+}
+
+impl Report for Rover {
+    fn serialize_command(&self) -> Result<Command, SputnikError> {
+        let json_args = serde_json::to_string(&self)?;
+        let mut value_args = serde_json::from_str(&json_args)?;
+        let serialized_command = get_command_from_args(&mut value_args);
+        log::debug!("{:?}", serialized_command);
+        Ok(serialized_command)
+    }
+
+    fn is_enabled(&self) -> bool {
+        option_env!("APOLLO_TELEMETRY_DISABLED").is_none()
+    }
+
+    fn endpoint(&self) -> Result<Url, SputnikError> {
+        if let Some(url) = option_env!("APOLLO_TELEMETRY_URL") {
+            Ok(url.parse()?)
+        } else if cfg!(debug_assertions) {
+            Ok(DEV_TELEMETRY_URL.parse()?)
+        } else {
+            Ok(PROD_TELEMETRY_URL.parse()?)
+        }
+    }
+
+    fn tool_name(&self) -> String {
+        option_env!("CARGO_PKG_NAME")
+            .unwrap_or("unknown")
+            .to_string()
+    }
+
+    fn version(&self) -> String {
+        option_env!("CARGO_PKG_VERSION")
+            .unwrap_or("unknown")
+            .to_string()
+    }
+
+    fn machine_id_config(&self) -> Result<PathBuf, SputnikError> {
+        let mut path = houston::dir().map_err(|_| SputnikError::ConfigError)?;
+        path.push("machine.txt");
+        Ok(path)
+    }
+}


### PR DESCRIPTION
fixes #44 

an example request when running the command `rover config profile list`

```
body: 
  command:     config profile list
  machine_id:  edd890f0-3f8d-43f5-a22e-d3731d7e5042
  session_id:  bbc30ec1-628e-4563-83af-cb2bfe06e997
  cwd_hash:    52b120fee6f41776b6fb561ecb708cfe187e6922fa33a2399f8e01cb94e89bb0
  platform: 
    os:                     macos
    continuous_integration: null
  cli_version: 0.0.0
```

good thing about this approach is that any new commands should be automatically serialized and reported without any additional code or remembering to add the command to the telemetry reporter. the downside to this is that if there are arguments/fields that contain sensitive information that we don't want to collect, you must mark that field as `#[serde(skip_serializing)]` so that it is not included in the report.

all of this capturing happens on a background thread which should mitigate most performance issues that could occur if the reporting was run synchronously.

outstanding work

- [X] decide on capturing additional info (federated v non-federated)
  - **punting until later, not gonna do anything with this one right now**
- [X] figure out back end
  - **wip pr [here](https://github.com/apollographql/spaceport/pull/4)**
- [ ] make an opt-in serialization API to prevent accidentally capturing user-specified arguments
  - **waiting on a response [here](https://github.com/serde-rs/serde/issues/1897)**
- [x] document usage of `APOLLO_TELEMETRY_DISABLED` and the data we collect
- [x] add section to CONTRIBUTING.md for new folks :)
- [x] figure out how to display `command` nicely in Segment
    - ~should we just have the top level subcommand (`Config` in this example) be the `event` and then have the rest of the arguments be a part of `properties`?~ **yes**
    - ~should we do that part up front in Rover, or should we do it in the Worker?~ **this PR does it in Rover**
