### PR TITLE
tests(rover): cleans up invalid API key tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dabd011e19821a348abb0dec7b7fda959cd6b3477c474395b958b291942b0e"
+dependencies = [
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +135,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -209,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +255,29 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9db17aec586697a93219b19726b5b68307eba92898c34b170857343fe67c99d"
+dependencies = [
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -258,6 +319,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +347,15 @@ name = "libc"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+
+[[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -298,6 +386,36 @@ checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "predicates"
@@ -379,6 +497,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,16 +573,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rover"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "assert_fs",
  "console",
  "env_logger",
  "houston",
  "log",
  "predicates",
+ "serial_test",
  "structopt",
 ]
 
@@ -438,6 +608,21 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -458,6 +643,34 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serial_test"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b15f74add9a9d4a3eb2bf739c9a427d266d3895b53d992c3a7c234fec2ff1f1"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "strsim"
@@ -509,6 +722,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -609,6 +836,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,6 @@ structopt = "0.3.15"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"
+assert_fs = "1.0.0"
+serial_test = "0.5.0"
 predicates = "1.0.5"

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -1,4 +1,5 @@
 use anyhow::{Error, Result};
+use config::Profile;
 use console::{self, style};
 use houston as config;
 use structopt::StructOpt;
@@ -11,19 +12,15 @@ pub struct ApiKey {
 
 impl ApiKey {
     pub fn run(&self) -> Result<()> {
-        let api_key = get()?;
-        config::Profile::set_api_key(&self.profile_name, api_key)?;
-        match config::Profile::get_api_key(&self.profile_name) {
-            Ok(_) => {
-                log::info!("Successfully saved API key.");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let api_key = api_key_prompt()?;
+        Profile::set_api_key(&self.profile_name, api_key)?;
+        Profile::get_api_key(&self.profile_name).map(|_| {
+            log::info!("Successfully saved API key.");
+        })
     }
 }
 
-fn get() -> Result<String> {
+fn api_key_prompt() -> Result<String> {
     let term = console::Term::stdout();
     log::info!(
         "Go to {} and create a new Personal API Key.",
@@ -34,10 +31,46 @@ fn get() -> Result<String> {
     if is_valid(&api_key) {
         Ok(api_key)
     } else {
-        Err(Error::msg("Received an empty api-key. Please try again."))
+        Err(Error::msg("Received an empty API Key. Please try again."))
     }
 }
 
 fn is_valid(api_key: &str) -> bool {
     !api_key.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_fs::TempDir;
+    use serial_test::serial;
+
+    use houston::Profile;
+
+    const DEFAULT_PROFILE: &str = "default";
+    const DEFAULT_KEY: &str = "default-key";
+
+    const CUSTOM_PROFILE: &str = "custom";
+    const CUSTOM_KEY: &str = "custom-key";
+
+    #[test]
+    #[serial]
+    fn it_can_set_default_api_key() {
+        let temp = TempDir::new().unwrap();
+        std::env::set_var("APOLLO_CONFIG_HOME", temp.path());
+
+        Profile::set_api_key(DEFAULT_PROFILE, DEFAULT_KEY.into()).unwrap();
+        let result = Profile::get_api_key(DEFAULT_PROFILE).unwrap();
+        assert_eq!(result, DEFAULT_KEY);
+    }
+
+    #[test]
+    #[serial]
+    fn it_can_set_custom_api_key() {
+        let temp = TempDir::new().unwrap();
+        std::env::set_var("APOLLO_CONFIG_HOME", temp.path());
+
+        Profile::set_api_key(CUSTOM_PROFILE, CUSTOM_KEY.into()).unwrap();
+        let result = Profile::get_api_key(CUSTOM_PROFILE).unwrap();
+        assert_eq!(result, CUSTOM_KEY);
+    }
 }

--- a/tests/profile.rs
+++ b/tests/profile.rs
@@ -1,5 +1,12 @@
 use assert_cmd::Command;
+use assert_fs::TempDir;
 use predicates::prelude::*;
+use serial_test::serial;
+
+use houston::Profile;
+
+const CUSTOM_PROFILE: &str = "custom-profile";
+const CUSTOM_API_KEY: &str = "custom-api-key";
 
 #[test]
 fn it_can_list_no_profiles() {
@@ -14,13 +21,12 @@ fn it_can_list_no_profiles() {
 }
 
 #[test]
+#[serial]
 fn it_can_list_one_profile() {
+    let temp = TempDir::new().unwrap();
+    std::env::set_var("APOLLO_CONFIG_HOME", temp.path());
+    Profile::set_api_key(CUSTOM_PROFILE, CUSTOM_API_KEY.into()).unwrap();
     let mut cmd = Command::cargo_bin("rover").unwrap();
-    let result = cmd
-        .env("APOLLO_CONFIG_HOME", "./test_list_one_profile")
-        .arg("config")
-        .arg("api-key")
-        .write_stdin("testkey")
-        .assert();
-    result.stdout(predicate::str::contains("default"));
+    let result = cmd.arg("config").arg("profile").arg("list").assert();
+    result.stdout(predicate::str::contains(CUSTOM_PROFILE));
 }


### PR DESCRIPTION
fixes #51 - this should fix the issues we've been seeing across the repo's tests and does not test the functionality of the `console` library like the old tests were attempting to do