### PR TITLE
standardize command return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,16 +254,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "regex",
  "terminal_size",
- "termios",
  "unicode-width",
  "winapi 0.3.9",
  "winapi-util",
@@ -1447,6 +1446,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "atty",
  "console",
  "houston",
  "predicates",
@@ -1797,15 +1797,6 @@ checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -17,9 +17,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -44,13 +44,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
-
-[[package]]
-name = "apollo"
-version = "0.0.0"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "ascii"
@@ -104,9 +100,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -166,9 +162,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 
 [[package]]
 name = "cfg-if"
@@ -270,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -280,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -363,11 +359,11 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -431,6 +427,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fsio"
@@ -541,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "globset"
@@ -719,9 +725,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -733,7 +739,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 1.0.1",
  "socket2",
  "tokio",
  "tower-service",
@@ -911,9 +917,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mime"
@@ -974,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1009,9 +1015,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1019,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1038,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -1221,9 +1227,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
@@ -1355,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1377,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -1529,9 +1535,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "0.4.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1542,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1651,12 +1657,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest",
  "opaque-debug",
@@ -1810,18 +1816,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1986,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2810660b9d5b18895d140caba6401765749a6a162e5d0736cfc44ea50db9d79d"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2087,10 +2093,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ robot-panic = { path = "./crates/robot-panic" }
 
 # crates.io deps
 anyhow = "1.0.31"
-console = "0.12.0"
+atty = "0.2.14"
+console = "0.13.0"
 serde = "1.0"
 serde_json = "1.0"
 structopt = "0.3.15"

--- a/crates/apollo/Cargo.toml
+++ b/crates/apollo/Cargo.toml
@@ -1,7 +1,0 @@
-[package]
-name = "apollo"
-version = "0.0.0"
-authors = ["Apollo Developers <opensource@apollographql.com>"]
-edition = "2018"
-
-[dependencies]

--- a/crates/apollo/src/lib.rs
+++ b/crates/apollo/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     tracing::trace!(command_structure = ?app);
 
     // attempt to create a new `Session` to capture anonymous usage data
-    match Session::new(&app) {
+    let result = match Session::new(&app) {
         // if successful, report the usage data in the background
         Ok(session) => {
             // kicks off the reporting on a background thread
@@ -37,12 +37,13 @@ fn main() -> Result<()> {
 
             // return result of app execution
             // now that we have reported our usage data
-            app_result?
+            app_result
         }
 
         // otherwise just run the app without reporting
-        Err(_) => app.run()?,
-    }
+        Err(_) => app.run(),
+    }?;
 
+    result.print();
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 use structopt::StructOpt;
 use timber::{Level, DEFAULT_LEVEL, LEVELS};
 
-use crate::{command, stringify::from_display};
+use crate::command::{self, RoverStdout};
+use crate::stringify::from_display;
 
 #[derive(Debug, Serialize, StructOpt)]
 #[structopt(name = "Rover", about = "✨🤖🐶 the new CLI for apollo")]
@@ -20,18 +21,20 @@ pub struct Rover {
 pub enum Command {
     ///  ⚙️  Manage configuration
     Config(command::Config),
+
     ///  🧱  Work with a non-federated graph
     Schema(command::Schema),
+
     ///  🗺️  Work with a federated graph and implementing services
     Partial(command::Partial),
 }
 
 impl Rover {
-    pub fn run(self) -> Result<()> {
+    pub fn run(self) -> Result<RoverStdout> {
         match self.command {
-            Command::Config(config) => config.run(),
-            Command::Schema(schema) => schema.run(),
-            Command::Partial(partial) => partial.run(),
+            Command::Config(command) => command.run(),
+            Command::Schema(command) => command.run(),
+            Command::Partial(command) => command.run(),
         }
     }
 }

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -1,9 +1,12 @@
 use anyhow::{Error, Result};
-use config::Profile;
 use console::{self, style};
-use houston as config;
 use serde::Serialize;
 use structopt::StructOpt;
+
+use config::Profile;
+use houston as config;
+
+use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct ApiKey {
@@ -13,12 +16,13 @@ pub struct ApiKey {
 }
 
 impl ApiKey {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<RoverStdout> {
         let api_key = api_key_prompt()?;
         Profile::set_api_key(&self.profile_name, &api_key)?;
-        Ok(Profile::get_api_key(&self.profile_name).map(|_| {
+        Profile::get_api_key(&self.profile_name).map(|_| {
             tracing::info!("Successfully saved API key.");
-        })?)
+        })?;
+        Ok(RoverStdout::None)
     }
 }
 

--- a/src/command/config/clear.rs
+++ b/src/command/config/clear.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+
+use crate::command::RoverStdout;
+use houston as config;
+
+pub fn run() -> Result<RoverStdout> {
+    config::clear()?;
+    tracing::info!("Successfully cleared all configuration.");
+    Ok(RoverStdout::None)
+}

--- a/src/command/config/mod.rs
+++ b/src/command/config/mod.rs
@@ -1,10 +1,12 @@
 mod api_key;
+mod clear;
 mod profile;
 
 use anyhow::Result;
-use houston as config;
 use serde::Serialize;
 use structopt::StructOpt;
+
+use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Config {
@@ -23,15 +25,11 @@ pub enum Command {
 }
 
 impl Config {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<RoverStdout> {
         match &self.command {
-            Command::ApiKey(ak) => ak.run(),
-            Command::Profile(p) => p.run(),
-            Command::Clear => {
-                config::clear()?;
-                tracing::info!("Successfully cleared all configuration.");
-                Ok(())
-            }
+            Command::ApiKey(command) => command.run(),
+            Command::Profile(command) => command.run(),
+            Command::Clear => clear::run(),
         }
     }
 }

--- a/src/command/config/profile.rs
+++ b/src/command/config/profile.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result};
-use houston as config;
 use serde::Serialize;
 use structopt::StructOpt;
+
+use houston as config;
+
+use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Profile {
@@ -38,7 +41,7 @@ pub struct Delete {
 }
 
 impl Profile {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<RoverStdout> {
         match &self.command {
             Command::List => {
                 let profiles = config::Profile::list().context("Could not list profiles.")?;
@@ -50,7 +53,7 @@ impl Profile {
                         tracing::info!("{}", profile);
                     }
                 }
-                Ok(())
+                Ok(RoverStdout::None)
             }
             Command::Show(s) => {
                 let opts = config::LoadOpts {
@@ -68,12 +71,12 @@ impl Profile {
                 })?;
 
                 tracing::info!("{}: {}", &s.name, profile);
-                Ok(())
+                Ok(RoverStdout::None)
             }
             Command::Delete(d) => {
                 config::Profile::delete(&d.name).context("Could not delete profile.")?;
                 tracing::info!("Successfully deleted profile \"{}\"", &d.name);
-                Ok(())
+                Ok(RoverStdout::None)
             }
         }
     }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,7 +1,9 @@
 mod config;
+mod output;
 mod partial;
 mod schema;
 
 pub use config::Config;
+pub use output::RoverStdout;
 pub use partial::Partial;
 pub use schema::Schema;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1,0 +1,42 @@
+use atty::{self, Stream};
+
+/// RoverStdout defines all of the different types of data that are printed
+/// to `stdout`. Every one of Rover's commands should return `anyhow::Result<RoverStdout>`
+/// If the command needs to output some type of data, it should be structured
+/// in this enum, and its print logic should be handled in `RoverStdout::print`
+///
+/// Not all commands will output machine readable information, and those should
+/// return `Ok(RoverStdout::None)`. If a new command is added and it needs to
+/// return something that is not described well in this enum, it should be added.
+#[derive(Clone, PartialEq, Debug)]
+pub enum RoverStdout {
+    SDL(String),
+    SchemaHash(String),
+    None,
+}
+
+impl RoverStdout {
+    pub fn print(&self) {
+        match self {
+            RoverStdout::SDL(sdl) => {
+                // we check to see if stdout is redirected
+                // if it is, we don't print the content descriptor
+                // this is because it would look strange to see
+                // SDL:
+                // and nothing after the colon if you piped the output
+                // to another process or a file.
+                if atty::is(Stream::Stdout) {
+                    tracing::info!("SDL:");
+                }
+                println!("{}", &sdl);
+            }
+            RoverStdout::SchemaHash(hash) => {
+                if atty::is(Stream::Stdout) {
+                    tracing::info!("Schema Hash:");
+                }
+                println!("{}", &hash);
+            }
+            RoverStdout::None => (),
+        }
+    }
+}

--- a/src/command/partial/mod.rs
+++ b/src/command/partial/mod.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 use serde::Serialize;
 use structopt::StructOpt;
 
+use crate::command::RoverStdout;
+
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Partial {
     #[structopt(subcommand)]
@@ -17,9 +19,9 @@ pub enum Command {
 }
 
 impl Partial {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<RoverStdout> {
         match &self.command {
-            Command::Push(partial) => partial.run(),
+            Command::Push(command) => command.run(),
         }
     }
 }

--- a/src/command/partial/push.rs
+++ b/src/command/partial/push.rs
@@ -1,9 +1,11 @@
-use crate::client::get_rover_client;
 use anyhow::Result;
 use rover_client::query::partial::push::{self, PushPartialSchemaResponse};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
+
+use crate::client::get_rover_client;
+use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Push {
@@ -34,7 +36,7 @@ pub struct Push {
 }
 
 impl Push {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<RoverStdout> {
         let client = get_rover_client(&self.profile_name)?;
 
         tracing::info!(
@@ -62,7 +64,7 @@ impl Push {
         )?;
 
         handle_response(push_response, &self.service_name, &self.graph_name);
-        Ok(())
+        Ok(RoverStdout::None)
     }
 }
 

--- a/src/command/schema/fetch.rs
+++ b/src/command/schema/fetch.rs
@@ -1,8 +1,11 @@
-use crate::client::get_rover_client;
 use anyhow::Result;
-use rover_client::query::schema::get;
 use serde::Serialize;
 use structopt::StructOpt;
+
+use rover_client::query::schema::get;
+
+use crate::client::get_rover_client;
+use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
@@ -22,7 +25,7 @@ pub struct Fetch {
 }
 
 impl Fetch {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<RoverStdout> {
         let client = get_rover_client(&self.profile_name)?;
 
         tracing::info!(
@@ -32,7 +35,7 @@ impl Fetch {
             &self.profile_name
         );
 
-        let schema = get::run(
+        let sdl = get::run(
             get::get_schema_query::Variables {
                 graph_id: self.graph_name.clone(),
                 hash: None,
@@ -41,7 +44,6 @@ impl Fetch {
             client,
         )?;
 
-        println!("{}", schema);
-        Ok(())
+        Ok(RoverStdout::SDL(sdl))
     }
 }

--- a/src/command/schema/mod.rs
+++ b/src/command/schema/mod.rs
@@ -5,6 +5,8 @@ use anyhow::Result;
 use serde::Serialize;
 use structopt::StructOpt;
 
+use crate::command::RoverStdout;
+
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Schema {
     #[structopt(subcommand)]
@@ -15,15 +17,16 @@ pub struct Schema {
 pub enum Command {
     /// 🐶 Get a schema given an identifier
     Fetch(fetch::Fetch),
+
     /// Push a schema from a file
     Push(push::Push),
 }
 
-impl Schema {
-    pub fn run(&self) -> Result<()> {
+impl<'a> Schema {
+    pub fn run(&self) -> Result<RoverStdout> {
         match &self.command {
-            Command::Fetch(fetch) => fetch.run(),
-            Command::Push(schema) => schema.run(),
+            Command::Fetch(command) => command.run(),
+            Command::Push(command) => command.run(),
         }
     }
 }


### PR DESCRIPTION
this pr fixes #60 by introducing `RoverStdout` which defines all of the different types of output we want to print to `stdout`

currently we output either schema hashes and SDL (or nothing), so each command implementation should return `anyhow::Result<RoverStdout>`. if new types are needed, they can be added to the enum and their display implementation can be added to the `print` impl.

benefits:

- cleaner code, each command now returns `RoverStdout` which has more semantic meaning
- if we want to add `--json` or other output types, we can do so fairly easily at the top level instead of needing a big refactor later (would just pass the json flag right into the `print` impl and then do an if else right there instead of diving into each command)

drawbacks:

- doesn't allow for easy incremental output, you have to construct the entire String and return it in your command

edit: i also came across [this crate](https://docs.rs/convey/0.2.0/convey/) but it hasn't had a new version released in 2 years which makes me a bit nervous. i'd love to spend time on something like this eventually as i think it'd be great for the ecosystem to have.

---

this pr also has a commit that removes the unused `apollo` crate in the workspace that i think has been superseded by `rover-client`