### PR TITLE
feat: crash report panic handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_type"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1428,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "robot-panic"
+version = "1.0.3"
+dependencies = [
+ "backtrace",
+ "os_type",
+ "serde",
+ "termcolor",
+ "toml",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "rover"
 version = "0.0.0"
 dependencies = [
@@ -1428,6 +1450,7 @@ dependencies = [
  "console",
  "houston",
  "predicates",
+ "robot-panic",
  "rover-client",
  "serde",
  "serde_json",
@@ -1755,6 +1778,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 name = "rover"
 version = "0.0.0"
+repository = "https://github.com/apollographql/rover/"
 
 [dependencies]
 
@@ -11,6 +12,7 @@ houston = { path = "./crates/houston" }
 rover-client = { path = "./crates/rover-client" }
 sputnik = { path = "./crates/sputnik" }
 timber = { path = "./crates/timber" }
+robot-panic = { path = "./crates/robot-panic" }
 
 # crates.io deps
 anyhow = "1.0.31"

--- a/crates/robot-panic/Cargo.toml
+++ b/crates/robot-panic/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "robot-panic"
+version = "1.0.3"
+edition = "2018"
+
+[dependencies]
+backtrace = "0.3"
+os_type = "2.2"
+serde = "1.0"
+termcolor = "1.1"
+toml = "0.5"
+uuid = { version = "0.8", features = ["v4"], default-features = false }
+url = "2.1"

--- a/crates/robot-panic/README.md
+++ b/crates/robot-panic/README.md
@@ -1,0 +1,3 @@
+# robot-panic
+
+This is a fork of [robot-panic](https://github.com/rust-cli/robot-panic) that prints less output and directs folks to create a new GitHub issue with the panic dump _OR_ it creates a crash report on the filesystem.

--- a/crates/robot-panic/src/lib.rs
+++ b/crates/robot-panic/src/lib.rs
@@ -1,0 +1,252 @@
+//! Panic messages for humans by robots
+//!
+//! Handles panics by calling
+//! [`std::panic::set_hook`](https://doc.rust-lang.org/std/panic/fn.set_hook.html)
+//! to make errors nice for humans.
+//!
+//! ## Why?
+//! When you're building a CLI, polish is super important. Even though Rust is
+//! pretty great at safety, it's not unheard of to access the wrong index in a
+//! vector or have an assert fail somewhere.
+//!
+//! When an error eventually occurs, you probably will want to know about it. So
+//! instead of just providing an error message on the command line, we can create a
+//! call to action for people to submit a report.
+//!
+//! This should empower people to engage in communication, lowering the chances
+//! people might get frustrated. And making it easier to figure out what might be
+//! causing bugs.
+//!
+//! ### Default Output
+//!
+//! ```txt
+//! thread 'main' panicked at 'oh no', src/bin/rover.rs:11:5
+//! note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+//! ```
+//!
+//! ### Robot-Panic Output
+//!
+//! Houston, we have a problem. Rover crashed!
+//! To help us diagnose the problem you can send us a crash report.
+//!
+//! You can submit an issue with the crash report at this link: https://github.com/apollographql/rover//issues/new?title=bug%3A+crashed+while+%3Cinsert+description+here%3E&body=%3C%21--%0A++Please+add+some+additional+information+about+what+you+were+trying+to+do+before+submitting+this+report%0A+--%3E+%0A%0A**Crash+Report**%0A+%60%60%60toml%0Aname+%3D+%27rover%27%0Aoperating_system+%3D+%27unix%3AUbuntu%27%0Acrate_version+%3D+%270.0.0%27%0Aexplanation+%3D+%27%27%27%0APanic+occurred+in+file+%27src%2Fbin%2Frover.rs%27+at+line+11%0A%27%27%27%0Acause+%3D+%27oh+no%27%0Amethod+%3D+%27Panic%27%0Abacktrace+%3D+%27%27%27%0A%0A+++0%3A+0x5575363b5003+-+std%3A%3Asys_common%3A%3Abacktrace%3A%3A__rust_begin_short_backtrace%3A%3Ahcc063f8de39c7379%0A+++1%3A+0x5575363b505d+-+std%3A%3Art%3A%3Alang_start%3A%3A%7B%7Bclosure%7D%7D%3A%3Ahf77d52b639388bce%0A+++2%3A+0x5575364a2e41+-+core%3A%3Aops%3A%3Afunction%3A%3Aimpls%3A%3A%3Cimpl+core%3A%3Aops%3A%3Afunction%3A%3AFnOnce%3CA%3E+for+%26F%3E%3A%3Acall_once%3A%3Ah6a3209f124be2235%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fcore%2Fsrc%2Fops%2Ffunction.rs%3A259%0A+++++++++++++++++-+std%3A%3Apanicking%3A%3Atry%3A%3Ado_call%3A%3Ah88ce358792b64df0%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Fpanicking.rs%3A373%0A+++++++++++++++++-+std%3A%3Apanicking%3A%3Atry%3A%3Ah6311c259678e50fc%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Fpanicking.rs%3A337%0A+++++++++++++++++-+std%3A%3Apanic%3A%3Acatch_unwind%3A%3Ah56c5716807d659a1%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Fpanic.rs%3A379%0A+++++++++++++++++-+std%3A%3Art%3A%3Alang_start_internal%3A%3Ah73711f37ecfcb277%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Frt.rs%3A51%0A+++3%3A+0x5575363b4fc2+-+main%0A+++4%3A+0x7fa1956800b3+-+__libc_start_main%0A+++5%3A+0x5575363b40be+-+_start%0A+++6%3A++++++++0x0+-+%3Cunresolved%3E%27%27%27%0A%0A%60%60%60%0A
+//!
+//! We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.
+//!
+//! Thanks for your patience!
+
+pub mod report;
+use report::{Method, Report};
+
+use std::borrow::Cow;
+use std::io::{Result as IoResult, Write};
+use std::panic::PanicInfo;
+
+use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+
+/// A convenient metadata struct that describes a crate
+pub struct Metadata {
+    /// The crate version
+    pub version: Cow<'static, str>,
+
+    /// The crate name
+    pub name: Cow<'static, str>,
+
+    /// The list of authors of the crate
+    pub authors: Cow<'static, str>,
+
+    /// The URL of the crate's website
+    pub homepage: Cow<'static, str>,
+
+    /// The URL of the crate's repo
+    pub repository: Cow<'static, str>,
+}
+
+/// `robot-panic` initialisation macro
+///
+/// You can either call this macro with no arguments `setup_panic!()` or
+/// with a Metadata struct, if you don't want the error message to display
+/// the values used in your `Cargo.toml` file.
+///
+/// The Metadata struct can't implement `Default` because of orphan rules, which
+/// means you need to provide all fields for initialisation.
+///
+/// ```
+/// use robot_panic::setup_panic;
+///
+/// setup_panic!(Metadata {
+///     name: env!("CARGO_PKG_NAME").into(),
+///     version: env!("CARGO_PKG_VERSION").into(),
+///     authors: "My Company Support <support@mycompany.com>".into(),
+///     homepage: "support.mycompany.com".into(),
+///     repository: env!("CARGO_PKG_REPOSITORY").into()
+/// });
+/// ```
+#[macro_export]
+macro_rules! setup_panic {
+    ($meta:expr) => {
+        #[allow(unused_imports)]
+        use std::panic::{self, PanicInfo};
+        #[allow(unused_imports)]
+        use $crate::{get_report, print_msg, Metadata};
+
+        #[cfg(not(debug_assertions))]
+        match ::std::env::var("RUST_BACKTRACE") {
+            Err(_) => {
+                panic::set_hook(Box::new(move |info: &PanicInfo| {
+                    let crash_report = get_report(&$meta, info);
+                    print_msg(&crash_report, &$meta)
+                        .expect("robot-panic: printing error message to console failed");
+                }));
+            }
+            Ok(_) => {}
+        }
+    };
+
+    () => {
+        #[allow(unused_imports)]
+        use std::panic::{self, PanicInfo};
+        #[allow(unused_imports)]
+        use $crate::{get_report, print_msg, Metadata};
+
+        #[cfg(not(debug_assertions))]
+        match ::std::env::var("RUST_BACKTRACE") {
+            Err(_) => {
+                let meta = Metadata {
+                    version: env!("CARGO_PKG_VERSION").into(),
+                    name: env!("CARGO_PKG_NAME").into(),
+                    authors: env!("CARGO_PKG_AUTHORS").replace(":", ", ").into(),
+                    homepage: env!("CARGO_PKG_HOMEPAGE").into(),
+                    repository: env!("CARGO_PKG_REPOSITORY").into(),
+                };
+
+                panic::set_hook(Box::new(move |info: &PanicInfo| {
+                    let crash_report = get_report(&meta, info);
+                    print_msg(&crash_report, &meta)
+                        .expect("robot-panic: printing error message to console failed");
+                }));
+            }
+            Ok(_) => {}
+        }
+    };
+}
+
+/// Utility function that prints a message to our human users
+pub fn print_msg(crash_report: &Report, meta: &Metadata) -> IoResult<()> {
+    let (_version, name, _authors, _homepage, repository) = (
+        &meta.version,
+        &meta.name,
+        &meta.authors,
+        &meta.homepage,
+        &meta.repository,
+    );
+
+    // escape hatch for our use case ;)
+    let name = if name == "rover" {
+        "Rover".to_string()
+    } else {
+        name.to_string()
+    };
+
+    let stderr = BufferWriter::stderr(ColorChoice::Auto);
+    let mut buffer = stderr.buffer();
+    buffer.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+
+    writeln!(&mut buffer, "Houston, we have a problem. {} crashed!", name)?;
+    writeln!(
+        &mut buffer,
+        "To help us diagnose the \
+         problem you can send us a crash report.\n",
+    )?;
+    let issue_link = if !repository.is_empty() {
+        crash_report.get_github_issue(&repository).ok()
+    } else {
+        None
+    };
+
+    if let Some(issue_link) = issue_link {
+        writeln!(
+            &mut buffer,
+            "You can submit an \
+                 issue with the crash report at this link: {}",
+            &issue_link,
+        )?;
+    } else {
+        let path = crash_report.persist();
+        match path {
+            Ok(path) => {
+                writeln!(
+                    &mut buffer,
+                    "We have generated a report file at \"{}\". Submit an \
+                         issue with the subject of \"{} Crash Report\" and include the \
+                         report as an attachment.",
+                    path.display(),
+                    name
+                )?;
+            }
+            Err(_) => {
+                let crash_report = crash_report.serialize();
+                match crash_report {
+                    Some(crash_report) => {
+                        writeln!(
+                            &mut buffer,
+                            "We have generated a report which you can submit to \
+                        the authors of this tool.\n\n{}",
+                            &crash_report
+                        )?;
+                    }
+                    None => {
+                        writeln!(
+                            &mut buffer,
+                            "Unfortunately we could not generate a crash report."
+                        )?;
+                    }
+                }
+            }
+        }
+    }
+
+    writeln!(
+        &mut buffer,
+        "\nWe take privacy seriously, and do not perform any \
+         automated error collection. In order to improve the software, we rely on \
+         people to submit reports.\n"
+    )?;
+
+    writeln!(&mut buffer, "Thanks for your patience!")?;
+
+    buffer.reset()?;
+
+    stderr.print(&buffer).unwrap();
+    Ok(())
+}
+
+/// Utility function which will handle dumping information to disk
+pub fn get_report(meta: &Metadata, panic_info: &PanicInfo) -> Report {
+    let mut expl = String::new();
+
+    let message = match (
+        panic_info.payload().downcast_ref::<&str>(),
+        panic_info.payload().downcast_ref::<String>(),
+    ) {
+        (Some(s), _) => Some(s.to_string()),
+        (_, Some(s)) => Some(s.to_string()),
+        (None, None) => None,
+    };
+
+    let cause = match message {
+        Some(m) => m,
+        None => "Unknown".into(),
+    };
+
+    match panic_info.location() {
+        Some(location) => expl.push_str(&format!(
+            "Panic occurred in file '{}' at line {}\n",
+            location.file(),
+            location.line()
+        )),
+        None => expl.push_str("Panic location unknown.\n"),
+    }
+
+    Report::new(&meta.name, &meta.version, Method::Panic, expl, cause)
+}

--- a/crates/robot-panic/src/report.rs
+++ b/crates/robot-panic/src/report.rs
@@ -1,0 +1,184 @@
+//! This module encapsulates the report of a failure event.
+//!
+//! A `Report` contains the metadata collected about the event
+//! to construct a helpful error message.
+
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::Write as FmtWrite;
+use std::mem;
+use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
+
+use backtrace::Backtrace;
+use serde::Serialize;
+use url::Url;
+use uuid::Uuid;
+
+/// Method of failure.
+#[derive(Debug, Serialize, Clone, Copy)]
+pub enum Method {
+    /// Failure caused by a panic.
+    Panic,
+}
+
+/// Contains metadata about the crash like the backtrace and
+/// information about the crate and operating system. Can
+/// be used to be serialized and persisted or printed as
+/// information to the user.
+#[derive(Debug, Serialize)]
+pub struct Report {
+    name: String,
+    operating_system: Cow<'static, str>,
+    crate_version: String,
+    explanation: String,
+    cause: String,
+    method: Method,
+    backtrace: String,
+}
+
+impl Report {
+    /// Create a new instance.
+    pub fn new(
+        name: &str,
+        version: &str,
+        method: Method,
+        explanation: String,
+        cause: String,
+    ) -> Self {
+        let operating_system = if cfg!(windows) {
+            "windows".into()
+        } else {
+            let platform = os_type::current_platform();
+            format!("unix:{:?}", platform.os_type).into()
+        };
+
+        // We skip 3 frames from backtrace library
+        // Then we skip 3 frames for our own library
+        // (including closure that we set as hook)
+        // Then we skip 2 functions from Rust's runtime
+        // that calls panic hook
+        const SKIP_FRAMES_NUM: usize = 8;
+        // We take padding for address and extra two letters
+        // to padd after index.
+        const HEX_WIDTH: usize = mem::size_of::<usize>() + 2;
+        // Padding for next lines after frame's address
+        const NEXT_SYMBOL_PADDING: usize = HEX_WIDTH + 6;
+
+        let mut backtrace = String::new();
+
+        // Here we iterate over backtrace frames
+        // (each corresponds to function's stack)
+        // We need to print its address
+        // and symbol(e.g. function name),
+        // if it is available
+        for (idx, frame) in Backtrace::new()
+            .frames()
+            .iter()
+            .skip(SKIP_FRAMES_NUM)
+            .enumerate()
+        {
+            let ip = frame.ip();
+            let _ = write!(backtrace, "\n{:4}: {:2$?}", idx, ip, HEX_WIDTH);
+
+            let symbols = frame.symbols();
+            if symbols.is_empty() {
+                let _ = write!(backtrace, " - <unresolved>");
+                continue;
+            }
+
+            for (idx, symbol) in symbols.iter().enumerate() {
+                // Print symbols from this address,
+                // if there are several addresses
+                // we need to put it on next line
+                if idx != 0 {
+                    let _ = write!(backtrace, "\n{:1$}", "", NEXT_SYMBOL_PADDING);
+                }
+
+                if let Some(name) = symbol.name() {
+                    let _ = write!(backtrace, " - {}", name);
+                } else {
+                    let _ = write!(backtrace, " - <unknown>");
+                }
+
+                // See if there is debug information with file name and line
+                if let (Some(file), Some(line)) = (symbol.filename(), symbol.lineno()) {
+                    let _ = write!(
+                        backtrace,
+                        "\n{:3$}at {}:{}",
+                        "",
+                        file.display(),
+                        line,
+                        NEXT_SYMBOL_PADDING
+                    );
+                }
+            }
+        }
+
+        Self {
+            crate_version: version.into(),
+            name: name.into(),
+            operating_system,
+            method,
+            explanation,
+            cause,
+            backtrace,
+        }
+    }
+
+    /// Serialize the `Report` to a TOML string.
+    pub fn serialize(&self) -> Option<String> {
+        toml::to_string_pretty(&self).ok()
+    }
+
+    /// Write a file to disk.
+    pub fn persist(&self) -> Result<PathBuf, Box<dyn Error + 'static>> {
+        let uuid = Uuid::new_v4().to_hyphenated().to_string();
+        let tmp_dir = env::temp_dir();
+        let file_name = format!("report-{}.toml", &uuid);
+        let file_path = Path::new(&tmp_dir).join(file_name);
+        let mut file = File::create(&file_path)?;
+        let toml = self.serialize().unwrap();
+        file.write_all(toml.as_bytes())?;
+        Ok(file_path)
+    }
+
+    /// Create a new GitHub issue.
+    pub fn get_github_issue(&self, repo_home: &str) -> Result<Url, Box<dyn Error + 'static>> {
+        if !repo_home.contains("github") {
+            let err: Box<dyn Error + 'static> =
+                "repo is not hosted on GitHub, cannot generate an issue link."
+                    .to_string()
+                    .into();
+            return Err(err);
+        }
+
+        let new_issue = if repo_home.ends_with('/') {
+            format!("{}issues/new", repo_home)
+        } else {
+            format!("{}/issues/new", repo_home)
+        };
+
+        let crash_report = self.serialize();
+        let url = match crash_report {
+            Some(crash_report) => Url::parse_with_params(
+                &new_issue,
+                &[
+                    ("title", "bug: crashed while <insert description here>"),
+                    (
+                        "body",
+                        &format!(
+                            "<!--\n  Please add some additional information about what you were trying to \
+                            do before submitting this report\n --> \n\n\
+                            **Crash Report**\n \
+                    ```toml\n{}\n```\n",
+                            &crash_report
+                        ),
+                    ),
+                ],
+            )?,
+            None => Url::parse(&new_issue)?,
+        };
+
+        Ok(url)
+    }
+}

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use robot_panic::setup_panic;
 use rover::*;
 use sputnik::Session;
 use structopt::StructOpt;
@@ -6,6 +7,7 @@ use structopt::StructOpt;
 use std::thread;
 
 fn main() -> Result<()> {
+    setup_panic!();
     let app = cli::Rover::from_args();
     timber::init(app.log_level);
     tracing::trace!(command_structure = ?app);


### PR DESCRIPTION
i forked [human-panic](https://github.com/rust-cli/human-panic) since i like the functionality but dont like the default output.

if rover panics for some reason, we'll generate a crash report and provide a link that will automatically create an issue from the panic bakctrace.

important to note that this only happens in release mode and in debug mode panics look the same.

if we're able to successfully generate a github issue link, this is what the output looks like:

```
Houston, we have a problem. Rover crashed!
To help us diagnose the problem you can send us a crash report.

You can submit an issue with the crash report at this link: https://github.com/apollographql/rover/issues/new?title=bug%3A+crashed+while+%3Cinsert+description+here%3E&body=%3C%21--%0A++Please+add+some+additional+information+about+what+you+were+trying+to+do+before+submitting+this+report%0A+--%3E+%0A%0A**Crash+Report**%0A+%60%60%60toml%0Aname+%3D+%27rover%27%0Aoperating_system+%3D+%27unix%3AUbuntu%27%0Acrate_version+%3D+%270.0.0%27%0Aexplanation+%3D+%27%27%27%0APanic+occurred+in+file+%27src%2Fbin%2Frover.rs%27+at+line+11%0A%27%27%27%0Acause+%3D+%27oh+no%27%0Amethod+%3D+%27Panic%27%0Abacktrace+%3D+%27%27%27%0A%0A+++0%3A+0x5575363b5003+-+std%3A%3Asys_common%3A%3Abacktrace%3A%3A__rust_begin_short_backtrace%3A%3Ahcc063f8de39c7379%0A+++1%3A+0x5575363b505d+-+std%3A%3Art%3A%3Alang_start%3A%3A%7B%7Bclosure%7D%7D%3A%3Ahf77d52b639388bce%0A+++2%3A+0x5575364a2e41+-+core%3A%3Aops%3A%3Afunction%3A%3Aimpls%3A%3A%3Cimpl+core%3A%3Aops%3A%3Afunction%3A%3AFnOnce%3CA%3E+for+%26F%3E%3A%3Acall_once%3A%3Ah6a3209f124be2235%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fcore%2Fsrc%2Fops%2Ffunction.rs%3A259%0A+++++++++++++++++-+std%3A%3Apanicking%3A%3Atry%3A%3Ado_call%3A%3Ah88ce358792b64df0%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Fpanicking.rs%3A373%0A+++++++++++++++++-+std%3A%3Apanicking%3A%3Atry%3A%3Ah6311c259678e50fc%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Fpanicking.rs%3A337%0A+++++++++++++++++-+std%3A%3Apanic%3A%3Acatch_unwind%3A%3Ah56c5716807d659a1%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Fpanic.rs%3A379%0A+++++++++++++++++-+std%3A%3Art%3A%3Alang_start_internal%3A%3Ah73711f37ecfcb277%0A++++++++++++++++at+%2Frustc%2F18bf6b4f01a6feaf7259ba7cdae58031af1b7b39%2Flibrary%2Fstd%2Fsrc%2Frt.rs%3A51%0A+++3%3A+0x5575363b4fc2+-+main%0A+++4%3A+0x7fa1956800b3+-+__libc_start_main%0A+++5%3A+0x5575363b40be+-+_start%0A+++6%3A++++++++0x0+-+%3Cunresolved%3E%27%27%27%0A%0A%60%60%60%0A

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thanks for your patience!
```

if you follow that link, you'll create a new issue that looks like this: 
![image](https://user-images.githubusercontent.com/9408157/97740112-c2d06100-1aae-11eb-83d6-4e5d81c110c1.png)


if we were not able to create a github issue link, we'll create a tempfile with the crash report and this is what the output will look like:

```
Houston, we have a problem. Rover crashed!
To help us diagnose the problem you can send us a crash report.

We have generated a report file at "/tmp/report-92d20059-a834-4622-89e0-53587bbb1f50.toml". Submit an issue or email with the subject of "Rover Crash Report" and include the report as an attachment.

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thanks for your patience!
```