### PR TITLE
chore(houston): updates directories to directories-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,18 +53,6 @@ name = "apollo"
 version = "0.0.0"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,17 +127,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block-buffer"
@@ -293,12 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,19 +318,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "3.0.1"
+name = "directories-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
+name = "dirs-sys-next"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
  "libc",
  "redox_users",
@@ -706,7 +678,7 @@ dependencies = [
 name = "houston"
 version = "0.0.0"
 dependencies = [
- "directories",
+ "directories-next",
  "serde",
  "thiserror",
  "toml",
@@ -1371,7 +1343,6 @@ checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom",
  "redox_syscall",
- "rust-argon2",
 ]
 
 [[package]]
@@ -1479,18 +1450,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 
 [dependencies]
-directories = "3.0.1"
-serde = { version = "1.0.112", features = ["derive"] }
-toml = "0.5.6"
+directories-next = "2.0"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+toml = "0.5"
 tracing = "0.1"

--- a/crates/houston/src/home.rs
+++ b/crates/houston/src/home.rs
@@ -9,7 +9,7 @@ pub fn dir() -> Result<PathBuf, HoustonProblem> {
     let dir = match env::var("APOLLO_CONFIG_HOME").ok() {
         Some(home) => PathBuf::from(&home),
         None => {
-            directories::ProjectDirs::from("com", "Apollo", "Rover")
+            directories_next::ProjectDirs::from("com", "Apollo", "Rover")
                 .ok_or(HoustonProblem::ConfigDirNotFound)?
                 .config_dir()
                 .to_path_buf()


### PR DESCRIPTION
looks like there was some fallout w/the author of `directories` and the repo has been forked and published under `directories-next`.

paper trail if you're interested:

[RustSec advisory](https://github.com/RustSec/advisory-db/blob/master/crates/directories/RUSTSEC-2020-0054.md)
[RustSec  discussion prior to creating advisory](https://github.com/RustSec/advisory-db/issues/282)
[mild reddit drama](https://old.reddit.com/r/rust/comments/ga7f56/why_dirs_and_directories_repositories_have_been/foyqipp/)