### PR TITLE
Split up generic/studio clients

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -35,7 +35,14 @@ impl Client {
         Client::handle_response::<Q>(response)
     }
 
-    fn handle_response<Q: graphql_client::GraphQLQuery>(
+    /// To be used internally or by other implementations of a graphql client.
+    ///
+    /// This fn tries to parse the JSON response from a graphql server. It will
+    /// error if the JSON can't be parsed or if there are any graphql errors
+    /// in the JSON body (in body.errors).
+    ///
+    /// If successful, it will return body.data
+    pub fn handle_response<Q: graphql_client::GraphQLQuery>(
         response: reqwest::blocking::Response,
     ) -> Result<Option<Q::ResponseData>, RoverClientError> {
         let response_body: graphql_client::Response<Q::ResponseData> =

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -10,8 +10,8 @@ pub struct Client {
 }
 
 impl Client {
-    /// Construct a new [StudioClient] from 2 strings, an `api_key` and a `uri`.
-    /// For use in Rover, the `uri` is usually going to be to Apollo Studio
+    /// Construct a new [Client] from a `uri`.
+    /// This client is used for generic GraphQL requests, such as introspection.
     pub fn new(uri: &str) -> Client {
         Client {
             client: reqwest::blocking::Client::new(),

--- a/crates/rover-client/src/blocking/mod.rs
+++ b/crates/rover-client/src/blocking/mod.rs
@@ -1,3 +1,3 @@
-mod client;
+mod studio_client;
 
-pub use client::Client;
+pub use studio_client::StudioClient;

--- a/crates/rover-client/src/blocking/mod.rs
+++ b/crates/rover-client/src/blocking/mod.rs
@@ -1,3 +1,5 @@
+mod client;
 mod studio_client;
 
+pub use client::Client;
 pub use studio_client::StudioClient;

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -3,17 +3,17 @@ use crate::RoverClientError;
 use graphql_client::GraphQLQuery;
 
 /// Represents a client for making http requests.
-pub struct Client {
+pub struct StudioClient {
     api_key: String,
     client: reqwest::blocking::Client,
     uri: String,
 }
 
-impl Client {
-    /// Construct a new [Client] from 2 strings, an `api_key` and a `uri`.
+impl StudioClient {
+    /// Construct a new [StudioClient] from 2 strings, an `api_key` and a `uri`.
     /// For use in Rover, the `uri` is usually going to be to Apollo Studio
-    pub fn new(api_key: &str, uri: &str) -> Client {
-        Client {
+    pub fn new(api_key: &str, uri: &str) -> StudioClient {
+        StudioClient {
             api_key: api_key.to_string(),
             client: reqwest::blocking::Client::new(),
             uri: uri.to_string(),
@@ -27,12 +27,12 @@ impl Client {
         &self,
         variables: Q::Variables,
     ) -> Result<Option<Q::ResponseData>, RoverClientError> {
-        let h = headers::build(&self.api_key)?;
+        let h = headers::build_studio_headers(&self.api_key)?;
         let body = Q::build_query(variables);
 
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
 
-        Client::handle_response::<Q>(response)
+        StudioClient::handle_response::<Q>(response)
     }
 
     fn handle_response<Q: graphql_client::GraphQLQuery>(

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -5,17 +5,25 @@ use thiserror::Error;
 pub enum RoverClientError {
     /// The provided GraphQL was invalid.
     #[error("encountered a GraphQL error, registry responded with: {msg}")]
+
     /// The error message.
     GraphQL { msg: String },
+
+    /// Tried to build a [HeaderMap] with an invalid header name.
+    #[error("invalid header name")]
+    InvalidHeaderName(#[from] reqwest::header::InvalidHeaderName),
+
     /// Tried to build a [HeaderMap] with an invalid header value.
     #[error("invalid header value")]
-    InvalidHeader(#[from] http::header::InvalidHeaderValue),
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+
     /// Encountered an error handling the received response.
     #[error("encountered an error handling the response: {msg}")]
     HandleResponse {
         /// The error message.
         msg: String,
     },
+
     /// Encountered an error sending the request.
     #[error("encountered an error while sending a request")]
     SendRequest(#[from] reqwest::Error),

--- a/crates/rover-client/src/headers.rs
+++ b/crates/rover-client/src/headers.rs
@@ -1,33 +1,27 @@
 use crate::RoverClientError;
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::collections::HashMap;
 use std::env;
 
-const CONTENT_TYPE: &str = "application/json";
+const JSON_CONTENT_TYPE: &str = "application/json";
 const CLIENT_NAME: &str = "rover-client";
-
-struct StringHeader {
-    key: String,
-    value: String,
-}
-type HeaderList = Vec<StringHeader>;
 
 /// Function for building a [HeaderMap] for making http requests. Use for
 /// Generic requests to any graphql endpoint.
-/// 
-/// Takes a single argument, an optional list of header key/value pairs
-pub fn build(header_list: Option<HeaderList>) -> Result<HeaderMap, RoverClientError> {
+///
+/// Takes a single argument, list of header key/value pairs
+pub fn build(header_map: &HashMap<String, String>) -> Result<HeaderMap, RoverClientError> {
     let mut headers = HeaderMap::new();
 
     // this should be consistent for any graphql requests
-    let content_type = HeaderValue::from_str(CONTENT_TYPE)?;
+    let content_type = HeaderValue::from_str(JSON_CONTENT_TYPE)?;
     headers.insert("Content-Type", content_type);
 
-    if let Some(list) = header_list {
-        for header in list.iter() {
-            let header_value = HeaderValue::from_str(&header.value)?;
-            headers.insert(header.key.as_str(), header_value);
-        }
-    };
+    for (key, value) in header_map {
+        let header_key = HeaderName::from_bytes(key.as_bytes())?;
+        let header_value = HeaderValue::from_str(&value)?;
+        headers.insert(header_key, header_value);
+    }
 
     Ok(headers)
 }
@@ -39,7 +33,7 @@ pub fn build(header_list: Option<HeaderList>) -> Result<HeaderMap, RoverClientEr
 pub fn build_studio_headers(api_key: &str) -> Result<HeaderMap, RoverClientError> {
     let mut headers = HeaderMap::new();
 
-    let content_type = HeaderValue::from_str(CONTENT_TYPE)?;
+    let content_type = HeaderValue::from_str(JSON_CONTENT_TYPE)?;
     headers.insert("Content-Type", content_type);
 
     // this header value is used for client identification in Apollo Studio, so

--- a/crates/rover-client/src/headers.rs
+++ b/crates/rover-client/src/headers.rs
@@ -5,10 +5,38 @@ use std::env;
 const CONTENT_TYPE: &str = "application/json";
 const CLIENT_NAME: &str = "rover-client";
 
-/// Function for building a [HeaderMap] for making http requests.
+struct StringHeader {
+    key: String,
+    value: String,
+}
+type HeaderList = Vec<StringHeader>;
+
+/// Function for building a [HeaderMap] for making http requests. Use for
+/// Generic requests to any graphql endpoint.
+/// 
+/// Takes a single argument, an optional list of header key/value pairs
+pub fn build(header_list: Option<HeaderList>) -> Result<HeaderMap, RoverClientError> {
+    let mut headers = HeaderMap::new();
+
+    // this should be consistent for any graphql requests
+    let content_type = HeaderValue::from_str(CONTENT_TYPE)?;
+    headers.insert("Content-Type", content_type);
+
+    if let Some(list) = header_list {
+        for header in list.iter() {
+            let header_value = HeaderValue::from_str(&header.value)?;
+            headers.insert(header.key.as_str(), header_value);
+        }
+    };
+
+    Ok(headers)
+}
+
+/// Function for building a [HeaderMap] for making http requests. Use for making
+/// requests to Apollo Studio
 ///
 /// Takes a single argument, "api_key"m and returns a [HeaderMap].
-pub fn build(api_key: &str) -> Result<HeaderMap, RoverClientError> {
+pub fn build_studio_headers(api_key: &str) -> Result<HeaderMap, RoverClientError> {
     let mut headers = HeaderMap::new();
 
     let content_type = HeaderValue::from_str(CONTENT_TYPE)?;

--- a/crates/rover-client/src/headers.rs
+++ b/crates/rover-client/src/headers.rs
@@ -15,12 +15,12 @@ pub fn build(header_map: &HashMap<String, String>) -> Result<HeaderMap, RoverCli
 
     // this should be consistent for any graphql requests
     let content_type = HeaderValue::from_str(JSON_CONTENT_TYPE)?;
-    headers.insert("Content-Type", content_type);
+    headers.append("Content-Type", content_type);
 
     for (key, value) in header_map {
         let header_key = HeaderName::from_bytes(key.as_bytes())?;
         let header_value = HeaderValue::from_str(&value)?;
-        headers.insert(header_key, header_value);
+        headers.append(header_key, header_value);
     }
 
     Ok(headers)

--- a/crates/rover-client/src/headers.rs
+++ b/crates/rover-client/src/headers.rs
@@ -27,7 +27,8 @@ pub fn build(header_map: &HashMap<String, String>) -> Result<HeaderMap, RoverCli
 }
 
 /// Function for building a [HeaderMap] for making http requests. Use for making
-/// requests to Apollo Studio
+/// requests to Apollo Studio. We're leaving this separate from `build` since we
+/// need to be able to mark the api_key as sensitive (at the bottom)
 ///
 /// Takes a single argument, "api_key"m and returns a [HeaderMap].
 pub fn build_studio_headers(api_key: &str) -> Result<HeaderMap, RoverClientError> {

--- a/crates/rover-client/src/query/partial/push.rs
+++ b/crates/rover-client/src/query/partial/push.rs
@@ -1,5 +1,5 @@
 // PushPartialSchemaMutation
-use crate::blocking::Client;
+use crate::blocking::StudioClient;
 use crate::RoverClientError;
 use graphql_client::*;
 
@@ -27,7 +27,7 @@ pub struct PushPartialSchemaResponse {
 
 pub fn run(
     variables: push_partial_schema_mutation::Variables,
-    client: Client,
+    client: StudioClient,
 ) -> Result<PushPartialSchemaResponse, RoverClientError> {
     let data = execute_mutation(client, variables)?;
     let push_response = get_push_response_from_data(data)?;
@@ -38,7 +38,7 @@ pub fn run(
 type UpdateResponse = push_partial_schema_mutation::PushPartialSchemaMutationServiceUpsertImplementingServiceAndTriggerComposition;
 
 fn execute_mutation(
-    client: Client,
+    client: StudioClient,
     variables: push_partial_schema_mutation::Variables,
 ) -> Result<push_partial_schema_mutation::ResponseData, RoverClientError> {
     let res = client.post::<PushPartialSchemaMutation>(variables)?;

--- a/crates/rover-client/src/query/schema/get.rs
+++ b/crates/rover-client/src/query/schema/get.rs
@@ -1,4 +1,4 @@
-use crate::blocking::Client;
+use crate::blocking::StudioClient;
 use crate::RoverClientError;
 use graphql_client::*;
 
@@ -24,7 +24,7 @@ pub struct GetSchemaQuery;
 /// schema from apollo studio and returns it in either sdl (default) or json format
 pub fn run(
     variables: get_schema_query::Variables,
-    client: Client,
+    client: StudioClient,
 ) -> Result<String, RoverClientError> {
     let response_data = execute_query(client, variables)?;
     get_schema_from_response_data(response_data)
@@ -32,7 +32,7 @@ pub fn run(
 }
 
 fn execute_query(
-    client: Client,
+    client: StudioClient,
     variables: get_schema_query::Variables,
 ) -> Result<get_schema_query::ResponseData, RoverClientError> {
     let res = client.post::<GetSchemaQuery>(variables)?;

--- a/crates/rover-client/src/query/schema/push.rs
+++ b/crates/rover-client/src/query/schema/push.rs
@@ -1,4 +1,4 @@
-use crate::blocking::Client;
+use crate::blocking::StudioClient;
 use crate::RoverClientError;
 use graphql_client::*;
 
@@ -26,7 +26,7 @@ pub struct PushResponse {
 /// a sha256 hash of the schema to be used with `schema publish`
 pub fn run(
     variables: push_schema_mutation::Variables,
-    client: Client,
+    client: StudioClient,
 ) -> Result<PushResponse, RoverClientError> {
     let data = execute_mutation(client, variables)?;
     let push_response = get_push_response_from_data(data)?;
@@ -34,7 +34,7 @@ pub fn run(
 }
 
 fn execute_mutation(
-    client: Client,
+    client: StudioClient,
     variables: push_schema_mutation::Variables,
 ) -> Result<push_schema_mutation::ResponseData, RoverClientError> {
     let res = client.post::<PushSchemaMutation>(variables)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,3 +8,7 @@ pub(crate) fn get_studio_client(profile: &str) -> Result<StudioClient> {
     let api_key = config::Profile::get_api_key(profile)?;
     Ok(StudioClient::new(&api_key, STUDIO_PROD_API_ENDPOINT))
 }
+
+// pub(crate) fn get_client(uri: &str) -> Result<Client> {
+
+// }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use houston as config;
-use rover_client::blocking::studio_client::StudioClient;
+use rover_client::blocking::StudioClient;
 
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use houston as config;
-use rover_client::blocking::Client;
+use rover_client::blocking::studio_client::StudioClient;
 
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
 
-pub(crate) fn get_rover_client(profile: &str) -> Result<Client> {
+pub(crate) fn get_studio_client(profile: &str) -> Result<StudioClient> {
     let api_key = config::Profile::get_api_key(profile)?;
-    Ok(Client::new(&api_key, STUDIO_PROD_API_ENDPOINT))
+    Ok(StudioClient::new(&api_key, STUDIO_PROD_API_ENDPOINT))
 }

--- a/src/command/partial/push.rs
+++ b/src/command/partial/push.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::client::get_rover_client;
+use crate::client::get_studio_client;
 use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -37,7 +37,7 @@ pub struct Push {
 
 impl Push {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_rover_client(&self.profile_name)?;
+        let client = get_studio_client(&self.profile_name)?;
 
         tracing::info!(
             "Let's push this schema, {}@{}, mx. {}!",

--- a/src/command/schema/fetch.rs
+++ b/src/command/schema/fetch.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 
 use rover_client::query::schema::get;
 
-use crate::client::get_rover_client;
+use crate::client::get_studio_client;
 use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -26,7 +26,7 @@ pub struct Fetch {
 
 impl Fetch {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_rover_client(&self.profile_name)?;
+        let client = get_studio_client(&self.profile_name)?;
 
         tracing::info!(
             "Let's get this schema, {}@{}, mx. {}!",

--- a/src/command/schema/push.rs
+++ b/src/command/schema/push.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 
 use rover_client::query::schema::push;
 
-use crate::client::get_rover_client;
+use crate::client::get_studio_client;
 use crate::command::RoverStdout;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -34,7 +34,7 @@ pub struct Push {
 
 impl Push {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_rover_client(&self.profile_name)?;
+        let client = get_studio_client(&self.profile_name)?;
         tracing::info!(
             "Let's push this schema, {}@{}, mx. {}!",
             &self.graph_name,


### PR DESCRIPTION
This PR does 2 things to the existing `rover-client` http client for handling GraphQL requests

1. renames the existing `client` to `studio_client`. This client exists to easily work with Apollo Studio, but doesn't allow for custom headers to be passed through and doesn't allow commands to change the uri based on arguments. This is necessary for commands like `introspect`.
2. Creates a new generic client, using the old name, `client`. 

Todo:
- [ ] ~both of these clients use the same response handling logic. It's not a lot, but should we move that to a util file?~
  - This can just live in the `Client` module right now I feel like.
- [ ] ~rewrite the `studio_client` to use the `client` under the hood.~
  - I don't think this is necessary tbh