### PR TITLE
fix: remove deprecated add-path usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         if: matrix.build == 'macos'
         run: |
           brew install gnu-tar
-          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
 
       - name: Build (Linux)
         if: matrix.build == 'linux'


### PR DESCRIPTION
this does not change any behavior, just updates to new github release pattern. the old add-path method of updating paths will be removed entirely in like 5 days because of [reasons](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)