### PR TITLE
Clean up API-related errors

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -67,7 +67,7 @@ impl Client {
             Ok(data)
         } else {
             Err(RoverClientError::HandleResponse {
-                msg: "Response body's data was empty. This is probably a GraphQL execution error from the server.".to_string()
+                msg: "There was no data in the response body from the server. This is likely a result of failure to Execute GraphQL properly.".to_string()
             })
         }
     }

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -66,9 +66,7 @@ impl Client {
         if let Some(data) = response_body.data {
             Ok(data)
         } else {
-            Err(RoverClientError::HandleResponse {
-                msg: "There was no data in the response body from the server. This is likely a result of failure to Execute GraphQL properly.".to_string()
-            })
+            Err(RoverClientError::NoData)
         }
     }
 }

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -27,7 +27,7 @@ impl StudioClient {
     pub fn post<Q: GraphQLQuery>(
         &self,
         variables: Q::Variables,
-    ) -> Result<Option<Q::ResponseData>, RoverClientError> {
+    ) -> Result<Q::ResponseData, RoverClientError> {
         let h = headers::build_studio_headers(&self.api_key)?;
         let body = Q::build_query(variables);
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -25,4 +25,10 @@ pub enum RoverClientError {
     /// Encountered an error sending the request.
     #[error("encountered an error while sending a request")]
     SendRequest(#[from] reqwest::Error),
+
+    /// This error occurs when there are no `body.errors` but `body.data` is
+    /// also empty. In proper GraphQL responses, there should _always_ be either
+    /// body.errors or body.data
+    #[error("The response from the server was malformed. There was no data found in the reponse body. This is likely an error in GraphQL execution")]
+    NoData,
 }

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -22,10 +22,6 @@ pub enum RoverClientError {
         msg: String,
     },
 
-    /// There was no "data" in the response from Studio
-    #[error("There was no data in the response from Apollo Studio. This is likely caused by an error on Apollo's end. This should never occur without errors.")]
-    StudioNoResponse,
-
     /// Encountered an error sending the request.
     #[error("encountered an error while sending a request")]
     SendRequest(#[from] reqwest::Error),

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -5,8 +5,6 @@ use thiserror::Error;
 pub enum RoverClientError {
     /// The provided GraphQL was invalid.
     #[error("encountered a GraphQL error, registry responded with: {msg}")]
-
-    /// The error message.
     GraphQL { msg: String },
 
     /// Tried to build a [HeaderMap] with an invalid header name.
@@ -23,6 +21,10 @@ pub enum RoverClientError {
         /// The error message.
         msg: String,
     },
+
+    /// There was no "data" in the response from Studio
+    #[error("There was no data in the response from Apollo Studio. This is likely caused by an error on Apollo's end. This should never occur without errors.")]
+    StudioNoResponse,
 
     /// Encountered an error sending the request.
     #[error("encountered an error while sending a request")]

--- a/crates/rover-client/src/query/partial/push.rs
+++ b/crates/rover-client/src/query/partial/push.rs
@@ -29,27 +29,13 @@ pub fn run(
     variables: push_partial_schema_mutation::Variables,
     client: StudioClient,
 ) -> Result<PushPartialSchemaResponse, RoverClientError> {
-    let data = execute_mutation(client, variables)?;
+    let data = client.post::<PushPartialSchemaMutation>(variables)?;
     let push_response = get_push_response_from_data(data)?;
     build_response(push_response)
 }
 
 // alias this return type since it's disgusting
 type UpdateResponse = push_partial_schema_mutation::PushPartialSchemaMutationServiceUpsertImplementingServiceAndTriggerComposition;
-
-fn execute_mutation(
-    client: StudioClient,
-    variables: push_partial_schema_mutation::Variables,
-) -> Result<push_partial_schema_mutation::ResponseData, RoverClientError> {
-    let res = client.post::<PushPartialSchemaMutation>(variables)?;
-    if let Some(opt_res) = res {
-        Ok(opt_res)
-    } else {
-        Err(RoverClientError::HandleResponse {
-            msg: "Error fetching schema. Check your API key & graph id".to_string(),
-        })
-    }
-}
 
 fn get_push_response_from_data(
     data: push_partial_schema_mutation::ResponseData,

--- a/crates/rover-client/src/query/schema/get.rs
+++ b/crates/rover-client/src/query/schema/get.rs
@@ -26,23 +26,9 @@ pub fn run(
     variables: get_schema_query::Variables,
     client: StudioClient,
 ) -> Result<String, RoverClientError> {
-    let response_data = execute_query(client, variables)?;
+    let response_data = client.post::<GetSchemaQuery>(variables)?;
     get_schema_from_response_data(response_data)
     // if we want json, we can parse & serialize it here
-}
-
-fn execute_query(
-    client: StudioClient,
-    variables: get_schema_query::Variables,
-) -> Result<get_schema_query::ResponseData, RoverClientError> {
-    let res = client.post::<GetSchemaQuery>(variables)?;
-    if let Some(data) = res {
-        Ok(data)
-    } else {
-        Err(RoverClientError::HandleResponse {
-            msg: "Error fetching schema. No data in response".to_string(),
-        })
-    }
 }
 
 fn get_schema_from_response_data(

--- a/crates/rover-client/src/query/schema/push.rs
+++ b/crates/rover-client/src/query/schema/push.rs
@@ -28,23 +28,9 @@ pub fn run(
     variables: push_schema_mutation::Variables,
     client: StudioClient,
 ) -> Result<PushResponse, RoverClientError> {
-    let data = execute_mutation(client, variables)?;
+    let data = client.post::<PushSchemaMutation>(variables)?;
     let push_response = get_push_response_from_data(data)?;
     build_response(push_response)
-}
-
-fn execute_mutation(
-    client: StudioClient,
-    variables: push_schema_mutation::Variables,
-) -> Result<push_schema_mutation::ResponseData, RoverClientError> {
-    let res = client.post::<PushSchemaMutation>(variables)?;
-    if let Some(opt_res) = res {
-        Ok(opt_res)
-    } else {
-        Err(RoverClientError::HandleResponse {
-            msg: "Error fetching schema. Check your API key & graph id".to_string(),
-        })
-    }
 }
 
 fn get_push_response_from_data(

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -17,7 +17,7 @@ pub struct ApiKey {
 
 impl ApiKey {
     pub fn run(&self) -> Result<RoverStdout> {
-        let api_key = api_key_prompt().context("Failed to read from terminal")?;
+        let api_key = api_key_prompt().context("Failed to read API key from terminal")?;
         Profile::set_api_key(&self.profile_name, &api_key)
             .context("Failed while saving API key")?;
         Profile::get_api_key(&self.profile_name)

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result};
+use anyhow::{Error, Result, Context};
 use console::{self, style};
 use serde::Serialize;
 use structopt::StructOpt;
@@ -17,11 +17,11 @@ pub struct ApiKey {
 
 impl ApiKey {
     pub fn run(&self) -> Result<RoverStdout> {
-        let api_key = api_key_prompt()?;
-        Profile::set_api_key(&self.profile_name, &api_key)?;
+        let api_key = api_key_prompt().context("Failed to read from terminal")?;
+        Profile::set_api_key(&self.profile_name, &api_key).context("Failed while saving API key")?;
         Profile::get_api_key(&self.profile_name).map(|_| {
             tracing::info!("Successfully saved API key.");
-        })?;
+        }).context("Failed while loading API key")?;
         Ok(RoverStdout::None)
     }
 }

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result, Context};
+use anyhow::{Context, Error, Result};
 use console::{self, style};
 use serde::Serialize;
 use structopt::StructOpt;
@@ -18,10 +18,13 @@ pub struct ApiKey {
 impl ApiKey {
     pub fn run(&self) -> Result<RoverStdout> {
         let api_key = api_key_prompt().context("Failed to read from terminal")?;
-        Profile::set_api_key(&self.profile_name, &api_key).context("Failed while saving API key")?;
-        Profile::get_api_key(&self.profile_name).map(|_| {
-            tracing::info!("Successfully saved API key.");
-        }).context("Failed while loading API key")?;
+        Profile::set_api_key(&self.profile_name, &api_key)
+            .context("Failed while saving API key")?;
+        Profile::get_api_key(&self.profile_name)
+            .map(|_| {
+                tracing::info!("Successfully saved API key.");
+            })
+            .context("Failed while loading API key")?;
         Ok(RoverStdout::None)
     }
 }

--- a/src/command/config/clear.rs
+++ b/src/command/config/clear.rs
@@ -1,10 +1,10 @@
-use anyhow::Result;
+use anyhow::{Result, Context};
 
 use crate::command::RoverStdout;
 use houston as config;
 
 pub fn run() -> Result<RoverStdout> {
-    config::clear()?;
+    config::clear().context("Failed to clear profiles")?;
     tracing::info!("Successfully cleared all configuration.");
     Ok(RoverStdout::None)
 }

--- a/src/command/config/clear.rs
+++ b/src/command/config/clear.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 
 use crate::command::RoverStdout;
 use houston as config;

--- a/src/command/partial/push.rs
+++ b/src/command/partial/push.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, Context};
 use rover_client::query::partial::push::{self, PushPartialSchemaResponse};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -37,7 +37,7 @@ pub struct Push {
 
 impl Push {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_studio_client(&self.profile_name)?;
+        let client = get_studio_client(&self.profile_name).context("Failed to get studio client")?;
 
         tracing::info!(
             "Let's push this schema, {}@{}, mx. {}!",
@@ -46,7 +46,7 @@ impl Push {
             &self.profile_name
         );
 
-        let schema_document = get_schema_from_file_path(&self.schema_path)?;
+        let schema_document = get_schema_from_file_path(&self.schema_path).context("Failed while loading from SDL file")?;
 
         let push_response = push::run(
             push::push_partial_schema_mutation::Variables {
@@ -61,7 +61,7 @@ impl Push {
                 url: "".to_string(),
             },
             client,
-        )?;
+        ).context("Failed while pushing to Apollo Studio")?;
 
         handle_response(push_response, &self.service_name, &self.graph_name);
         Ok(RoverStdout::None)

--- a/src/command/partial/push.rs
+++ b/src/command/partial/push.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use rover_client::query::partial::push::{self, PushPartialSchemaResponse};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -37,7 +37,8 @@ pub struct Push {
 
 impl Push {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_studio_client(&self.profile_name).context("Failed to get studio client")?;
+        let client =
+            get_studio_client(&self.profile_name).context("Failed to get studio client")?;
 
         tracing::info!(
             "Let's push this schema, {}@{}, mx. {}!",
@@ -46,7 +47,8 @@ impl Push {
             &self.profile_name
         );
 
-        let schema_document = get_schema_from_file_path(&self.schema_path).context("Failed while loading from SDL file")?;
+        let schema_document = get_schema_from_file_path(&self.schema_path)
+            .context("Failed while loading from SDL file")?;
 
         let push_response = push::run(
             push::push_partial_schema_mutation::Variables {
@@ -61,7 +63,8 @@ impl Push {
                 url: "".to_string(),
             },
             client,
-        ).context("Failed while pushing to Apollo Studio")?;
+        )
+        .context("Failed while pushing to Apollo Studio")?;
 
         handle_response(push_response, &self.service_name, &self.graph_name);
         Ok(RoverStdout::None)

--- a/src/command/schema/fetch.rs
+++ b/src/command/schema/fetch.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, Context};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -27,7 +27,7 @@ pub struct Fetch {
 
 impl Fetch {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_studio_client(&self.profile_name)?;
+        let client = get_studio_client(&self.profile_name).context("Failed to get studio client")?;
 
         tracing::info!(
             "Let's get this schema, {}@{}, mx. {}!",
@@ -43,7 +43,7 @@ impl Fetch {
                 variant: Some(self.variant.clone()),
             },
             client,
-        )?;
+        ).context("Failed while fetching from Apollo Studio")?;
 
         Ok(RoverStdout::SDL(sdl))
     }

--- a/src/command/schema/fetch.rs
+++ b/src/command/schema/fetch.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -27,7 +27,8 @@ pub struct Fetch {
 
 impl Fetch {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_studio_client(&self.profile_name).context("Failed to get studio client")?;
+        let client =
+            get_studio_client(&self.profile_name).context("Failed to get studio client")?;
 
         tracing::info!(
             "Let's get this schema, {}@{}, mx. {}!",
@@ -43,7 +44,8 @@ impl Fetch {
                 variant: Some(self.variant.clone()),
             },
             client,
-        ).context("Failed while fetching from Apollo Studio")?;
+        )
+        .context("Failed while fetching from Apollo Studio")?;
 
         Ok(RoverStdout::SDL(sdl))
     }

--- a/src/command/schema/push.rs
+++ b/src/command/schema/push.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -34,7 +34,8 @@ pub struct Push {
 
 impl Push {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_studio_client(&self.profile_name).context("Failed to get studio client")?;
+        let client =
+            get_studio_client(&self.profile_name).context("Failed to get studio client")?;
         tracing::info!(
             "Let's push this schema, {}@{}, mx. {}!",
             &self.graph_name,
@@ -42,7 +43,8 @@ impl Push {
             &self.profile_name
         );
 
-        let schema_document = get_schema_from_file_path(&self.schema_path).context("Failed while loading from SDL file")?;
+        let schema_document = get_schema_from_file_path(&self.schema_path)
+            .context("Failed while loading from SDL file")?;
 
         let push_response = push::run(
             push::push_schema_mutation::Variables {
@@ -51,7 +53,8 @@ impl Push {
                 schema_document: Some(schema_document),
             },
             client,
-        ).context("Failed while pushing to Apollo Studio")?;
+        )
+        .context("Failed while pushing to Apollo Studio")?;
 
         let hash = handle_response(push_response);
 

--- a/src/command/schema/push.rs
+++ b/src/command/schema/push.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, Context};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -34,7 +34,7 @@ pub struct Push {
 
 impl Push {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = get_studio_client(&self.profile_name)?;
+        let client = get_studio_client(&self.profile_name).context("Failed to get studio client")?;
         tracing::info!(
             "Let's push this schema, {}@{}, mx. {}!",
             &self.graph_name,
@@ -42,7 +42,7 @@ impl Push {
             &self.profile_name
         );
 
-        let schema_document = get_schema_from_file_path(&self.schema_path)?;
+        let schema_document = get_schema_from_file_path(&self.schema_path).context("Failed while loading from SDL file")?;
 
         let push_response = push::run(
             push::push_schema_mutation::Variables {
@@ -51,7 +51,7 @@ impl Push {
                 schema_document: Some(schema_document),
             },
             client,
-        )?;
+        ).context("Failed while pushing to Apollo Studio")?;
 
         let hash = handle_response(push_response);
 


### PR DESCRIPTION
- Change the response handling to automatically unwrap `body.Option<data>`
  - This shoudn't be possible in a successful GraphQL response.
    In this case where `body.data` is empty, there should ALWAYS be
    `body.errors`. Since we already check for `body.errors` above, we should
    be able to error if `body.data` ends up empty after that check.
  - Since this is now unwrapped automatically, I removed that logic from
    all the `execute_` functions. Since that's pretty much all those
    functions were doing, I was able to remove them all in place of
    just calling `client.post`

FYI, the spec description of this response body shape that allows us to guarantee this error is correct is [here](https://spec.graphql.org/June2018/#sec-Errors)

> If the data entry in the response is not present, the errors entry in the response must not be empty. It must contain at least one error. The errors it contains should indicate why no data was able to be returned.