### PR TITLE
feat: less verbose logger

### DIFF
--- a/crates/timber/Cargo.toml
+++ b/crates/timber/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 serde = "1"
 tracing-core = "0.1"
 # the parking_lot feature uses a more performant mutex than std::sync::Mutex
-tracing-subscriber = { version = "0.2", features = [ "parking_lot" ] } 
+tracing-subscriber = { version = "0.2", features = [ "ansi", "fmt", "parking_lot" ] } 

--- a/crates/timber/src/formatter.rs
+++ b/crates/timber/src/formatter.rs
@@ -5,9 +5,10 @@ use tracing_subscriber::fmt;
 use std::io;
 
 pub(crate) fn least_verbose(level: Level) {
+    let format = fmt::format().without_time().with_target(false).compact();
     fmt()
         .with_max_level(level)
-        .without_time()
+        .event_format(format)
         .with_writer(io::stderr)
         .init();
 }


### PR DESCRIPTION
before, our logging was kinda cluttered with call stack info, which isn't great for end users to have to dig through. this change updates our default logger to look like this:

```console
$ rover config api-key -l info
  INFO Go to https://studio.apollographql.com/user-settings and create a new Personal API Key.
  INFO Copy the key and paste it into the prompt below.

  INFO Successfully saved API key.
```

```console
$ rover schema fetch averys-federated-graph
  INFO Let's get this schema, averys-federated-graph@current, mx. default!
  INFO SDL:
type Person {
  id: ID!
  pet: Boolean
  name: String
  appearedIn: [Film]
  directed: [Film]
}

type Film {
  id: ID!
  title: String
  actors: [Person]
  director: Person
}

type Query {
  person(id: ID!): Person
  people: [Person]
  film(id: ID!): Film
  films: [Film]
}
```