### PR TITLE
Add env var to change registry endpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,12 +1,15 @@
 use anyhow::Result;
 use houston as config;
 use rover_client::blocking::StudioClient;
+use std::env;
 
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
 
 pub(crate) fn get_studio_client(profile: &str) -> Result<StudioClient> {
     let api_key = config::Profile::get_api_key(profile)?;
-    Ok(StudioClient::new(&api_key, STUDIO_PROD_API_ENDPOINT))
+    let endpoint =
+        env::var("APOLLO_REGISTRY_URI").unwrap_or_else(|_| String::from(STUDIO_PROD_API_ENDPOINT));
+    Ok(StudioClient::new(&api_key, &endpoint))
 }
 
 // pub(crate) fn get_client(uri: &str) -> Result<Client> {


### PR DESCRIPTION
_insert v. bad screenshot showing the client using the proper uri overwrite here_

The first run is using the default with no env variable present. The second run uses the `APOLLO_REGISTRY_URI` var and properly sets the new uri 😄 

![image](https://user-images.githubusercontent.com/9259509/99720325-9be8c780-2a7b-11eb-8c32-7cb8f9ae8d97.png)