### PR TITLE
WIP log proper url with help messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ console = "0.13.0"
 serde = "1.0"
 serde_json = "1.0"
 structopt = "0.3.15"
-url = "2.1.1"
+url = "2.2.0"
 tracing = "0.1.21"
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,9 +2,23 @@ use anyhow::Result;
 use houston as config;
 use rover_client::blocking::StudioClient;
 use std::env;
+use url::Url;
 
-const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
+pub const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
 // const STUDIO_STAGING_API_ENDPOINT: &str = "https://engine-staging-graphql.apollographql.com/api/graphql";
+
+pub(crate) fn get_client_endpoint() -> String {
+    env::var("APOLLO_REGISTRY_URI").unwrap_or_else(|_| String::from(STUDIO_PROD_API_ENDPOINT))
+}
+
+/// this is just the client endpoint with no path. This should be the URL for
+/// the UI
+pub(crate) fn get_app_url() -> Result<String> {
+    let api_endpoint = get_client_endpoint();
+    let mut url = Url::parse(&api_endpoint)?;
+    url.set_path("");
+    Ok(url.to_string())
+}
 
 pub(crate) fn get_studio_client(profile: &str) -> Result<StudioClient> {
     let api_key = config::Profile::get_api_key(profile)?;

--- a/src/command/config/api_key.rs
+++ b/src/command/config/api_key.rs
@@ -1,3 +1,4 @@
+use crate::client::get_app_url;
 use anyhow::{Context, Error, Result};
 use console::{self, style};
 use serde::Serialize;
@@ -31,9 +32,11 @@ impl ApiKey {
 
 fn api_key_prompt() -> Result<String> {
     let term = console::Term::stdout();
+    let app_url = get_app_url()?;
+    let app_url = format!("{}/user-settings", &app_url);
     tracing::info!(
         "Go to {} and create a new Personal API Key.",
-        style("https://studio.apollographql.com/user-settings").cyan()
+        style(&app_url).cyan()
     );
     tracing::info!("Copy the key and paste it into the prompt below.");
     let api_key = term.read_secure_line()?;


### PR DESCRIPTION
## WIP this doesn't work 🙃 

This PR moves the logic for fetching the app url (as opposed to the api url) to the `client` file, since that's where the rest of that already lives. We can use this to get the `app url` and then we can append to it to redirect users to the correct url (if they're running off staging-studio for example)