### PR TITLE
Show change summary on graph push

### DIFF
--- a/crates/rover-client/src/query/schema/push.graphql
+++ b/crates/rover-client/src/query/schema/push.graphql
@@ -15,6 +15,20 @@ mutation PushSchemaMutation(
         schema {
           hash
         }
+        diffToPrevious {
+          changeSummary {
+            type {
+              additions
+              removals
+              edits
+            }
+            field {
+              additions
+              removals
+              edits
+            }
+          }
+        }
       }
     }
   }

--- a/src/command/graph/push.rs
+++ b/src/command/graph/push.rs
@@ -54,31 +54,42 @@ impl Push {
         )
         .context("Failed while pushing to Apollo Studio. To see a full printout of the schema attempting to push, rerun with `--log debug`")?;
 
-        let hash = handle_response(push_response);
+        let hash = handle_response(&self.graph, push_response);
         Ok(RoverStdout::SchemaHash(hash))
     }
 }
 
 /// handle all output logging from operation
-fn handle_response(response: push::PushResponse) -> String {
+fn handle_response(graph: &GraphRef, response: push::PushResponse) -> String {
     tracing::info!(
-        "{}\nSchema Hash:",
-        response.message, // the message will say if successful, and details
+        "{}@{}#{} Pushed successfully {}",
+        graph.name,
+        graph.variant,
+        response.schema_hash,
+        response.change_summary
     );
+
     response.schema_hash
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{handle_response, push};
+    use super::{handle_response, push, GraphRef};
 
     #[test]
     fn handle_response_doesnt_err() {
         let expected_hash = "123456".to_string();
-        let actual_hash = handle_response(push::PushResponse {
-            message: "oooh wowo it pushed successfully!".to_string(),
-            schema_hash: expected_hash.clone(),
-        });
+        let graph = GraphRef {
+            name: "harambe".to_string(),
+            variant: "inside-job".to_string(),
+        };
+        let actual_hash = handle_response(
+            &graph,
+            push::PushResponse {
+                schema_hash: expected_hash.clone(),
+                change_summary: "".to_string(),
+            },
+        );
         assert_eq!(actual_hash, expected_hash);
     }
 }


### PR DESCRIPTION
Resolves #81 

This PR is an attempt to make the output of the `graph push` command more usable and friendly with helpful information.

This new output, rather than just saying the push was successful, will show a diff summary of the fields/types changed in the format: 

```
GRAPH_NAME@VARIANT#HASH Pushed successfully [Fields: +1 -0 △0, Types: +1 -0 △0]
```

![image](https://user-images.githubusercontent.com/9259509/101405752-8e6a7480-38a6-11eb-8e1b-5244713f4786.png)


Or if there are no changes from last push:

```
GRAPH_NAME@VARIANT#HASH Pushed successfully [No Changes]
```

![image](https://user-images.githubusercontent.com/9259509/101405407-06846a80-38a6-11eb-8fee-5ed52ece2d1f.png)
