### PR TITLE
chore(workflow): run github workflow tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
## Description

This PR makes sure tests are also run on `push` so we get a nice green `tests passing` on main branch.

Leaving nightly tests to be run only on `pull-request` so people don't think our tests fail on main 😅 