### PR TITLE
wip: introspection

### DIFF
--- a/crates/rover-client/src/query/graph/introspect.rs
+++ b/crates/rover-client/src/query/graph/introspect.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+
+use crate::blocking::Client;
+use crate::RoverClientError;
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+// The paths are relative to the directory where your `Cargo.toml` is located.
+// Both json and the GraphQL schema language are supported as sources for the schema
+#[graphql(
+    query_path = "src/query/graph/introspect_query.graphql",
+    schema_path = "src/query/graph/introspect_schema.graphql",
+    response_derives = "PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+/// This struct is used to generate the module containing `Variables` and
+/// `ResponseData` structs.
+/// Snake case of this name is the mod name. i.e. introspection_query
+pub struct IntrospectionQuery;
+
+/// this struct contains all the info needed to print the result of the delete.
+/// `updated_gateway` is true when composition succeeds and the gateway config
+/// is updated for the gateway to consume. `composition_errors` is just a list
+/// of strings for when there are composition errors as a result of the delete.
+#[derive(Debug, PartialEq)]
+pub struct IntrospectionResponse {
+    pub result: String,
+}
+
+/// The main function to be used from this module. This function fetches a
+/// schema from apollo studio and returns it in either sdl (default) or json format
+pub fn run(client: &Client) -> Result<IntrospectionResponse, RoverClientError> {
+    let variables = introspection_query::Variables {};
+    let response_data = client.post::<IntrospectionQuery>(variables, &HashMap::new())?;
+    Ok(build_response(response_data))
+}
+
+fn build_response(response: introspection_query::ResponseData) -> IntrospectionResponse {
+    eprintln!("{:?}", response);
+    IntrospectionResponse {
+        result: "insert introspection response herea".to_string(),
+    }
+}

--- a/crates/rover-client/src/query/graph/introspect_query.graphql
+++ b/crates/rover-client/src/query/graph/introspect_query.graphql
@@ -1,0 +1,99 @@
+query IntrospectionQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ...TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/query/graph/introspect_schema.graphql
+++ b/crates/rover-client/src/query/graph/introspect_schema.graphql
@@ -1,0 +1,101 @@
+schema {
+  query: Query
+}
+
+type Query {
+  __schema: __Schema
+}
+
+type __Schema {
+  types: [__Type!]!
+  queryType: __Type!
+  mutationType: __Type
+  subscriptionType: __Type
+  directives: [__Directive!]!
+}
+
+type __Type {
+  kind: __TypeKind!
+  name: String
+  description: String
+
+  # OBJECT and INTERFACE only
+  fields(includeDeprecated: Boolean = false): [__Field!]
+
+  # OBJECT only
+  interfaces: [__Type!]
+
+  # INTERFACE and UNION only
+  possibleTypes: [__Type!]
+
+  # ENUM only
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+
+  # INPUT_OBJECT only
+  inputFields: [__InputValue!]
+
+  # NON_NULL and LIST only
+  ofType: __Type
+}
+
+type __Field {
+  name: String!
+  description: String
+  args: [__InputValue!]!
+  type: __Type!
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type __InputValue {
+  name: String!
+  description: String
+  type: __Type!
+  defaultValue: String
+}
+
+type __EnumValue {
+  name: String!
+  description: String
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+enum __TypeKind {
+  SCALAR
+  OBJECT
+  INTERFACE
+  UNION
+  ENUM
+  INPUT_OBJECT
+  LIST
+  NON_NULL
+}
+
+type __Directive {
+  name: String!
+  description: String
+  locations: [__DirectiveLocation!]!
+  args: [__InputValue!]!
+}
+
+enum __DirectiveLocation {
+  QUERY
+  MUTATION
+  SUBSCRIPTION
+  FIELD
+  FRAGMENT_DEFINITION
+  FRAGMENT_SPREAD
+  INLINE_FRAGMENT
+  SCHEMA
+  SCALAR
+  OBJECT
+  FIELD_DEFINITION
+  ARGUMENT_DEFINITION
+  INTERFACE
+  UNION
+  ENUM
+  ENUM_VALUE
+  INPUT_OBJECT
+  INPUT_FIELD_DEFINITION
+}

--- a/crates/rover-client/src/query/graph/mod.rs
+++ b/crates/rover-client/src/query/graph/mod.rs
@@ -6,3 +6,6 @@ pub mod push;
 
 /// "graph check" command exeuction
 pub mod check;
+
+/// "graph introspect" command execution
+pub mod introspect;

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -1,0 +1,28 @@
+use anyhow::{Context, Result};
+use serde::Serialize;
+use structopt::StructOpt;
+use url::Url;
+
+use rover_client::{blocking::Client, query::graph::introspect};
+
+use crate::command::RoverStdout;
+use crate::utils::parsers::parse_url;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Introspect {
+    /// The endpoint of the graph to introspect
+    #[structopt(parse(try_from_str = parse_url))]
+    #[serde(skip_serializing)]
+    pub endpoint: Url,
+}
+
+impl Introspect {
+    pub fn run(&self) -> Result<RoverStdout> {
+        let client = Client::new(&self.endpoint.to_string());
+
+        let introspection_response =
+            introspect::run(&client).context("Failed to introspect endpoint")?;
+
+        Ok(RoverStdout::Introspection(introspection_response.result))
+    }
+}

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -1,5 +1,6 @@
 mod check;
 mod fetch;
+mod introspect;
 mod push;
 
 use anyhow::Result;
@@ -25,6 +26,9 @@ pub enum Command {
 
     /// Validate changes to a graph
     Check(check::Check),
+
+    /// Introspect a local graph
+    Introspect(introspect::Introspect),
 }
 
 impl Graph {
@@ -33,6 +37,7 @@ impl Graph {
             Command::Fetch(command) => command.run(client_config),
             Command::Push(command) => command.run(client_config),
             Command::Check(command) => command.run(client_config),
+            Command::Introspect(command) => command.run(),
         }
     }
 }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -12,6 +12,7 @@ use atty::{self, Stream};
 pub enum RoverStdout {
     SDL(String),
     SchemaHash(String),
+    Introspection(String),
     None,
 }
 
@@ -35,6 +36,12 @@ impl RoverStdout {
                     tracing::info!("Schema Hash:");
                 }
                 println!("{}", &hash);
+            }
+            RoverStdout::Introspection(introspection_response) => {
+                if atty::is(Stream::Stdout) {
+                    tracing::info!("Introspection Response:");
+                }
+                println!("{}", &introspection_response);
             }
             RoverStdout::None => (),
         }

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use anyhow::*;
 use regex::Regex;
+use url::{ParseError as UrlParseError, Url};
+
 use std::path::PathBuf;
 
 #[derive(Debug, PartialEq)]
@@ -54,6 +56,11 @@ pub fn parse_graph_ref(graph_id: &str) -> Result<GraphRef> {
     } else {
         Err(anyhow!("Graph IDs must be in the format <NAME> or <NAME>@<VARIANT>, where <NAME> can only contain letters, numbers, or the characters `-` or `_`, and must be 64 characters or less. <VARIANT> must be 64 characters or less."))
     }
+}
+
+/// this function parses Urls from the command line
+pub fn parse_url(url: &str) -> Result<Url, UrlParseError> {
+    Url::parse(url)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
we had previously attempted to take a stab at introspection and i wanted to do a really quick spike on an alternative approach. unfortunately it seems like the `graphql-client` derive macro requires all of the types to be explicitly present in the schema file we give it (and it doesn't allow us to make a graphql query _without_ a schema file).

i ended up finding [this](https://github.com/graphql-rust/graphql-client/blob/master/graphql_client_cli/src/graphql/introspection_schema.graphql) which allows us to provide a special "introspection schema" that we would use for all introspection queries.

i set up a quick skeleton of `rover graph introspect <endpoint>` that performs the introspection query. remaining work here is to format the response and get some good error handling. pausing work on this until we finish up the scope document.