### PR TITLE
feat: update npm package in build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           echo "using version tag ${GITHUB_REF:10}"
           echo ::set-output name=version::"${GITHUB_REF:10}"
+        
+      - name: Install Node and npm
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Install Rust
         if: matrix.rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "timber",
  "tracing",
  "url",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ predicates = "1.0.5"
 
 [workspace]
 members = [".", "crates/*", "installers/binstall"]
+
+[build-dependencies]
+anyhow = "1"
+which = "4.0.2"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -26,15 +26,13 @@ If you are releasing a beta or a release candidate, no official changelog is nee
 
 1. Update the version in `Cargo.toml`.
 1. Run `cargo update`.
-1. Run `cargo test`.
-1. Run `cargo build`.
-
-<!-- TODO: @ashleygwilliams - add steps about npm installer here, if there are any -->
+1. Run `cargo test --workspace`.
+1. Run `cargo build --release`.
 
 ### Start a release PR
 
 1. Create a new branch "#.#.#" where "#.#.#" is this release's version (release) or "#.#.#-rc.#" (release candidate)
-1. Push up a commit with the `Cargo.toml`, `Cargo.lock` and `CHANGELOG.md` changes. The commit message can just be "#.#.#" (release) or "#.#.#-rc.#" (release candidate)
+1. Push up a commit with the `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, and `./installers/npm` changes. The commit message can just be "#.#.#" (release) or "#.#.#-rc.#" (release candidate)
 1. Request review from the Apollo GraphQL tooling team.
 
 ### Review
@@ -77,7 +75,7 @@ After CI builds the release binaries and they appear on the [releases page](http
 ## Publish
 
 1. Hit the big green Merge button on the release PR.
-1. `git checkout main` and `git pull --rebase origin main`
+1. Check out the tag you pushed with `git checkout v#.#.#`
 
 ### Publish to crates.io (full release only)
 
@@ -92,12 +90,8 @@ We don't publish release candidates to crates.io because they don't (as of this 
 
 Full releases are tagged `latest`. Release candidates are tagged `beta`. If for some reason you mix up the commands below, follow the troubleshooting guide.
 
-<!-- 
-
-TODO: @ashleygwilliams - uncomment this when we have the npm installer figured
-out
-
-1. If this is a full release, `cd npm && npm publish`. If it is a release candidate, `cd npm && npm publish --tag beta` -->
+1. If this is a full release, `cd installers/npm && npm publish`. 
+1. If it is a release candidate, `cd installers/npm && npm publish --tag beta`
 
 ## Troubleshooting a release
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,159 @@
+use anyhow::{anyhow, Context, Result};
+use std::{
+    env, fs,
+    path::Path,
+    process::{Command, Output},
+    str,
+};
+
+/// files to copy from the repo's root directory into the npm tarball
+const FILES_TO_COPY: &[&str; 2] = &["LICENSE", "README.md"];
+
+/// the version of Rover currently set in `Cargo.toml`
+const ROVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn main() -> Result<()> {
+    let is_release_build = env::var("PROFILE") == Ok("release".to_string());
+    // don't rerun this unless necessary for non-release builds
+    if !is_release_build {
+        rerun_if_changed("Cargo.toml");
+        for file in FILES_TO_COPY {
+            rerun_if_changed(file);
+        }
+    }
+
+    prep_npm(is_release_build)
+}
+
+fn rerun_if_changed(filename: &str) {
+    eprintln!("cargo:rerun-if-changed={}", filename);
+}
+
+fn cargo_warn(message: &str) {
+    println!("cargo:warn=/!\\ {}", message);
+}
+
+/// prep_npm prepares our npm installer package for release
+/// by default this runs on every build and does all the steps
+/// if the machine has npm installed.
+/// these steps are only _required_ when running in release mode
+fn prep_npm(is_release_build: bool) -> Result<()> {
+    let npm_install_path = match which::which("npm") {
+        Ok(install_path) => Some(install_path),
+        Err(_) => None,
+    };
+
+    // we have to work with absolute paths like this because of windows :P
+    let current_dir = env::current_dir().context("Could not find the current directory.")?;
+    let npm_dir = current_dir.join("installers").join("npm");
+
+    let is_npm_installed = npm_install_path.is_some();
+
+    if !npm_dir.exists() {
+        return Err(anyhow!(
+            "The npm package does not seem to be located here:\n{}",
+            npm_dir.display()
+        ));
+    }
+
+    if !is_npm_installed && is_release_build {
+        return Err(anyhow!(
+            "You need npm installed to build rover in release mode."
+        ));
+    } else if !is_npm_installed {
+        cargo_warn("npm is not installed. Skipping npm package steps.");
+        cargo_warn("You can ignore this message unless you are preparing Rover for a release.");
+    }
+
+    copy_files_to_npm_package(&["LICENSE", "README.md"], &current_dir, &npm_dir)?;
+
+    if let Some(npm_install_path) = npm_install_path {
+        update_dependency_tree(&npm_install_path, &npm_dir)
+            .context("Could not update the dependency tree.")?;
+
+        install_dependencies(&npm_install_path, &npm_dir)
+            .context("Could not install dependencies.")?;
+
+        update_version(&npm_install_path, &npm_dir)
+            .context("Could not update version in package.json.")?;
+
+        if is_release_build {
+            dry_run_publish(&npm_install_path, &npm_dir)
+                .context("Could not do a dry-run of 'npm publish'.")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn process_command_output(output: &Output) -> Result<()> {
+    if !output.status.success() {
+        let stdout =
+            str::from_utf8(&output.stdout).context("Command's stdout was not valid UTF-8.")?;
+        let stderr =
+            str::from_utf8(&output.stderr).context("Command's stderr was not valid UTF-8.")?;
+        cargo_warn(stderr);
+        cargo_warn(stdout);
+    }
+    Ok(())
+}
+
+fn update_dependency_tree(npm_install_path: &Path, npm_dir: &Path) -> Result<()> {
+    let command_output = Command::new(npm_install_path)
+        .current_dir(npm_dir)
+        .arg("update")
+        .output()
+        .context("Could not execute 'npm update'.")?;
+
+    process_command_output(&command_output).context("Could not print output of 'npm update'.")?;
+
+    Ok(())
+}
+
+fn install_dependencies(npm_install_path: &Path, npm_dir: &Path) -> Result<()> {
+    let command_output = Command::new(npm_install_path)
+        .current_dir(npm_dir)
+        .arg("install")
+        .output()
+        .context("Could not execute 'npm install'.")?;
+
+    process_command_output(&command_output).context("Could not print output of 'npm install'.")
+}
+
+fn update_version(npm_install_path: &Path, npm_dir: &Path) -> Result<()> {
+    let command_output = Command::new(npm_install_path)
+        .current_dir(npm_dir)
+        .arg("version")
+        .arg(ROVER_VERSION)
+        .arg("--allow-same-version")
+        .output()
+        .with_context(|| {
+            format!(
+                "Could not execute 'npm version {} --allow-same-version'.",
+                ROVER_VERSION
+            )
+        })?;
+
+    process_command_output(&command_output)
+        .with_context(|| format!("Could not print output of 'npm version {}'.", ROVER_VERSION))
+}
+
+fn dry_run_publish(npm_install_path: &Path, npm_dir: &Path) -> Result<()> {
+    let command_output = Command::new(npm_install_path)
+        .current_dir(npm_dir)
+        .arg("publish")
+        .arg("--dry-run")
+        .output()
+        .context("Could not execute 'npm publish --dry-run'.")?;
+
+    process_command_output(&command_output)
+        .context("Could not print output of 'npm publish --dry-run'.")
+}
+
+fn copy_files_to_npm_package(files: &[&str], current_dir: &Path, npm_dir: &Path) -> Result<()> {
+    for file in files {
+        let context = format!("Could not copy {} to npm package.", &file);
+        fs::copy(current_dir.join(file), npm_dir.join(file)).context(context)?;
+    }
+    Ok(())
+}

--- a/installers/npm/LICENSE
+++ b/installers/npm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Apollo GraphQL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -1,0 +1,65 @@
+# Rover
+> ✨🤖 🐶 the new CLI for apollo
+
+[![Tests](https://github.com/apollographql/apollo-cli/workflows/Tests/badge.svg)](https://github.com/apollographql/apollo-cli/actions?query=workflow%3ATests)
+![Stability: Experimental](https://img.shields.io/badge/stability-experimental-red)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/1646a37a-eb2b-48e8-b6c9-cd074f02bb50/deploy-status)](https://app.netlify.com/sites/apollo-cli-docs/deploys)
+
+This is the home of Rover, the new CLI for Apollo's suite of GraphQL developer productivity tools.
+
+## Command-line options
+
+```
+✨🤖🐶 the new CLI for Apollo
+
+USAGE:
+    rover [OPTIONS] <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -l, --log <log-level>     [default: debug]  [possible values: error, warn, info,
+                             debug, trace]
+
+SUBCOMMANDS:
+    config     ⚙️  Rover configuration
+    help       Prints this message or the help of the given subcommand(s)
+    subgraph   *️⃣  Federated schema/graph commands
+    graph      ⏺  Non-federated schema/graph commands
+```
+
+This repo is organized as a [`cargo` workspace], containing several related projects:
+
+- `rover`: Apollo's suite of GraphQL developer productivity tools
+- [`houston`]: utilities for configuring Rover
+- [`robot-panic`]: a fork of [rust-cli/robot-panic] adjusted for Rover
+- [`rover-client`]: an HTTP client for making GraphQL requests for Rover
+- [`sputnik`]: a crate to aid in collection of anonymous data for Rust CLIs
+- [`timber`]: a log formatter for `env_logger` and `log` crates
+
+[`cargo` workspace]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html
+[`houston`]: https://github.com/apollographql/rover/tree/main/crates/houston
+[`robot-panic`]: https://github.com/apollographql/rover/tree/main/crates/robot-panic
+[rust-cli/robot-panic]: https://github.com/rust-cli/robot-panic
+[`rover-client`]: https://github.com/apollographql/rover/tree/main/crates/rover-client
+[`sputnik`]: https://github.com/apollographql/rover/tree/main/crates/sputnik
+[`timber`]: https://github.com/apollographql/rover/tree/main/crates/timber
+
+## Installation
+You can install Rover by running
+```
+curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.0/installers/binstall/install.sh | VERSION=v0.0.1-rc.0 sh
+```
+Alternatively, you can [download the binary for your operating system](https://github.com/apollographql/rover/releases) and manually adding its location to your `PATH`.
+
+## Contributions
+
+This project is in very early development. As a result, we are not currently accepting external contributions.
+
+## License
+
+This project is licensed under the MIT License ([LICENSE] or  http://opensource.org/licenses/MIT).
+
+[LICENSE]: https://github.com/apollographql/apollo-cli/blob/main/LICENSE

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rover",
-  "version": "0.0.0",
+  "version": "0.0.1-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -182,9 +182,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "prettier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "rimraf": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rover",
-  "version": "0.0.0",
+  "version": "0.0.1-rc.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {
@@ -35,6 +35,6 @@
     "console.table": "^0.10.0"
   },
   "devDependencies": {
-    "prettier": "^2.1.2"
+    "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
this PR adds a build step to `build.rs` to update the npm package. 

1. copies the `README.md` and `LICENSE` from the root directory to the `installers/npm` directory
2. if it's a debug build, it checks if npm is installed. if it's not, it exits and lets the builder know it's not touching the npm package. 
3. if `npm` is installed, it continues
3. if it's a release build and npm is not installed, the build fails (this should prevent us from running a release CI job that breaks npm)
4. runs `npm update`, `npm install`, `npm version env!(CARGO_PKG_VERSION)` (version from `Cargo.toml`)
5. if it's a release build it runs `npm publish --dry-run` which will stop our release CI process if something were to go wrong