### PR TITLE
chore: only run CI once per push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:


### PR DESCRIPTION
currently we're running our tests twice on every PR since we run on both push and pull request. this makes it so we only run the tests on push!