### PR TITLE
chore: update dependencies and clean up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "tracing",
  "which",
  "winapi 0.3.9",
- "winreg",
+ "winreg 0.8.0",
 ]
 
 [[package]]
@@ -1493,7 +1493,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -2424,6 +2424,15 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d107f8c6e916235c4c01cabb3e8acf7bea8ef6a63ca2e7fa0527c049badfc48c"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,17 @@ robot-panic = { path = "./crates/robot-panic" }
 binstall = { path = "./installers/binstall" }
 
 # crates.io deps
-anyhow = "1.0.31"
+anyhow = "1.0.36"
 atty = "0.2.14"
 console = "0.13.0"
-heck = "0.3.1"
+heck = "0.3.2"
 prettytable-rs = "0.8.0"
 serde = "1.0"
 serde_json = "1.0"
-structopt = "0.3.15"
-tracing = "0.1.21"
+structopt = "0.3.21"
+tracing = "0.1.22"
 regex = "1"
-url = "2.1.1"
+url = "2.2.0"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rover
 > ✨ 🤖 🐶 the new CLI for apollo
 
-[![Tests](https://github.com/apollographql/apollo-cli/workflows/Tests/badge.svg)](https://github.com/apollographql/apollo-cli/actions?query=workflow%3ATests)
+[![Tests](https://github.com/apollographql/rover/workflows/Tests/badge.svg)](https://github.com/apollographql/rover/actions?query=workflow%3ATests)
 ![Stability: Experimental](https://img.shields.io/badge/stability-experimental-red)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/1646a37a-eb2b-48e8-b6c9-cd074f02bb50/deploy-status)](https://app.netlify.com/sites/apollo-cli-docs/deploys)
 
@@ -88,6 +88,6 @@ This project is in very early development. As a result, we are not currently acc
 
 ## License
 
-This project is licensed under the MIT License ([LICENSE] or  http://opensource.org/licenses/MIT).
+This project is licensed under the MIT License ([LICENSE] or http://opensource.org/licenses/MIT).
 
 [LICENSE]: https://github.com/apollographql/rover/blob/main/LICENSE

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -52,7 +52,7 @@ This part of the release process is handled by GitHub Actions, and our binaries 
 
 ### Edit the release
 
-After CI builds the release binaries and they appear on the [releases page](https://github.com/apollographql/apollo-cli/releases), click `Edit` and update release notes.
+After CI builds the release binaries and they appear on the [releases page](https://github.com/apollographql/rover/releases), click `Edit` and update release notes.
 
 #### If this is a stable release (not a release candidate)
 
@@ -67,7 +67,7 @@ After CI builds the release binaries and they appear on the [releases page](http
 1. If this is a rc.1 or later, the old release candidate testing instructions should be moved to the latest release candidate testing instructions, and replaced with the following message:
 
    ```markdown
-   This beta release is now out of date. If you previously installed this release, you should reinstall and see what's changed in the latest [release](https://github.com/apollographql/apollo-cli/releases).
+   This beta release is now out of date. If you previously installed this release, you should reinstall and see what's changed in the latest [release](https://github.com/apollographql/rover/releases).
    ```
 
    The new release candidate should then include updated testing instructions with a small changelog at the top to get folks who installed the old release candidate up to speed.

--- a/crates/robot-panic/Cargo.toml
+++ b/crates/robot-panic/Cargo.toml
@@ -10,4 +10,4 @@ serde = "1.0"
 termcolor = "1.1"
 toml = "0.5"
 uuid = { version = "0.8", features = ["v4"], default-features = false }
-url = "2.1"
+url = "2.2"

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 
 [dependencies]
 ci_info = { version = "0.11", features = ["serde-1"] }
-reqwest =  { version = "0.10", features = ["blocking"] }
+reqwest = { version = "0.10", features = ["blocking"] }
 semver = { version = "0.11", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
 structopt = "0.3"
 thiserror = "1.0"
-url = "2.1"
+url = "2.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -14,7 +14,7 @@ which = "4.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 cc = "1.0"
 winapi = "0.3"
-winreg = "0.7"
+winreg = "0.8"
 
 [dev-dependencies]
 assert_fs = "1.0"

--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -1,7 +1,7 @@
 # Rover
 > ✨ 🤖 🐶 the new CLI for apollo
 
-[![Tests](https://github.com/apollographql/apollo-cli/workflows/Tests/badge.svg)](https://github.com/apollographql/apollo-cli/actions?query=workflow%3ATests)
+[![Tests](https://github.com/apollographql/rover/workflows/Tests/badge.svg)](https://github.com/apollographql/rover/actions?query=workflow%3ATests)
 ![Stability: Experimental](https://img.shields.io/badge/stability-experimental-red)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/1646a37a-eb2b-48e8-b6c9-cd074f02bb50/deploy-status)](https://app.netlify.com/sites/apollo-cli-docs/deploys)
 
@@ -88,6 +88,6 @@ This project is in very early development. As a result, we are not currently acc
 
 ## License
 
-This project is licensed under the MIT License ([LICENSE] or  http://opensource.org/licenses/MIT).
+This project is licensed under the MIT License ([LICENSE] or http://opensource.org/licenses/MIT).
 
 [LICENSE]: https://github.com/apollographql/rover/blob/main/LICENSE

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -22,7 +22,8 @@ pub enum Command {
 
     /// Delete an implementing service and trigger composition
     Delete(delete::Delete),
-    /// ⬇️  Fetch an implementing service's schema from Apollo Studio
+
+    /// Fetch an implementing service's schema from Apollo Studio
     Fetch(fetch::Fetch),
 }
 


### PR DESCRIPTION
each commit can stand on its own but making separate PRs for each feels silly.

- removes a straggler emoji from `rover subgraph fetch`
- renames all `github.com/apollographql/apollo-cli` links to `github.com/apollographql/rover`
- updates all backwards compatible dependencies (no code necessary!)