### PR TITLE
chore(npm): s/rover/@apollo/rover

### DIFF
--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rover",
+  "name": "@apollo/rover",
   "version": "0.0.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rover",
+  "name": "@apollo/rover",
   "version": "0.0.1-rc.1",
   "description": "The new Apollo CLI",
   "main": "index.js",


### PR DESCRIPTION
updates npm package name to `@apollo/rover` from just `rover`.