### PR TITLE
spike: installer integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "atty",
  "binstall",
  "console",
+ "directories-next",
  "heck",
  "houston",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ url = "2.2.0"
 [dev-dependencies]
 assert_cmd = "1.0.1"
 assert_fs = "1.0.0"
+directories-next = "2.0.0"
 serial_test = "0.5.0"
 predicates = "1.0.5"
+which = "4.0.2"
 
 [workspace]
 members = [".", "crates/*", "installers/binstall"]

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -1,0 +1,38 @@
+use std::env;
+use std::ffi::{OsStr, OsString};
+
+use directories_next::BaseDirs;
+use which::which;
+
+#[test]
+fn it_can_install_all_versions() {
+    for release in get_releases() {
+        let old_path = clear_path();
+        assert!(which("rover").is_err());
+        attempt_install(&release);
+        assert!(which("rover").is_ok());
+        set_path(&old_path);
+    }
+}
+
+fn clear_path() -> OsString {
+    let old_path = env::var_os("PATH").unwrap();
+    env::remove_var("PATH");
+    old_path
+}
+
+fn get_releases() -> Vec<String> {
+    // TODO: query these from the GitHub API
+    vec!["v0.0.1-rc.0".to_string()]
+}
+
+fn set_path<P: AsRef<OsStr>>(path: P) {
+    env::set_var("PATH", path);
+}
+
+fn attempt_install(_release: &str) {
+    // TODO: replace this with a call to a curl | sh install command specific to a release version
+    let base_dirs = BaseDirs::new().unwrap();
+    let new_path = base_dirs.home_dir().join(".rover").join("bin");
+    set_path(new_path.as_os_str());
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod installers;
 mod schema;
 
 use assert_cmd::Command;


### PR DESCRIPTION
threw together a quick skeleton of what some integration tests for our `curl | sh` installers might look like. i think having something like this would give us some peace of mind that folks can still install old versions as long as they'd like.