### PR TITLE
fix: removing ~/.rover doesn't break future installs

### DIFF
--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -18,16 +18,6 @@ impl Installer {
     pub fn install(&self) -> Result<Option<PathBuf>, InstallerError> {
         let install_path = self.do_install()?;
 
-        // On Windows we likely popped up a console for the installation. If we were
-        // to exit here immediately then the user wouldn't see any error that
-        // happened above or any successful message. Let's wait for them to say
-        // they've read everything and then continue.
-        if cfg!(windows) {
-            tracing::info!("Press enter to close this window...");
-            let mut line = String::new();
-            drop(io::stdin().read_line(&mut line));
-        }
-
         Ok(install_path)
     }
 
@@ -114,7 +104,6 @@ impl Installer {
 
     #[cfg(windows)]
     fn add_binary_to_path(&self) -> Result<(), InstallerError> {
-        // System::Windows.add_binary_to_path(self)
         crate::windows::add_binary_to_path(self)
     }
 

--- a/installers/binstall/src/system/unix.rs
+++ b/installers/binstall/src/system/unix.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 use crate::{Installer, InstallerError};
 
 pub fn add_binary_to_path(installer: &Installer) -> Result<(), InstallerError> {
-    let mut written = vec![];
-
     for shell in get_available_shells() {
         let source_cmd = shell.source_string(installer)?;
+        let script = shell.env_script();
+        script.write(installer)?;
 
         for rc in shell.update_rcs() {
             if !rc.is_file() || !fs::read_to_string(&rc)?.contains(&source_cmd) {
@@ -22,13 +22,6 @@ pub fn add_binary_to_path(installer: &Installer) -> Result<(), InstallerError> {
                     .open(&rc)?;
                 writeln!(&mut dest_file, "{}", &source_cmd)?;
                 dest_file.sync_data()?;
-
-                let script = shell.env_script();
-
-                if !written.contains(&script) {
-                    script.write(installer)?;
-                    written.push(script);
-                }
             }
         }
     }


### PR DESCRIPTION
previously, if you ran `rm -rf ~/.rover` in an attempt to uninstall it, subsequent installs would not write the critical `~/.rover/env` script. this PR changes the behavior to allow manual removal of Rover's install location without cleaning up the various shell scripts.