### PR TITLE
fix(checks): update service_name for consistency

### DIFF
--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -19,7 +19,7 @@ pub struct Check {
     graph: GraphRef,
 
     /// Name of the implementing service to validate
-    #[structopt(required = true)]
+    #[structopt(long)]
     #[serde(skip_serializing)]
     service_name: String,
 


### PR DESCRIPTION
This PR just changes the `service_name` option in `subgraph check` from a positional arg to a flag to match the rest of the commands. 

