### PR TITLE
fix: s/APOLLO_REGISTRY_URI/APOLLO_REGISTRY_URL

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,7 +57,7 @@ impl Rover {
     }
 
     pub(crate) fn get_client_config(&self) -> Result<StudioClientConfig> {
-        let override_endpoint = self.env_store.get(RoverEnvKey::RegistryUri)?;
+        let override_endpoint = self.env_store.get(RoverEnvKey::RegistryUrl)?;
         let config = self.get_rover_config()?;
         Ok(StudioClientConfig::new(override_endpoint, config))
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -91,7 +91,7 @@ pub enum RoverEnvKey {
     ConfigHome,
     Home,
     Key,
-    RegistryUri,
+    RegistryUrl,
     TelemetryUrl,
     TelemetryDisabled,
 }


### PR DESCRIPTION
fixes #188 by renaming `APOLLO_REGISTRY_URI` to `APOLLO_REGISTRY_URL`. No docs update needed.