### PR TITLE
feat: improves introductory logs on graph/subgraph commands

### DIFF
--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -45,9 +45,8 @@ impl Check {
         .context("Failed to validate schema")?;
 
         tracing::info!(
-            "Validated the proposed subgraph against metrics from {}@{}",
-            &self.graph.name,
-            &self.graph.variant
+            "Validated the proposed subgraph against metrics from {}",
+            &self.graph
         );
 
         let num_changes = res.changes.len();

--- a/src/command/graph/fetch.rs
+++ b/src/command/graph/fetch.rs
@@ -1,3 +1,4 @@
+use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -25,11 +26,11 @@ pub struct Fetch {
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
+        let graph_ref = self.graph.to_string();
         tracing::info!(
-            "Let's get this schema, {}@{}, mx. {}!",
-            &self.graph.name,
-            &self.graph.variant,
-            &self.profile_name
+            "Fetching SDL from {} using credentials from the {} profile.",
+            Cyan.normal().paint(&graph_ref),
+            Yellow.normal().paint(&self.profile_name)
         );
 
         let sdl = fetch::run(

--- a/src/command/graph/push.rs
+++ b/src/command/graph/push.rs
@@ -1,3 +1,4 @@
+use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -32,11 +33,11 @@ pub struct Push {
 impl Push {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
+        let graph_ref = self.graph.to_string();
         tracing::info!(
-            "Let's push this schema, {}@{}, mx. {}!",
-            &self.graph.name,
-            &self.graph.variant,
-            &self.profile_name
+            "Pushing SDL to {} using credentials from the {} profile.",
+            Cyan.normal().paint(&graph_ref),
+            Yellow.normal().paint(&self.profile_name)
         );
 
         let schema_document = load_schema_from_flag(&self.schema, std::io::stdin())?;
@@ -61,9 +62,8 @@ impl Push {
 /// handle all output logging from operation
 fn handle_response(graph: &GraphRef, response: push::PushResponse) -> String {
     tracing::info!(
-        "{}@{}#{} Pushed successfully {}",
-        graph.name,
-        graph.variant,
+        "{}#{} Pushed successfully {}",
+        graph,
         response.schema_hash,
         response.change_summary
     );

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -57,11 +57,7 @@ impl Check {
         )
         .context("Failed to validate schema")?;
 
-        tracing::info!(
-            "Checked the proposed subgraph against {}@{}",
-            &self.graph.name,
-            &self.graph.variant
-        );
+        tracing::info!("Checked the proposed subgraph against {}", &self.graph);
 
         match res {
             check::CheckResponse::CompositionErrors(composition_errors) => {

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -1,3 +1,4 @@
+use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -30,13 +31,12 @@ pub struct Fetch {
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
-
+        let graph_ref = self.graph.to_string();
         tracing::info!(
-            "Let's get this schema, {}@{} (subgraph: {}), mx. {}!",
-            &self.graph.name,
-            &self.graph.variant,
-            &self.subgraph,
-            &self.profile_name
+            "Fetching SDL from {} (subgraph: {}) using credentials from the {} profile.",
+            Cyan.normal().paint(&graph_ref),
+            Cyan.normal().paint(&self.subgraph),
+            Yellow.normal().paint(&self.profile_name)
         );
 
         let sdl = fetch::run(

--- a/src/command/subgraph/list.rs
+++ b/src/command/subgraph/list.rs
@@ -27,9 +27,8 @@ impl List {
         let client = client_config.get_client(&self.profile_name)?;
 
         tracing::info!(
-            "Listing subgraphs for {}@{}, mx. {}!",
-            &self.graph.name,
-            &self.graph.variant,
+            "Listing subgraphs for {} using credentials from the {} profile.",
+            &self.graph,
             &self.profile_name
         );
 

--- a/src/command/subgraph/push.rs
+++ b/src/command/subgraph/push.rs
@@ -1,3 +1,4 @@
+use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -43,12 +44,12 @@ pub struct Push {
 impl Push {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
+        let graph_ref = format!("{}:{}", &self.graph.name, &self.graph.variant);
         tracing::info!(
-            "Pushing the {} subgraph to {}@{}, mx. {}!",
-            &self.subgraph,
-            &self.graph.name,
-            &self.graph.variant,
-            &self.profile_name
+            "Pushing SDL to {} (subgraph: {}) using credentials from the {} profile.",
+            Cyan.normal().paint(&graph_ref),
+            Cyan.normal().paint(&self.subgraph),
+            Yellow.normal().paint(&self.profile_name)
         );
 
         let schema_document = load_schema_from_flag(&self.schema, std::io::stdin())?;

--- a/src/env.rs
+++ b/src/env.rs
@@ -34,6 +34,7 @@ impl RoverEnv {
     /// returns the value of the environment variable if it exists
     pub fn get(&self, key: RoverEnvKey) -> std::io::Result<Option<String>> {
         let key = key.to_string();
+        tracing::debug!("reading {}", &key);
         match &self.mock_store {
             Some(mock_store) => Ok(mock_store.get(&key).map(|v| v.to_owned())),
             None => match env::var(&key) {
@@ -55,6 +56,7 @@ impl RoverEnv {
     /// sets an environment variable to a value
     pub fn insert(&mut self, key: RoverEnvKey, value: &str) {
         let key = key.to_string();
+        tracing::debug!("writing {}:{}", &key, value);
         match &mut self.mock_store {
             Some(mock_store) => {
                 mock_store.insert(key, value.into());
@@ -68,6 +70,7 @@ impl RoverEnv {
     /// unsets an environment variable
     pub fn remove(&mut self, key: RoverEnvKey) {
         let key = key.to_string();
+        tracing::debug!("removing {}", &key);
         match &mut self.mock_store {
             Some(mock_store) => {
                 mock_store.remove(&key);

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use crate::{anyhow, Result};
 
@@ -24,6 +24,12 @@ pub fn parse_schema_source(loc: &str) -> Result<SchemaSource> {
 pub struct GraphRef {
     pub name: String,
     pub variant: String,
+}
+
+impl fmt::Display for GraphRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.name, self.variant)
+    }
 }
 
 /// NOTE: THIS IS A TEMPORARY SOLUTION. IN THE FUTURE, ALL GRAPH ID PARSING


### PR DESCRIPTION
didn't want to spend too much time on improving logging since we have not yet formally designed them. that being said, `mx. default` was really bugging me 😆 this pr also adds some quick colors: blue for graph refs/subgraph names and yellow for profile names