### PR TITLE
fix: removes unnecessary context

### DIFF
--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -6,7 +6,7 @@ use config::Profile;
 use houston as config;
 
 use crate::command::RoverStdout;
-use crate::{anyhow, Context, Result};
+use crate::{anyhow, Result};
 
 #[derive(Debug, Serialize, StructOpt)]
 /// Authenticate a configuration profile with an API key
@@ -28,13 +28,10 @@ pub struct Auth {
 impl Auth {
     pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
         let api_key = api_key_prompt()?;
-        Profile::set_api_key(&self.profile_name, &config, &api_key)
-            .context("Failed while saving API key")?;
-        Profile::get_api_key(&self.profile_name, &config)
-            .map(|_| {
-                tracing::info!("Successfully saved API key.");
-            })
-            .context("Failed while loading API key")?;
+        Profile::set_api_key(&self.profile_name, &config, &api_key)?;
+        Profile::get_api_key(&self.profile_name, &config).map(|_| {
+            tracing::info!("Successfully saved API key.");
+        })?;
         Ok(RoverStdout::None)
     }
 }

--- a/src/command/config/clear.rs
+++ b/src/command/config/clear.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverStdout;
-use crate::{Context, Result};
+use crate::Result;
 
 use houston as config;
 
@@ -14,9 +14,7 @@ pub struct Clear {}
 
 impl Clear {
     pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
-        config
-            .clear()
-            .context("Failed to clear all configuration.")?;
+        config.clear()?;
         tracing::info!("Successfully cleared all configuration.");
         Ok(RoverStdout::None)
     }

--- a/src/command/config/delete.rs
+++ b/src/command/config/delete.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 use houston as config;
 
 use crate::command::RoverStdout;
-use crate::{Context, Result};
+use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 /// Delete a configuration profile
@@ -21,7 +21,7 @@ pub struct Delete {
 
 impl Delete {
     pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
-        config::Profile::delete(&self.name, &config).context("Could not delete profile.")?;
+        config::Profile::delete(&self.name, &config)?;
         tracing::info!("Successfully deleted profile \"{}\"", &self.name);
         Ok(RoverStdout::None)
     }

--- a/src/command/config/list.rs
+++ b/src/command/config/list.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use structopt::StructOpt;
 
-use crate::{Context, Result};
+use crate::Result;
 use houston as config;
 
 use crate::command::RoverStdout;
@@ -12,7 +12,7 @@ pub struct List {}
 
 impl List {
     pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
-        let profiles = config::Profile::list(&config).context("Could not list profiles.")?;
+        let profiles = config::Profile::list(&config)?;
         if profiles.is_empty() {
             tracing::info!("No profiles found.")
         } else {

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -8,7 +8,7 @@ use crate::client::StudioClientConfig;
 use crate::command::RoverStdout;
 use crate::utils::loaders::load_schema_from_flag;
 use crate::utils::parsers::{parse_graph_ref, parse_schema_source, GraphRef, SchemaSource};
-use crate::{Context, Result};
+use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Check {
@@ -41,8 +41,7 @@ impl Check {
                 schema: Some(sdl),
             },
             &client,
-        )
-        .context("Failed to validate schema")?;
+        )?;
 
         tracing::info!(
             "Validated the proposed subgraph against metrics from {}",

--- a/src/command/graph/push.rs
+++ b/src/command/graph/push.rs
@@ -8,7 +8,7 @@ use crate::client::StudioClientConfig;
 use crate::command::RoverStdout;
 use crate::utils::loaders::load_schema_from_flag;
 use crate::utils::parsers::{parse_graph_ref, parse_schema_source, GraphRef, SchemaSource};
-use crate::{Context, Result};
+use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Push {
@@ -51,8 +51,7 @@ impl Push {
                 schema_document: Some(schema_document),
             },
             &client,
-        )
-        .context("Failed while pushing to Apollo Studio. To see a full printout of the schema attempting to push, rerun with `--log debug`")?;
+        )?;
 
         let hash = handle_response(&self.graph, push_response);
         Ok(RoverStdout::SchemaHash(hash))

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -2,7 +2,7 @@ use prettytable::{cell, row, Table};
 use serde::Serialize;
 use structopt::StructOpt;
 
-use crate::{Context, Result};
+use crate::Result;
 use rover_client::query::subgraph::check;
 
 use crate::client::StudioClientConfig;
@@ -54,8 +54,7 @@ impl Check {
                 implementing_service_name: self.subgraph.clone(),
             },
             &client,
-        )
-        .context("Failed to validate schema")?;
+        )?;
 
         tracing::info!("Checked the proposed subgraph against {}", &self.graph);
 

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -7,7 +7,7 @@ use rover_client::query::subgraph::fetch;
 use crate::client::StudioClientConfig;
 use crate::command::RoverStdout;
 use crate::utils::parsers::{parse_graph_ref, GraphRef};
-use crate::{Context, Result};
+use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
@@ -46,8 +46,7 @@ impl Fetch {
             },
             &client,
             &self.subgraph,
-        )
-        .context("Failed while fetching from Apollo Studio")?;
+        )?;
 
         Ok(RoverStdout::SDL(sdl))
     }

--- a/src/command/subgraph/push.rs
+++ b/src/command/subgraph/push.rs
@@ -6,7 +6,7 @@ use crate::client::StudioClientConfig;
 use crate::command::RoverStdout;
 use crate::utils::loaders::load_schema_from_flag;
 use crate::utils::parsers::{parse_graph_ref, parse_schema_source, GraphRef, SchemaSource};
-use crate::{Context, Result};
+use crate::Result;
 
 use rover_client::query::subgraph::push::{self, PushPartialSchemaResponse};
 
@@ -69,8 +69,7 @@ impl Push {
                 url: self.routing_url.clone(),
             },
             &client,
-        )
-        .context("Failed while pushing to Apollo Studio. To see a full printout of the schema attempting to push, rerun with `--log debug`")?;
+        )?;
 
         handle_response(push_response, &self.subgraph, &self.graph.name);
         Ok(RoverStdout::None)


### PR DESCRIPTION
i'm removing these unnecessary context modifiers since we should be handling suggestions and the like directly in `error.rs`