### PR TITLE
Add reqwest logs

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -28,7 +28,8 @@ impl Client {
     ) -> Result<Q::ResponseData, RoverClientError> {
         let h = headers::build(headers)?;
         let body = Q::build_query(variables);
-        tracing::trace!(request_headers = ?h, request_body = ?serde_json::to_string(&body));
+        tracing::trace!(request_headers = ?h);
+        tracing::trace!(request_body = ?serde_json::to_string(&body));
 
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
         tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -29,7 +29,7 @@ impl Client {
         let h = headers::build(headers)?;
         let body = Q::build_query(variables);
         tracing::trace!(request_headers = ?h);
-        tracing::trace!(request_body = ?serde_json::to_string(&body));
+        tracing::trace!("Request Body: {}", serde_json::to_string(&body)?);
 
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
         tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -28,8 +28,10 @@ impl Client {
     ) -> Result<Q::ResponseData, RoverClientError> {
         let h = headers::build(headers)?;
         let body = Q::build_query(variables);
+        tracing::trace!(request_headers = ?h, request_body = ?serde_json::to_string(&body));
 
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
+        tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());
 
         Client::handle_response::<Q>(response)
     }

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -30,7 +30,11 @@ impl StudioClient {
     ) -> Result<Q::ResponseData, RoverClientError> {
         let h = headers::build_studio_headers(&self.api_key)?;
         let body = Q::build_query(variables);
+        tracing::trace!(request_headers = ?h, request_body = ?serde_json::to_string(&body));
+
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
+        tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());
+
         Client::handle_response::<Q>(response)
     }
 }

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -30,7 +30,8 @@ impl StudioClient {
     ) -> Result<Q::ResponseData, RoverClientError> {
         let h = headers::build_studio_headers(&self.api_key)?;
         let body = Q::build_query(variables);
-        tracing::trace!(request_headers = ?h, request_body = ?serde_json::to_string(&body));
+        tracing::trace!(request_headers = ?h);
+        tracing::trace!(request_body = ?serde_json::to_string(&body));
 
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
         tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -31,7 +31,7 @@ impl StudioClient {
         let h = headers::build_studio_headers(&self.api_key)?;
         let body = Q::build_query(variables);
         tracing::trace!(request_headers = ?h);
-        tracing::trace!(request_body = ?serde_json::to_string(&body));
+        tracing::trace!("Request Body: {}", serde_json::to_string(&body)?);
 
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
         tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());


### PR DESCRIPTION
Attempt to add some `--log trace` data for the reqwest lifecycle

So far, this is what I've been able to add:

**request headers/body**

```
Feb 02 10:16:07.037 TRACE ThreadId(01) rover_client::blocking::studio_client: headers={"content-type": "application/json",
 "apollographql-client-name": "rover-client", "apollographql-client-version": "0.0.1-rc.5", "x-api-key": Sensitive} body=Ok("
{\"variables\":{\"graphId\":\"acephei\",\"variant\":\"current\"},\"query\":\"query ListSubgraphsQuery($graphId: ID!, $variant: 
String!) {\\n  frontendUrlRoot\\n  service(id: $graphId) {\\n    implementingServices(graphVariant: $variant) {\\n      __typename\\n      
... on FederatedImplementingServices {\\n        services {\\n          name\\n          url\\n          updatedAt\\n        }\\n      }\\n    }\\n  
}\\n}\\n\",\"operationName\":\"ListSubgraphsQuery\"}")
```

**response headers/status**

```
Feb 02 10:16:07.471 TRACE ThreadId(01) rover_client::blocking::studio_client: response_status=200 response_headers={"x-
powered-by": "Express", "vary": "Origin", "access-control-allow-credentials": "true", "access-control-expose-headers": "logged-
in,identity", "strict-transport-security": "max-age=31536000; includeSubDomains", "logged-in": "true", "identity": 
"user:gh.JakeDawkins", "content-type": "application/json; charset=utf-8", "content-length": "575", "etag": "W/\"23f-
vpgLevFv7kWdmLuEbiGP5nWru9c\"", "date": "Tue, 02 Feb 2021 15:16:10 GMT", "via": "1.1 google", "alt-svc": "clear"}
```

It's pretty messy, but since this is only at the `trace` level, I think that's fine