### PR TITLE
fix(rover-client): reports correct version to graph API

### DIFF
--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -8,16 +8,18 @@ pub struct StudioClient {
     api_key: String,
     client: reqwest::blocking::Client,
     uri: String,
+    version: String,
 }
 
 impl StudioClient {
-    /// Construct a new [StudioClient] from 2 strings, an `api_key` and a `uri`.
+    /// Construct a new [StudioClient] from an `api_key`, a `uri`, and a `version`.
     /// For use in Rover, the `uri` is usually going to be to Apollo Studio
-    pub fn new(api_key: &str, uri: &str) -> StudioClient {
+    pub fn new(api_key: &str, uri: &str, version: &str) -> StudioClient {
         StudioClient {
             api_key: api_key.to_string(),
             client: reqwest::blocking::Client::new(),
             uri: uri.to_string(),
+            version: version.to_string(),
         }
     }
 
@@ -28,7 +30,7 @@ impl StudioClient {
         &self,
         variables: Q::Variables,
     ) -> Result<Q::ResponseData, RoverClientError> {
-        let h = headers::build_studio_headers(&self.api_key)?;
+        let h = headers::build_studio_headers(&self.api_key, &self.version)?;
         let body = Q::build_query(variables);
         let response = self.client.post(&self.uri).headers(h).json(&body).send()?;
         Client::handle_response::<Q>(response)

--- a/crates/rover-client/src/headers.rs
+++ b/crates/rover-client/src/headers.rs
@@ -1,7 +1,6 @@
 use crate::RoverClientError;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
-use std::env;
 
 const JSON_CONTENT_TYPE: &str = "application/json";
 const CLIENT_NAME: &str = "rover-client";
@@ -30,24 +29,28 @@ pub fn build(header_map: &HashMap<String, String>) -> Result<HeaderMap, RoverCli
 /// requests to Apollo Studio. We're leaving this separate from `build` since we
 /// need to be able to mark the api_key as sensitive (at the bottom)
 ///
-/// Takes a single argument, "api_key"m and returns a [HeaderMap].
-pub fn build_studio_headers(api_key: &str) -> Result<HeaderMap, RoverClientError> {
+/// Takes an `api_key` and a `client_version`, and returns a [HeaderMap].
+pub fn build_studio_headers(
+    api_key: &str,
+    client_version: &str,
+) -> Result<HeaderMap, RoverClientError> {
     let mut headers = HeaderMap::new();
 
     let content_type = HeaderValue::from_str(JSON_CONTENT_TYPE)?;
     headers.insert("Content-Type", content_type);
 
-    // this header value is used for client identification in Apollo Studio, so
-    // the metrics in Studio can help us keep track of what parts of the schema
-    // Rover uses and make sure we don't accidentally break those :)
-    // more here: https://www.apollographql.com/docs/studio/client-awareness/#using-apollo-server-and-apollo-client
+    // The headers "apollographql-client-name" and "apollographql-client-version"
+    // are used for client identification in Apollo Studio.
+
+    // This provides metrics in Studio that help keep track of what parts of the schema
+    // Rover uses, which ensures future changes to the API do not break Rover users.
+    // more info here:
+    // https://www.apollographql.com/docs/studio/client-awareness/#using-apollo-server-and-apollo-client
+
     let client_name = HeaderValue::from_str(CLIENT_NAME)?;
     headers.insert("apollographql-client-name", client_name);
-
-    // see note above
-    let client_version = HeaderValue::from_str(
-        &env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| String::from("unknown")),
-    )?;
+    tracing::debug!(?client_version);
+    let client_version = HeaderValue::from_str(&client_version)?;
     headers.insert("apollographql-client-version", client_version);
 
     let mut api_key = HeaderValue::from_str(api_key)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,23 +3,35 @@ use crate::Result;
 use houston as config;
 use rover_client::blocking::StudioClient;
 
+/// the Apollo graph registry's production API endpoint
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
+
+/// the version of Rover currently set in `Cargo.toml`
+const ROVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub struct StudioClientConfig {
     uri: String,
     config: config::Config,
+    version: String,
 }
 
 impl StudioClientConfig {
     pub fn new(override_endpoint: Option<String>, config: config::Config) -> StudioClientConfig {
+        let version = if cfg!(debug_assertions) {
+            format!("{} (dev)", ROVER_VERSION)
+        } else {
+            ROVER_VERSION.to_string()
+        };
+
         StudioClientConfig {
             uri: override_endpoint.unwrap_or_else(|| STUDIO_PROD_API_ENDPOINT.to_string()),
             config,
+            version,
         }
     }
 
     pub fn get_client(&self, profile_name: &str) -> Result<StudioClient> {
         let api_key = config::Profile::get_api_key(profile_name, &self.config)?;
-        Ok(StudioClient::new(&api_key, &self.uri))
+        Ok(StudioClient::new(&api_key, &self.uri, &self.version))
     }
 }


### PR DESCRIPTION
fixes #221 

this PR reads rover's version from `Cargo.toml` and passes it to `rover-client` to be used when reporting the client version to studio. 

it will look like "1.0.0" for production releases, and "1.0.0 (dev)" for when folks are building/testing from source