### PR TITLE
fix: error formatting

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum RoverClientError {
     /// The provided GraphQL was invalid.
-    #[error("GraphQL error:\n               {msg}")]
+    #[error("{msg}")]
     GraphQL {
         /// The encountered GraphQL error.
         msg: String,

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -10,7 +10,7 @@ fn main() {
     setup_panic!();
     if let Err(error) = run() {
         tracing::debug!(?error);
-        eprintln!("{}", error);
+        eprint!("{}", error);
         process::exit(1)
     } else {
         process::exit(0)


### PR DESCRIPTION
# Before

```console
$ rover subgraph list averys-federated-graph
  INFO Listing subgraphs for averys-federated-graph@current using credentials from the default profile.
error: GraphQL error:
               This API key does not have permission to perform that operation.

$
```

# After

```console
$ rover subgraph list averys-federated-graph
  INFO Listing subgraphs for averys-federated-graph@current using credentials from the default profile.
error: This API key does not have permission to perform that operation.
$
```

This PR removes the extra whitespace after an error, and also removes "GraphQL error" since it doesn't really provide any useful information.