### PR TITLE
Add `rover info` command to print basic info

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,6 @@ jobs:
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
       - name: Run Tests
-        run: cargo test --workspace --locked
+        run: cargo test --workspace --locked --nocapture
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,6 @@ jobs:
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
       - name: Run Tests
-        run: cargo test --workspace --locked -- --nocapture
+        run: cargo test --workspace --locked
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,6 @@ jobs:
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
       - name: Run Tests
-        run: cargo test --workspace --locked --nocapture
+        run: cargo test --workspace --locked -- --nocapture
         env:
           RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2127a5da3c69035537febc04cd07008bb643653303b213a49b036d944531207"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "os_type"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1492,7 @@ dependencies = [
  "git_info",
  "heck",
  "houston",
+ "os_info",
  "predicates",
  "prettytable-rs",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ url = "2.2.0"
 git_info = "0.1.2"
 git-url-parse = "0.3.1"
 chrono = "0.4"
+os_info = "3.0"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 structopt = "0.3.21"
 tracing = "0.1.22"
 regex = "1"
-url = "2.2.0
+url = "2.2.0"
 os_info = "3.0"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,9 @@ pub enum Command {
 
     #[structopt(setting(structopt::clap::AppSettings::Hidden))]
     Install(command::Install),
+
+    /// Show info about your environment for help debugging
+    Info(command::Info),
 }
 
 impl Rover {
@@ -107,6 +110,7 @@ impl Rover {
                 command.run(self.get_client_config()?, self.get_git_context()?)
             }
             Command::Install(command) => command.run(self.get_install_override_path()?),
+            Command::Info(command) => command.run(),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,7 +95,7 @@ pub enum Command {
     #[structopt(setting(structopt::clap::AppSettings::Hidden))]
     Install(command::Install),
 
-    /// Show info about your environment for help debugging
+    #[structopt(setting(structopt::clap::AppSettings::Hidden))]
     Info(command::Info),
 }
 

--- a/src/command/info.rs
+++ b/src/command/info.rs
@@ -1,0 +1,38 @@
+use crate::command::RoverStdout;
+use crate::Result;
+use serde::Serialize;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Info {}
+
+impl Info {
+    pub fn run(&self) -> Result<RoverStdout> {
+        let os = os_info::get();
+
+        // something like "/usr/bin/zsh" or "Unknown"
+        let shell = env::var("SHELL").unwrap_or_else(|_| "Unknown".to_string());
+
+        // the version of Rover currently set in `Cargo.toml`
+        let version: &str = env!("CARGO_PKG_VERSION");
+
+        let location = match env::current_exe() {
+            Ok(path) => path
+                .into_os_string()
+                .into_string()
+                .unwrap_or_else(|_| "Unknown".to_string()),
+            Err(_) => "Unknown".to_string(),
+        };
+
+        tracing::info!(
+            "Rover Info:\nVersion: {}\nInstall Location: {}\nOS: {}\nShell: {}",
+            version,
+            location,
+            os,
+            shell
+        );
+
+        Ok(RoverStdout::None)
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,11 +1,13 @@
 mod config;
 mod graph;
+mod info;
 mod install;
 mod output;
 mod subgraph;
 
 pub use config::Config;
 pub use graph::Graph;
+pub use info::Info;
 pub use install::Install;
 pub use output::RoverStdout;
 pub use subgraph::Subgraph;

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -1,0 +1,14 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn it_prints_info() {
+    let mut cmd = Command::cargo_bin("rover").unwrap();
+    let result = cmd.arg("info")
+        .assert()
+        .success();
+    
+    dbg!(&result.get_output());
+
+    result.stdout(predicate::str::contains("Info"));
+}

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -6,7 +6,7 @@ fn it_prints_info() {
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd.arg("info").assert().success();
 
-    println!("{:?}", &result.get_output());
-
-    //result.stdout(predicate::str::contains("Info"));
+    // the version should always be available in the `info` output
+    let version = env!("CARGO_PKG_VERSION");
+    result.stderr(predicate::str::contains(version));
 }

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -8,7 +8,7 @@ fn it_prints_info() {
         .assert()
         .success();
     
-    dbg!(&result.get_output());
+    println!("{:?}", &result.get_output());
 
-    result.stdout(predicate::str::contains("Info"));
+    //result.stdout(predicate::str::contains("Info"));
 }

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -4,10 +4,8 @@ use predicates::prelude::*;
 #[test]
 fn it_prints_info() {
     let mut cmd = Command::cargo_bin("rover").unwrap();
-    let result = cmd.arg("info")
-        .assert()
-        .success();
-    
+    let result = cmd.arg("info").assert().success();
+
     println!("{:?}", &result.get_output());
 
     //result.stdout(predicate::str::contains("Info"));


### PR DESCRIPTION
I got carried away and built a thing... If it doesn't find something, it just prints `Unknown`.

Local wsl:
```
INFO Rover Info:
Version: 0.0.1-rc.6
Install Location: /home/jake/projects/rover/target/release/rover
OS: Ubuntu 20.04 (focal) [64-bit]
Shell: /usr/bin/zsh
```

Windows in GH actions:
```
Rover Info:
Version: 0.0.1-rc.6
Install Location: D:\\a\\rover\\rover\\target\\debug\\rover.exe
OS: Windows 10.0.17763 (Windows Server 2019 Datacenter) [64-bit]
Shell: Unknown
```

MacOS in GH actions
```
Rover Info:
Version: 0.0.1-rc.6
Install Location: /Users/runner/work/rover/rover/target/debug/rover
OS: Mac OS 10.15.7 [64-bit]
Shell: /bin/bash\n
```