### PR TITLE
0.0.1-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,9 +413,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
 ]
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.0.1-rc.6"
+version = "0.0.1-rc.7"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 name = "rover"
-version = "0.0.1-rc.6"
+version = "0.0.1-rc.7"
 repository = "https://github.com/apollographql/rover/"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rover subgraph fetch --name=pets test@cats
 
 ```console
 $ rover --help
-Rover 0.0.1-rc.6
+Rover 0.0.1-rc.7
 
 Rover - Your Graph Companion
 Read the getting started guide: https://go.apollo.dev/r/start
@@ -97,13 +97,13 @@ You can install Rover by running
 #### Linux and MacOS
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.6/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.6 sh
+curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.7 sh
 ```
 
 #### Windows
 
 ```bash
-iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.6/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/windows/install.ps1' | iex
 ```
 
 Alternatively, you can [download the binary for your operating system](https://github.com/apollographql/rover/releases) and manually adding its location to your `PATH`.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -12,13 +12,13 @@ Install Rover by running the corresponding command for your operating system:
 ### Linux and MacOS
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.6/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.6 sh
+curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.7 sh
 ```
 
 ### Windows
 
 ```shell
-iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.6/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/windows/install.ps1' | iex
 ```
 
 Alternatively, you can [download the binary for your operating system](https://github.com/apollographql/rover/releases) and manually add its location to your `PATH`.

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -2,7 +2,7 @@ function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference
   $ErrorActionPreference = 'stop'
 
-  $version = "0.0.1-rc.6"
+  $version = "0.0.1-rc.7"
 
   Initialize-Environment
 

--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -34,7 +34,7 @@ rover subgraph fetch --name=pets test@cats
 
 ```console
 $ rover --help
-Rover 0.0.1-rc.6
+Rover 0.0.1-rc.7
 
 Rover - Your Graph Companion
 Read the getting started guide: https://go.apollo.dev/r/start
@@ -97,13 +97,13 @@ You can install Rover by running
 #### Linux and MacOS
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.6/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.6 sh
+curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.7 sh
 ```
 
 #### Windows
 
 ```bash
-iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.6/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/windows/install.ps1' | iex
 ```
 
 Alternatively, you can [download the binary for your operating system](https://github.com/apollographql/rover/releases) and manually adding its location to your `PATH`.

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.0.1-rc.6",
+  "version": "0.0.1-rc.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.0.1-rc.6",
+  "version": "0.0.1-rc.7",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
### Disclaimer: Rover is still in an experimental stage and should not be used in production. This release is intended for use by internal teams at Apollo.

## Installation

You can install Rover by running

#### Linux and MacOS

```bash
curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1-rc.7 sh
```

#### Windows

```bash
iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.1-rc.7/installers/binstall/scripts/windows/install.ps1' | iex
```

Alternatively, you can download the binary for your operating system and manually adding its location to your `PATH`.

---

## 0.0.1-rc.7

### Fixed

- `GitContext` now reports the long commit hash and has some extra regression tests