### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This `README` contains just enough info to get you started with Rover. Our [docs
 
 ## Usage
 
-A few useful Rover comamnds to interact with your graphs:
+A few useful Rover commands to interact with your graphs:
 
 1. Fetch a graph from a federated remote endpoint.
 


### PR DESCRIPTION
Corrects the misspelling of "commands" in the README.

`s/Rover co[ma]{3}nds to interact/Rover commands to interact/` 😉 