### PR TITLE
fix: handle malformed API key errors

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -55,6 +55,10 @@ impl Client {
             serde_json::from_str(&response_text)?;
 
         if let Some(errs) = response_body.errors {
+            if !errs.is_empty() && errs[0].message.contains("406") {
+                return Err(RoverClientError::MalformedKey);
+            }
+
             return Err(RoverClientError::GraphQL {
                 msg: errs
                     .into_iter()

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -75,6 +75,12 @@ pub enum RoverClientError {
     #[error("Invalid ChangeSeverity.")]
     InvalidSeverity,
 
+    /// This error occurs when a user has a malformed API key
+    #[error(
+        "The API key you provided is malformed. An API key must have three parts separated by a colon."
+    )]
+    MalformedKey,
+
     /// The registry could not find this key
     #[error("The registry did not recognize the provided API key")]
     InvalidKey,

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -70,6 +70,7 @@ impl From<&mut anyhow::Error> for Metadata {
                     (None, None)
                 }
                 RoverClientError::InvalidKey => (Some(Suggestion::CheckKey), None),
+                RoverClientError::MalformedKey => (Some(Suggestion::ProperKey), None),
             };
             return Metadata {
                 suggestion,

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -19,6 +19,7 @@ pub enum Suggestion {
     ProvideValidSubgraph(Vec<String>),
     Adhoc(String),
     CheckKey,
+    ProperKey,
 }
 
 impl Display for Suggestion {
@@ -78,6 +79,9 @@ impl Display for Suggestion {
             }
             Suggestion::CheckKey => {
                 "Check your API key to make sure it's valid (are you using the right profile?).".to_string()
+            }
+            Suggestion::ProperKey => {
+                format!("Visit {} for more details on Apollo's API keys.", Cyan.normal().paint("https://go.apollo.dev/r/api-keys"))
             }
             Suggestion::Adhoc(msg) => msg.to_string()
 


### PR DESCRIPTION
fixes #215

before:

```console
$ rover config whoami --profile malformed-key
error: 406: Not Acceptable
```

after:

```console
$ rover config whoami --profile malformed-key
error: The API key you provided is malformed. An API key must have three parts separated by a colon.
        Visit https://go.apollo.dev/r/api-keys for more details on Apollo's API keys.
```