### PR TITLE
chore: dont use console crate for colors

### DIFF
--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -1,4 +1,4 @@
-use console::{self, style};
+use ansi_term::Colour::Cyan;
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -40,7 +40,8 @@ fn api_key_prompt() -> Result<String> {
     let term = console::Term::stdout();
     tracing::info!(
         "Go to {} and create a new Personal API Key.",
-        style("https://studio.apollographql.com/user-settings").cyan()
+        Cyan.normal()
+            .paint("https://studio.apollographql.com/user-settings")
     );
     tracing::info!("Copy the key and paste it into the prompt below.");
     let api_key = term.read_secure_line()?;


### PR DESCRIPTION
just a minor thing. this means we're just using this console crate for like 1/100th of its functionality. maybe revisit using ansi_term for coloring, but for now this is the smallest lift