### PR TITLE
Add error for no profiles found (new user)

### DIFF
--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -25,6 +25,10 @@ pub enum HoustonProblem {
     #[error("There is no profile named \"{0}\".")]
     ProfileNotFound(String),
 
+    /// NoProfilesFound occurs When there are no profiles at all, often for new users
+    #[error("No config profiles found")]
+    NoConfigProfiles,
+
     /// NoNonSensitiveConfigFound occurs when non-sensitive config can't be found for a profile.
     #[error("No non-sensitive configuration found for profile \"{0}\".")]
     NoNonSensitiveConfigFound(String),

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -79,12 +79,15 @@ impl Profile {
     /// Loads and deserializes configuration from the file system for a
     /// specific profile.
     pub fn load(name: &str, config: &Config, opts: LoadOpts) -> Result<Profile, HoustonProblem> {
+        let profile_count = Profile::list(&config).unwrap_or(vec![]).len();
         if Profile::dir(name, config).exists() {
             if opts.sensitive {
                 let sensitive = Sensitive::load(name, config)?;
                 return Ok(Profile { sensitive });
             }
             Err(HoustonProblem::NoNonSensitiveConfigFound(name.to_string()))
+        } else if profile_count == 0 {
+            Err(HoustonProblem::NoConfigProfiles)
         } else {
             Err(HoustonProblem::ProfileNotFound(name.to_string()))
         }

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -79,7 +79,7 @@ impl Profile {
     /// Loads and deserializes configuration from the file system for a
     /// specific profile.
     pub fn load(name: &str, config: &Config, opts: LoadOpts) -> Result<Profile, HoustonProblem> {
-        let profile_count = Profile::list(&config).unwrap_or(vec![]).len();
+        let profile_count = Profile::list(&config).unwrap_or_default().len();
         if Profile::dir(name, config).exists() {
             if opts.sensitive {
                 let sensitive = Sensitive::load(name, config)?;

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -97,7 +97,7 @@ impl From<&mut anyhow::Error> for Metadata {
                         Some(Suggestion::CreateConfig)
                     };
                     (suggestion, code)
-                },
+                }
                 HoustonProblem::NoConfigProfiles => (Some(Suggestion::NewUserNoProfiles), None),
                 HoustonProblem::ProfileNotFound(_) => (Some(Suggestion::ListProfiles), None),
                 HoustonProblem::TomlDeserialization(_)

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -97,7 +97,8 @@ impl From<&mut anyhow::Error> for Metadata {
                         Some(Suggestion::CreateConfig)
                     };
                     (suggestion, code)
-                }
+                },
+                HoustonProblem::NoConfigProfiles => (Some(Suggestion::NewUserNoProfiles), None),
                 HoustonProblem::ProfileNotFound(_) => (Some(Suggestion::ListProfiles), None),
                 HoustonProblem::TomlDeserialization(_)
                 | HoustonProblem::TomlSerialization(_)

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -20,6 +20,7 @@ pub enum Suggestion {
     Adhoc(String),
     CheckKey,
     ProperKey,
+    NewUserNoProfiles,
 }
 
 impl Display for Suggestion {
@@ -82,6 +83,11 @@ impl Display for Suggestion {
             }
             Suggestion::ProperKey => {
                 format!("Visit {} for more details on Apollo's API keys.", Cyan.normal().paint("https://go.apollo.dev/r/api-keys"))
+            }
+            Suggestion::NewUserNoProfiles => {
+                format!("It looks like you may be new here (we couldn't find any existing config profiles). To authenticate with Apollo Studio, run {}",
+                    Cyan.normal().paint("rover config auth")
+                )
             }
             Suggestion::Adhoc(msg) => msg.to_string()
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -72,7 +72,7 @@ impl Display for RoverError {
                 suggestion_descriptor_message.push(' ');
             }
             let suggestion_descriptor = Cyan.bold().paint(&suggestion_descriptor_message);
-            write!(formatter, "{} {}", suggestion_descriptor, suggestion)?;
+            writeln!(formatter, "{} {}", suggestion_descriptor, suggestion)?;
         }
         Ok(())
     }


### PR DESCRIPTION
I think we could potentially build off this for a custom printer to avoid printing the `error:` syntax. This is just to get something out there for the preview :)