### PR TITLE
feat: adds origin to config whoami command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "graphql_client",
+ "houston",
  "http",
  "online",
  "reqwest",

--- a/crates/houston/src/lib.rs
+++ b/crates/houston/src/lib.rs
@@ -11,5 +11,4 @@ pub use error::HoustonProblem;
 
 pub use profile::mask_key;
 /// Utilites for saving, loading, and deleting configuration profiles.
-pub use profile::LoadOpts;
-pub use profile::Profile;
+pub use profile::{Credential, CredentialOrigin, LoadOpts, Profile};

--- a/crates/houston/tests/auth.rs
+++ b/crates/houston/tests/auth.rs
@@ -20,8 +20,9 @@ fn it_can_set_and_get_an_api_key_via_creds_file() {
     assert!(sensitive_file.exists());
 
     assert_eq!(
-        config::Profile::get_api_key(profile, &config)
-            .expect("retreiving api key for default profile failed"),
+        config::Profile::get_credential(profile, &config)
+            .expect("retreiving api key for default profile failed")
+            .api_key,
         String::from(api_key)
     );
 
@@ -41,8 +42,9 @@ fn it_can_get_an_api_key_via_env_var() {
     let config = get_config(Some(api_key.to_string()));
 
     assert_eq!(
-        config::Profile::get_api_key(profile, &config)
-            .expect("retreiving api key for default profile failed"),
+        config::Profile::get_credential(profile, &config)
+            .expect("retreiving api key for default profile failed")
+            .api_key,
         String::from(api_key)
     );
 }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -6,6 +6,11 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 
 [dependencies]
+
+# workspace deps
+houston = { path = "../houston" }
+
+# crates.io deps
 anyhow = "1"
 graphql_client = "0.9"
 http = "0.2"

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -1,11 +1,13 @@
 use crate::blocking::Client;
 use crate::headers;
 use crate::RoverClientError;
+use houston::Credential;
+
 use graphql_client::GraphQLQuery;
 
 /// Represents a client for making GraphQL requests to Apollo Studio.
 pub struct StudioClient {
-    api_key: String,
+    pub credential: Credential,
     client: reqwest::blocking::Client,
     uri: String,
     version: String,
@@ -14,9 +16,9 @@ pub struct StudioClient {
 impl StudioClient {
     /// Construct a new [StudioClient] from an `api_key`, a `uri`, and a `version`.
     /// For use in Rover, the `uri` is usually going to be to Apollo Studio
-    pub fn new(api_key: &str, uri: &str, version: &str) -> StudioClient {
+    pub fn new(credential: Credential, uri: &str, version: &str) -> StudioClient {
         StudioClient {
-            api_key: api_key.to_string(),
+            credential,
             client: reqwest::blocking::Client::new(),
             uri: uri.to_string(),
             version: version.to_string(),
@@ -30,7 +32,7 @@ impl StudioClient {
         &self,
         variables: Q::Variables,
     ) -> Result<Q::ResponseData, RoverClientError> {
-        let h = headers::build_studio_headers(&self.api_key, &self.version)?;
+        let h = headers::build_studio_headers(&self.credential.api_key, &self.version)?;
         let body = Q::build_query(variables);
         tracing::trace!(request_headers = ?h);
         tracing::trace!("Request Body: {}", serde_json::to_string(&body)?);

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -29,7 +29,7 @@ impl Auth {
     pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
         let api_key = api_key_prompt()?;
         Profile::set_api_key(&self.profile_name, &config, &api_key)?;
-        Profile::get_api_key(&self.profile_name, &config).map(|_| {
+        Profile::get_credential(&self.profile_name, &config).map(|_| {
             eprintln!("Successfully saved API key.");
         })?;
         Ok(RoverStdout::None)
@@ -78,7 +78,9 @@ mod tests {
         let config = get_config(None);
 
         Profile::set_api_key(DEFAULT_PROFILE, &config, DEFAULT_KEY).unwrap();
-        let result = Profile::get_api_key(DEFAULT_PROFILE, &config).unwrap();
+        let result = Profile::get_credential(DEFAULT_PROFILE, &config)
+            .unwrap()
+            .api_key;
         assert_eq!(result, DEFAULT_KEY);
     }
 
@@ -88,7 +90,9 @@ mod tests {
         let config = get_config(None);
 
         Profile::set_api_key(CUSTOM_PROFILE, &config, CUSTOM_KEY).unwrap();
-        let result = Profile::get_api_key(CUSTOM_PROFILE, &config).unwrap();
+        let result = Profile::get_credential(CUSTOM_PROFILE, &config)
+            .unwrap()
+            .api_key;
         assert_eq!(result, CUSTOM_KEY);
     }
 

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -31,7 +31,7 @@ impl StudioClientConfig {
     }
 
     pub fn get_client(&self, profile_name: &str) -> Result<StudioClient> {
-        let api_key = config::Profile::get_api_key(profile_name, &self.config)?;
-        Ok(StudioClient::new(&api_key, &self.uri, &self.version))
+        let credential = config::Profile::get_credential(profile_name, &self.config)?;
+        Ok(StudioClient::new(credential, &self.uri, &self.version))
     }
 }


### PR DESCRIPTION
fixes #273 

`rover config whoami` now shows the user the profile that their credentials are stored in, OR if Rover is reading their credentials from the `$APOLLO_KEY` environment variable.

output:

```console
$ rover config whoami --profile graph
Checking identity of your API key against the registry.
Key Type: GRAPH
Graph Title: averys-giant-sandy-box
Unique Graph ID: averys-giant-sandy-box
Origin: --profile graph
```

```console
$ APOLLO_KEY=mygraphkey rover config whoami
Checking identity of your API key against the registry.
Key Type: GRAPH
Graph Title: averys-giant-sandy-box
Unique Graph ID: averys-giant-sandy-box
Origin: $APOLLO_KEY
```

i am a _tad_ worried that adding `houston` as a dep to `rover-client` is a bad design decision, but I thought long and hard about how else we could do this and I came up empty handed. If anybody has any suggestions on how to maybe decouple those (or if you think it's fine) I'm all ears!

~Also, do we think exposing the actual file location is good here? Or do we think we should just say the name of the profile itself? I'd imagine it'd be useful to know the file location, but also showing it like this might give folks the wrong idea. We'd much rather them interact with this stuff through our `config` subcommand suite, so maybe we shouldn't lift the curtains on that abstraction.~

---

after this i think i'm gonna try to lump in `rover config show` with `whoami`!