### PR TITLE
chore: const env!(CARGO_PKG_*) vars

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ use std::{
 const FILES_TO_COPY: &[&str; 2] = &["LICENSE", "README.md"];
 
 /// the version of Rover currently set in `Cargo.toml`
-const ROVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> Result<()> {
     let is_release_build = env::var("PROFILE") == Ok("release".to_string());
@@ -124,18 +124,18 @@ fn update_version(npm_install_path: &Path, npm_dir: &Path) -> Result<()> {
     let command_output = Command::new(npm_install_path)
         .current_dir(npm_dir)
         .arg("version")
-        .arg(ROVER_VERSION)
+        .arg(PKG_VERSION)
         .arg("--allow-same-version")
         .output()
         .with_context(|| {
             format!(
                 "Could not execute 'npm version {} --allow-same-version'.",
-                ROVER_VERSION
+                PKG_VERSION
             )
         })?;
 
     process_command_output(&command_output)
-        .with_context(|| format!("Could not print output of 'npm version {}'.", ROVER_VERSION))
+        .with_context(|| format!("Could not print output of 'npm version {}'.", PKG_VERSION))
 }
 
 fn dry_run_publish(npm_install_path: &Path, npm_dir: &Path) -> Result<()> {

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -7,7 +7,13 @@ use structopt::StructOpt;
 use std::{process, thread};
 
 fn main() {
-    setup_panic!();
+    setup_panic!(PanicMetadata {
+        name: PKG_NAME.into(),
+        version: PKG_VERSION.into(),
+        authors: PKG_AUTHORS.into(),
+        homepage: PKG_HOMEPAGE.into(),
+        repository: PKG_REPOSITORY.into()
+    });
     if let Err(error) = run() {
         tracing::debug!(?error);
         eprint!("{}", error);

--- a/src/command/info.rs
+++ b/src/command/info.rs
@@ -1,5 +1,6 @@
 use crate::command::RoverStdout;
 use crate::Result;
+use crate::PKG_VERSION;
 use serde::Serialize;
 use std::env;
 use structopt::StructOpt;
@@ -14,9 +15,6 @@ impl Info {
         // something like "/usr/bin/zsh" or "Unknown"
         let shell = env::var("SHELL").unwrap_or_else(|_| "Unknown".to_string());
 
-        // the version of Rover currently set in `Cargo.toml`
-        let version: &str = env!("CARGO_PKG_VERSION");
-
         let location = match env::current_exe() {
             Ok(path) => path
                 .into_os_string()
@@ -27,7 +25,7 @@ impl Info {
 
         eprintln!(
             "Rover Info:\nVersion: {}\nInstall Location: {}\nOS: {}\nShell: {}",
-            version, location, os, shell
+            PKG_VERSION, location, os, shell
         );
 
         Ok(RoverStdout::None)

--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -4,6 +4,7 @@ use structopt::StructOpt;
 use binstall::Installer;
 
 use crate::command::RoverStdout;
+use crate::PKG_NAME;
 use crate::{anyhow, Context, Result};
 
 use std::env;
@@ -17,8 +18,7 @@ pub struct Install {
 
 impl Install {
     pub fn run(&self, override_install_path: Option<PathBuf>) -> Result<RoverStdout> {
-        let binary_name = env!("CARGO_PKG_NAME").to_string();
-
+        let binary_name = PKG_NAME.to_string();
         if let Ok(executable_location) = env::current_exe() {
             let install_location = Installer {
                 binary_name: binary_name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ mod error;
 pub mod utils;
 
 pub use error::{anyhow, Context, Result};
+
+pub use utils::pkg::*;

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -1,13 +1,11 @@
 use crate::Result;
+use crate::PKG_VERSION;
 
 use houston as config;
 use rover_client::blocking::StudioClient;
 
 /// the Apollo graph registry's production API endpoint
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
-
-/// the version of Rover currently set in `Cargo.toml`
-const ROVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub struct StudioClientConfig {
     uri: String,
@@ -18,9 +16,9 @@ pub struct StudioClientConfig {
 impl StudioClientConfig {
     pub fn new(override_endpoint: Option<String>, config: config::Config) -> StudioClientConfig {
         let version = if cfg!(debug_assertions) {
-            format!("{} (dev)", ROVER_VERSION)
+            format!("{} (dev)", PKG_VERSION)
         } else {
-            ROVER_VERSION.to_string()
+            PKG_VERSION.to_string()
         };
 
         StudioClientConfig {

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -186,6 +186,7 @@ impl Into<SubgraphCheckContextInput> for GitContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PKG_NAME;
 
     #[test]
     fn removed_user_from_remote_with_only_user() {
@@ -353,7 +354,7 @@ mod tests {
         assert!(git_context.message.is_none());
 
         if let Some(remote_url) = git_context.remote_url {
-            assert!(remote_url.contains(env!("CARGO_PKG_NAME")));
+            assert!(remote_url.contains(PKG_NAME));
         } else {
             panic!("GitContext could not find the remote url");
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,5 +3,6 @@ pub mod env;
 pub mod git;
 pub mod loaders;
 pub mod parsers;
+pub mod pkg;
 pub mod stringify;
 pub mod telemetry;

--- a/src/utils/pkg.rs
+++ b/src/utils/pkg.rs
@@ -1,0 +1,5 @@
+pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+pub const PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
+pub const PKG_HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
+pub const PKG_AUTHORS: &str = env!("CARGO_PKG_AUTHORS");

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -2,15 +2,13 @@ use url::Url;
 
 use std::path::PathBuf;
 
-use crate::cli::Rover;
 use crate::utils::env::RoverEnvKey;
+use crate::{cli::Rover, PKG_NAME, PKG_VERSION};
 use sputnik::{Command, Report, SputnikError};
 
 use std::collections::HashMap;
 
 const TELEMETRY_URL: &str = "https://install.apollographql.workers.dev/telemetry";
-const ROVER_VERSION: &str = env!("CARGO_PKG_VERSION");
-const ROVER_NAME: &str = env!("CARGO_PKG_NAME");
 
 fn get_command_from_args(mut raw_arguments: &mut serde_json::Value) -> Command {
     let mut commands = Vec::new();
@@ -98,11 +96,11 @@ impl Report for Rover {
     }
 
     fn tool_name(&self) -> String {
-        ROVER_NAME.to_string()
+        PKG_NAME.to_string()
     }
 
     fn version(&self) -> String {
-        ROVER_VERSION.to_string()
+        PKG_VERSION.to_string()
     }
 
     fn machine_id_config(&self) -> Result<PathBuf, SputnikError> {
@@ -118,6 +116,7 @@ mod tests {
     use crate::cli::Rover;
     use crate::utils::env::RoverEnvKey;
     use crate::utils::telemetry::Report;
+    use crate::PKG_NAME;
 
     use sputnik::Command;
 
@@ -126,11 +125,9 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use super::ROVER_NAME;
-
     #[test]
     fn it_can_serialize_commands() {
-        let args = vec![ROVER_NAME, "config", "list"];
+        let args = vec![PKG_NAME, "config", "list"];
         let rover = Rover::from_iter(args);
         let actual_serialized_command = rover
             .serialize_command()
@@ -144,7 +141,7 @@ mod tests {
 
     #[test]
     fn it_can_serialize_commands_with_arguments() {
-        let args = vec![ROVER_NAME, "config", "show", "default", "--sensitive"];
+        let args = vec![PKG_NAME, "config", "show", "default", "--sensitive"];
         let rover = Rover::from_iter(args);
         let actual_serialized_command = rover
             .serialize_command()
@@ -161,7 +158,7 @@ mod tests {
     #[test]
     fn it_respects_apollo_telemetry_url() {
         let apollo_telemetry_url = "https://example.com/telemetry";
-        let args = vec![ROVER_NAME, "config", "list"];
+        let args = vec![PKG_NAME, "config", "list"];
         let mut rover = Rover::from_iter(args);
         rover
             .env_store
@@ -177,7 +174,7 @@ mod tests {
 
     #[test]
     fn it_can_be_disabled() {
-        let args = vec![ROVER_NAME, "config", "list"];
+        let args = vec![PKG_NAME, "config", "list"];
         let mut rover = Rover::from_iter(args);
         rover.env_store.insert(RoverEnvKey::TelemetryDisabled, "1");
         let expect_enabled = false;
@@ -188,7 +185,7 @@ mod tests {
 
     #[test]
     fn it_is_enabled_by_default() {
-        let args = vec![ROVER_NAME, "config", "list"];
+        let args = vec![PKG_NAME, "config", "list"];
         let rover = Rover::from_iter(args);
         let expect_enabled = true;
         let is_telemetry_enabled = rover.is_telemetry_enabled().unwrap();

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use rover::PKG_VERSION;
 
 #[test]
 fn it_prints_info() {
@@ -7,6 +8,5 @@ fn it_prints_info() {
     let result = cmd.arg("info").assert().success();
 
     // the version should always be available in the `info` output
-    let version = env!("CARGO_PKG_VERSION");
-    result.stderr(predicate::str::contains(version));
+    result.stderr(predicate::str::contains(PKG_VERSION));
 }


### PR DESCRIPTION
this PR pulls out all calls to `env!(CARGO_PKG_*)` into one file. relatively small change with an incredibly minimal impact on build time. mostly just to make me happy