### PR TITLE
feat: prettier table

### DIFF
--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
       "funding": [
         {
           "type": "individual",
@@ -374,9 +374,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "fs-minipass": {
       "version": "2.1.0",

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -1,4 +1,3 @@
-use prettytable::{cell, row, Table};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -12,6 +11,7 @@ use crate::utils::parsers::{
     parse_graph_ref, parse_query_count_threshold, parse_query_percentage_threshold,
     parse_schema_source, parse_validation_period, GraphRef, SchemaSource, ValidationPeriod,
 };
+use crate::utils::table::{self, cell, row};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -111,8 +111,10 @@ fn print_changes(
     let mut num_failures = 0;
 
     if !checks.is_empty() {
-        let mut table = Table::new();
-        table.add_row(row!["Change", "Code", "Description"]);
+        let mut table = table::get_table();
+
+        // bc => sets top row to be bold and center
+        table.add_row(row![bc => "Change", "Code", "Description"]);
         for check in checks {
             let change = match check.severity {
                 check::check_schema_query::ChangeSeverity::NOTICE => "PASS",

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use ansi_term::Colour::Yellow;
-use prettytable::{cell, row, Table};
 use rover_client::query::subgraph::list::ListDetails;
+
+use crate::utils::table::{self, cell, row};
 
 /// RoverStdout defines all of the different types of data that are printed
 /// to `stdout`. Every one of Rover's commands should return `anyhow::Result<RoverStdout>`
@@ -31,8 +32,10 @@ impl RoverStdout {
                     "You can open any of these documentation pages by running {}.\n",
                     Yellow.normal().paint("`rover docs open <slug>`")
                 );
-                let mut table = Table::new();
-                table.add_row(row!["Slug", "Description"]);
+                let mut table = table::get_table();
+
+                // bc => sets top row to be bold and center
+                table.add_row(row![bc => "Slug", "Description"]);
                 for (shortlink_slug, shortlink_description) in shortlinks {
                     table.add_row(row![shortlink_slug, shortlink_description]);
                 }
@@ -47,8 +50,10 @@ impl RoverStdout {
                 println!("{}", &hash);
             }
             RoverStdout::SubgraphList(details) => {
-                let mut table = Table::new();
-                table.add_row(row!["Name", "Routing Url", "Last Updated"]);
+                let mut table = table::get_table();
+
+                // bc => sets top row to be bold and center
+                table.add_row(row![bc => "Name", "Routing Url", "Last Updated"]);
 
                 for subgraph in &details.subgraphs {
                     // if the url is None or empty (""), then set it to "N/A"

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -1,4 +1,3 @@
-use prettytable::{cell, row, Table};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -13,6 +12,7 @@ use crate::utils::parsers::{
     parse_graph_ref, parse_query_count_threshold, parse_query_percentage_threshold,
     parse_schema_source, parse_validation_period, GraphRef, SchemaSource, ValidationPeriod,
 };
+use crate::utils::table::{self, cell, row};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Check {
@@ -119,8 +119,10 @@ fn handle_checks(check_result: check::CheckResult) -> Result<RoverStdout> {
     let mut num_failures = 0;
 
     if !check_result.changes.is_empty() {
-        let mut table = Table::new();
-        table.add_row(row!["Change", "Code", "Description"]);
+        let mut table = table::get_table();
+
+        // bc => sets top row to be bold and center
+        table.add_row(row![bc => "Change", "Code", "Description"]);
         for check in check_result.changes {
             let change = match check.severity {
                 check::check_partial_schema_query::ChangeSeverity::NOTICE => "PASS",

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,4 +5,5 @@ pub mod loaders;
 pub mod parsers;
 pub mod pkg;
 pub mod stringify;
+pub mod table;
 pub mod telemetry;

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,0 +1,9 @@
+use prettytable::{format::consts::FORMAT_BOX_CHARS, Table};
+
+pub use prettytable::{cell, row};
+
+pub fn get_table() -> Table {
+    let mut table = Table::new();
+    table.set_format(*FORMAT_BOX_CHARS);
+    table
+}


### PR DESCRIPTION
before:

```console
$ rover subgraph list averys-federated-graph
Listing subgraphs for averys-federated-graph@current using credentials from the default profile.
+--------+-------------+----------------------------+
| Name   | Routing Url | Last Updated               |
+--------+-------------+----------------------------+
| films  | N/A         | 2020-12-18 12:26:10 -06:00 |
+--------+-------------+----------------------------+
| people | N/A         | 2020-12-18 12:25:44 -06:00 |
+--------+-------------+----------------------------+

View full details at https://studio.apollographql.com/graph/averys-federated-graph/service-list
```

after:

```console
$ rover subgraph list averys-federated-graph
Listing subgraphs for averys-federated-graph@current using credentials from the default profile.
┌────────┬─────────────┬────────────────────────────┐
│  Name  │ Routing Url │        Last Updated        │
├────────┼─────────────┼────────────────────────────┤
│ films  │ N/A         │ 2020-12-18 12:26:10 -06:00 │
├────────┼─────────────┼────────────────────────────┤
│ people │ N/A         │ 2020-12-18 12:25:44 -06:00 │
└────────┴─────────────┴────────────────────────────┘

View full details at https://studio.apollographql.com/graph/averys-federated-graph/service-list
```