### PR TITLE
feat(binstall): don't require terminal reload

### DIFF
--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -30,7 +30,11 @@ impl Install {
             .with_context(|| format!("could not install {}", &binary_name))?;
 
             if let Some(install_location) = install_location {
-                eprintln!("{} was successfully installed to `{}`. You may need to reload your terminal for the binary to be loaded into your PATH.", &binary_name, install_location.display())
+                eprintln!(
+                    "{} was successfully installed to `{}`.",
+                    &binary_name,
+                    install_location.display()
+                )
             } else {
                 eprintln!("{} was not installed. To override the existing installation, you can pass the `--force` flag to the installer.", &binary_name);
             }


### PR DESCRIPTION
fixes #212 - windows doesn't need any changes since there aren't really "shell startup scripts", we're just directly modifying the PATH in that case. *nix installers just call the `-c source ~/.rover/env` command and call it a day :)