### PR TITLE
feat: check for available updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.0.2"
+version = "0.0.1"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1581,6 +1581,7 @@ dependencies = [
  "robot-panic",
  "rover-client",
  "rustversion",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",
@@ -1602,6 +1603,7 @@ dependencies = [
  "houston",
  "http",
  "online",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "billboard"
+version = "0.1.0"
+source = "git+https://github.com/EverlastingBugstopper/billboard.git?branch=main#96a9bab4bbdc2f3ae70da62efab965e82c941c52"
+dependencies = [
+ "console 0.9.2",
+ "term_size",
+ "thiserror",
+]
+
+[[package]]
 name = "binstall"
 version = "0.1.0"
 dependencies = [
@@ -258,6 +268,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clicolors-control"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +290,22 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "console"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e0f3986890b3acbc782009e2629dfe2baa430ac091519ce3be26164a2ae6c0"
+dependencies = [
+ "clicolors-control",
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "termios",
+ "unicode-width",
+ "winapi",
 ]
 
 [[package]]
@@ -1557,16 +1595,17 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.0.2"
+version = "0.0.1"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
  "assert_cmd",
  "assert_fs",
  "atty",
+ "billboard",
  "binstall",
  "chrono",
- "console",
+ "console 0.14.0",
  "git-url-parse",
  "git2",
  "heck",
@@ -1947,6 +1986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2012,15 @@ checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1588,6 +1588,7 @@ dependencies = [
  "sputnik",
  "structopt",
  "timber",
+ "toml",
  "tracing",
  "url",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 name = "rover"
-version = "0.0.1"
+version = "0.0.2"
 repository = "https://github.com/apollographql/rover/"
 
 [dependencies]
@@ -35,6 +35,7 @@ tracing = "0.1.22"
 regex = "1"
 url = "2.2.0"
 semver = "0.11"
+toml = "0.5"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 name = "rover"
-version = "0.0.2"
+version = "0.0.1"
 repository = "https://github.com/apollographql/rover/"
 
 [dependencies]
@@ -34,6 +34,7 @@ structopt = "0.3.21"
 tracing = "0.1.22"
 regex = "1"
 url = "2.2.0"
+semver = "0.11"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 name = "rover"
-version = "0.0.2"
+version = "0.0.1"
 repository = "https://github.com/apollographql/rover/"
 
 [dependencies]
@@ -19,6 +19,7 @@ timber = { path = "./crates/timber" }
 anyhow = "1.0.38"
 atty = "0.2.14"
 ansi_term = "0.12.1"
+billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
 chrono = "0.4"
 console = "0.14.0"
 git2 = "0.13.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 name = "rover"
-version = "0.0.1"
+version = "0.0.2"
 repository = "https://github.com/apollographql/rover/"
 
 [dependencies]

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
 chrono = "0.4"
+regex = "1"
 
 [build-dependencies]
 online = "0.2.2"

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -84,4 +84,8 @@ pub enum RoverClientError {
     /// The registry could not find this key
     #[error("The registry did not recognize the provided API key")]
     InvalidKey,
+
+    /// could not parse the latest version
+    #[error("Could not get the latest release version")]
+    UnparseableReleaseVersion,
 }

--- a/crates/rover-client/src/lib.rs
+++ b/crates/rover-client/src/lib.rs
@@ -14,3 +14,6 @@ pub use error::RoverClientError;
 
 /// Module for actually querying studio
 pub mod query;
+
+/// Module for getting release info
+pub mod releases;

--- a/crates/rover-client/src/releases.rs
+++ b/crates/rover-client/src/releases.rs
@@ -1,0 +1,26 @@
+use crate::RoverClientError;
+use regex::Regex;
+use reqwest::blocking;
+
+const LATEST_RELEASE_URL: &str = "https://github.com/apollographql/rover/releases/latest";
+
+/// Looks up the latest release version, and returns it as a string
+pub fn get_latest_release() -> Result<String, RoverClientError> {
+    let res = blocking::Client::new().head(LATEST_RELEASE_URL).send()?;
+
+    let release_url = res.url().to_string();
+    let release_url_parts: Vec<&str> = release_url.split('/').collect();
+
+    match release_url_parts.last() {
+        Some(version) => {
+            // Parse out the semver version (ex. v1.0.0 -> 1.0.0)
+            let re = Regex::new(r"^v[0-9]*\.[0-9]*\.[0-9]*$").unwrap();
+            if re.is_match(version) {
+                Ok(version.to_string().replace('v', ""))
+            } else {
+                Err(RoverClientError::UnparseableReleaseVersion)
+            }
+        }
+        None => Err(RoverClientError::UnparseableReleaseVersion),
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,9 @@ pub enum Command {
     /// Interact with Rover's documentation
     Docs(command::Docs),
 
+    /// Commands related to updating rover
+    Update(command::Update),
+
     /// Installs Rover
     #[structopt(setting(structopt::clap::AppSettings::Hidden))]
     Install(command::Install),
@@ -119,6 +122,7 @@ impl Rover {
             Command::Subgraph(command) => {
                 command.run(self.get_client_config()?, self.get_git_context()?)
             }
+            Command::Update(command) => command.run(),
             Command::Install(command) => command.run(self.get_install_override_path()?),
             Command::Info(command) => command.run(),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use crate::utils::{
     env::{RoverEnv, RoverEnvKey},
     git::GitContext,
     stringify::from_display,
+    version,
 };
 use crate::Result;
 use config::Config;
@@ -111,6 +112,15 @@ pub enum Command {
 
 impl Rover {
     pub fn run(&self) -> Result<RoverStdout> {
+        // before running any commands, we check if rover is up to date
+        // this only happens once a day automatically
+        // we skip this check for the `rover update` commands, since they
+        // do their own checks
+        if let Command::Update(_) = &self.command { /* skip check */
+        } else {
+            version::check_for_update(self.get_rover_config()?, false)?;
+        }
+
         match &self.command {
             Command::Config(command) => {
                 command.run(self.get_rover_config()?, self.get_client_config()?)
@@ -122,7 +132,7 @@ impl Rover {
             Command::Subgraph(command) => {
                 command.run(self.get_client_config()?, self.get_git_context()?)
             }
-            Command::Update(command) => command.run(),
+            Command::Update(command) => command.run(self.get_rover_config()?),
             Command::Install(command) => command.run(self.get_install_override_path()?),
             Command::Info(command) => command.run(),
         }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -5,6 +5,7 @@ mod info;
 mod install;
 mod output;
 mod subgraph;
+mod update;
 
 pub use config::Config;
 pub use docs::Docs;
@@ -13,3 +14,4 @@ pub use info::Info;
 pub use install::Install;
 pub use output::RoverStdout;
 pub use subgraph::Subgraph;
+pub use update::Update;

--- a/src/command/update/check.rs
+++ b/src/command/update/check.rs
@@ -1,0 +1,41 @@
+use ansi_term::Colour::Cyan;
+use serde::Serialize;
+use structopt::StructOpt;
+
+use crate::command::RoverStdout;
+use crate::{Result, PKG_VERSION};
+
+use semver::Version;
+
+use rover_client::releases::get_latest_release;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Check {
+    // TODO: support prerelease check through flag
+}
+
+impl Check {
+    pub fn run(&self) -> Result<RoverStdout> {
+        let latest = get_latest_release()?;
+        let update_available = needs_update(&latest, PKG_VERSION)?;
+
+        if update_available {
+            eprintln!(
+          "There is a newer version of Rover available for download: {} (currently running v{})\n\nFor instructions on how to install the latest version of Rover, see {}", 
+          Cyan.normal().paint(format!("v{}", latest)), 
+          PKG_VERSION,
+          Cyan.normal().paint("https://go.apollo.dev/r/start")
+        );
+        } else {
+            eprintln!("Rover is up to date!");
+        }
+
+        Ok(RoverStdout::None)
+    }
+}
+
+fn needs_update(latest: &str, running: &str) -> Result<bool> {
+    let latest = Version::parse(latest)?;
+    let running = Version::parse(running)?;
+    Ok(latest > running)
+}

--- a/src/command/update/check.rs
+++ b/src/command/update/check.rs
@@ -1,41 +1,19 @@
-use ansi_term::Colour::Cyan;
 use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverStdout;
-use crate::{Result, PKG_VERSION};
+use crate::{utils::version, Result};
 
-use semver::Version;
-
-use rover_client::releases::get_latest_release;
+use houston as config;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Check {
-    // TODO: support prerelease check through flag
+    // future: support prerelease check through flag --prerelease
 }
 
 impl Check {
-    pub fn run(&self) -> Result<RoverStdout> {
-        let latest = get_latest_release()?;
-        let update_available = needs_update(&latest, PKG_VERSION)?;
-
-        if update_available {
-            eprintln!(
-          "There is a newer version of Rover available for download: {} (currently running v{})\n\nFor instructions on how to install the latest version of Rover, see {}", 
-          Cyan.normal().paint(format!("v{}", latest)), 
-          PKG_VERSION,
-          Cyan.normal().paint("https://go.apollo.dev/r/start")
-        );
-        } else {
-            eprintln!("Rover is up to date!");
-        }
-
+    pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
+        version::check_for_update(config, true)?;
         Ok(RoverStdout::None)
     }
-}
-
-fn needs_update(latest: &str, running: &str) -> Result<bool> {
-    let latest = Version::parse(latest)?;
-    let running = Version::parse(running)?;
-    Ok(latest > running)
 }

--- a/src/command/update/mod.rs
+++ b/src/command/update/mod.rs
@@ -1,0 +1,27 @@
+mod check;
+
+use serde::Serialize;
+use structopt::StructOpt;
+
+use crate::command::RoverStdout;
+use crate::Result;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Update {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Serialize, StructOpt)]
+pub enum Command {
+    /// Check to see if rover is up to date
+    Check(check::Check),
+}
+
+impl Update {
+    pub fn run(&self) -> Result<RoverStdout> {
+        match &self.command {
+            Command::Check(command) => command.run(),
+        }
+    }
+}

--- a/src/command/update/mod.rs
+++ b/src/command/update/mod.rs
@@ -6,6 +6,8 @@ use structopt::StructOpt;
 use crate::command::RoverStdout;
 use crate::Result;
 
+use houston as config;
+
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Update {
     #[structopt(subcommand)]
@@ -19,9 +21,9 @@ pub enum Command {
 }
 
 impl Update {
-    pub fn run(&self) -> Result<RoverStdout> {
+    pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
         match &self.command {
-            Command::Check(command) => command.run(),
+            Command::Check(command) => command.run(config),
         }
     }
 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -71,7 +71,9 @@ impl From<&mut anyhow::Error> for Metadata {
                 }
                 RoverClientError::InvalidKey => (Some(Suggestion::CheckKey), None),
                 RoverClientError::MalformedKey => (Some(Suggestion::ProperKey), None),
-                RoverClientError::UnparseableReleaseVersion => (Some(Suggestion::SubmitIssue), None),
+                RoverClientError::UnparseableReleaseVersion => {
+                    (Some(Suggestion::SubmitIssue), None)
+                }
             };
             return Metadata {
                 suggestion,

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -71,7 +71,7 @@ impl From<&mut anyhow::Error> for Metadata {
                 }
                 RoverClientError::InvalidKey => (Some(Suggestion::CheckKey), None),
                 RoverClientError::MalformedKey => (Some(Suggestion::ProperKey), None),
-                RoverClientError::UnparseableReleaseVersion => (None, None),
+                RoverClientError::UnparseableReleaseVersion => (Some(Suggestion::SubmitIssue), None),
             };
             return Metadata {
                 suggestion,

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -71,6 +71,7 @@ impl From<&mut anyhow::Error> for Metadata {
                 }
                 RoverClientError::InvalidKey => (Some(Suggestion::CheckKey), None),
                 RoverClientError::MalformedKey => (Some(Suggestion::ProperKey), None),
+                RoverClientError::UnparseableReleaseVersion => (None, None),
             };
             return Metadata {
                 suggestion,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,3 +6,4 @@ pub mod parsers;
 pub mod pkg;
 pub mod stringify;
 pub mod telemetry;
+pub mod version;

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -1,0 +1,99 @@
+use std::{fs, path::PathBuf, time::SystemTime};
+
+use rover_client::releases::get_latest_release;
+
+use ansi_term::Colour::Cyan;
+use semver::Version;
+
+use crate::{Result, PKG_VERSION};
+
+use houston as config;
+
+const ONE_HOUR: u64 = 60 * 60;
+const ONE_DAY: u64 = ONE_HOUR * 24;
+
+/// check for newer versions of rover.
+///
+/// If this fn is run explicitly from a user-facing command, we pass `force` to
+/// check for newer versions, even if we recently checked for updates.
+///
+/// If `force` is not passed, we check for updates every day at most
+pub fn check_for_update(config: config::Config, force: bool) -> Result<()> {
+    let version_file = config.home.join("version.toml");
+    let current_time = SystemTime::now();
+    // if we don't end up checking, we don't want to overwrite the last checked time
+    let mut checked = false;
+
+    // check fs for last check time
+    let last_checked_time = get_last_checked_time_from_disk(&version_file);
+
+    match last_checked_time {
+        Some(last_checked_time) => {
+            let time_since_check = current_time.duration_since(last_checked_time)?.as_secs();
+            tracing::debug!(
+                "Time since last update check: {:?}h",
+                time_since_check / ONE_HOUR
+            );
+
+            if force || time_since_check > ONE_DAY {
+                do_update_check(&mut checked)?;
+            } else {
+                tracing::debug!(
+                    "No need to check for updates. Automatic checks happen once per day"
+                );
+            }
+        }
+        // we haven't checked for updates before -- check now :)
+        None => {
+            do_update_check(&mut checked)?;
+        }
+    }
+
+    if checked {
+        tracing::debug!("Checked for available updates. Writing current time to disk");
+        fs::write(&version_file, toml::to_string(&current_time)?)?;
+    }
+
+    Ok(())
+}
+
+fn do_update_check(checked: &mut bool) -> Result<()> {
+    let latest = get_latest_release()?;
+    let update_available = is_latest_newer(&latest, PKG_VERSION)?;
+
+    if update_available {
+        eprintln!(
+            "There is a newer version of Rover available for download: {} (currently running v{})\n\nFor instructions on how to install the latest version of Rover, see {}", 
+            Cyan.normal().paint(format!("v{}", latest)), 
+            PKG_VERSION,
+            Cyan.normal().paint("https://go.apollo.dev/r/start")
+        );
+    } else {
+        eprintln!("Rover is up to date!");
+    }
+
+    *checked = true;
+    Ok(())
+}
+
+fn get_last_checked_time_from_disk(version_file: &PathBuf) -> Option<SystemTime> {
+    match fs::read_to_string(&version_file) {
+        Ok(contents) => match toml::from_str(&contents) {
+            Ok(last_checked_version) => Some(last_checked_version),
+            Err(_) => {
+                tracing::debug!("Failed to parse last update check time from version file");
+                None
+            }
+        },
+        Err(_) => {
+            tracing::debug!("Failed to read version file containing last update check time");
+            None
+        }
+    }
+}
+
+fn is_latest_newer(latest: &str, running: &str) -> Result<bool> {
+    let latest = Version::parse(latest)?;
+    let running = Version::parse(running)?;
+    Ok(latest > running)
+}

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -2,8 +2,8 @@ use std::{fs, path::PathBuf, time::SystemTime};
 
 use rover_client::releases::get_latest_release;
 
-use ansi_term::Colour::Yellow;
-use billboard::{Billboard, Alignment};
+use ansi_term::Colour::{Cyan, Yellow};
+use billboard::{Alignment, Billboard};
 use semver::Version;
 
 use crate::{Result, PKG_VERSION};
@@ -68,7 +68,7 @@ fn do_update_check(checked: &mut bool) -> Result<()> {
             Cyan.normal().paint(format!("v{}", latest)), 
             PKG_VERSION,
             Yellow.normal().paint("`rover docs open start`")
-        ); 
+        );
         Billboard::builder()
             .box_alignment(Alignment::Left)
             .build()

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -2,7 +2,7 @@ use std::{fs, path::PathBuf, time::SystemTime};
 
 use rover_client::releases::get_latest_release;
 
-use ansi_term::Colour::Cyan;
+use ansi_term::Colour::Yellow;
 use billboard::{Billboard, Alignment};
 use semver::Version;
 
@@ -64,10 +64,10 @@ fn do_update_check(checked: &mut bool) -> Result<()> {
 
     if update_available {
         let message = format!(
-            "There is a newer version of Rover available: {} (currently running v{})\n\nFor instructions on how to install, see {}", 
+            "There is a newer version of Rover available: {} (currently running v{})\n\nFor instructions on how to install, run {}", 
             Cyan.normal().paint(format!("v{}", latest)), 
             PKG_VERSION,
-            Cyan.normal().paint("https://go.apollo.dev/r/start")
+            Yellow.normal().paint("`rover docs open start`")
         ); 
         Billboard::builder()
             .box_alignment(Alignment::Left)

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf, time::SystemTime};
 use rover_client::releases::get_latest_release;
 
 use ansi_term::Colour::Cyan;
+use billboard::{Billboard, Alignment};
 use semver::Version;
 
 use crate::{Result, PKG_VERSION};
@@ -62,12 +63,16 @@ fn do_update_check(checked: &mut bool) -> Result<()> {
     let update_available = is_latest_newer(&latest, PKG_VERSION)?;
 
     if update_available {
-        eprintln!(
-            "There is a newer version of Rover available for download: {} (currently running v{})\n\nFor instructions on how to install the latest version of Rover, see {}", 
+        let message = format!(
+            "There is a newer version of Rover available: {} (currently running v{})\n\nFor instructions on how to install, see {}", 
             Cyan.normal().paint(format!("v{}", latest)), 
             PKG_VERSION,
             Cyan.normal().paint("https://go.apollo.dev/r/start")
-        );
+        ); 
+        Billboard::builder()
+            .box_alignment(Alignment::Left)
+            .build()
+            .eprint(message);
     } else {
         eprintln!("Rover is up to date!");
     }


### PR DESCRIPTION
Fixes #296 

I added a util `version` module that can be called from the root of the cli (in the `run` fn) or from the `rover update check` command.

I kept the interaction with GitHub and the network requests in `rover-client` even though it's not graphql :) 

Logging was a bit of a weird question, so I used `eprintln` inside the check fn, not inside their calling commands. Happy to hear other recommendations though!