### PR TITLE
feat: enforce all Paths to be valid Unicode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ version = "0.1.0"
 dependencies = [
  "assert_fs",
  "atty",
+ "camino",
  "cc",
  "directories-next",
  "serial_test",
@@ -212,6 +213,12 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "camino"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd065703998b183ed0b348a22555691373a9345a1431141e5778b48bb17e4703"
 
 [[package]]
 name = "cc"
@@ -799,6 +806,7 @@ name = "houston"
 version = "0.0.0"
 dependencies = [
  "assert_fs",
+ "camino",
  "directories-next",
  "regex",
  "serde",
@@ -1585,6 +1593,7 @@ name = "robot-panic"
 version = "1.0.3"
 dependencies = [
  "backtrace",
+ "camino",
  "os_type",
  "serde",
  "termcolor",
@@ -1604,6 +1613,7 @@ dependencies = [
  "atty",
  "billboard",
  "binstall",
+ "camino",
  "chrono",
  "console 0.14.0",
  "git-url-parse",
@@ -1639,6 +1649,7 @@ name = "rover-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "camino",
  "chrono",
  "graphql_client",
  "houston",
@@ -1877,6 +1888,7 @@ name = "sputnik"
 version = "0.0.0"
 dependencies = [
  "assert_fs",
+ "camino",
  "ci_info",
  "reqwest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ timber = { path = "./crates/timber" }
 anyhow = "1.0.38"
 atty = "0.2.14"
 ansi_term = "0.12.1"
+camino = "1.0.2"
 billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
 chrono = "0.4"
 console = "0.14.0"
@@ -52,4 +53,5 @@ members = [".", "crates/*", "installers/binstall"]
 
 [build-dependencies]
 anyhow = "1"
+camino = "1.0"
 which = "4.0.2"

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 
 [dependencies]
+camino = "1.0"
 directories-next = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/crates/houston/src/config.rs
+++ b/crates/houston/src/config.rs
@@ -2,8 +2,8 @@ use directories_next::ProjectDirs;
 
 use crate::HoustonProblem;
 
+use camino::{Utf8Path, Utf8PathBuf};
 use std::fs;
-use std::path::{Path, PathBuf};
 
 /// Config allows end users to override default settings
 /// usually determined by Houston. They are intended to
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct Config {
     /// home is the path to the user's global config directory
-    pub home: PathBuf,
+    pub home: Utf8PathBuf,
 
     /// override_api_key is used for overriding the API key returned
     /// when loading a profile
@@ -22,15 +22,15 @@ pub struct Config {
 impl Config {
     /// Creates a new instance of `Config`
     pub fn new(
-        override_home: Option<&impl AsRef<Path>>,
+        override_home: Option<&impl AsRef<Utf8Path>>,
         override_api_key: Option<String>,
     ) -> Result<Config, HoustonProblem> {
         let home = match override_home {
             Some(home) => {
-                let home_path = PathBuf::from(home.as_ref());
+                let home_path = Utf8PathBuf::from(home.as_ref());
                 if home_path.exists() && !home_path.is_dir() {
                     Err(HoustonProblem::InvalidOverrideConfigDir(
-                        home_path.display().to_string(),
+                        home_path.to_string(),
                     ))
                 } else {
                     Ok(home_path)
@@ -40,17 +40,22 @@ impl Config {
                 // Lin: /home/alice/.config/rover
                 // Win: C:\Users\Alice\AppData\Roaming\Apollo\Rover\config
                 // Mac: /Users/Alice/Library/Application Support/com.Apollo.Rover
-                Ok(ProjectDirs::from("com", "Apollo", "Rover")
+                let project_dirs = ProjectDirs::from("com", "Apollo", "Rover")
                     .ok_or(HoustonProblem::DefaultConfigDirNotFound)?
                     .config_dir()
-                    .to_path_buf())
+                    .to_path_buf();
+
+                Ok(Utf8PathBuf::from_path_buf(project_dirs).map_err(|pb| {
+                    HoustonProblem::PathNotUnicode {
+                        path_display: pb.display().to_string(),
+                    }
+                })?)
             }
         }?;
 
         if !home.exists() {
-            fs::create_dir_all(&home).map_err(|_| {
-                HoustonProblem::CouldNotCreateConfigHome(home.display().to_string())
-            })?;
+            fs::create_dir_all(&home)
+                .map_err(|_| HoustonProblem::CouldNotCreateConfigHome(home.to_string()))?;
         }
 
         Ok(Config {
@@ -63,7 +68,7 @@ impl Config {
     pub fn clear(&self) -> Result<(), HoustonProblem> {
         tracing::debug!(home_dir = ?self.home);
         fs::remove_dir_all(&self.home)
-            .map_err(|_| HoustonProblem::NoConfigFound(self.home.display().to_string()))
+            .map_err(|_| HoustonProblem::NoConfigFound(self.home.to_string()))
     }
 }
 
@@ -71,10 +76,12 @@ impl Config {
 mod tests {
     use super::Config;
     use assert_fs::TempDir;
+    use camino::Utf8PathBuf;
     #[test]
     fn it_can_clear_global_config() {
         let tmp_home = TempDir::new().unwrap();
-        let config = Config::new(Some(&tmp_home.path()), None).unwrap();
+        let tmp_path = Utf8PathBuf::from_path_buf(tmp_home.path().to_path_buf()).unwrap();
+        let config = Config::new(Some(&tmp_path), None).unwrap();
         assert!(config.home.exists());
         config.clear().unwrap();
         assert_eq!(config.home.exists(), false);

--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -21,6 +21,13 @@ pub enum HoustonProblem {
     #[error("Could not find a configuration directory at \"{0}\".")]
     NoConfigFound(String),
 
+    /// PathNotUnicode occurs when Houston encounteres a file path that is not valid UTF-8
+    #[error("File path \"{path_display}\" is not valid Unicode")]
+    PathNotUnicode {
+        /// The display name of the invalid path
+        path_display: String,
+    },
+
     /// ProfileNotFound occurs when a profile with a specified name can't be found.
     #[error("There is no profile named \"{0}\".")]
     ProfileNotFound(String),

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -4,7 +4,7 @@ use crate::{Config, HoustonProblem};
 use sensitive::Sensitive;
 use serde::{Deserialize, Serialize};
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf as PathBuf;
 use std::{fmt, fs, io};
 
 /// Collects configuration related to a profile.

--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -1,7 +1,7 @@
 use crate::{profile::Profile, Config, HoustonProblem};
 use serde::{Deserialize, Serialize};
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf as PathBuf;
 use std::{fmt, fs};
 
 /// Holds sensitive information regarding authentication.

--- a/crates/houston/tests/auth.rs
+++ b/crates/houston/tests/auth.rs
@@ -2,6 +2,7 @@ use config::Config;
 use houston as config;
 
 use assert_fs::TempDir;
+use camino::Utf8Path;
 
 #[test]
 fn it_can_set_and_get_an_api_key_via_creds_file() {
@@ -51,5 +52,6 @@ fn it_can_get_an_api_key_via_env_var() {
 
 fn get_config(override_api_key: Option<String>) -> Config {
     let tmp_home = TempDir::new().unwrap();
-    Config::new(Some(&tmp_home.path()), override_api_key).unwrap()
+    let tmp_home_path = Utf8Path::from_path(tmp_home.path()).unwrap().to_owned();
+    Config::new(Some(&tmp_home_path), override_api_key).unwrap()
 }

--- a/crates/houston/tests/profile.rs
+++ b/crates/houston/tests/profile.rs
@@ -1,4 +1,5 @@
 use assert_fs::TempDir;
+use camino::Utf8Path;
 use config::Config;
 use houston as config;
 
@@ -28,5 +29,6 @@ fn it_lists_many_profiles() {
 
 fn get_config(override_api_key: Option<String>) -> Config {
     let tmp_home = TempDir::new().unwrap();
-    Config::new(Some(&tmp_home.path()), override_api_key).unwrap()
+    let tmp_home_path = Utf8Path::from_path(tmp_home.path()).unwrap().to_owned();
+    Config::new(Some(&tmp_home_path), override_api_key).unwrap()
 }

--- a/crates/robot-panic/Cargo.toml
+++ b/crates/robot-panic/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 backtrace = "0.3"
+camino = "1.0"
 os_type = "2.2"
 serde = "1.0"
 termcolor = "1.1"

--- a/crates/robot-panic/src/lib.rs
+++ b/crates/robot-panic/src/lib.rs
@@ -180,8 +180,7 @@ pub fn print_msg(crash_report: &Report, meta: &Metadata) -> IoResult<()> {
                     "We have generated a report file at \"{}\". Submit an \
                          issue with the subject of \"{} Crash Report\" and include the \
                          report as an attachment.",
-                    path.display(),
-                    name
+                    path, name
                 )?;
             }
             Err(_) => {

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -12,6 +12,7 @@ houston = { path = "../houston" }
 
 # crates.io deps
 anyhow = "1"
+camino = "1"
 graphql_client = "0.9"
 http = "0.2"
 reqwest = { version = "0.11", features = ["json", "blocking", "native-tls-vendored"] }
@@ -23,6 +24,7 @@ chrono = "0.4"
 regex = "1"
 
 [build-dependencies]
+camino = "1"
 online = "0.2.2"
 reqwest = { version = "0.11", features = ["blocking", "native-tls-vendored"] }
 uuid = { version = "0.8", features = ["v4"] }

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs::{self, read, write};
-use std::path::PathBuf;
 
+use camino::Utf8PathBuf as PathBuf;
 use reqwest::blocking::Client;
 use uuid::Uuid;
 

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 
 [dependencies]
+camino = "1.0"
 ci_info = { version = "0.14", features = ["serde-1"] }
 reqwest = { version = "0.11", features = ["blocking"] }
 semver = { version = "0.11", features = ["serde"] }

--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -1,9 +1,9 @@
 use url::Url;
 use uuid::Uuid;
 
+use camino::{Utf8Path, Utf8PathBuf};
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::{Path, PathBuf};
 
 use crate::{Command, SputnikError};
 
@@ -34,7 +34,7 @@ pub trait Report {
 
     /// returns the location the tool stores a globally persistent
     /// machine identifier
-    fn machine_id_config(&self) -> Result<PathBuf, SputnikError>;
+    fn machine_id_config(&self) -> Result<Utf8PathBuf, SputnikError>;
 
     /// returns the globally persistent machine identifier
     /// and writes it if it does not exist
@@ -46,8 +46,8 @@ pub trait Report {
     }
 }
 
-fn get_or_write_machine_id(path: &PathBuf) -> Result<Uuid, SputnikError> {
-    if Path::exists(path) {
+fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
+    if Utf8Path::exists(path) {
         if let Ok(contents) = fs::read_to_string(path) {
             if let Ok(machine_uuid) = Uuid::parse_str(&contents) {
                 return Ok(machine_uuid);
@@ -58,7 +58,7 @@ fn get_or_write_machine_id(path: &PathBuf) -> Result<Uuid, SputnikError> {
     write_machine_id(path)
 }
 
-fn write_machine_id(path: &PathBuf) -> Result<Uuid, SputnikError> {
+fn write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
     let machine_id = Uuid::new_v4();
     let mut file = File::create(path)?;
     file.write_all(machine_id.to_string().as_bytes())?;
@@ -70,6 +70,7 @@ mod tests {
     use super::{get_or_write_machine_id, write_machine_id};
 
     use assert_fs::prelude::*;
+    use camino::Utf8PathBuf;
 
     /// if a machine ID hasn't been written already, one will be created
     /// and saved.
@@ -77,7 +78,7 @@ mod tests {
     fn it_can_write_machine_id() {
         let fixture = assert_fs::TempDir::new().unwrap();
         let test_file = fixture.child("test_write_machine_id.txt");
-        let test_path = test_file.path().to_path_buf();
+        let test_path = Utf8PathBuf::from_path_buf(test_file.path().to_path_buf()).unwrap();
         assert!(write_machine_id(&test_path).is_ok());
     }
 
@@ -87,7 +88,7 @@ mod tests {
     fn it_can_read_machine_id() {
         let fixture = assert_fs::TempDir::new().unwrap();
         let test_file = fixture.child("test_read_machine_id.txt");
-        let test_path = test_file.path().to_path_buf();
+        let test_path = Utf8PathBuf::from_path_buf(test_file.path().to_path_buf()).unwrap();
         let written_uuid = write_machine_id(&test_path).expect("could not write machine id");
         let read_uuid = get_or_write_machine_id(&test_path).expect("could not read machine id");
         assert_eq!(written_uuid, read_uuid);
@@ -100,7 +101,7 @@ mod tests {
     fn it_can_read_and_write_machine_id() {
         let fixture = assert_fs::TempDir::new().unwrap();
         let test_file = fixture.child("test_read_and_write_machine_id.txt");
-        let test_path = test_file.path().to_path_buf();
+        let test_path = Utf8PathBuf::from_path_buf(test_file.path().to_path_buf()).unwrap();
         assert!(get_or_write_machine_id(&test_path).is_ok());
     }
 }

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 atty = "0.2"
+camino = "1.0"
 directories-next = "2.0"
 thiserror = "1.0"
 tracing = "0.1"

--- a/installers/binstall/src/error.rs
+++ b/installers/binstall/src/error.rs
@@ -17,6 +17,6 @@ pub enum InstallerError {
     #[error("Zsh setup failed")]
     ZshSetup,
 
-    #[error("Computed install path is not valid Unicode")]
-    PathNotUnicode,
+    #[error("File path \"{path_display}\" is not valid Unicode")]
+    PathNotUnicode { path_display: String },
 }

--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -3,25 +3,25 @@ use crate::InstallerError;
 use std::env;
 use std::fs;
 use std::io;
-use std::path::PathBuf;
 
 use atty::{self, Stream};
+use camino::Utf8PathBuf;
 
 pub struct Installer {
     pub binary_name: String,
     pub force_install: bool,
-    pub executable_location: PathBuf,
-    pub override_install_path: Option<PathBuf>,
+    pub executable_location: Utf8PathBuf,
+    pub override_install_path: Option<Utf8PathBuf>,
 }
 
 impl Installer {
-    pub fn install(&self) -> Result<Option<PathBuf>, InstallerError> {
+    pub fn install(&self) -> Result<Option<Utf8PathBuf>, InstallerError> {
         let install_path = self.do_install()?;
 
         Ok(install_path)
     }
 
-    fn do_install(&self) -> Result<Option<PathBuf>, InstallerError> {
+    fn do_install(&self) -> Result<Option<Utf8PathBuf>, InstallerError> {
         let bin_destination = self.get_bin_path()?;
 
         if !self.force_install
@@ -34,7 +34,7 @@ impl Installer {
         tracing::debug!("Creating directory for binary");
         self.create_bin_dir()?;
 
-        eprintln!("Writing binary to {}", &bin_destination.display());
+        eprintln!("Writing binary to {}", &bin_destination);
         self.write_bin_to_fs()?;
 
         tracing::debug!("Adding binary to PATH");
@@ -43,7 +43,7 @@ impl Installer {
         Ok(Some(bin_destination))
     }
 
-    pub(crate) fn get_base_dir_path(&self) -> Result<PathBuf, InstallerError> {
+    pub(crate) fn get_base_dir_path(&self) -> Result<Utf8PathBuf, InstallerError> {
         let base_dir = if let Some(base_dir) = &self.override_install_path {
             Ok(base_dir.to_owned())
         } else {
@@ -52,7 +52,7 @@ impl Installer {
         Ok(base_dir.join(&format!(".{}", &self.binary_name)))
     }
 
-    pub(crate) fn get_bin_dir_path(&self) -> Result<PathBuf, InstallerError> {
+    pub(crate) fn get_bin_dir_path(&self) -> Result<Utf8PathBuf, InstallerError> {
         let bin_dir = self.get_base_dir_path()?.join("bin");
         Ok(bin_dir)
     }
@@ -62,7 +62,7 @@ impl Installer {
         Ok(())
     }
 
-    fn get_bin_path(&self) -> Result<PathBuf, InstallerError> {
+    fn get_bin_path(&self) -> Result<Utf8PathBuf, InstallerError> {
         Ok(self
             .get_bin_dir_path()?
             .join(&self.binary_name)
@@ -71,13 +71,13 @@ impl Installer {
 
     fn write_bin_to_fs(&self) -> Result<(), InstallerError> {
         let bin_path = self.get_bin_path()?;
-        tracing::debug!("copying from: {}", &self.executable_location.display());
-        tracing::debug!("copying to: {}", &bin_path.display());
+        tracing::debug!("copying from: {}", &self.executable_location);
+        tracing::debug!("copying to: {}", &bin_path);
         fs::copy(&self.executable_location, &bin_path)?;
         Ok(())
     }
 
-    fn should_overwrite(&self, destination: &PathBuf) -> Result<bool, InstallerError> {
+    fn should_overwrite(&self, destination: &Utf8PathBuf) -> Result<bool, InstallerError> {
         // If we're not attached to a TTY then we can't get user input, so there's
         // nothing to do except inform the user about the `-f` flag.
         if !atty::is(Stream::Stdin) {
@@ -88,8 +88,7 @@ impl Installer {
         // like to overwrite the previous installation.
         eprintln!(
             "existing {} installation found at `{}`",
-            &self.binary_name,
-            destination.display()
+            &self.binary_name, destination
         );
         eprintln!("Would you like to overwrite this file? [y/N]: ");
         let mut line = String::new();

--- a/installers/binstall/src/lib.rs
+++ b/installers/binstall/src/lib.rs
@@ -50,10 +50,16 @@ pub(crate) fn get_home_dir_path() -> Result<Utf8PathBuf, InstallerError> {
 
 #[cfg(test)]
 mod tests {
-    use super::Installer;
-    use assert_fs::TempDir;
+    #[cfg(not(windows))]
     use serial_test::serial;
 
+    #[cfg(not(windows))]
+    use super::Installer;
+
+    #[cfg(not(windows))]
+    use assert_fs::TempDir;
+
+    #[cfg(not(windows))]
     use camino::Utf8PathBuf;
 
     #[cfg(not(windows))]

--- a/installers/binstall/src/system/windows.rs
+++ b/installers/binstall/src/system/windows.rs
@@ -7,11 +7,7 @@ use std::io;
 /// Adds the downloaded binary in Installer to a Windows PATH
 pub fn add_binary_to_path(installer: &Installer) -> Result<(), InstallerError> {
     let windows_path = get_windows_path_var()?;
-    let bin_path = installer
-        .get_bin_dir_path()?
-        .to_str()
-        .ok_or(InstallerError::PathNotUnicode)?
-        .to_string();
+    let bin_path = installer.get_bin_dir_path()?.to_string();
     if let Some(old_path) = windows_path {
         if let Some(new_path) = add_to_path(&old_path, &bin_path) {
             apply_new_path(&new_path)?;

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -101,9 +101,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
       "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
-      "dependencies": {
-        "wcwidth": ">=1.0.1"
-      },
       "optionalDependencies": {
         "wcwidth": ">=1.0.1"
       }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use config::Config;
 use houston as config;
 use timber::{Level, LEVELS};
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 #[derive(Debug, Serialize, StructOpt)]
 #[structopt(name = "Rover", global_settings = &[structopt::clap::AppSettings::ColoredHelp], about = "
@@ -55,10 +55,10 @@ pub struct Rover {
 
 impl Rover {
     pub(crate) fn get_rover_config(&self) -> Result<Config> {
-        let override_home: Option<PathBuf> = self
+        let override_home: Option<Utf8PathBuf> = self
             .env_store
             .get(RoverEnvKey::ConfigHome)?
-            .map(|p| PathBuf::from(&p));
+            .map(|p| Utf8PathBuf::from(&p));
         let override_api_key = self.env_store.get(RoverEnvKey::Key)?;
         Ok(Config::new(override_home.as_ref(), override_api_key)?)
     }
@@ -69,11 +69,11 @@ impl Rover {
         Ok(StudioClientConfig::new(override_endpoint, config))
     }
 
-    pub(crate) fn get_install_override_path(&self) -> Result<Option<PathBuf>> {
+    pub(crate) fn get_install_override_path(&self) -> Result<Option<Utf8PathBuf>> {
         Ok(self
             .env_store
             .get(RoverEnvKey::Home)?
-            .map(|p| PathBuf::from(&p)))
+            .map(|p| Utf8PathBuf::from(&p)))
     }
 
     pub(crate) fn get_git_context(&self) -> Result<GitContext> {

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -62,6 +62,7 @@ fn is_valid(api_key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use assert_fs::TempDir;
+    use camino::Utf8Path;
     use serial_test::serial;
 
     use houston::{Config, Profile};
@@ -98,6 +99,7 @@ mod tests {
 
     fn get_config(override_api_key: Option<String>) -> Config {
         let tmp_home = TempDir::new().unwrap();
-        Config::new(Some(&tmp_home.path()), override_api_key).unwrap()
+        let tmp_home_path = Utf8Path::from_path(tmp_home.path()).unwrap().to_owned();
+        Config::new(Some(&tmp_home_path), override_api_key).unwrap()
     }
 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -106,6 +106,7 @@ impl From<&mut anyhow::Error> for Metadata {
                 HoustonProblem::NoConfigProfiles => (Some(Suggestion::NewUserNoProfiles), None),
                 HoustonProblem::ProfileNotFound(_) => (Some(Suggestion::ListProfiles), None),
                 HoustonProblem::NoNonSensitiveConfigFound(_)
+                | HoustonProblem::PathNotUnicode { path_display: _ }
                 | HoustonProblem::TomlDeserialization(_)
                 | HoustonProblem::TomlSerialization(_)
                 | HoustonProblem::IOError(_) => (Some(Suggestion::SubmitIssue), None),

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -1,13 +1,15 @@
+use camino::Utf8PathBuf;
 use regex::Regex;
 use serde::Serialize;
-use std::{convert::TryInto, fmt, path::PathBuf};
+
+use std::{convert::TryInto, fmt};
 
 use crate::{error::RoverError, Result};
 
 #[derive(Debug, PartialEq)]
 pub enum SchemaSource {
     Stdin,
-    File(PathBuf),
+    File(Utf8PathBuf),
 }
 
 pub fn parse_schema_source(loc: &str) -> Result<SchemaSource> {
@@ -18,7 +20,7 @@ pub fn parse_schema_source(loc: &str) -> Result<SchemaSource> {
             "The path provided to find a schema is empty",
         ))
     } else {
-        let path = PathBuf::from(loc);
+        let path = Utf8PathBuf::from(loc);
         Ok(SchemaSource::File(path))
     }
 }
@@ -137,7 +139,7 @@ mod tests {
         let loc = parse_schema_source("./schema.graphql").unwrap();
         match loc {
             SchemaSource::File(buf) => {
-                assert_eq!(buf.to_str().unwrap(), "./schema.graphql");
+                assert_eq!(buf.to_string(), "./schema.graphql".to_string());
             }
             _ => panic!("parsed incorrectly as stdin"),
         }

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -1,6 +1,5 @@
+use camino::Utf8PathBuf;
 use url::Url;
-
-use std::path::PathBuf;
 
 use crate::utils::env::RoverEnvKey;
 use crate::{cli::Rover, PKG_NAME, PKG_VERSION};
@@ -103,7 +102,7 @@ impl Report for Rover {
         PKG_VERSION.to_string()
     }
 
-    fn machine_id_config(&self) -> Result<PathBuf, SputnikError> {
+    fn machine_id_config(&self) -> Result<Utf8PathBuf, SputnikError> {
         let config = self
             .get_rover_config()
             .map_err(|_| SputnikError::ConfigError)?;

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -1,14 +1,13 @@
-use std::{fs, path::PathBuf, time::SystemTime};
-
-use rover_client::releases::get_latest_release;
+use std::{fs, time::SystemTime};
 
 use ansi_term::Colour::{Cyan, Yellow};
 use billboard::{Alignment, Billboard};
+use camino::Utf8PathBuf;
 use semver::Version;
 
 use crate::{Result, PKG_VERSION};
-
 use houston as config;
+use rover_client::releases::get_latest_release;
 
 const ONE_HOUR: u64 = 60 * 60;
 const ONE_DAY: u64 = ONE_HOUR * 24;
@@ -81,7 +80,7 @@ fn do_update_check(checked: &mut bool) -> Result<()> {
     Ok(())
 }
 
-fn get_last_checked_time_from_disk(version_file: &PathBuf) -> Option<SystemTime> {
+fn get_last_checked_time_from_disk(version_file: &Utf8PathBuf) -> Option<SystemTime> {
     match fs::read_to_string(&version_file) {
         Ok(contents) => match toml::from_str(&contents) {
             Ok(last_checked_version) => Some(last_checked_version),

--- a/tests/config/profile.rs
+++ b/tests/config/profile.rs
@@ -1,7 +1,7 @@
 use assert_cmd::Command;
 use assert_fs::TempDir;
+use camino::Utf8PathBuf;
 use predicates::prelude::*;
-use std::path::PathBuf;
 
 use houston::{Config, Profile};
 use rover::utils::env::RoverEnvKey;
@@ -15,10 +15,7 @@ fn it_can_list_no_profiles() {
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd
         .arg("config")
-        .env(
-            RoverEnvKey::ConfigHome.to_string(),
-            temp_dir.to_string_lossy().to_string(),
-        )
+        .env(RoverEnvKey::ConfigHome.to_string(), temp_dir.to_string())
         .arg("list")
         .assert();
     result.stderr(predicate::str::contains("No profiles"));
@@ -32,16 +29,13 @@ fn it_can_list_one_profile() {
 
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd
-        .env(
-            RoverEnvKey::ConfigHome.to_string(),
-            temp_dir.to_string_lossy().to_string(),
-        )
+        .env(RoverEnvKey::ConfigHome.to_string(), temp_dir.to_string())
         .arg("config")
         .arg("list")
         .assert();
     result.stdout(predicate::str::contains(CUSTOM_PROFILE));
 }
 
-fn get_temp_dir() -> PathBuf {
-    TempDir::new().unwrap().path().to_path_buf()
+fn get_temp_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(TempDir::new().unwrap().path().to_path_buf()).unwrap()
 }

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -1,7 +1,7 @@
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 
+use camino::Utf8PathBuf;
 use serde_json::Value;
 
 // The behavior of these tests _must_ remain unchanged
@@ -27,7 +27,7 @@ fn it_has_windows_installer() {
     assert!(!windows_script.is_empty())
 }
 
-fn get_binstall_scripts_root() -> PathBuf {
+fn get_binstall_scripts_root() -> Utf8PathBuf {
     let cargo_locate_project_output = Command::new("cargo")
         .arg("locate-project")
         .output()
@@ -41,7 +41,7 @@ fn get_binstall_scripts_root() -> PathBuf {
         .as_str()
         .expect("`root` either does not exist or is not a String");
 
-    let root_directory = PathBuf::from(cargo_toml_location)
+    let root_directory = Utf8PathBuf::from(cargo_toml_location)
         .parent()
         .expect("Could not find parent of `Cargo.toml`")
         .to_path_buf();


### PR DESCRIPTION
This PR introduces the `camino` dependency across the codebase, ensuring that all Paths are valid UTF-8, making them much easier to work with, and be confident that invalid UTF-8 will not muck up our plans.

---

It does change the API surface of quite a few of our subcrates, which maybe we don't want to do! I'm open to hearing that this is not something we should be doing, but it feels valuable to me to be confident when doing IO.

--- 

I've opened [this issue](https://github.com/withoutboats/camino/issues/6) to see if we can't get a nice `try_from` that returns a real error instead of the `from_path_buf` combined with `map_err` we're currently using.