### PR TITLE
feat(POC): output table in terminal, csv if redirected

### DIFF
--- a/out.csv
+++ b/out.csv
@@ -1,0 +1,3 @@
+Name, Routing Url, Last Updated
+people, https://people.my-app.com, 2021-02-26 12:17:49 -06:00
+films, https://films.my-app.com, 2021-02-26 12:16:26 -06:00


### PR DESCRIPTION
This PR is a proof of concept for some more context aware tables. If folks are running `subgraph list` right in their terminal it makes a lot of sense to show a nicely formatted table:

```console
$ rover subgraph list averys-federated-graph
Listing subgraphs for averys-federated-graph@current using credentials from the default profile.
┌────────┬───────────────────────────┬────────────────────────────┐
│  Name  │        Routing Url        │        Last Updated        │
├────────┼───────────────────────────┼────────────────────────────┤
│ people │ https://people.my-app.com │ 2021-02-26 12:17:49 -06:00 │
├────────┼───────────────────────────┼────────────────────────────┤
│ films  │ https://films.my-app.com  │ 2021-02-26 12:16:26 -06:00 │
└────────┴───────────────────────────┴────────────────────────────┘

View full details at https://studio.apollographql.com/graph/averys-federated-graph/service-list
```

When redirecting to a file, it would be nice to have it in a csv format so folks can interact with it in excel or other tools that can operate on CSV if they so choose - it's much more machine readable than the pretty table we currently print.

```console
$ rover subgraph list averys-federated-graph > averys-federated-subgraphs.csv
Listing subgraphs for averys-federated-graph@current using credentials from the default profile.
View full details at https://studio.apollographql.com/graph/averys-federated-graph/service-list
```

I've included the CSV in the commit here since it's a proof of concept, but I'll paste it here again:

```csv
Name, Routing Url, Last Updated
people, https://people.my-app.com, 2021-02-26 12:17:49 -06:00
films, https://films.my-app.com, 2021-02-26 12:16:26 -06:00
```

---

This is just a proof of concept but if we like it I think we should do this for all of our commands that output info in tabular form.