### PR TITLE
fix: output composition errors to stderr

### DIFF
--- a/installers/binstall/src/system/windows.rs
+++ b/installers/binstall/src/system/windows.rs
@@ -38,7 +38,7 @@ fn get_windows_path_var() -> Result<Option<String>, InstallerError> {
             if let Some(s) = string_from_winreg_value(&val) {
                 Ok(Some(s))
             } else {
-                tracing::warn!("the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. \
+                eprintln!("warn: the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. \
                        Not modifying the PATH variable");
                 Ok(None)
             }

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -1,3 +1,4 @@
+use ansi_term::Colour::Red;
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -159,7 +160,7 @@ fn handle_composition_errors(
     let mut num_failures = 0;
     for error in composition_errors {
         num_failures += 1;
-        tracing::error!("{}", &error.message);
+        eprintln!("{} {}", Red.bold().paint("error:"), &error.message);
     }
     match num_failures {
         0 => Ok(RoverStdout::None),


### PR DESCRIPTION
somehow in #263 i missed this instance of `tracing::error` which meant composition errors are only showing up if you turn on `-l debug`. i'm.. honestly surprised nobody has said anything about this. we should probably do a patch release to get this fix out there.