### PR TITLE
integration test for installer? maybe?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "binstall",
  "camino",
  "chrono",
+ "ci_info",
  "console 0.14.0",
  "git-url-parse",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,12 @@ toml = "0.5"
 [dev-dependencies]
 assert_cmd = "1.0.1"
 assert_fs = "1.0.0"
+ci_info = "0.14"
+predicates = "1.0.5"
 reqwest = "0.11.1"
 rustversion = "1.0.4"
 serial_test = "0.5.0"
-predicates = "1.0.5"
+which = "4.0.2"
 
 [workspace]
 members = [".", "crates/*", "installers/binstall"]

--- a/docs/source/configuring.md
+++ b/docs/source/configuring.md
@@ -92,6 +92,7 @@ If present, an environment variable's value takes precedence over all other meth
 
 | Name                        | Value          |
 |-----------------------------|----------------|
+| `APOLLO_HOME` | The base path where Rover's binary is stored. The default value is `$HOME/.rover`. |
 | `APOLLO_CONFIG_HOME` | The path where Rover's configuration is stored. The default value is your operating system's default configuration directory. |
 | `APOLLO_KEY` | The API key that Rover should use to authenticate with Apollo Studio. |
 | `APOLLO_TELEMETRY_DISABLED` | Set to `1` if you don't want Rover to collect anonymous usage data. |

--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -35,7 +35,7 @@ impl Install {
                 eprintln!(
                     "{} was successfully installed to `{}`.",
                     &binary_name, install_location
-                )
+                );
             } else {
                 eprintln!("{} was not installed. To override the existing installation, you can pass the `--force` flag to the installer.", &binary_name);
             }

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -1,8 +1,10 @@
-use std::fs;
-use std::process::Command;
+use std::{env, fs, process::Command};
 
+use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 use serde_json::Value;
+
+use rover::utils::env::RoverEnvKey;
 
 // The behavior of these tests _must_ remain unchanged
 // should we want our installer scripts to remain stable.
@@ -50,4 +52,30 @@ fn get_binstall_scripts_root() -> Utf8PathBuf {
         .join("installers")
         .join("binstall")
         .join("scripts")
+}
+
+#[test]
+fn it_can_install() {
+    // this test only runs in CI because we don't want to muck up people's profiles
+    // if they run tests. Eventually we should run this locally as well, we'll
+    // just need to make sure that we can also _uninstall_ properly and revert
+    // folks' profile scripts to the way they were before they installed Rover.
+    if ci_info::is_ci() {
+        let tmp_home = TempDir::new().unwrap();
+        let tmp_path = Utf8PathBuf::from_path_buf(tmp_home.path().to_path_buf()).unwrap();
+        env::set_var(RoverEnvKey::Home.to_string(), tmp_path.to_string());
+        let install_output = Command::new("cargo")
+            .arg("run")
+            .arg("--")
+            .arg("install")
+            .arg("--force")
+            .output()
+            .expect("Could not run `cargo run -- install`");
+        if !install_output.status.success() {
+            panic!("`cargo run -- install` failed.");
+        } else {
+            which::which("rover").expect("Could not find `rover`.");
+        }
+        env::remove_var(RoverEnvKey::Home.to_string());
+    }
 }


### PR DESCRIPTION
i've added an integration test for our installer that should _maybe_ work in CI? not sure really... I don't want to run it locally because it would totally muck up any dev machine that has installs of rover. once we have an uninstall command that can clean up after itself we should be able to run this test locally.

i'm interested to see if github actions will even like this test given it needs stuff in `GITHUB_ENV` or whatever that magic env variable is.

also added docs for the `APOLLO_HOME` env var - though I can't seem to build docs locally at the moment.