### PR TITLE
push -> publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ rover graph fetch test@cats
 rover graph check --schema=./path-to-valid-sdl test@cats
 ```
 
-1. Push your local graph to Apollo Studio.
+1. Publish your local graph to Apollo Studio.
 
 ```bash
-rover graph push --schema ./path-to-valid-schema test@cats
+rover graph publish --schema ./path-to-valid-schema test@cats
 ```
 
 
@@ -58,7 +58,7 @@ The most common commands from there are:
     - rover graph fetch: Fetch a graph schema from the Apollo graph registry
     - rover graph check: Check for breaking changes in a local graph schema against a graph schema in the Apollo graph
 registry
-    - rover graph push: Push an updated graph schema to the Apollo graph registry
+    - rover graph publish: Publish an updated graph schema to the Apollo graph registry
 
 You can open the full documentation for Rover by running:
 

--- a/crates/rover-client/src/query/graph/check.rs
+++ b/crates/rover-client/src/query/graph/check.rs
@@ -20,7 +20,7 @@ type Timestamp = String;
 pub struct CheckSchemaQuery;
 
 /// The main function to be used from this module.
-/// This function takes a proposed schema and validates it against a pushed
+/// This function takes a proposed schema and validates it against a published
 /// schema.
 pub fn run(
     variables: check_schema_query::Variables,

--- a/crates/rover-client/src/query/graph/mod.rs
+++ b/crates/rover-client/src/query/graph/mod.rs
@@ -1,8 +1,8 @@
 /// "graph fetch" command execution
 pub mod fetch;
 
-/// "graph push" command execution
-pub mod push;
+/// "graph publish" command execution
+pub mod publish;
 
 /// "graph check" command exeuction
 pub mod check;

--- a/crates/rover-client/src/query/graph/publish.graphql
+++ b/crates/rover-client/src/query/graph/publish.graphql
@@ -1,4 +1,4 @@
-mutation PushSchemaMutation(
+mutation PublishSchemaMutation(
   $variant: String!
   $graphId: ID!
   $schemaDocument: String

--- a/crates/rover-client/src/query/graph/publish.rs
+++ b/crates/rover-client/src/query/graph/publish.rs
@@ -6,7 +6,7 @@ use graphql_client::*;
 // The paths are relative to the directory where your `Cargo.toml` is located.
 // Both json and the GraphQL schema language are supported as sources for the schema
 #[graphql(
-    query_path = "src/query/graph/push.graphql",
+    query_path = "src/query/graph/publish.graphql",
     schema_path = ".schema/schema.graphql",
     response_derives = "PartialEq, Debug, Serialize, Deserialize",
     deprecated = "warn"
@@ -14,10 +14,10 @@ use graphql_client::*;
 /// This struct is used to generate the module containing `Variables` and
 /// `ResponseData` structs.
 /// Snake case of this name is the mod name. i.e. stash_schema_query
-pub struct PushSchemaMutation;
+pub struct PublishSchemaMutation;
 
 #[derive(Debug, PartialEq)]
-pub struct PushResponse {
+pub struct PublishResponse {
     pub schema_hash: String,
     pub change_summary: String,
 }
@@ -25,19 +25,19 @@ pub struct PushResponse {
 /// Returns a message from apollo studio about the status of the update, and
 /// a sha256 hash of the schema to be used with `schema publish`
 pub fn run(
-    variables: push_schema_mutation::Variables,
+    variables: publish_schema_mutation::Variables,
     client: &StudioClient,
-) -> Result<PushResponse, RoverClientError> {
+) -> Result<PublishResponse, RoverClientError> {
     let graph = variables.graph_id.clone();
-    let data = client.post::<PushSchemaMutation>(variables)?;
-    let push_response = get_push_response_from_data(data, graph)?;
-    build_response(push_response)
+    let data = client.post::<PublishSchemaMutation>(variables)?;
+    let publish_response = get_publish_response_from_data(data, graph)?;
+    build_response(publish_response)
 }
 
-fn get_push_response_from_data(
-    data: push_schema_mutation::ResponseData,
+fn get_publish_response_from_data(
+    data: publish_schema_mutation::ResponseData,
     graph: String,
-) -> Result<push_schema_mutation::PushSchemaMutationServiceUploadSchema, RoverClientError> {
+) -> Result<publish_schema_mutation::PublishSchemaMutationServiceUploadSchema, RoverClientError> {
     // then, from the response data, get .service?.upload_schema?
     let service_data = match data.service {
         Some(data) => data,
@@ -54,43 +54,43 @@ fn get_push_response_from_data(
 }
 
 fn build_response(
-    push_response: push_schema_mutation::PushSchemaMutationServiceUploadSchema,
-) -> Result<PushResponse, RoverClientError> {
-    if !push_response.success {
-        let msg = format!("Schema upload failed with error: {}", push_response.message);
+    publish_response: publish_schema_mutation::PublishSchemaMutationServiceUploadSchema,
+) -> Result<PublishResponse, RoverClientError> {
+    if !publish_response.success {
+        let msg = format!("Schema upload failed with error: {}", publish_response.message);
         return Err(RoverClientError::AdhocError { msg });
     }
 
-    let hash = match &push_response.tag {
+    let hash = match &publish_response.tag {
         // we only want to print the first 6 chars of a hash
         Some(tag_data) => tag_data.schema.hash.clone()[..6].to_string(),
         None => {
             let msg = format!(
-                "No data in response from schema push. Failed with message: {}",
-                push_response.message
+                "No data in response from schema publish. Failed with message: {}",
+                publish_response.message
             );
             return Err(RoverClientError::AdhocError { msg });
         }
     };
 
-    // If you push the exact same schema as is currently published,
+    // If you publish the exact same schema as is currently published,
     // the response CODE is NO_CHANGES but under the result diff,
-    // it gives you the diff for that hash (i.e., the first time it was pushed)
+    // it gives you the diff for that hash (i.e., the first time it was published)
     // which very well may have changes. For this, we'll just look at the code
     // first and handle the response as if there was `None` for the diff
-    let change_summary = if push_response.code == "NO_CHANGES" {
+    let change_summary = if publish_response.code == "NO_CHANGES" {
         build_change_summary(None)
     } else {
-        build_change_summary(push_response.tag.unwrap().diff_to_previous)
+        build_change_summary(publish_response.tag.unwrap().diff_to_previous)
     };
 
-    Ok(PushResponse {
+    Ok(PublishResponse {
         schema_hash: hash,
         change_summary,
     })
 }
 
-type ChangeDiff = push_schema_mutation::PushSchemaMutationServiceUploadSchemaTagDiffToPrevious;
+type ChangeDiff = publish_schema_mutation::PublishSchemaMutationServiceUploadSchemaTagDiffToPrevious;
 
 /// builds a string-representation of the diff between two schemas
 /// e.g. ` [Fields: +2 -1 △0, Types: +4 -0 △7]` or `[No Changes]`
@@ -118,12 +118,12 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn get_push_response_from_data_gets_data() {
+    fn get_publish_response_from_data_gets_data() {
         let json_response = json!({
             "service": {
                 "uploadSchema": {
                     "code": "IT_WERK",
-                    "message": "it really do be pushed",
+                    "message": "it really do be published",
                     "success": true,
                     "tag": {
                         "variant": { "name": "current" },
@@ -132,25 +132,25 @@ mod tests {
                 }
             }
         });
-        let data: push_schema_mutation::ResponseData =
+        let data: publish_schema_mutation::ResponseData =
             serde_json::from_value(json_response).unwrap();
-        let output = get_push_response_from_data(data, "mygraph".to_string());
+        let output = get_publish_response_from_data(data, "mygraph".to_string());
 
         assert!(output.is_ok());
         assert_eq!(
             output.unwrap(),
-            push_schema_mutation::PushSchemaMutationServiceUploadSchema {
+            publish_schema_mutation::PublishSchemaMutationServiceUploadSchema {
                 code: "IT_WERK".to_string(),
-                message: "it really do be pushed".to_string(),
+                message: "it really do be published".to_string(),
                 success: true,
                 tag: Some(
-                    push_schema_mutation::PushSchemaMutationServiceUploadSchemaTag {
+                    publish_schema_mutation::PublishSchemaMutationServiceUploadSchemaTag {
                         variant:
-                            push_schema_mutation::PushSchemaMutationServiceUploadSchemaTagVariant {
+                            publish_schema_mutation::PublishSchemaMutationServiceUploadSchemaTagVariant {
                                 name: "current".to_string()
                             },
                         schema:
-                            push_schema_mutation::PushSchemaMutationServiceUploadSchemaTagSchema {
+                            publish_schema_mutation::PublishSchemaMutationServiceUploadSchemaTagSchema {
                                 hash: "123456".to_string()
                             },
                         diff_to_previous: None,
@@ -161,25 +161,25 @@ mod tests {
     }
 
     #[test]
-    fn get_push_response_from_data_errs_with_no_service() {
+    fn get_publish_response_from_data_errs_with_no_service() {
         let json_response = json!({ "service": null });
-        let data: push_schema_mutation::ResponseData =
+        let data: publish_schema_mutation::ResponseData =
             serde_json::from_value(json_response).unwrap();
-        let output = get_push_response_from_data(data, "mygraph".to_string());
+        let output = get_publish_response_from_data(data, "mygraph".to_string());
 
         assert!(output.is_err());
     }
 
     #[test]
-    fn get_push_response_from_data_errs_with_no_upload_response() {
+    fn get_publish_response_from_data_errs_with_no_upload_response() {
         let json_response = json!({
             "service": {
                 "uploadSchema": null
             }
         });
-        let data: push_schema_mutation::ResponseData =
+        let data: publish_schema_mutation::ResponseData =
             serde_json::from_value(json_response).unwrap();
-        let output = get_push_response_from_data(data, "mygraph".to_string());
+        let output = get_publish_response_from_data(data, "mygraph".to_string());
 
         assert!(output.is_err());
     }
@@ -188,21 +188,21 @@ mod tests {
     fn build_response_struct_from_success() {
         let json_response = json!({
             "code": "IT_WERK",
-            "message": "it really do be pushed",
+            "message": "it really do be published",
             "success": true,
             "tag": {
                 "variant": { "name": "current" },
                 "schema": { "hash": "123456" }
             }
         });
-        let update_response: push_schema_mutation::PushSchemaMutationServiceUploadSchema =
+        let update_response: publish_schema_mutation::PublishSchemaMutationServiceUploadSchema =
             serde_json::from_value(json_response).unwrap();
         let output = build_response(update_response);
 
         assert!(output.is_ok());
         assert_eq!(
             output.unwrap(),
-            PushResponse {
+            PublishResponse {
                 schema_hash: "123456".to_string(),
                 change_summary: "[No Changes]".to_string(),
             }
@@ -217,7 +217,7 @@ mod tests {
             "success": false,
             "tag": null
         });
-        let update_response: push_schema_mutation::PushSchemaMutationServiceUploadSchema =
+        let update_response: publish_schema_mutation::PublishSchemaMutationServiceUploadSchema =
             serde_json::from_value(json_response).unwrap();
         let output = build_response(update_response);
 
@@ -232,7 +232,7 @@ mod tests {
             "success": true,
             "tag": null
         });
-        let update_response: push_schema_mutation::PushSchemaMutationServiceUploadSchema =
+        let update_response: publish_schema_mutation::PublishSchemaMutationServiceUploadSchema =
             serde_json::from_value(json_response).unwrap();
         let output = build_response(update_response);
 

--- a/crates/rover-client/src/query/graph/publish.rs
+++ b/crates/rover-client/src/query/graph/publish.rs
@@ -57,7 +57,10 @@ fn build_response(
     publish_response: publish_schema_mutation::PublishSchemaMutationServiceUploadSchema,
 ) -> Result<PublishResponse, RoverClientError> {
     if !publish_response.success {
-        let msg = format!("Schema upload failed with error: {}", publish_response.message);
+        let msg = format!(
+            "Schema upload failed with error: {}",
+            publish_response.message
+        );
         return Err(RoverClientError::AdhocError { msg });
     }
 
@@ -90,7 +93,8 @@ fn build_response(
     })
 }
 
-type ChangeDiff = publish_schema_mutation::PublishSchemaMutationServiceUploadSchemaTagDiffToPrevious;
+type ChangeDiff =
+    publish_schema_mutation::PublishSchemaMutationServiceUploadSchemaTagDiffToPrevious;
 
 /// builds a string-representation of the diff between two schemas
 /// e.g. ` [Fields: +2 -1 △0, Types: +4 -0 △7]` or `[No Changes]`

--- a/crates/rover-client/src/query/subgraph/check.rs
+++ b/crates/rover-client/src/query/subgraph/check.rs
@@ -20,7 +20,7 @@ type Timestamp = String;
 pub struct CheckPartialSchemaQuery;
 
 /// The main function to be used from this module.
-/// This function takes a proposed schema and validates it against a pushed
+/// This function takes a proposed schema and validates it against a published
 /// schema.
 pub fn run(
     variables: check_partial_schema_query::Variables,

--- a/crates/rover-client/src/query/subgraph/mod.rs
+++ b/crates/rover-client/src/query/subgraph/mod.rs
@@ -7,8 +7,8 @@ pub mod check;
 /// "subgraph fetch" command execution
 pub mod fetch;
 
-/// "subgraph push" command execution
-pub mod push;
+/// "subgraph publish" command execution
+pub mod publish;
 
 /// "subgraph list"
 pub mod list;

--- a/crates/rover-client/src/query/subgraph/publish.graphql
+++ b/crates/rover-client/src/query/subgraph/publish.graphql
@@ -1,4 +1,4 @@
-mutation PushPartialSchemaMutation(
+mutation PublishPartialSchemaMutation(
   $graphId: ID!
   $graphVariant: String!
   $name: String!

--- a/docs/source/configuring.md
+++ b/docs/source/configuring.md
@@ -106,13 +106,13 @@ If present, an environment variable's value takes precedence over all other meth
 
 ### Git Context
 
-Apollo uses information about your git environment when running `check` and `push` commands This context is used to impprove the experience in Apollo Studio. This includes the remote url of your git repository (stripped of any usernames/passwords), commit sha, commiter, and branch name.
+Apollo uses information about your git environment when running `check` and `publish` commands This context is used to impprove the experience in Apollo Studio. This includes the remote url of your git repository (stripped of any usernames/passwords), commit sha, commiter, and branch name.
 
 This information powers the ability to be able to link to a specific commit from the checks or history tabs in Apollo Studio, making it easier to track down where schema changes were proposed or published.
 
 <img src="./assets/checks-git-info.png" alt="Checks info in Apollo Studio" width="400">
 
-To see these values, just run any `check` or `push` command with the `--log trace` option.
+To see these values, just run any `check` or `publish` command with the `--log trace` option.
 
 None of this information should be sensitive, but if you would rather overwrite these values, you may use the `APOLLO_VCS_REMOTE_URL`, `APOLLO_VCS_BRANCH`, `APOLLO_VCS_COMMIT`, and `APOLLO_VCS_COMMITTER` environment variables documented [here](./configuring#all-supported-environment-variables).
 

--- a/docs/source/graphs.md
+++ b/docs/source/graphs.md
@@ -47,7 +47,7 @@ The server must be reachable by Rover and it must have introspection enabled.
 By default, both `graph fetch` and `graph introspect`  output fetched [SDL](https://www.apollographql.com/docs/resources/graphql-glossary/#schema-definition-language-sdl) to `stdout`. This is useful for providing the schema as input to _other_ Rover commands:
 
 ```shell
-rover graph introspect http://localhost:4000 | rover graph push my-graph@dev --schema -
+rover graph introspect http://localhost:4000 | rover graph publish my-graph@dev --schema -
 ```
 
 You can also save the output to a local `.graphql` file like so:
@@ -59,21 +59,21 @@ rover graph fetch my-graph@my-variant > prod-schema.graphql
 
 > For more on passing values via `stdout`, see [Essential concepts](./essentials#using-stdout).
 
-## Pushing a schema to Apollo Studio
+## Publishing a schema to Apollo Studio
 
 > This requires first [authenticating Rover with Apollo Studio](./configuring/#authenticating-with-apollo-studio).
 
-You can use Rover to push schema changes to one of your [Apollo Studio graphs](https://www.apollographql.com/docs/studio/org/graphs/).
+You can use Rover to publish schema changes to one of your [Apollo Studio graphs](https://www.apollographql.com/docs/studio/org/graphs/).
 
-Use the `graph push` command, like so:
+Use the `graph publish` command, like so:
 
 ```shell
-rover graph push my-graph@my-variant --schema ./schema.graphql
+rover graph publish my-graph@my-variant --schema ./schema.graphql
 ```
 
-The argument `my-graph@my-variant` in the example above specifies the ID of the Studio graph you're pushing to, along with which [variant](https://www.apollographql.com/docs/studio/org/graphs/#managing-variants) you're pushing to.
+The argument `my-graph@my-variant` in the example above specifies the ID of the Studio graph you're publishing to, along with which [variant](https://www.apollographql.com/docs/studio/org/graphs/#managing-variants) you're publishing to.
 
-> You can omit `@` and the variant name. If you do, Rover pushes the schema to the default variant, named `current`.
+> You can omit `@` and the variant name. If you do, Rover publishes the schema to the default variant, named `current`.
 
 ### Providing the schema
 
@@ -85,7 +85,7 @@ If your schema isn't stored in a compatible file, you can provide `-` as the val
 
 ```shell
 # Note: The introspect command does not exist yet, and will be included in a future beta release
-rover graph introspect http://localhost:4000 | rover graph push my-graph@dev --schema -
+rover graph introspect http://localhost:4000 | rover graph publish my-graph@dev --schema -
 ```
 
 > For more on accepting input via `stdin`, see [Essential concepts](./essentials#using-stdin).
@@ -94,7 +94,7 @@ rover graph introspect http://localhost:4000 | rover graph push my-graph@dev --s
 
 > Schema checks require a [paid plan](https://www.apollographql.com/pricing).
 
-Before you [push schema changes to Apollo Studio](#pushing-a-schema-to-apollo-studio), you can [check those changes](https://www.apollographql.com/docs/studio/schema-checks/) to confirm that you aren't introducing breaking changes to your application clients.
+Before you [publish schema changes to Apollo Studio](#publishing-a-schema-to-apollo-studio), you can [check those changes](https://www.apollographql.com/docs/studio/schema-checks/) to confirm that you aren't introducing breaking changes to your application clients.
 
 To do so, you can run the `graph check` command:
 
@@ -109,6 +109,6 @@ rover graph check my-graph@my-variant --schema ./schema.graphql
 rover graph introspect http://localhost:4000 | rover graph check my-graph --schema -
 ```
 
-As shown, arguments and options are similar to [`graph push`](#pushing-a-schema-to-apollo-studio).
+As shown, arguments and options are similar to [`graph publish`](#publishing-a-schema-to-apollo-studio).
 
 To configure the behavior of schema checks (such as the time range of past operations to check against), see the [documentation for schema checks](https://www.apollographql.com/docs/studio/check-configurations/#using-apollo-studio-recommended).

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -12,7 +12,7 @@ import { colors } from 'gatsby-theme-apollo-core';
 >
 > For details, see [Public preview](#public-preview).
 
-**Rover** is a CLI for managing and maintaining data graphs with [Apollo Studio](https://www.apollographql.com/docs/studio/). It helps you safely push and pull GraphQL schemas (both federated and non-federated) from the Apollo schema registry.
+**Rover** is a CLI for managing and maintaining data graphs with [Apollo Studio](https://www.apollographql.com/docs/studio/). It helps you safely publish and fetch GraphQL schemas (both federated and non-federated) from the Apollo schema registry.
 
 Upon full release, Rover will replace the existing [Apollo CLI](https://www.apollographql.com/docs/devtools/cli/) as the primary command-line tool for communicating with Studio.
 

--- a/docs/source/subgraphs.md
+++ b/docs/source/subgraphs.md
@@ -50,7 +50,7 @@ The subgraph must be reachable by Rover. The subgraph does _not_ need to have in
 
 ```sh
 rover subgraph introspect http://localhost:4001\
-  | rover subgraph push my-graph@dev\
+  | rover subgraph publish my-graph@dev\
   --schema - --name accounts\
   --routing-url https://my-running-subgraph.com/api
 ```
@@ -104,24 +104,24 @@ Subgraphs:
 View full details at https://studio.apollographql.com/graph/my-graph/service-list
 ```
 
-## Pushing a subgraph schema to Apollo Studio
+## Publishing a subgraph schema to Apollo Studio
 
 > This requires first [authenticating Rover with Apollo Studio](./configuring/#authenticating-with-apollo-studio).
 
-You can use Rover to push schema changes to an subgraph in one of your [Apollo Studio graphs](https://www.apollographql.com/docs/studio/org/graphs/).
+You can use Rover to publish schema changes to an subgraph in one of your [Apollo Studio graphs](https://www.apollographql.com/docs/studio/org/graphs/).
 
-Use the `subgraph push` command, like so:
+Use the `subgraph publish` command, like so:
 
 ```bash
-rover subgraph push my-graph@my-variant \
+rover subgraph publish my-graph@my-variant \
   --schema ./accounts/schema.graphql\
   --name accounts\
   --routing-url https://my-running-subgraph.com/api
 ```
 
-The argument `my-graph@my-variant` in the example above specifies the ID of the Studio graph you're pushing to, along with which [variant](https://www.apollographql.com/docs/studio/org/graphs/#managing-variants) you're pushing to.
+The argument `my-graph@my-variant` in the example above specifies the ID of the Studio graph you're publishing to, along with which [variant](https://www.apollographql.com/docs/studio/org/graphs/#managing-variants) you're publishing to.
 
-> You can omit `@` and the variant name. If you do, Rover pushes the schema to the default variant, named `current`.
+> You can omit `@` and the variant name. If you do, Rover publishes the schema to the default variant, named `current`.
 
 Options include:
 
@@ -159,7 +159,7 @@ For more on accepting input via `stdin`, see [Essential Concepts](./essentials#u
 
 <td>
 
-**Required.** The name of the subgraph to push to.
+**Required.** The name of the subgraph to publish to.
 
 </td>
 </tr>
@@ -186,7 +186,7 @@ If you're running a subgraph that hasn't been deployed yet or isn't using manage
 
 > Schema checks require a [paid plan](https://www.apollographql.com/pricing).
 
-Before you [push subgraph schema changes to Apollo Studio](#pushing-a-subgraph-schema-to-apollo-studio), you can [check those changes](https://www.apollographql.com/docs/studio/schema-checks/) to confirm that you aren't introducing breaking changes to your application clients.
+Before you [publish subgraph schema changes to Apollo Studio](#publishing-a-subgraph-schema-to-apollo-studio), you can [check those changes](https://www.apollographql.com/docs/studio/schema-checks/) to confirm that you aren't introducing breaking changes to your application clients.
 
 To do so, you can run the `subgraph check` command:
 
@@ -201,6 +201,6 @@ rover subgraph check my-graph@my-variant --schema ./schema.graphql --name accoun
 rover subgraph introspect http://localhost:4000 | rover subgraph check my-graph@my-variant --schema - --name accounts
 ```
 
-As shown, arguments and options are similar to [`subgraph push`](#pushing-a-subgraph-schema-to-apollo-studio).
+As shown, arguments and options are similar to [`subgraph publish`](#publishing-a-subgraph-schema-to-apollo-studio).
 
 To configure the behavior of schema checks (such as the time range of past operations to check against), see the [documentation for schema checks](https://www.apollographql.com/docs/studio/check-configurations/#using-apollo-studio-recommended).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,11 +19,11 @@ use camino::Utf8PathBuf;
 #[derive(Debug, Serialize, StructOpt)]
 #[structopt(name = "Rover", global_settings = &[structopt::clap::AppSettings::ColoredHelp], about = "
 Rover - Your Graph Companion
-Read the getting started guide by running: 
+Read the getting started guide by running:
 
     $ rover docs open start
 
-To begin working with Rover and to authenticate with Apollo Studio, 
+To begin working with Rover and to authenticate with Apollo Studio,
 run the following command:
 
     $ rover config auth
@@ -33,8 +33,9 @@ This will prompt you for an API Key that can be generated in Apollo Studio.
 The most common commands from there are:
 
     - rover graph fetch: Fetch a graph schema from the Apollo graph registry
-    - rover graph check: Check for breaking changes in a local graph schema against a graph schema in the Apollo graph registry
-    - rover graph push: Push an updated graph schema to the Apollo graph registry
+    - rover graph check: Check for breaking changes in a local graph schema against a graph schema in the Apollo graph
+registry
+    - rover graph publish: Publish an updated graph schema to the Apollo graph registry
 
 You can open the full documentation for Rover by running:
 

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -27,7 +27,7 @@ pub struct Check {
     #[serde(skip_serializing)]
     profile_name: String,
 
-    /// The schema file to push
+    /// The schema file to check
     /// Can pass `-` to use stdin instead of a file
     #[structopt(long, short = "s", parse(try_from_str = parse_schema_source))]
     #[serde(skip_serializing)]

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -1,6 +1,6 @@
 mod check;
 mod fetch;
-mod push;
+mod publish;
 
 use serde::Serialize;
 use structopt::StructOpt;
@@ -24,8 +24,8 @@ pub enum Command {
     /// Fetch a graph schema from the Apollo graph registry
     Fetch(fetch::Fetch),
 
-    /// Push an updated graph schema to the Apollo graph registry
-    Push(push::Push),
+    /// Publish an updated graph schema to the Apollo graph registry
+    Publish(publish::Publish),
 }
 
 impl Graph {
@@ -36,7 +36,7 @@ impl Graph {
     ) -> Result<RoverStdout> {
         match &self.command {
             Command::Fetch(command) => command.run(client_config),
-            Command::Push(command) => command.run(client_config, git_context),
+            Command::Publish(command) => command.run(client_config, git_context),
             Command::Check(command) => command.run(client_config, git_context),
         }
     }

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -12,14 +12,14 @@ use crate::utils::parsers::{parse_graph_ref, parse_schema_source, GraphRef, Sche
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
-pub struct Push {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to push to.
+pub struct Publish {
+    /// <NAME>@<VARIANT> of graph in Apollo Studio to publish to.
     /// @<VARIANT> may be left off, defaulting to @current
     #[structopt(name = "GRAPH_REF", parse(try_from_str = parse_graph_ref))]
     #[serde(skip_serializing)]
     graph: GraphRef,
 
-    /// The schema file to push
+    /// The schema file to publish
     /// Can pass `-` to use stdin instead of a file
     #[structopt(long, short = "s", parse(try_from_str = parse_schema_source))]
     #[serde(skip_serializing)]
@@ -31,7 +31,7 @@ pub struct Push {
     profile_name: String,
 }
 
-impl Push {
+impl Publish {
     pub fn run(
         &self,
         client_config: StudioClientConfig,
@@ -40,7 +40,7 @@ impl Push {
         let client = client_config.get_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
         eprintln!(
-            "Pushing SDL to {} using credentials from the {} profile.",
+            "Publishing SDL to {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
             Yellow.normal().paint(&self.profile_name)
         );
@@ -49,7 +49,7 @@ impl Push {
 
         tracing::debug!(?schema_document);
 
-        let push_response = push::run(
+        let publish_response = push::run(
             push::push_schema_mutation::Variables {
                 graph_id: self.graph.name.clone(),
                 variant: self.graph.variant.clone(),
@@ -59,7 +59,7 @@ impl Push {
             &client,
         )?;
 
-        let hash = handle_response(&self.graph, push_response);
+        let hash = handle_response(&self.graph, publish_response);
         Ok(RoverStdout::SchemaHash(hash))
     }
 }
@@ -67,7 +67,7 @@ impl Push {
 /// handle all output logging from operation
 fn handle_response(graph: &GraphRef, response: push::PushResponse) -> String {
     eprintln!(
-        "{}#{} Pushed successfully {}",
+        "{}#{} Published successfully {}",
         graph, response.schema_hash, response.change_summary
     );
 

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -2,7 +2,7 @@ use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
-use rover_client::query::graph::push;
+use rover_client::query::graph::publish;
 
 use crate::command::RoverStdout;
 use crate::utils::client::StudioClientConfig;
@@ -49,8 +49,8 @@ impl Publish {
 
         tracing::debug!(?schema_document);
 
-        let publish_response = push::run(
-            push::push_schema_mutation::Variables {
+        let publish_response = publish::run(
+            publish::publish_schema_mutation::Variables {
                 graph_id: self.graph.name.clone(),
                 variant: self.graph.variant.clone(),
                 schema_document: Some(schema_document),
@@ -65,7 +65,7 @@ impl Publish {
 }
 
 /// handle all output logging from operation
-fn handle_response(graph: &GraphRef, response: push::PushResponse) -> String {
+fn handle_response(graph: &GraphRef, response: publish::PublishResponse) -> String {
     eprintln!(
         "{}#{} Published successfully {}",
         graph, response.schema_hash, response.change_summary
@@ -76,7 +76,7 @@ fn handle_response(graph: &GraphRef, response: push::PushResponse) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{handle_response, push, GraphRef};
+    use super::{handle_response, publish, GraphRef};
 
     #[test]
     fn handle_response_doesnt_err() {
@@ -87,7 +87,7 @@ mod tests {
         };
         let actual_hash = handle_response(
             &graph,
-            push::PushResponse {
+            publish::PublishResponse {
                 schema_hash: expected_hash.clone(),
                 change_summary: "".to_string(),
             },

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -33,7 +33,7 @@ pub struct Check {
     #[serde(skip_serializing)]
     profile_name: String,
 
-    /// The schema file to push
+    /// The schema file to check
     /// Can pass `-` to use stdin instead of a file
     #[structopt(long, short = "s", parse(try_from_str = parse_schema_source))]
     #[serde(skip_serializing)]

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -2,7 +2,7 @@ mod check;
 mod delete;
 mod fetch;
 mod list;
-mod push;
+mod publish;
 
 use serde::Serialize;
 use structopt::StructOpt;
@@ -32,8 +32,8 @@ pub enum Command {
     /// List all subgraphs for a federated graph
     List(list::List),
 
-    /// Push an updated subgraph schema to the Apollo graph registry and trigger composition in the graph router
-    Push(push::Push),
+    /// Publish an updated subgraph schema to the Apollo graph registry and trigger composition in the graph router
+    Publish(publish::Publish),
 }
 
 impl Subgraph {
@@ -43,7 +43,7 @@ impl Subgraph {
         git_context: GitContext,
     ) -> Result<RoverStdout> {
         match &self.command {
-            Command::Push(command) => command.run(client_config, git_context),
+            Command::Publish(command) => command.run(client_config, git_context),
             Command::Delete(command) => command.run(client_config),
             Command::Fetch(command) => command.run(client_config),
             Command::Check(command) => command.run(client_config, git_context),

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -11,7 +11,7 @@ use crate::utils::{
 };
 use crate::Result;
 
-use rover_client::query::subgraph::push::{self, PushPartialSchemaResponse};
+use rover_client::query::subgraph::publish::{self, PublishPartialSchemaResponse};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Publish {
@@ -63,12 +63,12 @@ impl Publish {
 
         tracing::debug!("Schema Document to publish:\n{}", &schema_document);
 
-        let publish_response = push::run(
-            push::push_partial_schema_mutation::Variables {
+        let publish_response = publish::run(
+            publish::publish_partial_schema_mutation::Variables {
                 graph_id: self.graph.name.clone(),
                 graph_variant: self.graph.variant.clone(),
                 name: self.subgraph.clone(),
-                active_partial_schema: push::push_partial_schema_mutation::PartialSchemaInput {
+                active_partial_schema: publish::publish_partial_schema_mutation::PartialSchemaInput {
                     sdl: Some(schema_document),
                     hash: None,
                 },
@@ -84,7 +84,7 @@ impl Publish {
     }
 }
 
-fn handle_response(response: PushPartialSchemaResponse, subgraph: &str, graph: &str) {
+fn handle_response(response: PublishPartialSchemaResponse, subgraph: &str, graph: &str) {
     if response.service_was_created {
         eprintln!(
             "A new subgraph called '{}' for the '{}' graph was created",
@@ -118,13 +118,13 @@ fn handle_response(response: PushPartialSchemaResponse, subgraph: &str, graph: &
 
 #[cfg(test)]
 mod tests {
-    use super::{handle_response, PushPartialSchemaResponse};
+    use super::{handle_response, PublishPartialSchemaResponse};
 
     // this test is a bit weird, since we can't test the output. We just verify it
     // doesn't error
     #[test]
     fn handle_response_doesnt_error_with_all_successes() {
-        let response = PushPartialSchemaResponse {
+        let response = PublishPartialSchemaResponse {
             schema_hash: Some("123456".to_string()),
             did_update_gateway: true,
             service_was_created: true,
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn handle_response_doesnt_error_with_all_failures() {
-        let response = PushPartialSchemaResponse {
+        let response = PublishPartialSchemaResponse {
             schema_hash: None,
             did_update_gateway: false,
             service_was_created: false,

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -14,14 +14,14 @@ use crate::Result;
 use rover_client::query::subgraph::push::{self, PushPartialSchemaResponse};
 
 #[derive(Debug, Serialize, StructOpt)]
-pub struct Push {
-    /// <NAME>@<VARIANT> of federated graph in Apollo Studio to push to.
+pub struct Publish {
+    /// <NAME>@<VARIANT> of federated graph in Apollo Studio to publish to.
     /// @<VARIANT> may be left off, defaulting to @current
     #[structopt(name = "GRAPH_REF", parse(try_from_str = parse_graph_ref))]
     #[serde(skip_serializing)]
     graph: GraphRef,
 
-    /// The schema file to push
+    /// The schema file to publish
     /// Can pass `-` to use stdin instead of a file
     #[structopt(long, short = "s", parse(try_from_str = parse_schema_source))]
     #[serde(skip_serializing)]
@@ -44,7 +44,7 @@ pub struct Push {
     routing_url: String,
 }
 
-impl Push {
+impl Publish {
     pub fn run(
         &self,
         client_config: StudioClientConfig,
@@ -53,7 +53,7 @@ impl Push {
         let client = client_config.get_client(&self.profile_name)?;
         let graph_ref = format!("{}:{}", &self.graph.name, &self.graph.variant);
         eprintln!(
-            "Pushing SDL to {} (subgraph: {}) using credentials from the {} profile.",
+            "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
             Cyan.normal().paint(&self.subgraph),
             Yellow.normal().paint(&self.profile_name)
@@ -61,9 +61,9 @@ impl Push {
 
         let schema_document = load_schema_from_flag(&self.schema, std::io::stdin())?;
 
-        tracing::debug!("Schema Document to push:\n{}", &schema_document);
+        tracing::debug!("Schema Document to publish:\n{}", &schema_document);
 
-        let push_response = push::run(
+        let publish_response = push::run(
             push::push_partial_schema_mutation::Variables {
                 graph_id: self.graph.name.clone(),
                 graph_variant: self.graph.variant.clone(),
@@ -79,7 +79,7 @@ impl Push {
             &client,
         )?;
 
-        handle_response(push_response, &self.subgraph, &self.graph.name);
+        handle_response(publish_response, &self.subgraph, &self.graph.name);
         Ok(RoverStdout::None)
     }
 }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -68,10 +68,11 @@ impl Publish {
                 graph_id: self.graph.name.clone(),
                 graph_variant: self.graph.variant.clone(),
                 name: self.subgraph.clone(),
-                active_partial_schema: publish::publish_partial_schema_mutation::PartialSchemaInput {
-                    sdl: Some(schema_document),
-                    hash: None,
-                },
+                active_partial_schema:
+                    publish::publish_partial_schema_mutation::PartialSchemaInput {
+                        sdl: Some(schema_document),
+                        hash: None,
+                    },
                 revision: "".to_string(),
                 url: self.routing_url.clone(),
                 git_context: git_context.into(),

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -157,7 +157,8 @@ impl Into<GraphCheckContextInput> for GitContext {
     }
 }
 
-type SubgraphPublishContextInput = subgraph::publish::publish_partial_schema_mutation::GitContextInput;
+type SubgraphPublishContextInput =
+    subgraph::publish::publish_partial_schema_mutation::GitContextInput;
 impl Into<SubgraphPublishContextInput> for GitContext {
     fn into(self) -> SubgraphPublishContextInput {
         SubgraphPublishContextInput {

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -131,7 +131,7 @@ impl GitContext {
     }
 }
 
-type GraphPublishContextInput = graph::push::push_schema_mutation::GitContextInput;
+type GraphPublishContextInput = graph::publish::publish_schema_mutation::GitContextInput;
 impl Into<GraphPublishContextInput> for GitContext {
     fn into(self) -> GraphPublishContextInput {
         GraphPublishContextInput {
@@ -157,7 +157,7 @@ impl Into<GraphCheckContextInput> for GitContext {
     }
 }
 
-type SubgraphPublishContextInput = subgraph::push::push_partial_schema_mutation::GitContextInput;
+type SubgraphPublishContextInput = subgraph::publish::publish_partial_schema_mutation::GitContextInput;
 impl Into<SubgraphPublishContextInput> for GitContext {
     fn into(self) -> SubgraphPublishContextInput {
         SubgraphPublishContextInput {

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -131,10 +131,10 @@ impl GitContext {
     }
 }
 
-type GraphPushContextInput = graph::push::push_schema_mutation::GitContextInput;
-impl Into<GraphPushContextInput> for GitContext {
-    fn into(self) -> GraphPushContextInput {
-        GraphPushContextInput {
+type GraphPublishContextInput = graph::push::push_schema_mutation::GitContextInput;
+impl Into<GraphPublishContextInput> for GitContext {
+    fn into(self) -> GraphPublishContextInput {
+        GraphPublishContextInput {
             branch: self.branch,
             commit: self.commit,
             committer: self.committer,
@@ -157,10 +157,10 @@ impl Into<GraphCheckContextInput> for GitContext {
     }
 }
 
-type SubgraphPushContextInput = subgraph::push::push_partial_schema_mutation::GitContextInput;
-impl Into<SubgraphPushContextInput> for GitContext {
-    fn into(self) -> SubgraphPushContextInput {
-        SubgraphPushContextInput {
+type SubgraphPublishContextInput = subgraph::push::push_partial_schema_mutation::GitContextInput;
+impl Into<SubgraphPublishContextInput> for GitContext {
+    fn into(self) -> SubgraphPublishContextInput {
+        SubgraphPublishContextInput {
             branch: self.branch,
             commit: self.commit,
             committer: self.committer,


### PR DESCRIPTION
Fixes #344 

This PR is broken up by 3 commits for each of the following respectively:

- update naming for all the public-facing commands/help texts
- update internal references to push (i.e. rover-client)
- update docs with publish
