### PR TITLE
feat: displays complete error chain if it exists

### DIFF
--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -12,7 +12,7 @@ use crate::utils::parsers::{
     parse_schema_source, parse_validation_period, GraphRef, SchemaSource, ValidationPeriod,
 };
 use crate::utils::table::{self, cell, row};
-use crate::Result;
+use crate::{anyhow, Result};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Check {
@@ -99,8 +99,8 @@ impl Check {
 
         match num_failures {
             0 => Ok(RoverStdout::None),
-            1 => Err(anyhow::anyhow!("Encountered 1 failure.").into()),
-            _ => Err(anyhow::anyhow!("Encountered {} failures.", num_failures).into()),
+            1 => Err(anyhow!("Encountered 1 failure.").into()),
+            _ => Err(anyhow!("Encountered {} failures.", num_failures).into()),
         }
     }
 }

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -2,7 +2,7 @@ use ansi_term::Colour::Red;
 use serde::Serialize;
 use structopt::StructOpt;
 
-use crate::Result;
+use crate::{anyhow, Result};
 use rover_client::query::subgraph::check;
 
 use crate::command::RoverStdout;
@@ -145,8 +145,8 @@ fn handle_checks(check_result: check::CheckResult) -> Result<RoverStdout> {
 
     match num_failures {
         0 => Ok(RoverStdout::None),
-        1 => Err(anyhow::anyhow!("Encountered 1 failure while checking your subgraph.").into()),
-        _ => Err(anyhow::anyhow!(
+        1 => Err(anyhow!("Encountered 1 failure while checking your subgraph.").into()),
+        _ => Err(anyhow!(
             "Encountered {} failures while checking your subgraph.",
             num_failures
         )
@@ -164,10 +164,8 @@ fn handle_composition_errors(
     }
     match num_failures {
         0 => Ok(RoverStdout::None),
-        1 => Err(
-            anyhow::anyhow!("Encountered 1 composition error while composing the subgraph.").into(),
-        ),
-        _ => Err(anyhow::anyhow!(
+        1 => Err(anyhow!("Encountered 1 composition error while composing the subgraph.").into()),
+        _ => Err(anyhow!(
             "Encountered {} composition errors while composing the subgraph.",
             num_failures
         )

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,11 +1,11 @@
 mod metadata;
 
-pub use anyhow::{anyhow, Context};
+pub use anyhow::{anyhow, Context, Error};
 pub(crate) use metadata::Metadata;
 
 pub type Result<T> = std::result::Result<T, RoverError>;
 
-use ansi_term::Colour::{Cyan, Red};
+use ansi_term::Colour::Red;
 
 use std::borrow::BorrowMut;
 use std::fmt::{self, Debug, Display};
@@ -39,41 +39,62 @@ impl RoverError {
 
         Self { error, metadata }
     }
+
+    fn get_leftpad(&self, descriptor: &str) -> usize {
+        if self.metadata.is_parse_error {
+            // there are 6 characters in structopts "error:" prefix
+            6
+        } else {
+            descriptor.len()
+        }
+    }
 }
 
 impl Display for RoverError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let error_descriptor_message = if self.metadata.is_parse_error {
+        if self.metadata.is_parse_error {
             // don't display parse errors since structopt handles it
-            writeln!(formatter)?;
-            "".to_string()
+            return writeln!(formatter);
+        }
+
+        let error_descriptor_message = if let Some(code) = &self.metadata.code {
+            format!("error[{}]:", code)
         } else {
-            let error_descriptor_message = if let Some(code) = &self.metadata.code {
-                format!("error[{}]:", code)
-            } else {
-                "error:".to_string()
-            };
-            let error_descriptor = Red.bold().paint(&error_descriptor_message);
-            writeln!(formatter, "{} {}", error_descriptor, &self.error)?;
-            error_descriptor_message
+            "error:".to_string()
         };
+        let error_descriptor = Red.bold().paint(&error_descriptor_message);
+        writeln!(formatter, "{} {}", error_descriptor, &self.error)?;
+
+        let leftpad = self.get_leftpad(&error_descriptor_message);
+
+        let causes = self.error.chain();
+        if causes.len() > 1 {
+            writeln!(formatter, "\nCaused by:")?;
+
+            for (cause_num, cause) in causes.enumerate() {
+                if cause_num != 0 {
+                    let mut cause_message_descriptor = "".to_string();
+
+                    for _ in 0..leftpad {
+                        cause_message_descriptor.push(' ');
+                    }
+
+                    let cause_descriptor = Red.bold().paint(&cause_message_descriptor);
+                    writeln!(formatter, "{} {}", cause_descriptor, cause)?;
+                }
+            }
+        }
 
         if let Some(suggestion) = &self.metadata.suggestion {
-            let mut suggestion_descriptor_message = "".to_string();
-
-            let leftpad = if self.metadata.is_parse_error {
-                // there are 6 characters in structopts "error:" prefix
-                6
-            } else {
-                error_descriptor_message.len()
-            };
+            let mut suggestion_descriptor = "".to_string();
 
             for _ in 0..leftpad + 1 {
-                suggestion_descriptor_message.push(' ');
+                suggestion_descriptor.push(' ');
             }
-            let suggestion_descriptor = Cyan.bold().paint(&suggestion_descriptor_message);
+
             writeln!(formatter, "{} {}", suggestion_descriptor, suggestion)?;
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
not sure if we want this or not, but currently we're re-exporting the `anyhow::Context` trait from the top level of our crate and if we use it anywhere it just completely squashes the error it came from which could be surprising for folks working on Rover.

I think we should either go ahead with this PR so you can use `.with_context(|| format!("Couldn't do the thing you asked the application to do"))?` or we should stop re-exporting `Context`.

for _context_ on what this change does, i've added a `with_context` strawdog to the docs open command:

before:

```console
$ BROWSER=bad rover docs open
Opening https://go.apollo.dev/r/docs with the application specified by $BROWSER.
error: Couldn't open docs with bad: No such file or directory (os error 2)
```

after:

```console
$ BROWSER=bad rover docs open
Opening https://go.apollo.dev/r/docs with the application specified by $BROWSER.
error: Could not open https://go.apollo.dev/r/docs automatically with $BROWSER bad

Caused by:
       No such file or directory (os error 2)
```

If there's a "suggestion" it would be printed after the top level error and before caused by (in this PR at least).

I'm not sure if I actually like the "after" in this case, we could very easily make it so that the causes are displayed inline with the first error if we so choose sorta like this:

```console
$ BROWSER=bad rover docs open
Opening https://go.apollo.dev/r/docs with the application specified by $BROWSER.
error: Could not open https://go.apollo.dev/r/docs automatically with $BROWSER bad: No such file or directory (os error 2)
```

^ this one gets tricky if there are a bunch of errors in the chain. do we only display the first one inline and exclude the rest? do we display it inline if there's only one cause and do the bigger "caused by" block if there are more than one cause?

---

**attn: reviewers**

I got started thinking on this as I was working a lot with config file parsing with my composition PR. There are a bunch of different IO errors and parse errors that can occur, and they aren't necessarily as Rover-specific or even as user-friendly as most of the errors we have in `rover-client` are. I have a feeling these errors will be more common as Rover starts to do more and more. This PR is mostly a spike to get conversation rolling. 

I find the `with_context` syntax to be a _bit_ nicer than `map_err`, and as we do more of this type of logic right in Rover, having the ergonomics to just tack on our own context-aware error message right in Rover seems like a good idea and means we can just leave the underlying errors untouched and have them displayed as is.

The other argument to be made here is that we should be doing all of this error handling _with_ `map_err`, and constructing different top-level errors that may differ depending on the exact underlying error. For instance, when reading a file, there are numerous errors that could happen.

Take this fn signature for example: `std::fs::read_to_string<P: AsRef<Path>>(path: P) -> Result<String, std::io::ErrorKind>`

`ErrorKind` has _18_ different causes. The overarching error here is clearly something like "Could not read file ${filename}". But that's not necessarily enough info for the user. So, the two options we have here are like this:

1) Use `map_err` and forbid `Context` usage:

```
let file_contents = fs::read_to_string(&my_file_path).map_err(|e| {
  let msg = match e {
    ErrorKind::NotFound => format!("Could not find file {}.", &my_file_path),
    ErrorKind::PermissionDenied => format!("You do not have permissions to read file {}.", &my_file_path),
    _ => format!("Could not read {}: {}", &my_file_path, &e)
  };
  Err(msg).into()
})?;
```

this would print an error like what we currently allow in Rover:

```
error: Could not find file /path/to/file.txt
```

2) use `anyhow::Context`:

```
let file_contents = fs::read_to_string(&my_file_path).with_context(|| format!("Could not read {}.", &my_file_path))?;
```

this would print an error like what I have in this PR:

```
error: Could not read /path/to/file.txt.

Caused by:
       No such file or directory (os error 2)
```

The second option would not prevent using `map_err` like we have outlined in the first use case, if we really wanted to handle specific errors like that we could still do so, this would just make the ergonomics of wrapping the underlying error causes a _tad_ more ergonomic to work with, _maybe_ at the expense of user experience.

Anyhoo, if you made it this far congrats. I'll stop typing now. Would love any and all thoughts on this :)

