### PR TITLE
Add header flag parser and passthru for introspection

### DIFF
--- a/crates/rover-client/src/query/graph/introspect.rs
+++ b/crates/rover-client/src/query/graph/introspect.rs
@@ -25,9 +25,12 @@ pub struct IntrospectionResponse {
 
 /// The main function to be used from this module. This function fetches a
 /// schema from apollo studio and returns it in either sdl (default) or json format
-pub fn run(client: &Client) -> Result<IntrospectionResponse, RoverClientError> {
+pub fn run(
+    client: &Client,
+    headers: &HashMap<String, String>,
+) -> Result<IntrospectionResponse, RoverClientError> {
     let variables = introspection_query::Variables {};
-    let response_data = client.post::<IntrospectionQuery>(variables, &HashMap::new())?;
+    let response_data = client.post::<IntrospectionQuery>(variables, headers)?;
     build_response(response_data)
 }
 

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -1,12 +1,13 @@
 use crate::Result;
 use serde::Serialize;
+use std::collections::HashMap;
 use structopt::StructOpt;
 use url::Url;
 
 use rover_client::{blocking::Client, query::graph::introspect};
 
 use crate::command::RoverStdout;
-use crate::utils::parsers::parse_url;
+use crate::utils::parsers::{parse_header, parse_url};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Introspect {
@@ -14,13 +15,31 @@ pub struct Introspect {
     #[structopt(parse(try_from_str = parse_url))]
     #[serde(skip_serializing)]
     pub endpoint: Url,
+
+    /// headers to pass to the endpoint. Values must be key:value pairs.
+    /// If a value has a space in it, use quotes around the pair,
+    /// ex. -H "Auth:some key"
+
+    // The `name` here is for the help text and error messages, to print like
+    // --header <key:value> rather than the plural field name --header <headers>
+    #[structopt(name="key:value", multiple=true, long="header", short="H", parse(try_from_str = parse_header))]
+    #[serde(skip_serializing)]
+    pub headers: Option<Vec<(String, String)>>,
 }
 
 impl Introspect {
     pub fn run(&self) -> Result<RoverStdout> {
         let client = Client::new(&self.endpoint.to_string());
 
-        let introspection_response = introspect::run(&client)?;
+        // add the flag headers to a hashmap to pass along to rover-client
+        let mut headers = HashMap::new();
+        if self.headers.is_some() {
+            for (key, value) in self.headers.clone().unwrap() {
+                headers.insert(key, value);
+            }
+        }
+
+        let introspection_response = introspect::run(&client, &headers)?;
 
         Ok(RoverStdout::Introspection(introspection_response.result))
     }

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -133,6 +133,19 @@ pub fn parse_url(url: &str) -> Result<Url> {
     Ok(res)
 }
 
+/// Parses a key:value pair from a string and returns a tuple of key:value.
+/// If a full key:value can't be parsed, it will error.
+pub fn parse_header(header: &str) -> Result<(String, String)> {
+    // only split once, a header's value may have a ":" in it, but not a key. Right?
+    let pair: Vec<&str> = header.splitn(2, ':').collect();
+    if pair.len() < 2 {
+        let msg = format!("Could not parse \"key:value\" pair for provided header: \"{}\". Headers must be provided in key:value pairs, with quotes around the pair if there are any spaces in the key or value.", header);
+        Err(RoverError::parse_error(msg))
+    } else {
+        Ok((pair[0].to_string(), pair[1].to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{parse_graph_ref, parse_schema_source, GraphRef, SchemaSource};


### PR DESCRIPTION
These changes are fairly small, but add the ability to pass through headers, similarly to how `curl` works with `--header` or `-H`.

Valid examples:

```
# single headers
rover graph introspect http://localhost:4000 --header auth:hello
rover graph introspect http://localhost:4000 -H auth:hello
rover graph introspect http://localhost:4000 -H "auth:hello"
rover graph introspect http://localhost:4000 --header auth:"hello"
rover graph introspect http://localhost:4000 --header "auth:value with spaces"
rover graph introspect http://localhost:4000 --header auth:"value with spaces"

# I think reqwest is stripping leading whitespace from header values automatically (which is what we'd want), 
# even though with the current implementation, leading whitespaces are added to the header map
rover graph introspect http://localhost:4000 --header "auth: value with leading spaces"

# multiple headers
rover graph introspect http://localhost:4000 --header auth:hello another:header
rover graph introspect http://localhost:4000 --header auth:hello --header another:header
rover graph introspect http://localhost:4000 --header auth:hello -H another:header
rover graph introspect http://localhost:4000 --header auth:hello -H "another-header:with spaces"

```