### PR TITLE
chore(installer): use x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
   GITHUB_REF: "${{ github.ref }}"
   WINDOWS_TARGET: x86_64-pc-windows-msvc
   MACOS_TARGET: x86_64-apple-darwin
-  LINUX_TARGET: x86_64-unknown-linux-musl
+  LINUX_TARGET: x86_64-unknown-linux-gnu
 
   # Space separated paths to include in the archive.
   RELEASE_ADDS: README.md LICENSE
@@ -54,12 +54,6 @@ jobs:
         run: |
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
-
-      - name: Install musl-tools (Linux)
-        if: matrix.build == 'linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install musl-tools -y
 
       - name: Install p7zip (MacOS)
         if: matrix.build == 'macos'

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -112,7 +112,7 @@ get_architecture() {
 
     case "$_ostype" in
         Linux)
-            local _ostype=unknown-linux-musl
+            local _ostype=unknown-linux-gnu
             ;;
 
         Darwin)

--- a/installers/binstall/scripts/nix/local-install.sh
+++ b/installers/binstall/scripts/nix/local-install.sh
@@ -71,7 +71,7 @@ get_architecture() {
 
     case "$_ostype" in
         Linux)
-            local _ostype=unknown-linux-musl
+            local _ostype=unknown-linux-gnu
             ;;
 
         Darwin)

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -21,7 +21,7 @@ const supportedPlatforms = [
   {
     TYPE: "Linux",
     ARCHITECTURE: "x64",
-    RUST_TARGET: "x86_64-unknown-linux-musl",
+    RUST_TARGET: "x86_64-unknown-linux-gnu",
     BINARY_NAME: name,
   },
   {


### PR DESCRIPTION
As we are building with deno and rusty_v8 which both require libc,
let's make sure we use the standard version of libc instead of musl
libc we were using before for our release builds.