### PR TITLE
chore: address new clippy 0.1.51 warnings

### DIFF
--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -48,7 +48,7 @@ pub enum HoustonProblem {
     #[error(transparent)]
     TomlDeserialization(#[from] toml::de::Error),
 
-    /// IOError occurs when any given std::io::Error arises.
+    /// IoError occurs when any given std::io::Error arises.
     #[error(transparent)]
-    IOError(#[from] io::Error),
+    IoError(#[from] io::Error),
 }

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -119,10 +119,10 @@ impl Profile {
     pub fn delete(name: &str, config: &Config) -> Result<(), HoustonProblem> {
         let dir = Profile::dir(name, config);
         tracing::debug!(dir = ?dir);
-        Ok(fs::remove_dir_all(dir).map_err(|e| match e.kind() {
+        fs::remove_dir_all(dir).map_err(|e| match e.kind() {
             io::ErrorKind::NotFound => HoustonProblem::ProfileNotFound(name.to_string()),
             _ => HoustonProblem::IoError(e),
-        })?)
+        })
     }
 
     /// Lists profiles based on directories in `$APOLLO_CONFIG_HOME/profiles`

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -121,7 +121,7 @@ impl Profile {
         tracing::debug!(dir = ?dir);
         Ok(fs::remove_dir_all(dir).map_err(|e| match e.kind() {
             io::ErrorKind::NotFound => HoustonProblem::ProfileNotFound(name.to_string()),
-            _ => HoustonProblem::IOError(e),
+            _ => HoustonProblem::IoError(e),
         })?)
     }
 

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -59,7 +59,7 @@ impl Client {
                 return Err(RoverClientError::MalformedKey);
             }
 
-            return Err(RoverClientError::GraphQL {
+            return Err(RoverClientError::GraphQl {
                 msg: errs
                     .into_iter()
                     .map(|err| err.message)

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 pub enum RoverClientError {
     /// The provided GraphQL was invalid.
     #[error("{msg}")]
-    GraphQL {
+    GraphQl {
         /// The encountered GraphQL error.
         msg: String,
     },
@@ -27,7 +27,7 @@ pub enum RoverClientError {
 
     /// Invalid JSON in response body.
     #[error("could not parse JSON")]
-    InvalidJSON(#[from] serde_json::Error),
+    InvalidJson(#[from] serde_json::Error),
 
     /// Encountered an error handling the received response.
     #[error("{msg}")]

--- a/crates/rover-client/src/lib.rs
+++ b/crates/rover-client/src/lib.rs
@@ -16,6 +16,7 @@ pub mod introspection;
 pub use error::RoverClientError;
 
 /// Module for actually querying studio
+#[allow(clippy::upper_case_acronyms)]
 pub mod query;
 
 /// Module for getting release info

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -5,9 +5,9 @@ use std::io;
 /// SputnikError is the type of Error that occured.
 #[derive(Error, Debug)]
 pub enum SputnikError {
-    /// IOError occurs when any given std::io::Error arises.
+    /// IoError occurs when any given std::io::Error arises.
     #[error(transparent)]
-    IOError(#[from] io::Error),
+    IoError(#[from] io::Error),
 
     /// JSONError occurs when an error occurs when serializing/deserializing JSON.
     #[error(transparent)]

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -21,9 +21,9 @@ pub enum SputnikError {
     #[error("Could not parse the version of the tool.")]
     VersionParseError(#[from] semver::SemVerError),
 
-    /// URLParseError occurs when the URL to POST the anonymous usage data cannot be parsed.
+    /// UrlParseError occurs when the URL to POST the anonymous usage data cannot be parsed.
     #[error("Could not parse telemetry URL.")]
-    URLParseError(#[from] url::ParseError),
+    UrlParseError(#[from] url::ParseError),
 
     /// ConfigError occurs when the configuration location of the globally persistent machine
     /// identifier cannot be found.

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -9,9 +9,9 @@ pub enum SputnikError {
     #[error(transparent)]
     IoError(#[from] io::Error),
 
-    /// JSONError occurs when an error occurs when serializing/deserializing JSON.
+    /// JsonError occurs when an error occurs when serializing/deserializing JSON.
     #[error(transparent)]
-    JSONError(#[from] serde_json::Error),
+    JsonError(#[from] serde_json::Error),
 
     /// HttpError occurs when an error occurs while reporting anonymous usage data.
     #[error("Could not report anonymous usage data.")]

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -13,9 +13,9 @@ pub enum SputnikError {
     #[error(transparent)]
     JSONError(#[from] serde_json::Error),
 
-    /// HTTPError occurs when an error occurs while reporting anonymous usage data.
+    /// HttpError occurs when an error occurs while reporting anonymous usage data.
     #[error("Could not report anonymous usage data.")]
-    HTTPError(#[from] reqwest::Error),
+    HttpError(#[from] reqwest::Error),
 
     /// VersionParseError occurs when the version of the tool cannot be determined.
     #[error("Could not parse the version of the tool.")]

--- a/installers/binstall/src/error.rs
+++ b/installers/binstall/src/error.rs
@@ -6,7 +6,7 @@ use std::io;
 #[derive(Error, Debug)]
 pub enum InstallerError {
     #[error(transparent)]
-    IOError(#[from] io::Error),
+    IoError(#[from] io::Error),
 
     #[error("Could not find the home directory of the current user")]
     NoHomeUnix,

--- a/src/command/core/build.rs
+++ b/src/command/core/build.rs
@@ -21,7 +21,7 @@ impl Build {
         let subgraph_definitions = core_config.get_subgraph_definitions(&self.config_path)?;
 
         match harmonizer::harmonize(subgraph_definitions) {
-            Ok(csdl) => Ok(RoverStdout::CSDL(csdl)),
+            Ok(csdl) => Ok(RoverStdout::Csdl(csdl)),
             Err(composition_errors) => {
                 let num_failures = composition_errors.len();
                 for composition_error in composition_errors {

--- a/src/command/graph/fetch.rs
+++ b/src/command/graph/fetch.rs
@@ -42,6 +42,6 @@ impl Fetch {
             &client,
         )?;
 
-        Ok(RoverStdout::SDL(sdl))
+        Ok(RoverStdout::Sdl(sdl))
     }
 }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -17,8 +17,8 @@ use crate::utils::table::{self, cell, row};
 #[derive(Clone, PartialEq, Debug)]
 pub enum RoverStdout {
     DocsList(HashMap<&'static str, &'static str>),
-    SDL(String),
-    CSDL(String),
+    Sdl(String),
+    Csdl(String),
     SchemaHash(String),
     SubgraphList(ListDetails),
     VariantList(Vec<String>),
@@ -44,11 +44,11 @@ impl RoverStdout {
                 }
                 println!("{}", table);
             }
-            RoverStdout::SDL(sdl) => {
+            RoverStdout::Sdl(sdl) => {
                 eprintln!("SDL:");
                 println!("{}", &sdl);
             }
-            RoverStdout::CSDL(csdl) => {
+            RoverStdout::Csdl(csdl) => {
                 eprintln!("CSDL:");
                 println!("{}", &csdl);
             }

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -48,6 +48,6 @@ impl Fetch {
             &self.subgraph,
         )?;
 
-        Ok(RoverStdout::SDL(sdl))
+        Ok(RoverStdout::Sdl(sdl))
     }
 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -109,7 +109,7 @@ impl From<&mut anyhow::Error> for Metadata {
                 | HoustonProblem::PathNotUnicode { path_display: _ }
                 | HoustonProblem::TomlDeserialization(_)
                 | HoustonProblem::TomlSerialization(_)
-                | HoustonProblem::IOError(_) => (Some(Suggestion::SubmitIssue), None),
+                | HoustonProblem::IoError(_) => (Some(Suggestion::SubmitIssue), None),
             };
             return Metadata {
                 suggestion,

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -38,7 +38,7 @@ impl From<&mut anyhow::Error> for Metadata {
     fn from(error: &mut anyhow::Error) -> Self {
         if let Some(rover_client_error) = error.downcast_ref::<RoverClientError>() {
             let (suggestion, code) = match rover_client_error {
-                RoverClientError::InvalidJSON(_)
+                RoverClientError::InvalidJson(_)
                 | RoverClientError::InvalidHeaderName(_)
                 | RoverClientError::InvalidHeaderValue(_)
                 | RoverClientError::SendRequest(_)
@@ -72,7 +72,7 @@ impl From<&mut anyhow::Error> for Metadata {
                     (Some(Suggestion::CheckGraphNameAndAuth), None)
                 }
                 RoverClientError::AdhocError { msg: _ }
-                | RoverClientError::GraphQL { msg: _ }
+                | RoverClientError::GraphQl { msg: _ }
                 | RoverClientError::IntrospectionError { msg: _ } => (None, None),
                 RoverClientError::InvalidKey => (Some(Suggestion::CheckKey), None),
                 RoverClientError::MalformedKey => (Some(Suggestion::ProperKey), None),

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -132,54 +132,54 @@ impl GitContext {
 }
 
 type GraphPublishContextInput = graph::publish::publish_schema_mutation::GitContextInput;
-impl Into<GraphPublishContextInput> for GitContext {
-    fn into(self) -> GraphPublishContextInput {
+impl From<GitContext> for GraphPublishContextInput {
+    fn from(git_context: GitContext) -> GraphPublishContextInput {
         GraphPublishContextInput {
-            branch: self.branch,
-            commit: self.commit,
-            committer: self.author,
-            remote_url: self.remote_url,
-            message: self.message,
+            branch: git_context.branch,
+            commit: git_context.commit,
+            committer: git_context.author,
+            remote_url: git_context.remote_url,
+            message: git_context.message,
         }
     }
 }
 
 type GraphCheckContextInput = graph::check::check_schema_query::GitContextInput;
-impl Into<GraphCheckContextInput> for GitContext {
-    fn into(self) -> GraphCheckContextInput {
+impl From<GitContext> for GraphCheckContextInput {
+    fn from(git_context: GitContext) -> GraphCheckContextInput {
         GraphCheckContextInput {
-            branch: self.branch,
-            commit: self.commit,
-            committer: self.author,
-            remote_url: self.remote_url,
-            message: self.message,
+            branch: git_context.branch,
+            commit: git_context.commit,
+            committer: git_context.author,
+            remote_url: git_context.remote_url,
+            message: git_context.message,
         }
     }
 }
 
 type SubgraphPublishContextInput =
     subgraph::publish::publish_partial_schema_mutation::GitContextInput;
-impl Into<SubgraphPublishContextInput> for GitContext {
-    fn into(self) -> SubgraphPublishContextInput {
+impl From<GitContext> for SubgraphPublishContextInput {
+    fn from(git_context: GitContext) -> SubgraphPublishContextInput {
         SubgraphPublishContextInput {
-            branch: self.branch,
-            commit: self.commit,
-            committer: self.author,
-            remote_url: self.remote_url,
-            message: self.message,
+            branch: git_context.branch,
+            commit: git_context.commit,
+            committer: git_context.author,
+            remote_url: git_context.remote_url,
+            message: git_context.message,
         }
     }
 }
 
 type SubgraphCheckContextInput = subgraph::check::check_partial_schema_query::GitContextInput;
-impl Into<SubgraphCheckContextInput> for GitContext {
-    fn into(self) -> SubgraphCheckContextInput {
+impl From<GitContext> for SubgraphCheckContextInput {
+    fn from(git_context: GitContext) -> SubgraphCheckContextInput {
         SubgraphCheckContextInput {
-            branch: self.branch,
-            commit: self.commit,
-            committer: self.author,
-            remote_url: self.remote_url,
-            message: self.message,
+            branch: git_context.branch,
+            commit: git_context.commit,
+            committer: git_context.author,
+            remote_url: git_context.remote_url,
+            message: git_context.message,
         }
     }
 }


### PR DESCRIPTION
new clippy update enforces rusty naming conventions and disallows capitalizing acronyms in enum variants/struct names. we had to ignore those clippy warnings in our `rover-client/query` module because all of that stuff is autogenerated and there's nothing we can do.

also wanted us to implement `From` instead of `Into` for `GitContext` since `From` gives you `Into` for free while that is not the case the other way around.

none of this changes any behavior.