### PR TITLE
chore: adds rust caching to clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,23 @@ jobs:
           rustup default stable
           rustup component add rustfmt
           rustup component add clippy
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: linux-stable-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            linux-stable-cargo-registry-
+
+      - name: Cache Cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: linux-stable-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            linux-stable-cargo-index-
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
the rest of our GitHub actions workflows pull from the cache to take advantage of rust's incremental compilation. we should do this for clippy too so it finishes (and fails) faster..

it only shaved about a minute off of our linter time but hey. those minutes add up.