### PR TITLE
feat(installer): graceful fallback to monochromic output when `tput` is unavailable

### DIFF
--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -29,7 +29,6 @@ download_binary_and_run_installer() {
     need_cmd tar
     need_cmd which
     need_cmd dirname
-    need_cmd tput
 
     # if $VERSION isn't provided or has 0 length, use version from Rover cargo.toml
     # ${VERSION:-} checks if version exists, and if doesn't uses the default
@@ -143,14 +142,14 @@ get_architecture() {
 
 
 say() {
-    local green=`tput setaf 2`
-    local reset=`tput sgr0`
+    local green=`tput setaf 2 2>/dev/null || echo ''`
+    local reset=`tput sgr0 2>/dev/null || echo ''`
     echo "$1"
 }
 
 err() {
-    local red=`tput setaf 1`
-    local reset=`tput sgr0`
+    local red=`tput setaf 1 2>/dev/null || echo ''`
+    local reset=`tput sgr0 2>/dev/null || echo ''`
     say "${red}ERROR${reset}: $1" >&2
     exit 1
 }

--- a/installers/binstall/scripts/nix/local-install.sh
+++ b/installers/binstall/scripts/nix/local-install.sh
@@ -21,7 +21,6 @@ copy_binary_and_run_installer() {
     need_cmd which
     need_cmd dirname
     need_cmd cargo
-    need_cmd tput
 
     say "building rover"
     ensure cargo build --workspace
@@ -101,16 +100,15 @@ get_architecture() {
     RETVAL="$_arch"
 }
 
-
 say() {
-    local green=`tput setaf 2`
-    local reset=`tput sgr0`
+    local green=`tput setaf 2 2>/dev/null || echo ''`
+    local reset=`tput sgr0 2>/dev/null || echo ''`
     echo "  ${green}INFO${reset} sh::wrapper: $1"
 }
 
 err() {
-    local red=`tput setaf 1`
-    local reset=`tput sgr0`
+    local red=`tput setaf 1 2>/dev/null || echo ''`
+    local reset=`tput sgr0 2>/dev/null || echo ''`
     say "  ${red}ERROR${reset} sh::wrapper: $1" >&2
     exit 1
 }


### PR DESCRIPTION
The `tput` command allows easier ANSI output using named values in rather than control characters.

While we could just use control characters and maintain colored output in the absence of `tput`, it's probably also reasonable to gracefully fall back to monochromatic output.

Fixes #371