### PR TITLE
infra: test, build and release on ubuntu-16.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         build: [linux, macos, windows]
         include:
           - build: linux
-            os: ubuntu-latest
+            os: ubuntu-16.04
             rust: stable
           - build: macos
             os: macos-latest
@@ -222,7 +222,7 @@ jobs:
   release:
     name: GitHub Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - name: Query version number
         id: get_version

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -17,7 +17,7 @@ jobs:
           ]
         include:
           - build: linux-nightly
-            os: ubuntu-latest
+            os: ubuntu-16.04
             rust: nightly
           - build: macos-nightly
             os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         build: [linux-stable, macos-stable, windows-stable]
         include:
           - build: linux-stable
-            os: ubuntu-latest
+            os: ubuntu-16.04
             rust: stable
           - build: macos-stable
             os: macos-latest


### PR DESCRIPTION
This pins us to Ubuntu 16.04 which ships with glib 2.19.  This should allow
us to work with a wider range of operating systems than the newer glib that
we get with Ubuntu 20.04, which is `ubuntu-latest` on GitHub Actions Virtual
Environments (which resulted in a Rover that wouldn't run on my Ubuntu 18.04).

Ubuntu 16.04 is LTS until April 2024, and is still receiving active updates
through the LTS program.