### PR TITLE
Use docker instead of machine on CircleCI

### DIFF
--- a/docs/source/ci-cd.md
+++ b/docs/source/ci-cd.md
@@ -32,8 +32,8 @@ version: 2.1
 
 jobs:
   build:
-    machine:
-      image: ubuntu-1604:202007-01
+    docker:
+      - image: cimg/node:15.11.0        
     steps:
       - run:
           name: Install


### PR DESCRIPTION
Use a common docker image instead of a machine executor in the CircleCI example -- docker builds are lighter weight and more common CircleCI