### PR TITLE
chore: rename core to supergraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     config      Configuration profile commands
-    supergraph        Supergraph schema commands
+    supergraph    Supergraph schema commands
     docs        Interact with Rover's documentation
     graph       Non-federated schema/graph commands
     help        Prints this message or the help of the given subcommand(s)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     config      Configuration profile commands
-    core        Core schema commands
+    supergraph        Supergraph schema commands
     docs        Interact with Rover's documentation
     graph       Non-federated schema/graph commands
     help        Prints this message or the help of the given subcommand(s)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     config      Configuration profile commands
-    supergraph    Supergraph schema commands
+    supergraph  Supergraph schema commands
     docs        Interact with Rover's documentation
     graph       Non-federated schema/graph commands
     help        Prints this message or the help of the given subcommand(s)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,10 +93,10 @@ pub enum Command {
     /// Supergraph schema commands
     Supergraph(command::Supergraph),
 
-    /// Non-federated schema/graph commands
+    /// Graph API schema commands
     Graph(command::Graph),
 
-    /// Federated schema/graph commands
+    /// Subgraph schema commands
     Subgraph(command::Subgraph),
 
     /// Interact with Rover's documentation

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,8 +90,8 @@ pub enum Command {
     /// Configuration profile commands
     Config(command::Config),
 
-    /// Core schema commands
-    Core(command::Core),
+    /// Supergraph schema commands
+    Supergraph(command::Supergraph),
 
     /// Non-federated schema/graph commands
     Graph(command::Graph),
@@ -129,7 +129,7 @@ impl Rover {
             Command::Config(command) => {
                 command.run(self.get_rover_config()?, self.get_client_config()?)
             }
-            Command::Core(command) => command.run(),
+            Command::Supergraph(command) => command.run(),
             Command::Docs(command) => command.run(),
             Command::Graph(command) => {
                 command.run(self.get_client_config()?, self.get_git_context()?)

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,7 +8,6 @@ mod subgraph;
 mod supergraph;
 mod update;
 
-pub use supergraph::Supergraph;
 pub use config::Config;
 pub use docs::Docs;
 pub use graph::Graph;
@@ -16,4 +15,5 @@ pub use info::Info;
 pub use install::Install;
 pub use output::RoverStdout;
 pub use subgraph::Subgraph;
+pub use supergraph::Supergraph;
 pub use update::Update;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,7 +8,7 @@ mod subgraph;
 mod supergraph;
 mod update;
 
-pub use self::supergraph::Supergraph;
+pub use supergraph::Supergraph;
 pub use config::Config;
 pub use docs::Docs;
 pub use graph::Graph;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,14 +1,14 @@
 mod config;
-mod core;
 mod docs;
 mod graph;
 mod info;
 mod install;
 mod output;
 mod subgraph;
+mod supergraph;
 mod update;
 
-pub use self::core::Core;
+pub use self::supergraph::Supergraph;
 pub use config::Config;
 pub use docs::Docs;
 pub use graph::Graph;

--- a/src/command/supergraph/build.rs
+++ b/src/command/supergraph/build.rs
@@ -9,7 +9,7 @@ use super::config;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Build {
-    /// The relative path to the core configuration file.
+    /// The relative path to the supergraph configuration file.
     #[structopt(long = "config")]
     #[serde(skip_serializing)]
     config_path: Utf8PathBuf,
@@ -17,8 +17,8 @@ pub struct Build {
 
 impl Build {
     pub fn run(&self) -> Result<RoverStdout> {
-        let core_config = config::parse_core_config(&self.config_path)?;
-        let subgraph_definitions = core_config.get_subgraph_definitions(&self.config_path)?;
+        let supergraph_config = config::parse_supergraph_config(&self.config_path)?;
+        let subgraph_definitions = supergraph_config.get_subgraph_definitions(&self.config_path)?;
 
         match harmonizer::harmonize(subgraph_definitions) {
             Ok(csdl) => Ok(RoverStdout::Csdl(csdl)),

--- a/src/command/supergraph/compose.rs
+++ b/src/command/supergraph/compose.rs
@@ -8,14 +8,14 @@ use structopt::StructOpt;
 use super::config;
 
 #[derive(Debug, Serialize, StructOpt)]
-pub struct Build {
+pub struct Compose {
     /// The relative path to the supergraph configuration file.
     #[structopt(long = "config")]
     #[serde(skip_serializing)]
     config_path: Utf8PathBuf,
 }
 
-impl Build {
+impl Compose {
     pub fn run(&self) -> Result<RoverStdout> {
         let supergraph_config = config::parse_supergraph_config(&self.config_path)?;
         let subgraph_definitions = supergraph_config.get_subgraph_definitions(&self.config_path)?;

--- a/src/command/supergraph/config.rs
+++ b/src/command/supergraph/config.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::fs;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct CoreConfig {
+pub(crate) struct SupergraphConfig {
     pub(crate) subgraphs: HashMap<String, Subgraph>,
 }
 
@@ -23,11 +23,11 @@ pub(crate) struct Schema {
     pub(crate) file: Utf8PathBuf,
 }
 
-pub(crate) fn parse_core_config(config_path: &Utf8PathBuf) -> Result<CoreConfig> {
-    let raw_core_config = fs::read_to_string(config_path)
+pub(crate) fn parse_supergraph_config(config_path: &Utf8PathBuf) -> Result<SupergraphConfig> {
+    let raw_supergraph_config = fs::read_to_string(config_path)
         .map_err(|e| anyhow!("Could not read \"{}\": {}", config_path, e))?;
 
-    let parsed_config = serde_yaml::from_str(&raw_core_config)
+    let parsed_config = serde_yaml::from_str(&raw_supergraph_config)
         .map_err(|e| anyhow!("Could not parse YAML from \"{}\": {}", config_path, e))?;
 
     tracing::debug!(?parsed_config);
@@ -35,7 +35,7 @@ pub(crate) fn parse_core_config(config_path: &Utf8PathBuf) -> Result<CoreConfig>
     Ok(parsed_config)
 }
 
-impl CoreConfig {
+impl SupergraphConfig {
     pub(crate) fn get_subgraph_definitions(
         &self,
         config_path: &Utf8PathBuf,
@@ -88,8 +88,8 @@ mod tests {
         config_path.push("config.yaml");
         fs::write(&config_path, raw_good_yaml).unwrap();
 
-        let core_config = super::parse_core_config(&config_path);
-        if let Err(e) = core_config {
+        let supergraph_config = super::parse_supergraph_config(&config_path);
+        if let Err(e) = supergraph_config {
             panic!(e.to_string())
         }
     }
@@ -108,7 +108,7 @@ mod tests {
         let mut config_path = Utf8PathBuf::from_path_buf(tmp_home.path().to_path_buf()).unwrap();
         config_path.push("config.yaml");
         fs::write(&config_path, raw_bad_yaml).unwrap();
-        assert!(super::parse_core_config(&config_path).is_err())
+        assert!(super::parse_supergraph_config(&config_path).is_err())
     }
 
     #[test]
@@ -126,8 +126,10 @@ mod tests {
         let mut config_path = Utf8PathBuf::from_path_buf(tmp_home.path().to_path_buf()).unwrap();
         config_path.push("config.yaml");
         fs::write(&config_path, raw_good_yaml).unwrap();
-        let core_config = super::parse_core_config(&config_path).unwrap();
-        assert!(core_config.get_subgraph_definitions(&config_path).is_err())
+        let supergraph_config = super::parse_supergraph_config(&config_path).unwrap();
+        assert!(supergraph_config
+            .get_subgraph_definitions(&config_path)
+            .is_err())
     }
 
     #[test]
@@ -150,8 +152,10 @@ mod tests {
         let people_path = tmp_dir.join("people.graphql");
         fs::write(films_path, "there is something here").unwrap();
         fs::write(people_path, "there is also something here").unwrap();
-        let core_config = super::parse_core_config(&config_path).unwrap();
-        assert!(core_config.get_subgraph_definitions(&config_path).is_ok())
+        let supergraph_config = super::parse_supergraph_config(&config_path).unwrap();
+        assert!(supergraph_config
+            .get_subgraph_definitions(&config_path)
+            .is_ok())
     }
 
     #[test]
@@ -177,8 +181,10 @@ mod tests {
         let people_path = tmp_dir.join("people.graphql");
         fs::write(films_path, "there is something here").unwrap();
         fs::write(people_path, "there is also something here").unwrap();
-        let core_config = super::parse_core_config(&config_path).unwrap();
-        let subgraph_definitions = core_config.get_subgraph_definitions(&config_path).unwrap();
+        let supergraph_config = super::parse_supergraph_config(&config_path).unwrap();
+        let subgraph_definitions = supergraph_config
+            .get_subgraph_definitions(&config_path)
+            .unwrap();
         let people_subgraph = subgraph_definitions.get(0).unwrap();
         let film_subgraph = subgraph_definitions.get(1).unwrap();
 

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -1,4 +1,4 @@
-mod build;
+mod compose;
 pub(crate) mod config;
 
 use serde::Serialize;
@@ -15,14 +15,14 @@ pub struct Supergraph {
 
 #[derive(Debug, Serialize, StructOpt)]
 pub enum Command {
-    /// Build a supergraph schema from a set of subgraphs.
-    Build(build::Build),
+    /// Locally compose a supergraph schema from a set of subgraph schemas
+    Compose(compose::Compose),
 }
 
 impl Supergraph {
     pub fn run(&self) -> Result<RoverStdout> {
         match &self.command {
-            Command::Build(command) => command.run(),
+            Command::Compose(command) => command.run(),
         }
     }
 }

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -8,18 +8,18 @@ use crate::command::RoverStdout;
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
-pub struct Core {
+pub struct Supergraph {
     #[structopt(subcommand)]
     command: Command,
 }
 
 #[derive(Debug, Serialize, StructOpt)]
 pub enum Command {
-    /// Build a core schema from a set of subgraphs.
+    /// Build a supergraph schema from a set of subgraphs.
     Build(build::Build),
 }
 
-impl Core {
+impl Supergraph {
     pub fn run(&self) -> Result<RoverStdout> {
         match &self.command {
             Command::Build(command) => command.run(),


### PR DESCRIPTION
## Description

This Draft is in place in case Product decides to rename `core` to `supergraph`. Do not merge until we get a green light from @ndintenfass!