### PR TITLE
chore(binstall): remove binary before overwriting it

### DIFF
--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -73,6 +73,9 @@ impl Installer {
         let bin_path = self.get_bin_path()?;
         tracing::debug!("copying from: {}", &self.executable_location);
         tracing::debug!("copying to: {}", &bin_path);
+        // attempt to remove the old binary
+        // but do not error if it doesn't exist.
+        let _ = fs::remove_file(&bin_path);
         fs::copy(&self.executable_location, &bin_path)?;
         Ok(())
     }


### PR DESCRIPTION
this will _maybe_ fix #398, but i'm not 100% sure! the idea here is to ~trick gatekeeper~ make gatekeeper realize that we really did download a new file and that it should reverify the signature the next time `rover` is run.

---

@lrlna when you get in tomorrow do you wanna try reproducing the current issue by swapping between two versions using the curl installer?

once you reproduce you can merge this and #401, and tag `v0.0.6-rc.0`which would prompt a CI release where you could see if everything is fixed.