### PR TITLE
chore(ci): removes hardened runtime requirement to allow supergraph compose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,8 @@ jobs:
       - name: Codesign (MacOS)
         if: matrix.build == 'macos'
         run: |
-          /usr/bin/codesign --force --sign ${{ env.APPLE_TEAM_ID }} --options runtime --timestamp ./dist/${{ env.RELEASE_BIN }} -v
-          /usr/bin/codesign -vvv --deep --strict ./dist/${{ env.RELEASE_BIN }}
+          /usr/bin/codesign --force --sign ${{ env.APPLE_TEAM_ID }} --deep --timestamp ./dist/${{ env.RELEASE_BIN }} -v
+          /usr/bin/codesign -vvv --strict ./dist/${{ env.RELEASE_BIN }}
           
       - name: Prepare zip for notarization (MacOS)
         if: matrix.build == 'macos'


### PR DESCRIPTION
this should definitely fix #399 - the problems we're seeing with running `supergraph compose` on macbooks is due to `--options runtime` which we were specifying in our CI script