### PR TITLE
fix: we no longer output CSDL but a core schema

### DIFF
--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -18,7 +18,7 @@ use crate::utils::table::{self, cell, row};
 pub enum RoverStdout {
     DocsList(HashMap<&'static str, &'static str>),
     Sdl(String),
-    Csdl(String),
+    CoreSchema(String),
     SchemaHash(String),
     SubgraphList(ListDetails),
     VariantList(Vec<String>),
@@ -48,8 +48,8 @@ impl RoverStdout {
                 eprintln!("SDL:");
                 println!("{}", &sdl);
             }
-            RoverStdout::Csdl(csdl) => {
-                eprintln!("CSDL:");
+            RoverStdout::CoreSchema(csdl) => {
+                eprintln!("CoreSchema:");
                 println!("{}", &csdl);
             }
             RoverStdout::SchemaHash(hash) => {

--- a/src/command/supergraph/compose.rs
+++ b/src/command/supergraph/compose.rs
@@ -21,7 +21,7 @@ impl Compose {
         let subgraph_definitions = supergraph_config.get_subgraph_definitions(&self.config_path)?;
 
         match harmonizer::harmonize(subgraph_definitions) {
-            Ok(csdl) => Ok(RoverStdout::Csdl(csdl)),
+            Ok(core_schema) => Ok(RoverStdout::CoreSchema(core_schema)),
             Err(composition_errors) => {
                 let num_failures = composition_errors.len();
                 for composition_error in composition_errors {


### PR DESCRIPTION
A small language change to reflect that Rover output a core schema with `rover supergraph compose`.