### PR TITLE
feat(binstall): adds postinstall instructions

### DIFF
--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -52,7 +52,7 @@ impl Installer {
         Ok(base_dir.join(&format!(".{}", &self.binary_name)))
     }
 
-    pub(crate) fn get_bin_dir_path(&self) -> Result<Utf8PathBuf, InstallerError> {
+    pub fn get_bin_dir_path(&self) -> Result<Utf8PathBuf, InstallerError> {
         let bin_dir = self.get_base_dir_path()?.join("bin");
         Ok(bin_dir)
     }

--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -32,7 +32,7 @@ impl Install {
                 .install()
                 .with_context(|| format!("could not install {}", &binary_name))?;
 
-            if let Some(_) = install_location {
+            if install_location.is_some() {
                 let bin_dir_path = installer.get_bin_dir_path()?;
                 eprintln!("{} was successfully installed. Great!", &binary_name);
                 if !cfg!(windows) {


### PR DESCRIPTION
in place of #336 - this is very similar to what Rust does (their installer also requires that you reload your shell manually the first time, doesn't seem to be possible to do automatically)

if it's a fresh install it looks like this:

```
Writing binary to /Users/avery/.rover/bin/rover
rover was successfully installed. Great!

To get started you need Rover's bin directory (/Users/avery/.rover/bin) in your PATH environment variable. Next time you log in this will be done automatically.

To configure your current shell, you can run:
exec /bin/zsh
```

if it's an upgrade install it looks like this:

```
Writing binary to /Users/avery/.rover/bin/rover
rover was successfully installed. Great!
```