### PR TITLE
feat: adds spinner feature for client requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+dependencies = [
+ "console 0.14.1",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1288,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
@@ -1795,6 +1813,7 @@ dependencies = [
  "graphql_client",
  "houston",
  "http",
+ "indicatif",
  "indoc",
  "online",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [".", "crates/*", "installers/binstall"]
 binstall = { path = "./installers/binstall" }
 houston = { path = "./crates/houston" }
 robot-panic = { path = "./crates/robot-panic" }
-rover-client = { path = "./crates/rover-client" }
+rover-client = { path = "./crates/rover-client", features = ["spinners"] }
 sdl-encoder = { path = "./crates/sdl-encoder" }
 sputnik = { path = "./crates/sputnik" }
 timber = { path = "./crates/timber" }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4"
 graphql-parser = "0.3.0"
 graphql_client = "0.9"
 http = "0.2"
+indicatif = { version = "0.15", optional = true }
 regex = "1.4.5"
 reqwest = {version = "0.11", features = ["json", "blocking", "native-tls-vendored"]}
 sdl-encoder = {path = "../sdl-encoder"}
@@ -24,6 +25,9 @@ serde = "1"
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
+
+[features]
+spinners = ["indicatif"]
 
 [build-dependencies]
 camino = "1"

--- a/crates/rover-client/src/query/config/whoami.rs
+++ b/crates/rover-client/src/query/config/whoami.rs
@@ -4,6 +4,8 @@ use houston::CredentialOrigin;
 
 use graphql_client::*;
 
+use std::fmt::Display;
+
 #[derive(GraphQLQuery)]
 // The paths are relative to the directory where your `Cargo.toml` is located.
 // Both json and the GraphQL schema language are supported as sources for the schema
@@ -40,6 +42,19 @@ pub fn run(
     client: &StudioClient,
 ) -> Result<RegistryIdentity, RoverClientError> {
     let response_data = client.post::<WhoAmIQuery>(variables)?;
+    get_identity_from_response_data(response_data, client.credential.origin.clone())
+}
+
+/// Get info from the registry about an API key, i.e. the name/id of the
+/// user/graph and what kind of key it is (GRAPH/USER/Other)
+/// Also prints a loading message with a progress spinner.
+#[cfg(feature = "spinners")]
+pub fn run_with_message<M: Display>(
+    variables: who_am_i_query::Variables,
+    message: M,
+    client: &StudioClient,
+) -> Result<RegistryIdentity, RoverClientError> {
+    let response_data = client.post_with_message::<WhoAmIQuery, M>(variables, message)?;
     get_identity_from_response_data(response_data, client.credential.origin.clone())
 }
 

--- a/crates/rover-client/src/query/graph/check.rs
+++ b/crates/rover-client/src/query/graph/check.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::blocking::StudioClient;
 use crate::RoverClientError;
 use graphql_client::*;
@@ -28,6 +30,21 @@ pub fn run(
 ) -> Result<CheckResponse, RoverClientError> {
     let graph = variables.graph_id.clone();
     let data = client.post::<CheckSchemaQuery>(variables)?;
+    get_check_response_from_data(data, graph)
+}
+
+/// The main function to be used from this module.
+/// This function takes a proposed schema and validates it against a published
+/// schema.
+/// Also prints a loading message with a progress spinner.
+#[cfg(feature = "spinners")]
+pub fn run_with_message<M: Display>(
+    variables: check_schema_query::Variables,
+    message: M,
+    client: &StudioClient,
+) -> Result<CheckResponse, RoverClientError> {
+    let graph = variables.graph_id.clone();
+    let data = client.post_with_message::<CheckSchemaQuery, M>(variables, message)?;
     get_check_response_from_data(data, graph)
 }
 

--- a/crates/rover-client/src/query/graph/fetch.rs
+++ b/crates/rover-client/src/query/graph/fetch.rs
@@ -2,6 +2,8 @@ use crate::blocking::StudioClient;
 use crate::RoverClientError;
 use graphql_client::*;
 
+use std::fmt::Display;
+
 // I'm not sure where this should live long-term
 /// this is because of the custom GraphQLDocument scalar in the schema
 type GraphQLDocument = String;
@@ -32,6 +34,24 @@ pub fn run(
         .clone()
         .unwrap_or_else(|| "current".to_string());
     let response_data = client.post::<FetchSchemaQuery>(variables)?;
+    get_schema_from_response_data(response_data, graph, invalid_variant)
+    // if we want json, we can parse & serialize it here
+}
+
+/// The main function to be used from this module. This function fetches a
+/// schema from apollo studio and returns it in either sdl (default) or json format
+#[cfg(feature = "spinners")]
+pub fn run_with_message<M: Display>(
+    variables: fetch_schema_query::Variables,
+    message: M,
+    client: &StudioClient,
+) -> Result<String, RoverClientError> {
+    let graph = variables.graph_id.clone();
+    let invalid_variant = variables
+        .variant
+        .clone()
+        .unwrap_or_else(|| "current".to_string());
+    let response_data = client.post_with_message::<FetchSchemaQuery, M>(variables, message)?;
     get_schema_from_response_data(response_data, graph, invalid_variant)
     // if we want json, we can parse & serialize it here
 }

--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -28,9 +28,12 @@ impl WhoAmI {
         client_config: StudioClientConfig,
     ) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
-        eprintln!("Checking identity of your API key against the registry.");
 
-        let identity = whoami::run(whoami::who_am_i_query::Variables {}, &client)?;
+        let identity = whoami::run_with_message(
+            whoami::who_am_i_query::Variables {},
+            "Checking identity of your API key against the registry.",
+            &client,
+        )?;
 
         let mut message = format!(
             "{}: {:?}\n",

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -57,7 +57,11 @@ impl Check {
     ) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
         let sdl = load_schema_from_flag(&self.schema, std::io::stdin())?;
-        let res = check::run(
+        let message = format!(
+            "Validated the proposed subgraph against metrics from {}",
+            &self.graph
+        );
+        let res = check::run_with_message(
             check::check_schema_query::Variables {
                 graph_id: self.graph.name.clone(),
                 variant: Some(self.graph.variant.clone()),
@@ -74,13 +78,9 @@ impl Check {
                     included_variants: None,
                 },
             },
+            message,
             &client,
         )?;
-
-        eprintln!(
-            "Validated the proposed subgraph against metrics from {}",
-            &self.graph
-        );
 
         let num_changes = res.changes.len();
 

--- a/src/command/graph/fetch.rs
+++ b/src/command/graph/fetch.rs
@@ -27,18 +27,19 @@ impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
-        eprintln!(
+        let message = format!(
             "Fetching SDL from {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
             Yellow.normal().paint(&self.profile_name)
         );
 
-        let sdl = fetch::run(
+        let sdl = fetch::run_with_message(
             fetch::fetch_schema_query::Variables {
                 graph_id: self.graph.name.clone(),
                 hash: None,
                 variant: Some(self.graph.variant.clone()),
             },
+            message,
             &client,
         )?;
 


### PR DESCRIPTION
hacked on a quick little thing to add spinner style loading messages to some of our client requests. most of the time you don't even see the spinner since the API is lightning quick (like `config whoami`), but other operations like `graph fetch` can take just a _tad_ longer sometimes.

not sure if i love the API i've set up here so before going all in on adding this to every single command i wanted to get some feedback.

if you'd like to see what it looks like, you can check out this [asciinema](https://asciinema.org/a/Pi00RF661kCPCOmVUuewO3eMF) 😄 

you can see that the message disappears after the spinner is done, which might be a problem for folks since it happens so fast. maybe we could have a "loading" message paired with a "done" message so it's not so jarring. 

also happy to just scrap this, just wanted to play around a bit after all that notarization work