### PR TITLE
feat: release rover nightly at 9AM UTC

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,49 @@
+name: Nightly Release
+
+on:
+  schedule: 
+    - cron: '0 9 * * *' # Release every day at 9AM UTC
+
+jobs:
+  tag:
+    name: Tag nightly release
+    runs-on: ubuntu-16.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        if: matrix.rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          cargo install cargo-incversion
+
+      - name: Install Node and npm
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Get nightly version
+        shell: bash
+        id: get_version
+        run: |
+          raw_version=$(cargo run -- --version)
+          split_version=($raw_version)
+          new_version="v${split_version[1]}-nightly"
+          echo ::set-output name=version::"$new_version"
+
+      - name: Update Rover's version
+        shell: bash
+        run: |
+          cargo-incversion -c ${{ steps.get_version.outputs.version }}
+          cargo update
+          cargo build
+
+      # This will trigger the job in release.yml
+      # We use `-f` to overwrite the nightly tag every day.
+      - name: Create and push nightly tag
+        shell: bash
+        run: |
+          git tag -a -f ${{ steps.get_version.outputs.version }}
+          git push --tags -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,26 @@ jobs:
             os: windows-latest
             rust: stable
 
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      is-nightly: ${{ contains(steps.get_version.outputs.version, 'nightly' }}
+      is-alpha: ${{ contains(steps.get_version.outputs.version, 'alpha') }}
+      is-beta: ${{ contains(steps.get_version.ouputs.version, 'beta') }}
+      is-test: ${{ contains(steps.get_version.ouputs.version, 'test') }}
+
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Rust
+        if: matrix.rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+
+      - name: Install Node and npm
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Query version number
         id: get_version
@@ -46,17 +64,6 @@ jobs:
         run: |
           echo "using version tag ${GITHUB_REF:10}"
           echo ::set-output name=version::"${GITHUB_REF:10}"
-        
-      - name: Install Node and npm
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
-      - name: Install Rust
-        if: matrix.rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
 
       - name: Install p7zip (MacOS)
         if: matrix.build == 'macos'
@@ -102,14 +109,14 @@ jobs:
         if: matrix.build == 'linux'
         run: |
           mv ./target/${{ env.LINUX_TARGET }}/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
-          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.version }}-${{ env.LINUX_TARGET }}.tar.gz
 
       - name: Create tarball (Windows)
         if: matrix.build == 'windows'
         shell: bash
         run: |
           mv ./target/release/${{ env.RELEASE_BIN }}.exe ./dist/${{ env.RELEASE_BIN }}.exe
-          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.version }}-${{ env.WINDOWS_TARGET }}.tar.gz
 
       - name: Create build keychain (MacOS)
         if: matrix.build == 'macos'
@@ -155,7 +162,7 @@ jobs:
       - name: Prepare zip for notarization (MacOS)
         if: matrix.build == 'macos'
         run: |
-          ditto -c -k --keepParent ./dist "rover-${{ steps.get_version.outputs.VERSION }}.zip"
+          ditto -c -k --keepParent ./dist "rover-${{ steps.get_version.outputs.version }}.zip"
           
       - name: Begin notarization process (MacOS)
         if: matrix.build == 'macos'
@@ -168,7 +175,7 @@ jobs:
           --username ${{ env.APPLE_USERNAME }} \
           --asc-provider ${{ env.APPLE_TEAM_ID }} \
           --password ${{ secrets.MACOS_NOTARIZATION_PASSWORD }} \
-          --file ./rover-${{ steps.get_version.outputs.VERSION }}.zip \
+          --file ./rover-${{ steps.get_version.outputs.version }}.zip \
           --output-format json)
           echo "::set-output name=NOTARIZE_JSON::$NOTARIZE_JSON"
 
@@ -223,7 +230,7 @@ jobs:
       - name: Create tarball (MacOS)
         if: matrix.build == 'macos'
         run: |
-          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.version }}-${{ env.MACOS_TARGET }}.tar.gz
 
       - name: Upload Tarball
         uses: actions/upload-artifact@v1
@@ -239,24 +246,20 @@ jobs:
       npm-dir: ./installers/npm
       node-version: '14.x'
       registry-url: 'https://registry.npmjs.org'
-      is-prerelease: ${{ contains(steps.get_version.outputs.VERSION, 'alpha') || contains(steps.get_version.ouputs.VERSION, 'beta') || contains(steps.get_version.outputs.VERSION, 'test')}}
-    steps:
-      - name: Query version number
-        id: get_version
-        shell: bash
-        run: |
-          echo "using version tag ${GITHUB_REF:10}"
-          echo ::set-output name=version::"${GITHUB_REF:10}"
+      rover-version: ${{ needs.build.outputs.version }}
+      is-prelease: ${{ needs.build.outputs.is-nightly || needs.build.outputs.is-alpha || needs.build.outputs.is-beta || needs.build.outputs.is-test }}
+      is-nightly: ${{ needs.build.outputs.is-nightly }}
 
+    steps:
       - name: Download artifacts
         uses: actions/download-artifact@v2
 
       - name: Unzip binaries
         shell: bash
         run: |
-          tar -xzvf ./linux/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }} ./linux-cli && rm -rf dist
-          tar -xzvf ./windows/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }}.exe ./windows-cli.exe && rm -rf dist
-          tar -xzvf ./macos/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }} ./macos-cli && rm -rf dist
+          tar -xzvf ./linux/${{ env.RELEASE_BIN }}-${{ env.rover-version }}-${{ env.LINUX_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }} ./linux-cli && rm -rf dist
+          tar -xzvf ./windows/${{ env.RELEASE_BIN }}-${{ env.rover-version }}-${{ env.WINDOWS_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }}.exe ./windows-cli.exe && rm -rf dist
+          tar -xzvf ./macos/${{ env.RELEASE_BIN }}-${{ env.rover-version }}-${{ env.MACOS_TARGET }}.tar.gz && mv ./dist/${{ env.RELEASE_BIN }} ./macos-cli && rm -rf dist
 
       - name: Hash binaries
         id: get_shas
@@ -272,8 +275,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: ${{ steps.get_version.outputs.VERSION }}
+          tag_name: ${{ env.rover-version }}
+          release_name: ${{ env.rover-version }}
           prerelease: ${{ env.is-prerelease }}
           body: |
             <!---
@@ -291,9 +294,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./linux/rover-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+          asset_path: ./linux/rover-${{ env.rover-version }}-${{ env.LINUX_TARGET }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: rover-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+          asset_name: rover-${{ env.rover-version }}-${{ env.LINUX_TARGET }}.tar.gz
 
       - name: Release Windows tarball
         uses: actions/upload-release-asset@v1
@@ -301,9 +304,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./windows/rover-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz
+          asset_path: ./windows/rover-${{ env.rover-version }}-${{ env.WINDOWS_TARGET }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: rover-${{ steps.get_version.outputs.VERSION }}-${{ env.WINDOWS_TARGET }}.tar.gz
+          asset_name: rover-${{ env.rover-version }}-${{ env.WINDOWS_TARGET }}.tar.gz
 
       - name: Release MacOS tarball
         uses: actions/upload-release-asset@v1
@@ -311,9 +314,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./macos/rover-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+          asset_path: ./macos/rover-${{ env.rover-version }}-${{ env.MACOS_TARGET }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: rover-${{ steps.get_version.outputs.VERSION }}-${{ env.MACOS_TARGET }}.tar.gz
+          asset_name: rover-${{ env.rover-version }}-${{ env.MACOS_TARGET }}.tar.gz
 
       - name: Set up .npmrc and install dependencies
         uses: actions/setup-node@v2
@@ -328,7 +331,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ !env.is-prerelease }}
         working-directory: ${{ env.npm-dir }}
-        run: npm publish --tag stable
+        run: npm publish
+
+      - name: Publish to npm (nightly)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ env.is-nightly }}
+        working-directory: ${{ env.npm-dir }}
+        run: npm publish --tag nightly
           
       - name: Publish to npm (prerelease)
         env:


### PR DESCRIPTION
once we merge #416 and update our docs to point installations to `rover.apollo.dev`, our release process will be completely automated, with the only manual step being writing the changelog. this means that nightly builds should be a relatively easy lift!

this PR adds a cron trigger to our release github action, meaning a tag in the form of `v${cargo.toml version}-nightly` will be built, tagged, and released every day at 9AM UTC. Happy to choose another time, I didn't put much thought into when this would be done (this is 11AM at @lrlna's time, and Jake and I are both out yet for a few hours, so maybe a different time is better to get some more overlap?) 

Our main `release.yml` remains (mostly) untouched, with one change being made to tag our nightly builds on npm, all nightly builds are triggered by `nightly.yml` which appends `-nightly` to the version in `Cargo.toml`, and then creates and force pushes a tag named after the nightly version. Since this begins with `v`, it will trigger the release process specified in `release.yml`.

I think it'd be great for nightly builds to be added to anybody using rover internally so we break them before we break external customers. My hope would be that if we did break nightly rover, we'd only be preventing new changes being pushed to graphs rather than taking down the API completely. 
