### PR TITLE
fix(rover): store SupergraphConfig in BTreeMap

### DIFF
--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.1.tgz",
+      "integrity": "sha512-qyTw2VPYRg31SlVU5WDdvCSyMTJ3YSP4Kz2CidWZFPFawCiHJdCyKyZeXIGMJ5ebMQYXEI56kDR8tcnDkbZstg=="
     },
     "node_modules/binary-install": {
       "version": "0.1.1",
@@ -306,9 +306,9 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.1.tgz",
+      "integrity": "sha512-qyTw2VPYRg31SlVU5WDdvCSyMTJ3YSP4Kz2CidWZFPFawCiHJdCyKyZeXIGMJ5ebMQYXEI56kDR8tcnDkbZstg=="
     },
     "binary-install": {
       "version": "0.1.1",

--- a/src/command/supergraph/config.rs
+++ b/src/command/supergraph/config.rs
@@ -4,12 +4,14 @@ use camino::Utf8PathBuf;
 use harmonizer::ServiceDefinition as SubgraphDefinition;
 use serde::{Deserialize, Serialize};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+
 use std::fs;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SupergraphConfig {
-    pub(crate) subgraphs: HashMap<String, Subgraph>,
+    // Store config in a BTreeMap, as HashMap is non-deterministic.
+    pub(crate) subgraphs: BTreeMap<String, Subgraph>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
SupergraphConfig was previously stored in a HashMap, the implementation
of which is non-deterministic in Rust. This commit changes it over to a
BTreeMap which ensures correct ordering.

closes #422