### PR TITLE
Update install instructions to use a static url

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,26 +106,32 @@ This repo is organized as a [`cargo` workspace], containing several related proj
 
 #### Linux and MacOS `curl | sh` installer
 
+To install the latest release of Rover: 
+
 ```bash
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/nix/install.sh | sh
+curl -sSL https://rover.apollo.dev/nix/latest | sh
 ```
 
-**To download older versions of Rover**, use the `VERSION` env variable when executing the installer (note: the `v` in the version number):
+To install a specific version of Rover (note the `v` prefixing the version number):
+
+> Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1 sh
+curl -sSL https://rover.apollo.dev/nix/v0.0.7 | sh
 ```
 
 #### Windows PowerShell installer
 
 ```bash
-iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://rover.apollo.dev/win/latest' | iex
 ```
 
-**To download older versions of Rover**, use the `VERSION` env variable when executing the installer (note: the `v` in the version number):
+To install a specific version of Rover (note the `v` prefixing the version number):
+
+> Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-$Env:VERSION='v0.0.1'; iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://rover.apollo.dev/win/v0.0.7' | iex
 ```
 
 #### npm installer

--- a/docs/source/ci-cd.md
+++ b/docs/source/ci-cd.md
@@ -39,7 +39,7 @@ jobs:
           name: Install
           command: |
             # download and install Rover
-            curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/nix/install.sh | sh
+            curl -sSL https://rover.apollo.dev/nix/v0.0.7 | sh
             
             # This allows the PATH changes to persist to the next `run` step
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/nix/install.sh | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.0.7 | sh
           
           # Add Rover to the $GITHUB_PATH so it can be used in another step
           # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -9,25 +9,32 @@ The Rover CLI is available for Linux, Mac, and Windows.
 
 #### Linux and MacOS `curl | sh` installer
 
-```bash
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/nix/install.sh | sh
-```
-
-**To download older versions of Rover**, use the `VERSION` env variable when executing the installer (note: the `v` in the version number):
+To install the latest release of Rover: 
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/nix/install.sh | VERSION=v0.0.1 sh
+curl -sSL https://rover.apollo.dev/nix/latest | sh
 ```
+
+To install a specific version of Rover (note the `v` prefixing the version number):
+
+> Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
+
+```bash
+curl -sSL https://rover.apollo.dev/nix/v0.0.7 | sh
+```
+
 #### Windows PowerShell installer
 
 ```bash
-iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://rover.apollo.dev/win/latest' | iex
 ```
 
-**To download older versions of Rover**, use the `VERSION` env variable when executing the installer (note: the `v` in the version number):
+To install a specific version of Rover (note the `v` prefixing the version number):
+
+> Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-$Env:VERSION='v0.0.1'; iwr 'https://raw.githubusercontent.com/apollographql/rover/v0.0.7/installers/binstall/scripts/windows/install.ps1' | iex
+iwr 'https://rover.apollo.dev/win/v0.0.7' | iex
 ```
 
 #### npm installer


### PR DESCRIPTION
I updated install instructions in

- root readme
- getting started/install instructions in docs
- ci instructions in docs (making sure the examples there point to a specific version, not just `latest`) 