### PR TITLE
feat: print link to getting started after installation

### DIFF
--- a/installers/npm/install.js
+++ b/installers/npm/install.js
@@ -2,3 +2,14 @@
 
 const { install } = require("./binary");
 install();
+// this is duplicated in `src/command/install/mod.rs`
+// for the curl installer.
+
+// use setTimeout so the message prints after the install happens.zzs
+setTimeout(
+  () =>
+    console.log(
+      "You can check out our getting started guide at https://go.apollo.dev/r/start."
+    ),
+  400
+);

--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -1,9 +1,11 @@
+use ansi_term::Colour::Cyan;
 use camino::Utf8PathBuf;
 use serde::Serialize;
 use structopt::StructOpt;
 
 use binstall::Installer;
 
+use crate::command::docs::shortlinks;
 use crate::command::RoverStdout;
 use crate::PKG_NAME;
 use crate::{anyhow, Context, Result};
@@ -35,6 +37,7 @@ impl Install {
             if install_location.is_some() {
                 let bin_dir_path = installer.get_bin_dir_path()?;
                 eprintln!("{} was successfully installed. Great!", &binary_name);
+
                 if !cfg!(windows) {
                     if let Some(path_var) = env::var_os("PATH") {
                         if !path_var
@@ -52,6 +55,13 @@ impl Install {
                         }
                     }
                 }
+
+                // this is duplicated in `installers/npm/install.js`
+                // for the npm installer.
+                eprintln!(
+                    "You can check out our getting started guide at {}.",
+                    Cyan.normal().paint(shortlinks::get_url_from_slug("start"))
+                );
             } else {
                 eprintln!("{} was not installed. To override the existing installation, you can pass the `--force` flag to the installer.", &binary_name);
             }


### PR DESCRIPTION
fixes #141 by printing the output of `rover --help` as long as the user does not need to reload their shell to get rover in their PATH.

if we think it's too much output right away, i'm happy to come up with an alternative solution that's a bit less verbose!