### PR TITLE
fix(ci): env.is-prerelease is a string, not a boolean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,13 +317,13 @@ jobs:
       - name: Publish to npm (stable)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ !env.is-prerelease }}
+        if: ${{ env.is-prerelease == 'false' }}
         working-directory: ${{ env.npm-dir }}
-        run: npm publish --tag stable
+        run: npm publish
           
       - name: Publish to npm (prerelease)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ env.is-prerelease }}
+        if: ${{ env.is-prerelease == 'true' }}
         working-directory: ${{ env.npm-dir }}
         run: npm publish --tag beta


### PR DESCRIPTION
storing booleans in `env` converts them to strings ([source](https://github.community/t/implementing-dry-run-logic-if-and-env/17834/2) - i also confirmed this by pushing up a test action), foiling my plans! this pr fixes it all up though