### PR TITLE
feat: update sha256 section of generated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,9 +251,9 @@ jobs:
         id: get_shas
         shell: bash
         run: |
-          echo ::set-output name=linux::"- __Linux__: $(sha256sum -b linux-cli | cut -d ' ' -f1)"
-          echo ::set-output name=windows::"- __Windows__: $(sha256sum -b windows-cli.exe | cut -d ' ' -f1)"
-          echo ::set-output name=macos::"- __MacOS__: $(sha256sum -b macos-cli | cut -d ' ' -f1)"
+          echo ::set-output name=linux-sha::"$(sha256sum -b linux-cli | cut -d ' ' -f1)"
+          echo ::set-output name=windows-sha::"$(sha256sum -b windows-cli.exe | cut -d ' ' -f1)"
+          echo ::set-output name=macos-sha::"$(sha256sum -b macos-cli | cut -d ' ' -f1)"
 
       - name: Create Release
         id: create_release
@@ -269,11 +269,49 @@ jobs:
               paste the changelog entry here!
             -->
             ---
-            ### SHA256 of release binaries for validation:
-            ${{ steps.get_shas.outputs.LINUX }}
-            ${{ steps.get_shas.outputs.WINDOWS }}
-            ${{ steps.get_shas.outputs.MACOS }}    
-      
+            This release was automatically created by [Github Actions](./.github/workflows/release.yml).
+
+            If you would like to verify that the binary you have downloaded was built from the source code
+            in this repository, you can compare the output of the commands below to the output of the same 
+            commands on your machine.
+
+            #### MacOS
+            Binaries built for MacOS are signed and notarized, and are automatically verified with [Gatekeeper](https://support.apple.com/guide/deployment-reference-macos/using-gatekeeper-apd02b925e38/web).
+            
+            Manual Verification: 
+            
+            ```console
+            $ sha256sum -b $(which rover) | cut -d ' ' -f1
+            ${{ steps.get_shas.outputs.macos-sha }}
+            ```
+
+            #### Linux
+
+            Manual Verification: 
+
+            ```console
+            $ sha256sum -b $(which rover) | cut -d ' ' -f1
+            ${{ steps.get_shas.outputs.linux-sha }}
+            ```
+
+            #### Windows
+
+            Manual Verification:
+
+            ```powershell
+            PS> Get-Command rover
+            
+            CommandType     Name                                               Version    Source
+            -----------     ----                                               -------    ------
+            Application     rover.exe                                          0.0.0.0    C:\Users\username\.rover\bin\rover.exe
+            
+            PS> Get-FileHash C:\Users\username\.rover\bin\rover.exe
+
+            Algorithm       Hash                                                                   Path
+            ---------       ----                                                                   ----
+            SHA256          ${{ steps.get_shas.outputs.windows-sha }}       C:\Users\username\.rover\bin\rover.exe
+            ```
+            
       - name: Release Linux tarball
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
I realized that the old sha256 section of our releases is likely not useful to our users as there's not really any information along with the binaries. I think we need to document how to actually compare the hashes that we've generated here to the hashes on a dev's machine. 

**currently it looks like this:**

---
## 🛠 Maintenance

- **Fix something random - [EverlastingBugstopper], [pull/123987123987123719287312]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/442]: https://github.com/apollographql/rover/pull/123987123987123719287312
---
### SHA256 of release binaries for validation:
- __Linux__: d5cdc0ff48b2c4b886e33e85b66627af31c247074393e9055fc22f40cdd3aa3d
- __Windows__: 55a333a62c9295a409008b5258c91b57050b541b259bdc76bbb5ef77f6f8caa3
- __MacOS__: e49f88721aec929ecf1a850e01b1460c3e987d4589faca85edf29d0bd79943ee
---

**after this pr, it would look like this:**

---
## 🛠 Maintenance

- **Fix something random - [EverlastingBugstopper], [pull/123987123987123719287312]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/123987123987123719287312]: https://github.com/apollographql/rover/pull/123987123987123719287312
---
This release was automatically created by [Github Actions](./.github/workflows/release.yml).

If you would like to verify that the binary you have downloaded was built from the source code
in this repository, you can compare the output of the commands below to the output of the same 
commands on your machine.

#### MacOS
Binaries built for MacOS are signed and notarized, and are automatically verified with [Gatekeeper](https://support.apple.com/guide/deployment-reference-macos/using-gatekeeper-apd02b925e38/web).

Manual Verification: 

```console
$ sha256sum -b $(which rover) | cut -d ' ' -f1
e49f88721aec929ecf1a850e01b1460c3e987d4589faca85edf29d0bd79943eez
```

#### Linux

Manual Verification: 

```console
$ sha256sum -b $(which rover) | cut -d ' ' -f1
d5cdc0ff48b2c4b886e33e85b66627af31c247074393e9055fc22f40cdd3aa3d
```

#### Windows

Manual Verification:

```powershell
PS> Get-Command rover

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Application     rover.exe                                          0.0.0.0    C:\Users\username\.rover\bin\rover.exe

PS> Get-FileHash C:\Users\username\.rover\bin\rover.exe

Algorithm       Hash                                                                   Path
---------       ----                                                                   ----
SHA256          55a333a62c9295a409008b5258c91b57050b541b259bdc76bbb5ef77f6f8caa3       C:\Users\username\.rover\bin\rover.exe
```
---

Let me know what y'all think! I'm not sure if the commands duplicated here in the changelog are super helpful, or if maybe we should document this elsewhere.

**TODO**:

It actually seems like the binary hashes don't quite match up on npm so I definitely need to investigate that and figure out what's going on. Might be some weirdness with npm or with how the `binary-install` module unzips the binary it downloads from GitHub releases.