### PR TITLE
add triage labels to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report 🐞
 about: Something isn't working as expected? Here is the right place to report.
-labels: "bug 🐞"
+labels: "bug 🐞, triage"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,7 +1,7 @@
 ---
 name: Docs Issues ✏
 about: Can't find something or notice an error in our docs? Go here!  
-labels: "docs 📝"
+labels: "docs 📝, triage"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request 💡 
 about: Do you have an idea for a new feature (or improvement on an existing feature)? Tell us here!
-labels: "feature 🎉"
+labels: "feature 🎉, triage"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question ❓
 about: Have a question about Rover that the docs can't answer? Go here! 
-labels: "question ❓"
+labels: "question ❓, triage"
 ---
 
 <!--


### PR DESCRIPTION
This _should_ add the `triage` labels to any new issues opened with issue templates. I'm not 1000% sure this will work, but from what I've read it _should_.