### PR TITLE
chore(ci): checks for broken links

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check for broken Markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          folder-path: 'crates, installers'
+          file-path: './README.md'
+
+
       - name: Install Rust
         run: |
           rustup update stable
@@ -37,12 +46,3 @@ jobs:
 
       - name: Check idiomatic code
         run: cargo clippy --all --all-features -- -D warnings
-
-      - name: Check for broken Markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          folder-path: 'crates, installers'
-          file-path: './README.md'
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,12 @@ jobs:
 
       - name: Check idiomatic code
         run: cargo clippy --all --all-features -- -D warnings
+
+      - name: Check for broken Markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          folder-path: 'crates, installers'
+          file-path: './README.md'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
   [pull/493]: https://github.com/apollographql/rover/pull/493
+
+- **Check for broken markdown links in CI - [EverlastingBugstopper], [issue/444] [pull/460]**
+
+  Occasionally links get out of date (or they were mistyped in the first place) - we want to
+  make sure links in this repository remain functional, so we now check for broken markdown
+  links in our CI jobs that run on each push.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/460]: https://github.com/apollographql/rover/pull/460
+  [issue/444]: https://github.com/apollographql/rover/issues/444
+
 ## 📚 Documentation 
 
 # [0.0.10] - 2021-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   Instead of downloading Rover's install script from the tagged GitHub URL, you can now use the much simpler endpoints:
 
-  https://rover.apollo.dev/install/nix/latest and https://rover.apollo.dev/install/windows/latest.
+  https://rover.apollo.dev/nix/latest and https://rover.apollo.dev/win/latest.
 
   You can see our [documentation](https://www.apollographql.com/docs/rover/getting-started/) for more info on the new installation pattern.
 
@@ -343,7 +343,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Core schema building capabilities - [EverlastingBugstopper], [pull/340]**
 
   Adds a new command, `rover core build` to handle building 
-  [core schema documents](https://apollo-specs.github.io/core/draft/pre-0/)
+  [core schema documents](https://specs.apollo.dev/#core-schemas)
   from multiple subgraph schemas. This also adds a new config format to support
   this command in YAML. Currently, this is only documented in [pull/340].
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This repo is organized as a [`cargo` workspace], containing several related proj
 
 - `rover`: Apollo's suite of GraphQL developer productivity tools
 - [`houston`]: utilities for configuring Rover
-- [`robot-panic`]: a fork of [rust-cli/robot-panic] adjusted for Rover
+- [`robot-panic`]: a fork of [`rust-cli/human-panic`] adjusted for Rover
 - [`rover-client`]: an HTTP client for making GraphQL requests for Rover
 - [`sdl-encoder`]: a crate to encode SDL
 - [`sputnik`]: a crate to aid in collection of anonymous data for Rust CLIs
@@ -95,7 +95,7 @@ This repo is organized as a [`cargo` workspace], containing several related proj
 [`cargo` workspace]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html
 [`houston`]: https://github.com/apollographql/rover/tree/main/crates/houston
 [`robot-panic`]: https://github.com/apollographql/rover/tree/main/crates/robot-panic
-[rust-cli/robot-panic]: https://github.com/rust-cli/robot-panic
+[`rust-cli/human-panic`]: https://github.com/rust-cli/human-panic
 [`rover-client`]: https://github.com/apollographql/rover/tree/main/crates/rover-client
 [`sdl-encoder`]: https://github.com/apollographql/rover/tree/main/crates/sdl-encoder
 [`sputnik`]: https://github.com/apollographql/rover/tree/main/crates/sputnik

--- a/crates/robot-panic/README.md
+++ b/crates/robot-panic/README.md
@@ -1,3 +1,3 @@
 # robot-panic
 
-This is a fork of [robot-panic](https://github.com/rust-cli/robot-panic) that prints less output and directs folks to create a new GitHub issue with the panic dump _OR_ it creates a crash report on the filesystem.
+This is a fork of [human-panic](https://github.com/rust-cli/human-panic) that prints less output and directs folks to create a new GitHub issue with the panic dump _OR_ it creates a crash report on the filesystem.

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,18 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost:.*"
+    }
+  ],
+  "httpHeaders": [
+    {
+      "urls": ["https://crates.io"],
+      "headers": {
+        "Accept": "*, text/html"
+      }
+    }
+  ],
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s"
+}


### PR DESCRIPTION
fixes #444 - also includes some fixes for broken links that it found already 😄 

note: there is an option to only include files that were changed in the PR that was pushed. we could combo that config option with a daily cron that checks the whole repo for broken links.

fine with the current approach since that's what we talked about in triage but wanted to let folks know of that option :)

---

i've opened [this issue](https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/105) to see if there is a way to exclude our nested `node_modules` directories from the ambitious link checker