### PR TITLE
chore: removes automated steps from release checklist

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -17,7 +17,7 @@ If you are releasing a beta or a release candidate, no official changelog is nee
    `https://github.com/issues?utf8=%E2%9C%93&q=repo%3Aapollographql%2Fapollo-cli+merged%3A%3E%3DYYYY-MM-DD`
 1. Go through the closed PRs in the milestone. Each should have a changelog
    label indicating if the change is documentation, feature, fix, or maintenance. If
-   there is a missing label, please add one. If it is a breaking change, also add a changelog - BREAKING label.
+   there is a missing label, please add one. If it is a breaking change, also add a BREAKING label.
 1. Add this release to the `CHANGELOG.md`. Use the structure of previous
    entries.
 
@@ -36,7 +36,6 @@ If you are releasing a beta or a release candidate, no official changelog is nee
 
 1. Create a new branch "#.#.#" where "#.#.#" is this release's version (release) or "#.#.#-rc.#" (release candidate)
 1. Push up a commit with the `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, and `./installers/npm` changes. The commit message can just be "#.#.#" (release) or "#.#.#-rc.#" (release candidate)
-1. Replace all instances of current version to the new version -- in README's installation instructions, documentation instructions, and [windows installer](https://github.com/apollographql/rover/blob/main/installers/binstall/scripts/windows/install.ps1#L5)
 1. Request review from the Apollo GraphQL tooling team.
 
 ### Review
@@ -63,8 +62,6 @@ After CI builds the release binaries and they appear on the [releases page](http
 #### If this is a stable release (not a release candidate)
 
 1. Paste the current release notes from `CHANGELOG.md` into the release body.
-1. Update the _title_ of the release (not the tag itself) to include the emoji for the current release
-1. Be sure to add any missing link definitions to the release.
 
 #### If this is a release candidate
 
@@ -83,6 +80,7 @@ After CI builds the release binaries and they appear on the [releases page](http
 1. Hit the big green Merge button on the release PR.
 1. Check out the tag you pushed with `git checkout v#.#.#`
 
+<!-- TODO: uncomment this when we can publish to crates.io
 ### Publish to crates.io (full release only)
 
 **IMPORTANT: This step is the hardest to fix if you mess it up. Do not run this step for Release Candidates**.
@@ -90,14 +88,7 @@ After CI builds the release binaries and they appear on the [releases page](http
 We don't publish release candidates to crates.io because they don't (as of this writing) have a concept of a "beta" version.
 
 1. Run `cargo test`
-1. (Release only) `cargo publish`
-
-### Publish to npm
-
-Full releases are tagged `latest`. Release candidates are tagged `beta`. If for some reason you mix up the commands below, follow the troubleshooting guide.
-
-1. If this is a full release, `cd installers/npm && npm publish`.
-1. If it is a release candidate, `cd installers/npm && npm publish --tag beta`
+1. (Release only) `cargo publish` -->
 
 ## Troubleshooting a release
 


### PR DESCRIPTION
a bunch of the stuff in the release checklist was a bit out of date since we automate it! this PR removes that cruft