### PR TITLE
Remove incorrect note about subgraph schemas

### DIFF
--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -45,8 +45,6 @@ subgraphs:
 
 The YAML file must specify each subgraph's public-facing URL (`routing_url`), along with the path to its schema (`schema.file`).
 
-> **Important:** Currently, `supergraph compose` only accepts federation-enhanced SDL files, which you can obtain with [`subgraph introspect`](./subgraphs#fetching-via-enhanced-introspection) or [`subgraph fetch`](subgraphs/#fetching-from-apollo-studio) (see also [Using `stdout`](./conventions#using-stdout)).
-
 ### Output format
 
 By default, `supergraph compose` outputs a [supergraph schema](https://apollo-specs.github.io/core/draft/pre-0) document to `stdout`. This will be useful for providing the schema as input to _other_ Rover commands in the future.


### PR DESCRIPTION
This PR removes a note in the `compose` command that was technically incorrect. While schemas must adhere to the federation spec, they don't have to have any annotating info if their types aren't overlapping/extending each other.

@StephenBarlow can you think of a better wording for this, or how do you feel about completely removing it. Maybe we could mention something about subgraph schemas being in compliance with the federation spec?