### PR TITLE
feat: `rover supergraph fetch`

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -86,7 +86,10 @@ pub enum RoverClientError {
     /// if someone attempts to get a core schema from a supergraph that has
     /// no composition results we return this error.
     #[error("There is no successful composition for supergraph \"{graph}\".")]
-    NoCompositionPublishes { graph: String },
+    NoCompositionPublishes { 
+        graph: String,
+        composition_errors: Vec<String>
+    },
 
     /// This error occurs when the Studio API returns no implementing services for a graph
     /// This response shouldn't be possible!

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -85,7 +85,7 @@ pub enum RoverClientError {
 
     /// if someone attempts to get a core schema from a supergraph that has
     /// no composition results we return this error.
-    #[error("There has been no successful composition for supergraph \"{graph}\".")]
+    #[error("There is no successful composition for supergraph \"{graph}\".")]
     NoCompositionPublishes { graph: String },
 
     /// This error occurs when the Studio API returns no implementing services for a graph

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -83,6 +83,11 @@ pub enum RoverClientError {
     #[error("Could not find graph with name \"{graph}\"")]
     NoService { graph: String },
 
+    /// if someone attempts to get a core schema from a supergraph that has
+    /// no composition results we return this error.
+    #[error("There has been no successful composition for supergraph \"{graph}\".")]
+    NoCompositionPublishes { graph: String },
+
     /// This error occurs when the Studio API returns no implementing services for a graph
     /// This response shouldn't be possible!
     #[error("The response from Apollo Studio was malformed. Response body contains `null` value for \"{null_field}\"")]

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -85,7 +85,7 @@ pub enum RoverClientError {
 
     /// if someone attempts to get a core schema from a supergraph that has
     /// no composition results we return this error.
-    #[error("There is no successful composition for supergraph \"{graph}\".")]
+    #[error("No supergraph SDL exists for \"{graph}\" because its subgraphs failed to compose.")]
     NoCompositionPublishes {
         graph: String,
         composition_errors: Vec<String>,

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -86,9 +86,9 @@ pub enum RoverClientError {
     /// if someone attempts to get a core schema from a supergraph that has
     /// no composition results we return this error.
     #[error("There is no successful composition for supergraph \"{graph}\".")]
-    NoCompositionPublishes { 
+    NoCompositionPublishes {
         graph: String,
-        composition_errors: Vec<String>
+        composition_errors: Vec<String>,
     },
 
     /// This error occurs when the Studio API returns no implementing services for a graph

--- a/crates/rover-client/src/query/mod.rs
+++ b/crates/rover-client/src/query/mod.rs
@@ -4,5 +4,8 @@ pub mod graph;
 /// all rover-client functionality for the "subgraph" commands in rover
 pub mod subgraph;
 
+/// all rover-client functionality for the "supergraph" commands in rover
+pub mod supergraph;
+
 /// all rover config-related functionality
 pub mod config;

--- a/crates/rover-client/src/query/supergraph/fetch.graphql
+++ b/crates/rover-client/src/query/supergraph/fetch.graphql
@@ -10,5 +10,10 @@ query FetchSupergraphQuery($graphId: ID!, $variant: String!) {
         supergraphSdl
       }
     }
+    mostRecentCompositionPublish(graphVariant: $variant) {
+      errors {
+        message
+      }
+    }
   }
 }

--- a/crates/rover-client/src/query/supergraph/fetch.graphql
+++ b/crates/rover-client/src/query/supergraph/fetch.graphql
@@ -1,0 +1,14 @@
+query FetchSupergraphQuery($graphId: ID!, $variant: String!) {
+  frontendUrlRoot
+  service(id: $graphId) {
+    variants {
+      name
+    }
+    schemaTag(tag: $variant) {
+      compositionResult {
+        __typename
+        supergraphSdl
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/query/supergraph/fetch.rs
+++ b/crates/rover-client/src/query/supergraph/fetch.rs
@@ -213,10 +213,7 @@ mod tests {
         let data: fetch_supergraph_query::ResponseData =
             serde_json::from_value(json_response).unwrap();
         let output = get_supergraph_sdl_from_response_data(data, graph.clone(), variant.clone());
-        let expected_error = RoverClientError::MalformedResponse {
-            null_field: "compositionResult".to_string(),
-        }
-        .to_string();
+        let expected_error = RoverClientError::ExpectedFederatedGraph { graph }.to_string();
         let actual_error = output.unwrap_err().to_string();
         assert_eq!(actual_error, expected_error);
     }

--- a/crates/rover-client/src/query/supergraph/fetch.rs
+++ b/crates/rover-client/src/query/supergraph/fetch.rs
@@ -58,9 +58,18 @@ fn get_supergraph_sdl_from_response_data(
                 null_field: "compositionResult".to_string(),
             })
         }
-    } else if let Some(most_recent_composition_publish) = service_data.most_recent_composition_publish {
-        let composition_errors = most_recent_composition_publish.errors.into_iter().map(|error| error.message).collect();
-        Err(RoverClientError::NoCompositionPublishes { graph, composition_errors })
+    } else if let Some(most_recent_composition_publish) =
+        service_data.most_recent_composition_publish
+    {
+        let composition_errors = most_recent_composition_publish
+            .errors
+            .into_iter()
+            .map(|error| error.message)
+            .collect();
+        Err(RoverClientError::NoCompositionPublishes {
+            graph,
+            composition_errors,
+        })
     } else {
         let mut valid_variants = Vec::new();
 
@@ -75,7 +84,7 @@ fn get_supergraph_sdl_from_response_data(
                 valid_variants,
                 frontend_url_root: response_data.frontend_url_root,
             })
-        }  else {
+        } else {
             Err(RoverClientError::ExpectedFederatedGraph { graph })
         }
     }
@@ -127,7 +136,10 @@ mod tests {
     #[test]
     fn get_schema_from_response_data_errs_on_no_schema_tag() {
         let (graph, variant) = mock_vars();
-        let composition_errors = vec!["Unknown type \"Unicorn\".".to_string(), "Type Query must define one or more fields.".to_string()];
+        let composition_errors = vec![
+            "Unknown type \"Unicorn\".".to_string(),
+            "Type Query must define one or more fields.".to_string(),
+        ];
         let composition_errors_json = json!([
           {
             "message": composition_errors[0]
@@ -149,7 +161,11 @@ mod tests {
         let data: fetch_supergraph_query::ResponseData =
             serde_json::from_value(json_response).unwrap();
         let output = get_supergraph_sdl_from_response_data(data, graph.clone(), variant);
-        let expected_error = RoverClientError::NoCompositionPublishes { graph, composition_errors }.to_string();
+        let expected_error = RoverClientError::NoCompositionPublishes {
+            graph,
+            composition_errors,
+        }
+        .to_string();
         let actual_error = output.unwrap_err().to_string();
         assert_eq!(actual_error, expected_error);
     }

--- a/crates/rover-client/src/query/supergraph/fetch.rs
+++ b/crates/rover-client/src/query/supergraph/fetch.rs
@@ -1,0 +1,144 @@
+use std::unimplemented;
+
+use crate::blocking::StudioClient;
+use crate::RoverClientError;
+use graphql_client::*;
+
+// I'm not sure where this should live long-term
+/// this is because of the custom GraphQLDocument scalar in the schema
+type GraphQLDocument = String;
+
+#[derive(GraphQLQuery)]
+// The paths are relative to the directory where your `Cargo.toml` is located.
+// Both json and the GraphQL schema language are supported as sources for the schema
+#[graphql(
+    query_path = "src/query/supergraph/fetch.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+/// This struct is used to generate the module containing `Variables` and
+/// `ResponseData` structs.
+/// Snake case of this name is the mod name. i.e. fetch_supergraph_query
+pub struct FetchSupergraphQuery;
+
+/// The main function to be used from this module. This function fetches a
+/// core schema from apollo studio
+pub fn run(
+    variables: fetch_supergraph_query::Variables,
+    client: &StudioClient,
+) -> Result<String, RoverClientError> {
+    let graph = variables.graph_id.clone();
+    let variant = variables.variant.clone();
+    let response_data = client.post::<FetchSupergraphQuery>(variables)?;
+    get_supergraph_sdl_from_response_data(response_data, graph, variant)
+}
+
+fn get_supergraph_sdl_from_response_data(
+    response_data: fetch_supergraph_query::ResponseData,
+    graph: String,
+    variant: String,
+) -> Result<String, RoverClientError> {
+    let service_data = match response_data.service {
+        Some(data) => Ok(data),
+        None => Err(RoverClientError::NoService {
+            graph: graph.clone(),
+        }),
+    }?;
+
+    if let Some(schema_tag) = service_data.schema_tag {
+        if let Some(composition_result) = schema_tag.composition_result {
+            if let Some(supergraph_sdl) = composition_result.supergraph_sdl {
+                Ok(supergraph_sdl)
+            } else {
+                // TODO: why would we have composition_result but not supergraph_sdl
+                // is this a server error?
+                unimplemented!()
+            }
+        } else {
+            // TODO: why would we have schema_tag but not composition_result
+            // is this a server error?
+            unimplemented!()
+        }
+    } else {
+        // we're not quite sure _why_ schema tag is null, it could either be because
+        // there is an invalid variant, or because there have been no successful
+        // composition publishes for this supergraph.
+        let mut valid_variants = Vec::new();
+
+        for variant in service_data.variants {
+            valid_variants.push(variant.name)
+        }
+
+        if !valid_variants.contains(&variant) {
+            Err(RoverClientError::NoSchemaForVariant {
+                graph,
+                invalid_variant: variant,
+                valid_variants,
+                frontend_url_root: response_data.frontend_url_root,
+            })
+        } else {
+            Err(RoverClientError::NoCompositionPublishes { graph })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    #[test]
+    fn get_supergraph_sdl_from_response_data_works() {
+        let json_response = json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "service": {
+                "schemaTag": {
+                    "compositionResult": {
+                        "supergraphSdl": "type Query { hello: String }",
+                    },
+                },
+                "variants": []
+            }
+        });
+        let data: fetch_supergraph_query::ResponseData =
+            serde_json::from_value(json_response).unwrap();
+        let (graph, invalid_variant) = mock_vars();
+        let output = get_supergraph_sdl_from_response_data(data, graph, invalid_variant);
+
+        assert!(output.is_ok());
+        assert_eq!(output.unwrap(), "type Query { hello: String }".to_string());
+    }
+
+    #[test]
+    fn get_schema_from_response_data_errs_on_no_service() {
+        let json_response =
+            json!({ "service": null, "frontendUrlRoot": "https://studio.apollographql.com" });
+        let data: fetch_supergraph_query::ResponseData =
+            serde_json::from_value(json_response).unwrap();
+        let (graph, invalid_variant) = mock_vars();
+        let output = get_supergraph_sdl_from_response_data(data, graph, invalid_variant);
+
+        assert!(output.is_err());
+    }
+
+    #[test]
+    fn get_schema_from_response_data_errs_on_no_result() {
+        let json_response = json!({
+            "frontendUrlRoot": "https://studio.apollographql.com/",
+            "service": {
+                "compositionResult": null,
+                "variants": [],
+            },
+        });
+        let data: fetch_supergraph_query::ResponseData =
+            serde_json::from_value(json_response).unwrap();
+        let (graph, invalid_variant) = mock_vars();
+        let output = get_supergraph_sdl_from_response_data(data, graph, invalid_variant);
+
+        assert!(output.is_err());
+    }
+
+    fn mock_vars() -> (String, String) {
+        ("mygraph".to_string(), "current".to_string())
+    }
+}

--- a/crates/rover-client/src/query/supergraph/fetch.rs
+++ b/crates/rover-client/src/query/supergraph/fetch.rs
@@ -54,9 +54,7 @@ fn get_supergraph_sdl_from_response_data(
                 })
             }
         } else {
-            Err(RoverClientError::MalformedResponse {
-                null_field: "compositionResult".to_string(),
-            })
+            Err(RoverClientError::ExpectedFederatedGraph { graph })
         }
     } else if let Some(most_recent_composition_publish) =
         service_data.most_recent_composition_publish

--- a/crates/rover-client/src/query/supergraph/mod.rs
+++ b/crates/rover-client/src/query/supergraph/mod.rs
@@ -1,0 +1,2 @@
+/// "supergraph fetch"
+pub mod fetch;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,7 +137,7 @@ impl Rover {
             Command::Config(command) => {
                 command.run(self.get_rover_config()?, self.get_client_config()?)
             }
-            Command::Supergraph(command) => command.run(),
+            Command::Supergraph(command) => command.run(self.get_client_config()?),
             Command::Docs(command) => command.run(),
             Command::Graph(command) => {
                 command.run(self.get_client_config()?, self.get_git_context()?)

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -18,6 +18,7 @@ use crate::utils::table::{self, cell, row};
 #[derive(Clone, PartialEq, Debug)]
 pub enum RoverStdout {
     DocsList(HashMap<&'static str, &'static str>),
+    SupergraphSdl(String),
     Sdl(String),
     CoreSchema(String),
     SchemaHash(String),
@@ -44,6 +45,10 @@ impl RoverStdout {
                     table.add_row(row![shortlink_slug, shortlink_description]);
                 }
                 println!("{}", table);
+            }
+            RoverStdout::SupergraphSdl(sdl) => {
+                print_descriptor("Supergraph SDL");
+                print_content(&sdl);
             }
             RoverStdout::Sdl(sdl) => {
                 print_descriptor("SDL");

--- a/src/command/supergraph/fetch.rs
+++ b/src/command/supergraph/fetch.rs
@@ -1,0 +1,45 @@
+use crate::utils::client::StudioClientConfig;
+use crate::utils::parsers::{parse_graph_ref, GraphRef};
+use crate::{command::RoverStdout, Result};
+
+use rover_client::query::supergraph::fetch;
+
+use ansi_term::Colour::{Cyan, Yellow};
+use serde::Serialize;
+use structopt::StructOpt;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Fetch {
+    /// <NAME>@<VARIANT> of graph in Apollo Studio to fetch from.
+    /// @<VARIANT> may be left off, defaulting to @current
+    #[structopt(name = "GRAPH_REF", parse(try_from_str = parse_graph_ref))]
+    #[serde(skip_serializing)]
+    graph: GraphRef,
+
+    /// Name of configuration profile to use
+    #[structopt(long = "profile", default_value = "default")]
+    #[serde(skip_serializing)]
+    profile_name: String,
+}
+
+impl Fetch {
+    pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
+        let client = client_config.get_client(&self.profile_name)?;
+        let graph_ref = self.graph.to_string();
+        eprintln!(
+            "Fetching supergraph SDL from {} using credentials from the {} profile.",
+            Cyan.normal().paint(&graph_ref),
+            Yellow.normal().paint(&self.profile_name)
+        );
+
+        let supergraph_sdl = fetch::run(
+            fetch::fetch_supergraph_query::Variables {
+                graph_id: self.graph.name.clone(),
+                variant: self.graph.variant.clone(),
+            },
+            &client,
+        )?;
+
+        Ok(RoverStdout::SupergraphSdl(supergraph_sdl))
+    }
+}

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -1,10 +1,12 @@
 mod compose;
 pub(crate) mod config;
+mod fetch;
 
 use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverStdout;
+use crate::utils::client::StudioClientConfig;
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -17,12 +19,17 @@ pub struct Supergraph {
 pub enum Command {
     /// Locally compose a supergraph schema from a set of subgraph schemas
     Compose(compose::Compose),
+
+    // TODO: fill in some more help info on this one depending on behavior we hash out
+    /// Fetch supergraph SDL
+    Fetch(fetch::Fetch),
 }
 
 impl Supergraph {
-    pub fn run(&self) -> Result<RoverStdout> {
+    pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         match &self.command {
             Command::Compose(command) => command.run(),
+            Command::Fetch(command) => command.run(client_config),
         }
     }
 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -44,6 +44,9 @@ impl From<&mut anyhow::Error> for Metadata {
                 | RoverClientError::SendRequest(_)
                 | RoverClientError::MalformedResponse { null_field: _ }
                 | RoverClientError::InvalidSeverity => (Some(Suggestion::SubmitIssue), None),
+                RoverClientError::NoCompositionPublishes { graph: _ } => {
+                    (Some(Suggestion::RunComposition), None)
+                }
                 RoverClientError::ExpectedFederatedGraph { graph: _ } => {
                     (Some(Suggestion::UseFederatedGraph), None)
                 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -11,6 +11,8 @@ use crate::utils::env::RoverEnvKey;
 
 use std::{env, fmt::Display};
 
+use ansi_term::Colour::Red;
+
 /// Metadata contains extra information about specific errors
 /// Currently this includes an optional error `Code`
 /// and an optional `Suggestion`
@@ -44,7 +46,10 @@ impl From<&mut anyhow::Error> for Metadata {
                 | RoverClientError::SendRequest(_)
                 | RoverClientError::MalformedResponse { null_field: _ }
                 | RoverClientError::InvalidSeverity => (Some(Suggestion::SubmitIssue), None),
-                RoverClientError::NoCompositionPublishes { graph: _ } => {
+                RoverClientError::NoCompositionPublishes { graph: _, composition_errors } => {
+                    for composition_error in composition_errors {
+                        eprintln!("{} {}", Red.bold().paint("error:"), composition_error);
+                    }
                     (Some(Suggestion::RunComposition), None)
                 }
                 RoverClientError::ExpectedFederatedGraph { graph: _ } => {

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -46,7 +46,10 @@ impl From<&mut anyhow::Error> for Metadata {
                 | RoverClientError::SendRequest(_)
                 | RoverClientError::MalformedResponse { null_field: _ }
                 | RoverClientError::InvalidSeverity => (Some(Suggestion::SubmitIssue), None),
-                RoverClientError::NoCompositionPublishes { graph: _, composition_errors } => {
+                RoverClientError::NoCompositionPublishes {
+                    graph: _,
+                    composition_errors,
+                } => {
                     for composition_error in composition_errors {
                         eprintln!("{} {}", Red.bold().paint("error:"), composition_error);
                     }

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -14,6 +14,7 @@ pub enum Suggestion {
     CreateConfig,
     ListProfiles,
     UseFederatedGraph,
+    RunComposition,
     CheckGraphNameAndAuth,
     ProvideValidSubgraph(Vec<String>),
     ProvideValidVariant {
@@ -57,6 +58,9 @@ impl Display for Suggestion {
                     Yellow.normal().paint("`rover config list`"),
                     Yellow.normal().paint("`--profile`")
                 )
+            }
+            Suggestion::RunComposition => {
+                format!("Try pushing a subgraph with the {} command.", Yellow.normal().paint("`rover subgraph publish`"))
             }
             Suggestion::UseFederatedGraph => {
                 "Try running the command on a valid federated graph.".to_string()

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -60,7 +60,7 @@ impl Display for Suggestion {
                 )
             }
             Suggestion::RunComposition => {
-                format!("Try pushing a subgraph with the {} command.", Yellow.normal().paint("`rover subgraph publish`"))
+                format!("Try resolving the composition errors in your subgraph(s), and publish them with the {} command.", Yellow.normal().paint("`rover subgraph publish`"))
             }
             Suggestion::UseFederatedGraph => {
                 "Try running the command on a valid federated graph.".to_string()

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -33,6 +33,7 @@ impl RoverEnv {
     /// returns the value of the environment variable if it exists
     pub fn get(&self, key: RoverEnvKey) -> io::Result<Option<String>> {
         let key_str = key.to_string();
+        tracing::debug!("Checking for ${}", &key_str);
         let result = match &self.mock_store {
             Some(mock_store) => Ok(mock_store.get(&key_str).map(|v| v.to_owned())),
             None => match env::var(&key_str) {
@@ -52,6 +53,8 @@ impl RoverEnv {
 
         if let Some(result) = &result {
             tracing::debug!("read {}", self.get_debug_value(key, result));
+        } else {
+            tracing::debug!("could not find #{}", &key_str);
         }
 
         Ok(result)


### PR DESCRIPTION
fixes #452

ran into some pretty interesting edge cases that I think are handled pretty well, with test cases to cover them.

the happy path will just return the latest successful composed `supergraphSDL`. we also do the usual detection for proper `graph@variant` combinations.

When `schema_tag` is null, and the variant they passed is valid, it means there has been no successful composition for this supergraph quite yet, so we return the latest composition error.

```console
$ rover supergraph fetch bad-bad-supergraph
Fetching supergraph SDL from bad-bad-supergraph@current using credentials from the default profile.
error: Unknown type: "Personnnn".
error: Unknown type "Personnnn". Did you mean "Person"?
error: Type Query must define one or more fields.
error: No supergraph SDL exists for "bad-bad-supergraph" because its subgraphs failed to compose.
        Try resolving the composition errors in your subgraph(s), and publish them with the `rover subgraph publish` command.
```

If both `compositionPublish` and `mostRecentCompositionPublish` are `null`, and the graph@variant exists, I figured it was safe to assume that users were attempting to run `supergraph fetch` on a non-federated graph. This might be a semi-reliable way to extend our other queries to check if they are running `supergraph` or `subgraph` commands on non-federated graphs as part of #121. Unless of course this is an invalid assumption on my part which should be addressed before merging this.