### PR TITLE
feat: adds help text to --log

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,7 @@ pub struct Rover {
     #[structopt(subcommand)]
     pub command: Command,
 
+    /// Specify Rover's log level
     #[structopt(long = "log", short = "l", global = true, possible_values = &LEVELS, case_insensitive = true)]
     #[serde(serialize_with = "from_display")]
     pub log_level: Option<Level>,


### PR DESCRIPTION
just realized we didn't have any help text for this flag!

before:

```console
$ rover --help
...
OPTIONS:
    -l, --log <log-level>     [possible values: error, warn, info, debug, trace]
...
```

after:

```console
$ rover --help
...
OPTIONS:
    -l, --log <log-level>    Specify Rover's log level [possible values: error, warn, info,
                             debug, trace]
...
```
