### PR TITLE
feat: removes -V from subcommands + strict utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- # [x.x.x] (unreleased) - 2021-mm-dd
 > Important: X breaking changes below, indicated by **❗ BREAKING ❗**
-## 🚀 Features
 ## ❗ BREAKING ❗
+## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance
 ## 📚 Documentation --> 
 
-# [x.x.x] (unreleased) - 2021-mm-dd
-> Important: X breaking changes below, indicated by **❗ BREAKING ❗**
-## 🚀 Features
+# [0.0.11] (upcoming) - 2021-05-11
+> Important: 1 breaking change below, indicated by **❗ BREAKING ❗**
 ## ❗ BREAKING ❗
+
+- **Removes -V/--version flag from subcommands - [EverlastingBugstopper], [pull/487]**
+
+  Rover's subcommands will always be the same version as Rover, so we no longer accept `-V` or `--version`
+  on Rover's subcommands.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/487]: https://github.com/apollographql/rover/pull/487
+
+- **Disallow all non-UTF-8 argument values - [EverlastingBugstopper], [pull/487]**
+
+  Rover will no longer accept any argument values that cannot be properly interpreted as UTF-8.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/487]: https://github.com/apollographql/rover/pull/487
+
+## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 
 use crate::command::{self, RoverStdout};
 use crate::utils::{
@@ -17,7 +17,14 @@ use timber::{Level, LEVELS};
 use camino::Utf8PathBuf;
 
 #[derive(Debug, Serialize, StructOpt)]
-#[structopt(name = "Rover", global_settings = &[structopt::clap::AppSettings::ColoredHelp], about = "
+#[structopt(
+    name = "Rover", 
+    global_settings = &[
+        AppSettings::ColoredHelp,
+        AppSettings::StrictUtf8,
+        AppSettings::VersionlessSubcommands,
+    ],
+    about = "
 Rover - Your Graph Companion
 Read the getting started guide by running:
 


### PR DESCRIPTION
added two new global app settings for rover, the first will reject any non-utf8 arguments, and the second removes the `--version/-V` flag from subcommands since we do not version our subcommands differently from rover itself. _technically_ this is a breaking change, but one that should be very very low impact.