### PR TITLE
chore: removes unnecessary URL parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,29 @@ All notable changes to Rover will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- # [x.x.x] - 2021-mm-dd
+<!-- # [x.x.x] (unreleased) - 2021-mm-dd
 > Important: X breaking changes below, indicated by **❗ BREAKING ❗**
 ## 🚀 Features
 ## ❗ BREAKING ❗
 ## 🐛 Fixes
 ## 🛠 Maintenance
 ## 📚 Documentation --> 
+
+# [x.x.x] (unreleased) - 2021-mm-dd
+> Important: X breaking changes below, indicated by **❗ BREAKING ❗**
+## 🚀 Features
+## ❗ BREAKING ❗
+## 🐛 Fixes
+## 🛠 Maintenance
+
+- **Removes unnecessary custom URL parser - [EverlastingBugstopper], [pull/493]**
+
+  `structopt` will automatically use the `FromStr` implementation on the `Url` type, so
+  we have removed the custom parser we were previously using.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/493]: https://github.com/apollographql/rover/pull/493
+## 📚 Documentation 
 
 # [0.0.10] - 2021-04-27
 

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -7,12 +7,11 @@ use url::Url;
 use rover_client::{blocking::Client, query::graph::introspect};
 
 use crate::command::RoverStdout;
-use crate::utils::parsers::{parse_header, parse_url};
+use crate::utils::parsers::parse_header;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Introspect {
     /// The endpoint of the graph to introspect
-    #[structopt(parse(try_from_str = parse_url))]
     #[serde(skip_serializing)]
     pub endpoint: Url,
 

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -6,13 +6,12 @@ use url::Url;
 use rover_client::{blocking::Client, query::subgraph::introspect};
 
 use crate::command::RoverStdout;
-use crate::utils::parsers::{parse_header, parse_url};
+use crate::utils::parsers::parse_header;
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Introspect {
     /// The endpoint of the subgraph to introspect
-    #[structopt(parse(try_from_str = parse_url))]
     #[serde(skip_serializing)]
     pub endpoint: Url,
 

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use std::{convert::TryInto, fmt};
 
 use crate::{error::RoverError, Result};
-use url::Url;
 
 #[derive(Debug, PartialEq)]
 pub enum SchemaSource {
@@ -124,13 +123,6 @@ pub fn parse_query_percentage_threshold(threshold: &str) -> Result<f64> {
     } else {
         Ok((threshold / 100) as f64)
     }
-}
-
-/// Parse Urls from the command line.
-// TODO: @lrlna return error for parse url
-pub fn parse_url(url: &str) -> Result<Url> {
-    let res = Url::parse(url)?;
-    Ok(res)
 }
 
 /// Parses a key:value pair from a string and returns a tuple of key:value.


### PR DESCRIPTION
`structopt` will use the [`FromStr`](https://docs.rs/url/2.2.1/url/struct.Url.html#impl-FromStr) implementation provided by the `Url` crate ([src](https://docs.rs/structopt/0.3.21/structopt/#type-magic)) (which [calls `Url::parse` directly](https://docs.rs/url/2.2.1/src/url/lib.rs.html#2358), just like our custom parser was doing, so there's no need for us to have our own function that calls `Url::parse`!