### PR TITLE
feat: adds `rover docs open migration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [pull/487]: https://github.com/apollographql/rover/pull/487
 
 ## 🚀 Features
+
+- **Adds link to the Apollo CLI -> Rover migration guide in `rover docs open` - [EverlastingBugstopper], [pull/492]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/492]: https://github.com/apollographql/rover/pull/492
+
 ## 🐛 Fixes
 ## 🛠 Maintenance
 

--- a/src/command/docs/shortlinks.rs
+++ b/src/command/docs/shortlinks.rs
@@ -7,6 +7,7 @@ pub fn get_shortlinks_with_description() -> HashMap<&'static str, &'static str> 
     links.insert("docs", "Rover's Documentation Homepage");
     links.insert("api-keys", "Understanding Apollo's API Keys");
     links.insert("contributing", "Contributing to Rover");
+    links.insert("migration", "Migrate from the Apollo CLI to Rover");
     links.insert("start", "Getting Started with Rover");
     links
 }


### PR DESCRIPTION
should only be merged after [this](https://github.com/apollographql/shortlinks/pull/19)