### PR TITLE
chore: display "unspecified" when subgraph's URL is absent

### DIFF
--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -64,10 +64,13 @@ impl RoverStdout {
                 table.add_row(row![bc => "Name", "Routing Url", "Last Updated"]);
 
                 for subgraph in &details.subgraphs {
-                    // if the url is None or empty (""), then set it to "N/A"
-                    let url = subgraph.url.clone().unwrap_or_else(|| "N/A".to_string());
+                    // Default to "unspecified" if the url is None or empty.
+                    let url = subgraph
+                        .url
+                        .clone()
+                        .unwrap_or_else(|| "unspecified".to_string());
                     let url = if url.is_empty() {
-                        "N/A".to_string()
+                        "unspecified".to_string()
                     } else {
                         url
                     };


### PR DESCRIPTION
This changes the text from "N/A" (which often means "not available", and
somewhat sounds like we don't have access to it) to "unspecified" (which is
what it is; this is what it is though represented by `null` in the DB).

Closes https://github.com/apollographql/rover/issues/483