### PR TITLE
fix: ignore routing url argument in telemetry

### DIFF
--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -41,6 +41,7 @@ pub struct Publish {
     /// (often a deployed subgraph). May be left empty ("") or a placeholder url
     /// if not running a gateway in managed federation mode
     #[structopt(long)]
+    #[serde(skip_serializing)]
     routing_url: Option<String>,
 }
 


### PR DESCRIPTION
likely shouldn't be collecting this!