### PR TITLE
docs: Change "Discuss on Spectrum" link to go to Spectrum root

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -11,6 +11,7 @@ module.exports = {
         subtitle: 'Rover CLI (Preview)',
         description: 'A guide to using Rover',
         githubRepo: 'apollographql/rover',
+        spectrumPath: '/',
         sidebarCategories: {
           null: [
             'index',


### PR DESCRIPTION
This adjusts the sidebar link to "Discuss on Spectrum" in the Rover docs.

We'll be adjusting our discussions platform and moving away from Spectrum in
the coming weeks, so this is a short-term adjustment to adjust a broken
link.  That's because, by default, our Gatsby theme configuration defaults
to the repository name, but we never created a Spectrum "rover" channel.
This commit changes the link to go to the root of the Spectrum repo, with
the intention of this link being wholesale replaced in the coming weeks.

Closes https://github.com/apollographql/rover/issues/492