### PR TITLE
chore: address clippy 1.52 warnings

### DIFF
--- a/crates/rover-client/src/query/subgraph/delete.rs
+++ b/crates/rover-client/src/query/subgraph/delete.rs
@@ -55,10 +55,7 @@ fn build_response(response: RawMutationResponse) -> DeleteServiceResponse {
     let composition_errors: Vec<String> = response
         .errors
         .iter()
-        .filter_map(|error| match error {
-            Some(e) => Some(e.message.clone()),
-            None => None,
-        })
+        .filter_map(|error| error.as_ref().map(|e| e.message.clone()))
         .collect();
 
     // if there are no errors, just return None

--- a/crates/rover-client/src/query/subgraph/publish.rs
+++ b/crates/rover-client/src/query/subgraph/publish.rs
@@ -54,10 +54,7 @@ fn build_response(publish_response: UpdateResponse) -> PublishPartialSchemaRespo
     let composition_errors: Vec<String> = publish_response
         .errors
         .iter()
-        .filter_map(|error| match error {
-            Some(e) => Some(e.message.clone()),
-            None => None,
-        })
+        .filter_map(|error| error.as_ref().map(|e| e.message.clone()))
         .collect();
 
     // if there are no errors, just return None


### PR DESCRIPTION
Removes two instances where we were using match instead of a more succinct map. Enforced by clippy's [manual map](https://rust-lang.github.io/rust-clippy/master/index.html#manual_map) lint.