### PR TITLE
fix(whoami): $APOLLO_KEY works with no default profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [pull/460]: https://github.com/apollographql/rover/pull/460
   [issue/444]: https://github.com/apollographql/rover/issues/444
 
+- **Fix credential retrieval in `rover config whoami` - [EverlastingBugstopper], [issue/514] [pull/516]**
+
+  `rover config whoami` no longer fails if `$APOLLO_KEY` is set but there is no default authentication profile.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/516]: https://github.com/apollographql/rover/pull/516
+  [issue/514]: https://github.com/apollographql/rover/issues/514
+
 ## 📚 Documentation 
 
 # [0.0.10] - 2021-04-27

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -100,7 +100,7 @@ impl Profile {
 
     /// Loads and deserializes configuration from the file system for a
     /// specific profile.
-    pub fn load(
+    fn load(
         profile_name: &str,
         config: &Config,
         opts: LoadOpts,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,9 +134,7 @@ impl Rover {
         }
 
         match &self.command {
-            Command::Config(command) => {
-                command.run(self.get_rover_config()?, self.get_client_config()?)
-            }
+            Command::Config(command) => command.run(self.get_client_config()?),
             Command::Supergraph(command) => command.run(self.get_client_config()?),
             Command::Docs(command) => command.run(),
             Command::Graph(command) => {

--- a/src/command/config/mod.rs
+++ b/src/command/config/mod.rs
@@ -7,8 +7,6 @@ mod whoami;
 use serde::Serialize;
 use structopt::StructOpt;
 
-use houston as config;
-
 use crate::command::RoverStdout;
 use crate::utils::client::StudioClientConfig;
 use crate::Result;
@@ -38,17 +36,13 @@ pub enum Command {
 }
 
 impl Config {
-    pub fn run(
-        &self,
-        config: config::Config,
-        client_config: StudioClientConfig,
-    ) -> Result<RoverStdout> {
+    pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         match &self.command {
-            Command::Auth(command) => command.run(config),
-            Command::List(command) => command.run(config),
-            Command::Delete(command) => command.run(config),
-            Command::Clear(command) => command.run(config),
-            Command::Whoami(command) => command.run(config, client_config),
+            Command::Auth(command) => command.run(client_config.config),
+            Command::List(command) => command.run(client_config.config),
+            Command::Delete(command) => command.run(client_config.config),
+            Command::Clear(command) => command.run(client_config.config),
+            Command::Whoami(command) => command.run(client_config),
         }
     }
 }

--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -22,11 +22,7 @@ pub struct WhoAmI {
 }
 
 impl WhoAmI {
-    pub fn run(
-        &self,
-        config: config::Config,
-        client_config: StudioClientConfig,
-    ) -> Result<RoverStdout> {
+    pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
         let client = client_config.get_client(&self.profile_name)?;
         eprintln!("Checking identity of your API key against the registry.");
 
@@ -74,12 +70,12 @@ impl WhoAmI {
 
         message.push_str(&format!("{}: {}", Green.normal().paint("Origin"), &origin));
 
-        let opts = config::LoadOpts { sensitive: true };
-        let profile = config::Profile::load(&self.profile_name, &config, opts)?;
+        let credential =
+            config::Profile::get_credential(&self.profile_name, &client_config.config)?;
         message.push_str(&format!(
             "\n{}: {}",
             Green.normal().paint("API Key"),
-            profile
+            credential.api_key
         ));
 
         eprintln!("{}", message);

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -9,7 +9,7 @@ const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/ap
 
 pub struct StudioClientConfig {
     uri: String,
-    config: config::Config,
+    pub config: config::Config,
     version: String,
 }
 


### PR DESCRIPTION
fixes #514 by removing a direct invocation of `Profile::load` and using the correct `Profile::get_credential` function, and making `Profile::load` a private function.

I also removed a redundant config parameter, `StudioClientConfig` wraps houston's config so just using that directly should be more efficient.