### PR TITLE
feat: RoverClientError::CouldNotConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [pull/484]: https://github.com/apollographql/rover/pull/484
   [issue/169]: https://github.com/apollographql/rover/issues/169
 
+- **Better error messages for HTTP errors - [EverlastingBugstopper], [issue/489] [pull/518]**
+
+  Previously, Rover obfuscated the information about HTTP errors that occurred. Now, if something goes wrong between your machine and any HTTP server, you'll get some more information about what exactly went wrong.
+
+  [Author]: https://github.com/EverlastingBugstopper
+  [pull/PR #]: https://github.com/apollographql/rover/pull/518
+  [issue/Issue #]: https://github.com/apollographql/rover/issues/489
+
 ## 🐛 Fixes
 ## 🛠 Maintenance
 

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -40,7 +40,17 @@ impl Client {
             .post(&self.uri)
             .headers(h)
             .json(&body)
-            .send()?
+            .send()
+            .map_err(|e| {
+                if e.is_connect() {
+                    RoverClientError::CouldNotConnect {
+                        url: e.url().cloned(),
+                        source: e,
+                    }
+                } else {
+                    e.into()
+                }
+            })?
             .error_for_status()?;
 
         Client::handle_response::<Q>(response)

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -1,3 +1,4 @@
+use reqwest::Url;
 use thiserror::Error;
 
 /// RoverClientError represents all possible failures that can occur during a client request.
@@ -18,15 +19,15 @@ pub enum RoverClientError {
     },
 
     /// Tried to build a [HeaderMap] with an invalid header name.
-    #[error("invalid header name")]
+    #[error("Invalid header name")]
     InvalidHeaderName(#[from] reqwest::header::InvalidHeaderName),
 
     /// Tried to build a [HeaderMap] with an invalid header value.
-    #[error("invalid header value")]
+    #[error("Invalid header value")]
     InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
 
     /// Invalid JSON in response body.
-    #[error("could not parse JSON")]
+    #[error("Could not parse JSON")]
     InvalidJson(#[from] serde_json::Error),
 
     /// Encountered an error handling the received response.
@@ -73,8 +74,20 @@ pub enum RoverClientError {
         frontend_url_root: String,
     },
 
+    #[error("Could not connect to {}.",
+        if let Some(url) = .url {
+            url.to_string()
+        } else {
+            "Unknown URL".to_string()
+        }
+    )]
+    CouldNotConnect {
+        source: reqwest::Error,
+        url: Option<Url>,
+    },
+
     /// Encountered an error sending the request.
-    #[error("encountered an error while sending a request")]
+    #[error(transparent)]
     SendRequest(#[from] reqwest::Error),
 
     /// when someone provides a bad graph/variant combination or isn't

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -43,9 +43,12 @@ impl From<&mut anyhow::Error> for Metadata {
                 RoverClientError::InvalidJson(_)
                 | RoverClientError::InvalidHeaderName(_)
                 | RoverClientError::InvalidHeaderValue(_)
-                | RoverClientError::SendRequest(_)
                 | RoverClientError::MalformedResponse { null_field: _ }
                 | RoverClientError::InvalidSeverity => (Some(Suggestion::SubmitIssue), None),
+                RoverClientError::SendRequest(_) => (None, None),
+                RoverClientError::CouldNotConnect { .. } => {
+                    (Some(Suggestion::CheckServerConnection), None)
+                }
                 RoverClientError::NoCompositionPublishes {
                     graph: _,
                     composition_errors,

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -27,6 +27,7 @@ pub enum Suggestion {
     CheckKey,
     ProperKey,
     NewUserNoProfiles,
+    CheckServerConnection,
 }
 
 impl Display for Suggestion {
@@ -115,6 +116,7 @@ impl Display for Suggestion {
                 )
             }
             Suggestion::Adhoc(msg) => msg.to_string(),
+            Suggestion::CheckServerConnection => "Make sure the endpoint is spelled correctly accepting connections.".to_string()
 
 
         };

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -116,7 +116,7 @@ impl Display for Suggestion {
                 )
             }
             Suggestion::Adhoc(msg) => msg.to_string(),
-            Suggestion::CheckServerConnection => "Make sure the endpoint is spelled correctly accepting connections.".to_string()
+            Suggestion::CheckServerConnection => "Make sure the endpoint accepting connections is spelled correctly".to_string()
 
 
         };


### PR DESCRIPTION
fixes #489 


before:

```console
$ rover subgraph introspect http://localhost:4000
error: encountered an error while sending a request
        This error was unexpected! Please submit an issue with any relevant details about what you were trying to do: https://github.com/apollographql/rover/issues/new
```

after:

```console
$ rover subgraph introspect http://localhost:4000
error: Could not connect to http://localhost:4000/.
        Make sure the endpoint is spelled correctly and accepting connections.
```

---

other HTTP request related errors now just use the default reqwest formatting, and provides no suggestion. we can incrementally improve this as time goes on.

---

couple fun new patterns here for intelligent error handling in this PR. This error currently applies to any request made by rover-client, not just introspection. folks might see this error if Studio ever starts refusing incoming TCP connections. Most folks will run into this when running introspection on an invalid endpoint. I'm wondering if this catch-all approach is good here (returning this error type on every request made by rover-client where the server refuses a connection) or if we should try to provide more granular info based on the command they're running or if the Url it can't connect to is supplied by the user vs. one that we coded. 