### PR TITLE
add extra new lines to descriptor formatting

### DIFF
--- a/crates/rover-client/src/query/graph/publish.rs
+++ b/crates/rover-client/src/query/graph/publish.rs
@@ -261,7 +261,7 @@ mod tests {
         });
         let diff_to_previous: ChangeDiff = serde_json::from_value(json_diff).unwrap();
         let output = build_change_summary(Some(diff_to_previous));
-        assert_eq!(output, "[Fields: +3 -1 △0, Types: +4 -0 △2]".to_string())
+        assert_eq!(output, "[Fields: +3 -1 △ 0, Types: +4 -0 △ 2]".to_string())
     }
 
     #[test]

--- a/crates/rover-client/src/query/graph/publish.rs
+++ b/crates/rover-client/src/query/graph/publish.rs
@@ -104,11 +104,11 @@ fn build_change_summary(diff: Option<ChangeDiff>) -> String {
         Some(diff) => {
             let changes = diff.change_summary;
             let fields = format!(
-                "Fields: +{} -{} △{}",
+                "Fields: +{} -{} △ {}",
                 changes.field.additions, changes.field.removals, changes.field.edits
             );
             let types = format!(
-                "Types: +{} -{} △{}",
+                "Types: +{} -{} △ {}",
                 changes.type_.additions, changes.type_.removals, changes.type_.edits
             );
             format!("[{}, {}]", fields, types)

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::{collections::HashMap, fmt::Display};
 
 use crate::utils::table::{self, cell, row};
-use ansi_term::Colour::Yellow;
+use ansi_term::{Style, Colour::Yellow};
 use atty::Stream;
 use crossterm::style::Attribute::Underlined;
 use rover_client::query::subgraph::list::ListDetails;
@@ -62,7 +62,7 @@ impl RoverStdout {
                 print_content(&csdl);
             }
             RoverStdout::SchemaHash(hash) => {
-                print_descriptor("Schema Hash");
+                print_one_line_descriptor("Schema Hash");
                 print_content(&hash);
             }
             RoverStdout::SubgraphList(details) => {
@@ -135,7 +135,12 @@ impl RoverStdout {
 
 fn print_descriptor(descriptor: impl Display) {
     if atty::is(Stream::Stdout) {
-        eprintln!("{}: ", descriptor);
+        eprintln!("{}: \n", Style::new().bold().paint(descriptor.to_string()));
+    }
+}
+fn print_one_line_descriptor(descriptor: impl Display) {
+    if atty::is(Stream::Stdout) {
+        eprint!("{}: ", Style::new().bold().paint(descriptor.to_string()));
     }
 }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::{collections::HashMap, fmt::Display};
 
 use crate::utils::table::{self, cell, row};
-use ansi_term::{Style, Colour::Yellow};
+use ansi_term::{Colour::Yellow, Style};
 use atty::Stream;
 use crossterm::style::Attribute::Underlined;
 use rover_client::query::subgraph::list::ListDetails;


### PR DESCRIPTION
1. adds extra new lines to all descriptors, i.e. 
```
Fetching SDL from rover-adventure@current using credentials from the adventure profile.
SDL:

type Cat {
  id: ID!
  name: String
}

type Query {
  cat(id: ID!): Cat
  cats: [Cat]
}
```

2. Schema Hash descriptor and the actual schema hash are one lined (screenshot at the bottom).
3. Adds an extra white space after triangle when displaying `graph publish` diff, as it was very much overlapping.
![image](https://user-images.githubusercontent.com/8107784/117840614-9e82e780-b27c-11eb-9043-7348dc6d08b7.png)
