### PR TITLE
fix: removes unwrap from is_federated query

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -109,8 +109,16 @@ pub enum RoverClientError {
     #[error("The response from Apollo Studio was malformed. Response body contains `null` value for \"{null_field}\"")]
     MalformedResponse { null_field: String },
 
-    #[error("The graph `{graph}` is a non-federated graph. This operation is only possible for federated graphs")]
-    ExpectedFederatedGraph { graph: String },
+    /// This error occurs when an operation expected a federated graph but a non-federated
+    /// graph was supplied.
+    /// `can_operation_convert` is only set to true when a non-federated graph
+    /// was encountered during an operation that could potentially convert a non-federated graph
+    /// to a federated graph.
+    #[error("The graph `{graph}` is a non-federated graph. This operation is only possible for federated graphs.")]
+    ExpectedFederatedGraph {
+        graph: String,
+        can_operation_convert: bool,
+    },
 
     /// The API returned an invalid ChangeSeverity value
     #[error("Invalid ChangeSeverity.")]

--- a/crates/rover-client/src/query/graph/fetch.rs
+++ b/crates/rover-client/src/query/graph/fetch.rs
@@ -41,12 +41,9 @@ fn get_schema_from_response_data(
     graph: String,
     invalid_variant: String,
 ) -> Result<String, RoverClientError> {
-    let service_data = match response_data.service {
-        Some(data) => Ok(data),
-        None => Err(RoverClientError::NoService {
-            graph: graph.clone(),
-        }),
-    }?;
+    let service_data = response_data.service.ok_or(RoverClientError::NoService {
+        graph: graph.clone(),
+    })?;
 
     let mut valid_variants = Vec::new();
 

--- a/crates/rover-client/src/query/graph/publish.rs
+++ b/crates/rover-client/src/query/graph/publish.rs
@@ -39,18 +39,13 @@ fn get_publish_response_from_data(
     graph: String,
 ) -> Result<publish_schema_mutation::PublishSchemaMutationServiceUploadSchema, RoverClientError> {
     // then, from the response data, get .service?.upload_schema?
-    let service_data = match data.service {
-        Some(data) => data,
-        None => return Err(RoverClientError::NoService { graph }),
-    };
+    let service_data = data.service.ok_or(RoverClientError::NoService { graph })?;
 
-    if let Some(opt_data) = service_data.upload_schema {
-        Ok(opt_data)
-    } else {
-        Err(RoverClientError::MalformedResponse {
+    service_data
+        .upload_schema
+        .ok_or(RoverClientError::MalformedResponse {
             null_field: "service.upload_schema".to_string(),
         })
-    }
 }
 
 fn build_response(

--- a/crates/rover-client/src/query/subgraph/delete.rs
+++ b/crates/rover-client/src/query/subgraph/delete.rs
@@ -43,10 +43,9 @@ fn get_delete_data_from_response(
     response_data: delete_service_mutation::ResponseData,
     graph: String,
 ) -> Result<RawMutationResponse, RoverClientError> {
-    let service_data = match response_data.service {
-        Some(data) => Ok(data),
-        None => Err(RoverClientError::NoService { graph }),
-    }?;
+    let service_data = response_data
+        .service
+        .ok_or(RoverClientError::NoService { graph })?;
 
     Ok(service_data.remove_implementing_service_and_trigger_composition)
 }
@@ -76,7 +75,7 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    type RawCompositionErrrors = delete_service_mutation::DeleteServiceMutationServiceRemoveImplementingServiceAndTriggerCompositionErrors;
+    type RawCompositionErrors = delete_service_mutation::DeleteServiceMutationServiceRemoveImplementingServiceAndTriggerCompositionErrors;
 
     #[test]
     fn get_delete_data_from_response_works() {
@@ -100,11 +99,11 @@ mod tests {
 
         let expected_response = RawMutationResponse {
             errors: vec![
-                Some(RawCompositionErrrors {
+                Some(RawCompositionErrors {
                     message: "wow".to_string(),
                 }),
                 None,
-                Some(RawCompositionErrrors {
+                Some(RawCompositionErrors {
                     message: "boo".to_string(),
                 }),
             ],
@@ -117,11 +116,11 @@ mod tests {
     fn build_response_works_with_successful_responses() {
         let response = RawMutationResponse {
             errors: vec![
-                Some(RawCompositionErrrors {
+                Some(RawCompositionErrors {
                     message: "wow".to_string(),
                 }),
                 None,
-                Some(RawCompositionErrrors {
+                Some(RawCompositionErrors {
                     message: "boo".to_string(),
                 }),
             ],

--- a/crates/rover-client/src/query/subgraph/fetch.rs
+++ b/crates/rover-client/src/query/subgraph/fetch.rs
@@ -36,12 +36,9 @@ fn get_services_from_response_data(
     response_data: fetch_subgraph_query::ResponseData,
     graph: String,
 ) -> Result<ServiceList, RoverClientError> {
-    let service_data = match response_data.service {
-        Some(data) => Ok(data),
-        None => Err(RoverClientError::NoService {
-            graph: graph.clone(),
-        }),
-    }?;
+    let service_data = response_data.service.ok_or(RoverClientError::NoService {
+        graph: graph.clone(),
+    })?;
 
     // get list of services
     let services = match service_data.implementing_services {
@@ -52,6 +49,7 @@ fn get_services_from_response_data(
         // wont' for long. Check on this later (Jake) :)
         None => Err(RoverClientError::ExpectedFederatedGraph {
             graph: graph.clone(),
+            can_operation_convert: false,
         }),
     }?;
 
@@ -60,7 +58,7 @@ fn get_services_from_response_data(
             Ok(services.services)
         },
         fetch_subgraph_query::FetchSubgraphQueryServiceImplementingServices::NonFederatedImplementingService => {
-            Err(RoverClientError::ExpectedFederatedGraph { graph })
+            Err(RoverClientError::ExpectedFederatedGraph { graph, can_operation_convert: false })
         }
     }
 }

--- a/crates/rover-client/src/query/subgraph/introspect.rs
+++ b/crates/rover-client/src/query/subgraph/introspect.rs
@@ -41,14 +41,11 @@ pub fn run(
 }
 
 fn build_response(
-    response: introspection_query::ResponseData,
+    data: introspection_query::ResponseData,
 ) -> Result<IntrospectionResponse, RoverClientError> {
-    let service_data = match response.service {
-        Some(data) => Ok(data),
-        None => Err(RoverClientError::IntrospectionError {
-            msg: "No introspection response available.".to_string(),
-        }),
-    }?;
+    let service_data = data.service.ok_or(RoverClientError::IntrospectionError {
+        msg: "No introspection response available.".to_string(),
+    })?;
 
     Ok(IntrospectionResponse {
         result: service_data.sdl,

--- a/crates/rover-client/src/query/subgraph/list.rs
+++ b/crates/rover-client/src/query/subgraph/list.rs
@@ -54,12 +54,9 @@ fn get_subgraphs_from_response_data(
     response_data: list_subgraphs_query::ResponseData,
     graph: String,
 ) -> Result<Vec<RawSubgraphInfo>, RoverClientError> {
-    let service_data = match response_data.service {
-        Some(data) => Ok(data),
-        None => Err(RoverClientError::NoService {
-            graph: graph.clone(),
-        }),
-    }?;
+    let service_data = response_data.service.ok_or(RoverClientError::NoService {
+        graph: graph.clone(),
+    })?;
 
     // get list of services
     let services = match service_data.implementing_services {
@@ -79,7 +76,7 @@ fn get_subgraphs_from_response_data(
             Ok(services.services)
         },
         list_subgraphs_query::ListSubgraphsQueryServiceImplementingServices::NonFederatedImplementingService => {
-            Err(RoverClientError::ExpectedFederatedGraph { graph })
+            Err(RoverClientError::ExpectedFederatedGraph { graph, can_operation_convert: false })
         }
     }
 }

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -2,8 +2,7 @@ use ansi_term::Colour::Red;
 use serde::Serialize;
 use structopt::StructOpt;
 
-use crate::{anyhow, error::RoverError, Result, Suggestion};
-use rover_client::query::{config::is_federated, subgraph::check};
+use rover_client::query::subgraph::check;
 
 use crate::command::RoverStdout;
 use crate::utils::client::StudioClientConfig;
@@ -14,6 +13,7 @@ use crate::utils::parsers::{
     parse_schema_source, parse_validation_period, GraphRef, SchemaSource, ValidationPeriod,
 };
 use crate::utils::table::{self, cell, row};
+use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Check {
@@ -64,24 +64,6 @@ impl Check {
         let client = client_config.get_client(&self.profile_name)?;
 
         let sdl = load_schema_from_flag(&self.schema, std::io::stdin())?;
-
-        // This response is used to check whether or not the current graph is federated.
-        let federated_response = is_federated::run(
-            is_federated::is_federated_graph::Variables {
-                graph_id: self.graph.name.clone(),
-                graph_variant: self.graph.variant.clone(),
-            },
-            &client,
-        )?;
-
-        // We don't want to run subgraph check on a non-federated graph, so
-        // return an error and recommend running graph check instead.
-        if !federated_response.result {
-            let err = anyhow!("Not able to run subgraph check on a non-federated graph.");
-            let mut err = RoverError::new(err);
-            err.set_suggestion(Suggestion::UseFederatedGraph);
-            return Err(err);
-        }
 
         let partial_schema = check::check_partial_schema_query::PartialSchemaInput {
             sdl: Some(sdl),

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -58,9 +58,18 @@ impl From<&mut anyhow::Error> for Metadata {
                 RoverClientError::InvalidSeverity => {
                     (Some(Suggestion::SubmitIssue), Some(Code::E006))
                 }
-                RoverClientError::SubgraphIntrospectionNotAvailable
-                | RoverClientError::ExpectedFederatedGraph { graph: _ } => {
+                RoverClientError::SubgraphIntrospectionNotAvailable => {
                     (Some(Suggestion::UseFederatedGraph), Some(Code::E007))
+                }
+                RoverClientError::ExpectedFederatedGraph {
+                    graph: _,
+                    can_operation_convert,
+                } => {
+                    if *can_operation_convert {
+                        (Some(Suggestion::ConvertGraphToSubgraph), Some(Code::E007))
+                    } else {
+                        (Some(Suggestion::UseFederatedGraph), Some(Code::E007))
+                    }
                 }
                 RoverClientError::NoSchemaForVariant {
                     graph,

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -68,7 +68,7 @@ impl Display for Suggestion {
                 format!("Try resolving the composition errors in your subgraph(s), and publish them with the {} command.", Yellow.normal().paint("`rover subgraph publish`"))
             }
             Suggestion::UseFederatedGraph => {
-                "Try running the command on a valid federated graph or use the appropriate `rover graph` command instead of `rover subgraph`.".to_string()
+                "Try running the command on a valid federated graph, or use the appropriate `rover graph` command instead of `rover subgraph`.".to_string()
             }
             Suggestion::CheckGraphNameAndAuth => {
                 "Make sure your graph name is typed correctly, and that your API key is valid. (Are you using the right profile?)".to_string()


### PR DESCRIPTION
Fixes #548 by removing the `.unwrap` call in the `is_federated` run that occurs if anything goes wrong with the query (for instance, mistyping your graph name). 

This PR includes a few other refactors:

- No longer run the `is_federated` check if the `--convert` flag is passed to `subgraph publish`, removing the extra network hop
- Perform the `is_federated` query directly in the `rover_client::query` modules that need them, instead of in `rover` code.
  - This includes returning `RoverClientError::ExpectedFederatedGraph` directly from `rover_client` instead of constructing the error manually in `rover`
  - We still keep the suggestion for using `--convert` 😄 
- Replaced some verbose matches with a more ergonomic `.ok_or`

Also fixes #550 