### PR TITLE
fix: don't squash request errors

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -50,8 +50,9 @@ impl Client {
                 } else {
                     e.into()
                 }
-            })?
-            .error_for_status()?;
+            })?;
+        // we don't `.error_for_status` here because it is handled
+        // in `Client::handle_response`
 
         Client::handle_response::<Q>(response)
     }

--- a/crates/rover-client/src/query/subgraph/introspect.rs
+++ b/crates/rover-client/src/query/subgraph/introspect.rs
@@ -22,9 +22,9 @@ pub fn run(
     client: &Client,
     headers: &HashMap<String, String>,
 ) -> Result<IntrospectionResponse, RoverClientError> {
-    // let graph = variables.graph_id.clone();
     let variables = introspection_query::Variables {};
     let response_data = client.post::<IntrospectionQuery>(variables, headers);
+
     match response_data {
         Ok(data) => build_response(data),
         Err(e) => {
@@ -37,7 +37,6 @@ pub fn run(
             }
         }
     }
-    // build_response(response_data)
 }
 
 fn build_response(

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -14,7 +14,7 @@ pub use self::metadata::Suggestion;
 
 /// A specialized `Error` type for Rover that wraps `anyhow`
 /// and provides some extra `Metadata` for end users depending
-/// on the speicif error they encountered.
+/// on the specific error they encountered.
 #[derive(Debug)]
 pub struct RoverError {
     error: anyhow::Error,


### PR DESCRIPTION
fixes #539 and #573

An `.error_for_status()?` was erroneously added to `rover-client` which bypassed some nicer error handling that we had set up.