### PR TITLE
corrected "subgraph push" to "subgraph publish" on line 270

### DIFF
--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -267,5 +267,5 @@ apollo service:push --serviceName users
 # (no config file needed)
 # globs don't work natively with Rover, so you can use `cat` to combine
 # multiple files on *nix machines
-cat *.graphql | rover subgraph push my-graph@prod --name users --schema -
+cat *.graphql | rover subgraph publish my-graph@prod --name users --schema -
 ```


### PR DESCRIPTION
I noticed that the documentation stated that to publish a federated subgraph you have to run:

```diff 
- rover subgraph push my-graph@prod --name users --schema -
```

whereas, the `push` command is not present in "Rover CLI"
The correct command is:
```diff
+ rover subgraph publish my-graph@prod --name users --schema -
```
replacing `push` with `publish`.