### PR TITLE
fix: don't panic on empty error array

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -1,5 +1,5 @@
 use crate::{headers, RoverClientError};
-use graphql_client::{GraphQLQuery, Response as GraphQLResponse};
+use graphql_client::{Error as GraphQLError, GraphQLQuery, Response as GraphQLResponse};
 use reqwest::{
     blocking::{Client as ReqwestClient, Response},
     header::HeaderMap,
@@ -8,16 +8,16 @@ use reqwest::{
 use std::collections::HashMap;
 
 /// Represents a generic GraphQL client for making http requests.
-pub struct GraphqlClient {
+pub struct GraphQLClient {
     client: ReqwestClient,
     graphql_endpoint: String,
 }
 
-impl GraphqlClient {
+impl GraphQLClient {
     /// Construct a new [Client] from a `graphql_endpoint`.
     /// This client is used for generic GraphQL requests, such as introspection.
-    pub fn new(graphql_endpoint: &str) -> GraphqlClient {
-        GraphqlClient {
+    pub fn new(graphql_endpoint: &str) -> GraphQLClient {
+        GraphQLClient {
             client: ReqwestClient::new(),
             graphql_endpoint: graphql_endpoint.to_string(),
         }
@@ -33,7 +33,7 @@ impl GraphqlClient {
     ) -> Result<Q::ResponseData, RoverClientError> {
         let header_map = headers::build(header_map)?;
         let response = self.execute::<Q>(variables, header_map)?;
-        GraphqlClient::handle_response::<Q>(response)
+        GraphQLClient::handle_response::<Q>(response)
     }
 
     pub(crate) fn execute<Q: GraphQLQuery>(
@@ -43,7 +43,7 @@ impl GraphqlClient {
     ) -> Result<Response, RoverClientError> {
         let body = Q::build_query(variables);
         tracing::trace!(request_headers = ?header_map);
-        tracing::trace!("Request Body: {}", serde_json::to_string(&body)?);
+        tracing::debug!("Request Body: {}", serde_json::to_string(&body)?);
         self.client
             .post(&self.graphql_endpoint)
             .headers(header_map)
@@ -72,70 +72,99 @@ impl GraphqlClient {
     pub(crate) fn handle_response<Q: GraphQLQuery>(
         response: Response,
     ) -> Result<Q::ResponseData, RoverClientError> {
-        tracing::debug!(response_status = ?response.status(), response_headers = ?response.headers());
-
-        match response.status() {
-            StatusCode::OK => {
-                let response_body: graphql_client::Response<Q::ResponseData> = response.json()?;
-
-                if let Some(errs) = response_body.errors {
-                    if !errs.is_empty() && errs[0].message.contains("406") {
-                        return Err(RoverClientError::MalformedKey);
-                    }
-
-                    return Err(RoverClientError::GraphQl {
-                        msg: errs
-                            .into_iter()
-                            .map(|err| err.message)
-                            .collect::<Vec<String>>()
-                            .join("\n"),
-                    });
+        let response_status = response.status();
+        tracing::debug!(response_status = ?response_status, response_headers = ?response.headers());
+        match response.json::<GraphQLResponse<Q::ResponseData>>() {
+            Ok(response_body) => {
+                if let Some(response_body_errors) = response_body.errors {
+                    handle_graphql_body_errors(response_body_errors)?;
                 }
-
-                if let Some(data) = response_body.data {
-                    Ok(data)
-                } else {
-                    Err(RoverClientError::MalformedResponse {
-                        null_field: "data".to_string(),
-                    })
-                }
-            }
-            // This block specifically handles an error that is returned when
-            // Introspection is set to false on a production ApolloServer.
-            //
-            // We first check for a 400 HTTP Status Code (Bad Request). We then
-            // get the message sent by the server and display that to our users.
-            StatusCode::BAD_REQUEST => {
-                // It's not a given that an HTTP response is valid JSON,
-                // so let's match for a successful parse. Return a standard 400
-                // RoverClientError if we are unable to parse.
-                match response.json::<GraphQLResponse<Q::ResponseData>>() {
-                    Ok(body) => {
-                        if let Some(errs) = body.errors {
-                            return Err(RoverClientError::ClientError {
-                                msg: errs[0].message.to_string(),
-                            });
-                        }
-                        Err(RoverClientError::ClientError {
-                            msg: StatusCode::BAD_REQUEST.to_string(),
-                        })
+                match response_status {
+                    StatusCode::OK => {
+                        response_body
+                            .data
+                            .ok_or_else(|| RoverClientError::MalformedResponse {
+                                null_field: "data".to_string(),
+                            })
                     }
-                    Err(_) => Err(RoverClientError::ClientError {
-                        msg: StatusCode::BAD_REQUEST.to_string(),
+                    status_code => Err(RoverClientError::ClientError {
+                        msg: status_code.to_string(),
                     }),
                 }
             }
-            status => Err(RoverClientError::ClientError {
-                msg: status.to_string(),
-            }),
+            Err(e) => {
+                if response_status.is_success() {
+                    Err(e.into())
+                } else {
+                    Err(RoverClientError::ClientError {
+                        msg: response_status.to_string(),
+                    })
+                }
+            }
         }
+    }
+}
+
+fn handle_graphql_body_errors(errors: Vec<GraphQLError>) -> Result<(), RoverClientError> {
+    if errors.is_empty() {
+        Ok(())
+    } else if errors[0].message.contains("406") {
+        Err(RoverClientError::MalformedKey)
+    } else {
+        Err(RoverClientError::GraphQl {
+            msg: errors
+                .into_iter()
+                .map(|error| error.message)
+                .collect::<Vec<String>>()
+                .join("\n"),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn exploration() {
-        assert_eq!(2 + 2, 4);
+    fn it_is_ok_on_empty_errors() {
+        let errors = vec![];
+        assert!(handle_graphql_body_errors(errors).is_ok());
+    }
+
+    #[test]
+    fn it_returns_malformed_key() {
+        let errors = vec![GraphQLError {
+            message: "406: Not Acceptable".to_string(),
+            locations: None,
+            extensions: None,
+            path: None,
+        }];
+        let expected_error = RoverClientError::MalformedKey.to_string();
+        let actual_error = handle_graphql_body_errors(errors).unwrap_err().to_string();
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn it_returns_random_graphql_error() {
+        let errors = vec![
+            GraphQLError {
+                message: "Something went wrong".to_string(),
+                locations: None,
+                extensions: None,
+                path: None,
+            },
+            GraphQLError {
+                message: "Something else went wrong".to_string(),
+                locations: None,
+                extensions: None,
+                path: None,
+            },
+        ];
+        let expected_error = RoverClientError::GraphQl {
+            msg: format!("{}\n{}", errors[0].message, errors[1].message),
+        }
+        .to_string();
+        let actual_error = handle_graphql_body_errors(errors).unwrap_err().to_string();
+        assert_eq!(actual_error, expected_error);
     }
 }

--- a/crates/rover-client/src/blocking/mod.rs
+++ b/crates/rover-client/src/blocking/mod.rs
@@ -1,5 +1,5 @@
 mod client;
 mod studio_client;
 
-pub use client::GraphqlClient;
+pub use client::GraphQLClient;
 pub use studio_client::StudioClient;

--- a/crates/rover-client/src/blocking/mod.rs
+++ b/crates/rover-client/src/blocking/mod.rs
@@ -1,5 +1,5 @@
 mod client;
 mod studio_client;
 
-pub use client::Client;
+pub use client::GraphqlClient;
 pub use studio_client::StudioClient;

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -1,4 +1,4 @@
-use crate::{blocking::GraphqlClient, headers, RoverClientError};
+use crate::{blocking::GraphQLClient, headers, RoverClientError};
 use houston::Credential;
 
 use graphql_client::GraphQLQuery;
@@ -6,7 +6,7 @@ use graphql_client::GraphQLQuery;
 /// Represents a client for making GraphQL requests to Apollo Studio.
 pub struct StudioClient {
     pub credential: Credential,
-    client: GraphqlClient,
+    client: GraphQLClient,
     version: String,
 }
 
@@ -16,7 +16,7 @@ impl StudioClient {
     pub fn new(credential: Credential, graphql_endpoint: &str, version: &str) -> StudioClient {
         StudioClient {
             credential,
-            client: GraphqlClient::new(graphql_endpoint),
+            client: GraphQLClient::new(graphql_endpoint),
             version: version.to_string(),
         }
     }
@@ -30,6 +30,6 @@ impl StudioClient {
     ) -> Result<Q::ResponseData, RoverClientError> {
         let header_map = headers::build_studio_headers(&self.credential.api_key, &self.version)?;
         let response = self.client.execute::<Q>(variables, header_map)?;
-        GraphqlClient::handle_response::<Q>(response)
+        GraphQLClient::handle_response::<Q>(response)
     }
 }

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -1,6 +1,4 @@
-use crate::blocking::Client;
-use crate::headers;
-use crate::RoverClientError;
+use crate::{blocking::GraphqlClient, headers, RoverClientError};
 use houston::Credential;
 
 use graphql_client::GraphQLQuery;
@@ -8,44 +6,30 @@ use graphql_client::GraphQLQuery;
 /// Represents a client for making GraphQL requests to Apollo Studio.
 pub struct StudioClient {
     pub credential: Credential,
-    client: reqwest::blocking::Client,
-    uri: String,
+    client: GraphqlClient,
     version: String,
 }
 
 impl StudioClient {
     /// Construct a new [StudioClient] from an `api_key`, a `uri`, and a `version`.
     /// For use in Rover, the `uri` is usually going to be to Apollo Studio
-    pub fn new(credential: Credential, uri: &str, version: &str) -> StudioClient {
+    pub fn new(credential: Credential, graphql_endpoint: &str, version: &str) -> StudioClient {
         StudioClient {
             credential,
-            client: reqwest::blocking::Client::new(),
-            uri: uri.to_string(),
+            client: GraphqlClient::new(graphql_endpoint),
             version: version.to_string(),
         }
     }
 
-    /// Client method for making a GraphQL request.
+    /// Client method for making a GraphQL request to Apollo Studio.
     ///
-    /// Takes one argument, `variables`. Returns an optional response.
+    /// Takes one argument, `variables`. Returns a Response or a RoverClientError.
     pub fn post<Q: GraphQLQuery>(
         &self,
         variables: Q::Variables,
     ) -> Result<Q::ResponseData, RoverClientError> {
-        let h = headers::build_studio_headers(&self.credential.api_key, &self.version)?;
-        let body = Q::build_query(variables);
-        tracing::trace!(request_headers = ?h);
-        tracing::trace!("Request Body: {}", serde_json::to_string(&body)?);
-
-        let response = self
-            .client
-            .post(&self.uri)
-            .headers(h)
-            .json(&body)
-            .send()?
-            .error_for_status()?;
-        tracing::trace!(response_status = ?response.status(), response_headers = ?response.headers());
-
-        Client::handle_response::<Q>(response)
+        let header_map = headers::build_studio_headers(&self.credential.api_key, &self.version)?;
+        let response = self.client.execute::<Q>(variables, header_map)?;
+        GraphqlClient::handle_response::<Q>(response)
     }
 }

--- a/crates/rover-client/src/query/graph/introspect.rs
+++ b/crates/rover-client/src/query/graph/introspect.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, convert::TryFrom};
 
-use crate::blocking::GraphqlClient;
+use crate::blocking::GraphQLClient;
 use crate::introspection::Schema;
 use crate::RoverClientError;
 use graphql_client::*;
@@ -26,7 +26,7 @@ pub struct IntrospectionResponse {
 /// The main function to be used from this module. This function fetches a
 /// schema from apollo studio and returns it in either sdl (default) or json format
 pub fn run(
-    client: &GraphqlClient,
+    client: &GraphQLClient,
     headers: &HashMap<String, String>,
 ) -> Result<IntrospectionResponse, RoverClientError> {
     let variables = introspection_query::Variables {};

--- a/crates/rover-client/src/query/graph/introspect.rs
+++ b/crates/rover-client/src/query/graph/introspect.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, convert::TryFrom};
 
-use crate::blocking::Client;
+use crate::blocking::GraphqlClient;
 use crate::introspection::Schema;
 use crate::RoverClientError;
 use graphql_client::*;
@@ -26,7 +26,7 @@ pub struct IntrospectionResponse {
 /// The main function to be used from this module. This function fetches a
 /// schema from apollo studio and returns it in either sdl (default) or json format
 pub fn run(
-    client: &Client,
+    client: &GraphqlClient,
     headers: &HashMap<String, String>,
 ) -> Result<IntrospectionResponse, RoverClientError> {
     let variables = introspection_query::Variables {};

--- a/crates/rover-client/src/query/subgraph/introspect.rs
+++ b/crates/rover-client/src/query/subgraph/introspect.rs
@@ -1,4 +1,4 @@
-use crate::blocking::GraphqlClient;
+use crate::blocking::GraphQLClient;
 use crate::RoverClientError;
 use graphql_client::*;
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ pub struct IntrospectionResponse {
 }
 
 pub fn run(
-    client: &GraphqlClient,
+    client: &GraphQLClient,
     headers: &HashMap<String, String>,
 ) -> Result<IntrospectionResponse, RoverClientError> {
     let variables = introspection_query::Variables {};

--- a/crates/rover-client/src/query/subgraph/introspect.rs
+++ b/crates/rover-client/src/query/subgraph/introspect.rs
@@ -1,4 +1,4 @@
-use crate::blocking::Client;
+use crate::blocking::GraphqlClient;
 use crate::RoverClientError;
 use graphql_client::*;
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ pub struct IntrospectionResponse {
 }
 
 pub fn run(
-    client: &Client,
+    client: &GraphqlClient,
     headers: &HashMap<String, String>,
 ) -> Result<IntrospectionResponse, RoverClientError> {
     let variables = introspection_query::Variables {};

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use structopt::StructOpt;
 use url::Url;
 
-use rover_client::{blocking::GraphqlClient, query::graph::introspect};
+use rover_client::{blocking::GraphQLClient, query::graph::introspect};
 
 use crate::command::RoverStdout;
 use crate::utils::parsers::parse_header;
@@ -28,7 +28,7 @@ pub struct Introspect {
 
 impl Introspect {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = GraphqlClient::new(&self.endpoint.to_string());
+        let client = GraphQLClient::new(&self.endpoint.to_string());
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use structopt::StructOpt;
 use url::Url;
 
-use rover_client::{blocking::Client, query::graph::introspect};
+use rover_client::{blocking::GraphqlClient, query::graph::introspect};
 
 use crate::command::RoverStdout;
 use crate::utils::parsers::parse_header;
@@ -28,7 +28,7 @@ pub struct Introspect {
 
 impl Introspect {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = Client::new(&self.endpoint.to_string());
+        let client = GraphqlClient::new(&self.endpoint.to_string());
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use structopt::StructOpt;
 use url::Url;
 
-use rover_client::{blocking::Client, query::subgraph::introspect};
+use rover_client::{blocking::GraphqlClient, query::subgraph::introspect};
 
 use crate::command::RoverStdout;
 use crate::utils::parsers::parse_header;
@@ -33,7 +33,7 @@ pub struct Introspect {
 
 impl Introspect {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = Client::new(&self.endpoint.to_string());
+        let client = GraphqlClient::new(&self.endpoint.to_string());
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use structopt::StructOpt;
 use url::Url;
 
-use rover_client::{blocking::GraphqlClient, query::subgraph::introspect};
+use rover_client::{blocking::GraphQLClient, query::subgraph::introspect};
 
 use crate::command::RoverStdout;
 use crate::utils::parsers::parse_header;
@@ -33,7 +33,7 @@ pub struct Introspect {
 
 impl Introspect {
     pub fn run(&self) -> Result<RoverStdout> {
-        let client = GraphqlClient::new(&self.endpoint.to_string());
+        let client = GraphQLClient::new(&self.endpoint.to_string());
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -6,7 +6,7 @@ use ansi_term::Colour::Red;
 use camino::Utf8PathBuf;
 
 use rover_client::{
-    blocking::Client,
+    blocking::GraphqlClient,
     query::subgraph::{fetch, introspect},
 };
 use serde::Serialize;
@@ -102,7 +102,7 @@ pub(crate) fn get_subgraph_definitions(
             SchemaSource::SubgraphIntrospection { subgraph_url } => {
                 // given a federated introspection URL, use subgraph introspect to
                 // obtain SDL and add it to subgraph_definition.
-                let client = Client::new(&subgraph_url.to_string());
+                let client = GraphqlClient::new(&subgraph_url.to_string());
 
                 let introspection_response = introspect::run(&client, &HashMap::new())?;
                 let schema = introspection_response.result;

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -6,7 +6,7 @@ use ansi_term::Colour::Red;
 use camino::Utf8PathBuf;
 
 use rover_client::{
-    blocking::GraphqlClient,
+    blocking::GraphQLClient,
     query::subgraph::{fetch, introspect},
 };
 use serde::Serialize;
@@ -102,7 +102,7 @@ pub(crate) fn get_subgraph_definitions(
             SchemaSource::SubgraphIntrospection { subgraph_url } => {
                 // given a federated introspection URL, use subgraph introspect to
                 // obtain SDL and add it to subgraph_definition.
-                let client = GraphqlClient::new(&subgraph_url.to_string());
+                let client = GraphQLClient::new(&subgraph_url.to_string());
 
                 let introspection_response = introspect::run(&client, &HashMap::new())?;
                 let schema = introspection_response.result;


### PR DESCRIPTION
Fixes #590, in addition to some light refactoring and regression tests.

Previously, we were handling errors differently and duplicating a bit of code between the studio client and our generic GraphQL client that we use for things like introspection. 

Now, the studio client just wraps the GraphQL client so that they both follow the same exact execution flow for executing the request, and subsequently handling errors in the response.

Eventually I'd love to have even more tests here which will be much easier after we can mock out types in our tests (see #557 and #575). 

Right now the fact that we can't create types on the fly due to the graphql-client we're using this will have to be good enough.