### PR TITLE
release: v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.1.6]  2021-06-08
+
+## 🐛 Fixes
+
+- **Fix panic on empty GraphQL Error array - [EverlastingBugstopper], [issue/590] [pull/592]**
+
+  In certain scenarios, Rover will encounter GraphQL errors, which are return as an array of strings. Previously, we were not checking if that array was empty before attempting to print the first error in the array, which caused Rover to [panic](https://doc.rust-lang.org/std/macro.panic.html). Rover has now been refactored a bit to have simpler GraphQL error handling and will no longer panic in this scenario.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/592]: https://github.com/apollographql/rover/pull/592
+  [issue/590]: https://github.com/apollographql/rover/issues/590
+
+- **Don't mangle `stderr` when an update to Rover is available - [EverlastingBugstopper], [issue/584] [pull/586]**
+
+  Once a day, when a new version of Rover is available, it messages users letting them know that they can update. Unfortunately, this message was being printed to `stdout` instead of `stderr` due to a bug in an upstream dependency. This bug has now been fixed, and update messages are now properly routed to `stderr`.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/586]: https://github.com/apollographql/rover/pull/586
+  [issue/584]: https://github.com/apollographql/rover/issues/584
+
+## 📚 Documentation
+
+- **Update Error Code docs title - [StephenBarlow], [pull/597]**
+
+  "Index of Errors" -> "Rover CLI error codes"
+
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [pull/597]: https://github.com/apollographql/rover/pull/597
+
+- **Bump docs theme - [StephenBarlow], [pull/596]**
+
+  Updates Gatsby and Apollo's Gatsby theme to match the rest of Apollo's docs.
+
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [pull/596]: https://github.com/apollographql/rover/pull/596
+
+- **Correct instance of `subgraph push` - [DNature], [pull/585]**
+
+  Fixes an instance of `subgraph push` to be `subgraph publish`.
+
+  [DNature]: https://github.com/DNature
+  [pull/585]: https://github.com/apollographql/rover/pull/585
+
 # [0.1.5]  2021-05-25
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.1.5"
+version = "0.1.6"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.1.5
+Rover 0.1.6
 
 Rover - Your Graph Companion
 Read the getting started guide by running:

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.1.5"
+PACKAGE_VERSION="v0.1.6"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.1.5'
+$package_version = 'v0.1.6'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -476,9 +476,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
       "dev": true
     },
     "rimraf": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.1.6]  2021-06-08

## 🐛 Fixes

- **Fix panic on empty GraphQL Error array - [EverlastingBugstopper], [issue/590] [pull/592]**

  In certain scenarios, Rover will encounter GraphQL errors, which are return as an array of strings. Previously, we were not checking if that array was empty before attempting to print the first error in the array, which caused Rover to [panic](https://doc.rust-lang.org/std/macro.panic.html). Rover has now been refactored a bit to have simpler GraphQL error handling and will no longer panic in this scenario.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/592]: https://github.com/apollographql/rover/pull/592
  [issue/590]: https://github.com/apollographql/rover/issues/590

- **Don't mangle `stderr` when an update to Rover is available - [EverlastingBugstopper], [issue/584] [pull/586]**

  Once a day, when a new version of Rover is available, it messages users letting them know that they can update. Unfortunately, this message was being printed to `stdout` instead of `stderr` due to a bug in an upstream dependency. This bug has now been fixed, and update messages are now properly routed to `stderr`.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/586]: https://github.com/apollographql/rover/pull/586
  [issue/584]: https://github.com/apollographql/rover/issues/584

## 📚 Documentation

- **Update Error Code docs title - [StephenBarlow], [pull/597]**

  "Index of Errors" -> "Rover CLI error codes"

  [StephenBarlow]: https://github.com/StephenBarlow
  [pull/597]: https://github.com/apollographql/rover/pull/597

- **Bump docs theme - [StephenBarlow], [pull/596]**

  Updates Gatsby and Apollo's Gatsby theme to match the rest of Apollo's docs.

  [StephenBarlow]: https://github.com/StephenBarlow
  [pull/596]: https://github.com/apollographql/rover/pull/596

- **Correct instance of `subgraph push` - [DNature], [pull/585]**

  Fixes an instance of `subgraph push` to be `subgraph publish`.

  [DNature]: https://github.com/DNature
  [pull/585]: https://github.com/apollographql/rover/pull/585