### PR TITLE
fix: don't fail command on failed version check && use rustls

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -5,6 +5,7 @@ use reqwest::{
     header::HeaderMap,
     Error as ReqwestError, StatusCode,
 };
+
 use std::collections::HashMap;
 
 /// Represents a generic GraphQL client for making http requests.
@@ -18,7 +19,10 @@ impl GraphQLClient {
     /// This client is used for generic GraphQL requests, such as introspection.
     pub fn new(graphql_endpoint: &str) -> Result<GraphQLClient, ReqwestError> {
         Ok(GraphQLClient {
-            client: ReqwestClient::builder().gzip(true).build()?,
+            client: ReqwestClient::builder()
+                .use_rustls_tls()
+                .gzip(true)
+                .build()?,
             graphql_endpoint: graphql_endpoint.to_string(),
         })
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,9 +131,13 @@ impl Rover {
         // this only happens once a day automatically
         // we skip this check for the `rover update` commands, since they
         // do their own checks
+
         if let Command::Update(_) = &self.command { /* skip check */
         } else {
-            version::check_for_update(self.get_rover_config()?, false)?;
+            let config = self.get_rover_config();
+            if let Ok(config) = config {
+                let _ = version::check_for_update(config, false);
+            }
         }
 
         match &self.command {


### PR DESCRIPTION
This PR switches Rover from using `openssl` to `rustls`, which I thought it was already doing. I believe this will also fix the underlying issue in #609, meaning folks will not need to install `ca-certificates` to execute Rover.

Additionally, Rover will no longer stop executing if it fails to check for an updated version, it will simply ignore the failure and continue with the command execution.