### PR TITLE
release: v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,66 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.1.7]  2021-06-22
+
+## 🚀 Features
+
+- **Auto-decode gzipped responses - [EverlastingBugstopper], [issue/608] [pull/620]**
+
+  If your GraphQL server responds with a gzipped introspection response, it will now be decoded automatically instead of failing the command.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/620]: https://github.com/apollographql/rover/pull/620
+  [issue/608]: https://github.com/apollographql/rover/issues/608
+
+## 🐛 Fixes
+
+- **Prevent update checker from aborting commands - [EverlastingBugstopper], [pull/624]**
+
+  Previously, if there was a spurious network error when attempting to check for a newer version of Rover, the command would fail. This is no longer the case, if GitHub is down, you will still be able to run Rover commands.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/624]: https://github.com/apollographql/rover/pull/624
+
+## 🛠 Maintenance
+
+- **Address Clippy 0.1.53 warnings - [EverlastingBugstopper], [pull/621]**
+
+  Updated Rover's code to conform to the latest lints.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/621]: https://github.com/apollographql/rover/pull/621
+
+- **New `cargo xtask` command suite - [EverlastingBugstopper], [issue/388] [pull/562]**
+
+  We've replaced a decent chunk of bash scripting in GitHub actions with Rust code. This means you can locally run most commands you need for contributing to Rover with `cargo xtask`.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/562]: https://github.com/apollographql/rover/pull/562
+  [issue/388]: https://github.com/apollographql/rover/issues/388
+
+## 📚 Documentation
+
+- **Extend contribution guide and create an architecture document - [EverlastingBugstopper], [JakeDawkins] & [StephenBarlow], [issue/561] [pull/594]**
+
+  Our new architecture document includes a guide on how to add a new command to Rover, and the `CONTRIBUTING.md` file at the root of the Rover repository is automatically included on our documentation site.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [JakeDawkins]: https://github.com/JakeDawkins
+  [pull/594]: https://github.com/apollographql/rover/pull/594
+  [issue/561]: https://github.com/apollographql/rover/issues/561
+
+- **Use rover@latest in BitBucket documentation - [setchy], [pull/617]**
+
+  [setchy]: https://github.com/setchy
+  [pull/617]: https://github.com/apollographql/rover/pull/617
+
+- **Small clarifications/tweaks - [StephenBarlow], [pull/619]**
+
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [pull/619]: https://github.com/apollographql/rover/pull/619
+
 # [0.1.6]  2021-06-08
 
 ## 🐛 Fixes
@@ -225,7 +285,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   [Author]: https://github.com/EverlastingBugstopper
   [pull/PR #]: https://github.com/apollographql/rover/pull/518
-  [issue/Issue #]: https://github.com/apollographql/rover/issues/489
+  [issue/489]: https://github.com/apollographql/rover/issues/489
 
 - **Add help text to `--log` argument - [EverlastingBugstopper], [pull/486]**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.1.6"
+version = "0.1.7"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.1.6
+Rover 0.1.7
 
 Rover - Your Graph Companion
 Read the getting started guide by running:

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -40,7 +40,7 @@ To build and run the CLI with a set of arguments:
 cargo run -- <args>
 ```
 
-e.g. To build and run `rover supergraph compose`:
+For example, to build and run `rover supergraph compose`:
 
 ```bash
 cargo run -- supergraph compose --config config.yaml
@@ -94,9 +94,9 @@ The Rover team primarily uses [VS Code](https://code.visualstudio.com/) along wi
 
 The Rover team works largely in public using GitHub [issues] to track work. To make sure contributions are aligned with the project's goals, keep the following issue etiquette in mind:
 
-1. [Open an issue](https://github.com/apollographql/rover/issues/new/choose) for your contribution. If there is already an issue open, please ask if anyone is working on it or let us know you plan on working on it. This will let us know what to expect, help us to prioritize reviews, and ensure there is no duplication of work.
-1. Use issue templates! These templates have been created to help minimize back-and-forth between creators and the Rover team. They include the necessary information to help the team triage your issue or question, as well as automatically applying the appropriate labels.
-1. Issues with the `triage` label still applied have not yet been reviewed by the Rover team, and there are no guarantees that PRs fixing an untriaged issue will be accepted. It's best to wait for issues to be triaged before beginning work.
+* [Open an issue](https://github.com/apollographql/rover/issues/new/choose) for your contribution. If there is already an issue open, please ask if anyone is working on it or let us know you plan on working on it. This will let us know what to expect, help us to prioritize reviews, and ensure there is no duplication of work.
+* Use issue templates! These templates have been created to help minimize back-and-forth between creators and the Rover team. They include the necessary information to help the team triage your issue or question, as well as automatically applying the appropriate labels.
+* Issues with the `triage` label still applied have not yet been reviewed by the Rover team, and there are no guarantees that PRs fixing an untriaged issue will be accepted. It's best to wait for issues to be triaged before beginning work.
 
 [issues]: https://github.com/apollographql/rover/issues
 
@@ -104,11 +104,11 @@ The Rover team works largely in public using GitHub [issues] to track work. To m
 
 Pull requests (PRs) should only be opened after discussion and consensus has been reached in a related issue, and you have communicated your intentions to create a PR with the Rover team.
 
-1. When creating a PR, make sure to link it to an issue or use the `Fixes #123` syntax to make sure others know which issue(s) your PR is trying to address and to help us automatically close resolved issues.
-1. Include a helpful description. It is important to provide context to reviewers that show _how_ your PR addresses an issue and any questions you still have unanswered, or portions of the code you think deserve some extra attention.
-1. If your work is still in-progress and you're opening a PR to get early feedback, let us know by opening it as a draft PR and adding `wip:` prefix in the PR title.
-1. Add tests for any logic changes in your code, especially if you are fixing a bug. Your PR should have no failing tests before merging. Please let us know if you need help writing tests, there are still some portions of the Rover codebase that do not have established testing patterns.
-1. Add a changelog entry in [CHANGELOG.md](https://github.com/apollographql/rover/blob/main/CHANGELOG.md) under the `Unreleased` heading, following the pattern of previous entries.
+* When creating a PR, make sure to link it to an issue or use the `Fixes #123` syntax to make sure others know which issue(s) your PR is trying to address and to help us automatically close resolved issues.
+* Include a helpful description. It is important to provide context to reviewers that show _how_ your PR addresses an issue and any questions you still have unanswered, or portions of the code you think deserve some extra attention.
+* If your work is still in-progress and you're opening a PR to get early feedback, let us know by opening it as a draft PR and adding `wip:` prefix in the PR title.
+* Add tests for any logic changes in your code, especially if you are fixing a bug. Your PR should have no failing tests before merging. Please let us know if you need help writing tests, there are still some portions of the Rover codebase that do not have established testing patterns.
+* Add a changelog entry in [CHANGELOG.md](https://github.com/apollographql/rover/blob/main/CHANGELOG.md) under the `Unreleased` heading, following the pattern of previous entries.
 
 ### Documentation
 
@@ -132,7 +132,7 @@ To see how the sidebar is built and how pages are grouped and named, see [this s
 
 To read about Rover's architecture, and to see a guide on how to add new commands, please see our [Architecture document](https://github.com/apollographql/rover/blob/main/ARCHITECTURE.md).
 
-## Code of Conduct
+## Code of conduct
 
 The project has a [Code of Conduct] that *all* contributors are expected to
 follow. This code describes the *minimum* behavior expectations for all
@@ -154,7 +154,7 @@ Open, diverse, and inclusive communities live and die on the basis of trust.
 Contributors can disagree with one another so long as they trust that those
 disagreements are in good faith and everyone is working towards a common goal.
 
-## Bad Actors
+## Bad actors
 All contributors to tacitly agree to abide by both the letter and spirit of the
 [Code of Conduct]. Failure, or unwillingness, to do so will result in
 contributions being respectfully declined.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.5 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.7 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.5' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.7' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.1.6"
+PACKAGE_VERSION="v0.1.7"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.1.6'
+$package_version = 'v0.1.7'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.1.7]  2021-06-22

## 🚀 Features

- **Auto-decode gzipped responses - [EverlastingBugstopper], [issue/608] [pull/620]**

  If your GraphQL server responds with a gzipped introspection response, it will now be decoded automatically instead of failing the command.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/620]: https://github.com/apollographql/rover/pull/620
  [issue/608]: https://github.com/apollographql/rover/issues/608

## 🐛 Fixes

- **Prevent update checker from aborting commands - [EverlastingBugstopper], [pull/624]**

  Previously, if there was a spurious network error when attempting to check for a newer version of Rover, the command would fail. This is no longer the case, if GitHub is down, you will still be able to run Rover commands.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/624]: https://github.com/apollographql/rover/pull/624

## 🛠 Maintenance

- **Address Clippy 0.1.53 warnings - [EverlastingBugstopper], [pull/621]**

  Updated Rover's code to conform to the latest lints.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/621]: https://github.com/apollographql/rover/pull/621

- **New `cargo xtask` command suite - [EverlastingBugstopper], [issue/388] [pull/562]**

  We've replaced a decent chunk of bash scripting in GitHub actions with Rust code. This means you can locally run most commands you need for contributing to Rover with `cargo xtask`.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/562]: https://github.com/apollographql/rover/pull/562
  [issue/388]: https://github.com/apollographql/rover/issues/388

## 📚 Documentation

- **Extend contribution guide and create an architecture document - [EverlastingBugstopper], [JakeDawkins] & [StephenBarlow], [issue/561] [pull/594]**

  Our new architecture document includes a guide on how to add a new command to Rover, and the `CONTRIBUTING.md` file at the root of the Rover repository is automatically included on our documentation site.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [StephenBarlow]: https://github.com/StephenBarlow
  [JakeDawkins]: https://github.com/JakeDawkins
  [pull/594]: https://github.com/apollographql/rover/pull/594
  [issue/561]: https://github.com/apollographql/rover/issues/561

- **Use rover@latest in BitBucket documentation - [setchy], [pull/617]**

  [setchy]: https://github.com/setchy
  [pull/617]: https://github.com/apollographql/rover/pull/617

- **Small clarifications/tweaks - [StephenBarlow], [pull/619]**

  [StephenBarlow]: https://github.com/StephenBarlow
  [pull/619]: https://github.com/apollographql/rover/pull/619