### PR TITLE
chore: refactor subgraph publish

### DIFF
--- a/crates/rover-client/src/query/subgraph/check/types.rs
+++ b/crates/rover-client/src/query/subgraph/check/types.rs
@@ -9,6 +9,7 @@ type QueryVariables = subgraph_check_query::Variables;
 type QueryChangeSeverity = subgraph_check_query::ChangeSeverity;
 type QuerySchema = subgraph_check_query::PartialSchemaInput;
 type QueryConfig = subgraph_check_query::HistoricQueryParameters;
+type GitContextInput = subgraph_check_query::GitContextInput;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubgraphCheckInput {
@@ -98,4 +99,16 @@ pub struct SchemaChange {
 pub struct CompositionError {
     pub message: String,
     pub code: Option<String>,
+}
+
+impl From<GitContext> for GitContextInput {
+    fn from(git_context: GitContext) -> GitContextInput {
+        GitContextInput {
+            branch: git_context.branch,
+            commit: git_context.commit,
+            committer: git_context.author,
+            remote_url: git_context.remote_url,
+            message: None,
+        }
+    }
 }

--- a/crates/rover-client/src/query/subgraph/publish/mod.rs
+++ b/crates/rover-client/src/query/subgraph/publish/mod.rs
@@ -1,0 +1,3 @@
+pub mod mutation_runner;
+pub(crate) mod types;
+pub use types::{SubgraphPublishInput, SubgraphPublishResponse};

--- a/crates/rover-client/src/query/subgraph/publish/publish_mutation.graphql
+++ b/crates/rover-client/src/query/subgraph/publish/publish_mutation.graphql
@@ -1,19 +1,19 @@
-mutation PublishPartialSchemaMutation(
+mutation SubgraphPublishMutation(
   $graphId: ID!
-  $graphVariant: String!
-  $name: String!
+  $variant: String!
+  $subgraph: String!
   $url: String
   $revision: String!
-  $activePartialSchema: PartialSchemaInput!
+  $schema: PartialSchemaInput!
   $gitContext: GitContextInput!
 ) {
   service(id: $graphId) {
     upsertImplementingServiceAndTriggerComposition(
-      name: $name
+      name: $subgraph
       url: $url
       revision: $revision
-      activePartialSchema: $activePartialSchema
-      graphVariant: $graphVariant
+      activePartialSchema: $schema
+      graphVariant: $variant
       gitContext: $gitContext
     ) {
       compositionConfig {

--- a/crates/rover-client/src/query/subgraph/publish/types.rs
+++ b/crates/rover-client/src/query/subgraph/publish/types.rs
@@ -1,0 +1,58 @@
+use super::mutation_runner::subgraph_publish_mutation;
+
+use crate::utils::GitContext;
+
+pub(crate) type ResponseData = subgraph_publish_mutation::ResponseData;
+pub(crate) type MutationVariables = subgraph_publish_mutation::Variables;
+pub(crate) type UpdateResponse = subgraph_publish_mutation::SubgraphPublishMutationServiceUpsertImplementingServiceAndTriggerComposition;
+
+type SchemaInput = subgraph_publish_mutation::PartialSchemaInput;
+type GitContextInput = subgraph_publish_mutation::GitContextInput;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubgraphPublishInput {
+    pub graph_id: String,
+    pub variant: String,
+    pub subgraph: String,
+    pub url: Option<String>,
+    pub schema: String,
+    pub git_context: GitContext,
+    pub convert_to_federated_graph: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SubgraphPublishResponse {
+    pub schema_hash: Option<String>,
+    pub did_update_gateway: bool,
+    pub service_was_created: bool,
+    pub composition_errors: Option<Vec<String>>,
+}
+
+impl From<SubgraphPublishInput> for MutationVariables {
+    fn from(publish_input: SubgraphPublishInput) -> Self {
+        Self {
+            graph_id: publish_input.graph_id,
+            variant: publish_input.variant,
+            subgraph: publish_input.subgraph,
+            url: publish_input.url,
+            schema: SchemaInput {
+                sdl: Some(publish_input.schema),
+                hash: None,
+            },
+            git_context: publish_input.git_context.into(),
+            revision: "".to_string(),
+        }
+    }
+}
+
+impl From<GitContext> for GitContextInput {
+    fn from(git_context: GitContext) -> GitContextInput {
+        GitContextInput {
+            branch: git_context.branch,
+            commit: git_context.commit,
+            committer: git_context.author,
+            remote_url: git_context.remote_url,
+            message: None,
+        }
+    }
+}

--- a/crates/rover-client/src/utils/git.rs
+++ b/crates/rover-client/src/utils/git.rs
@@ -1,4 +1,4 @@
-use crate::query::{graph, subgraph};
+use crate::query::graph;
 
 use std::env;
 
@@ -154,34 +154,6 @@ type GraphCheckContextInput = graph::check::check_schema_query::GitContextInput;
 impl From<GitContext> for GraphCheckContextInput {
     fn from(git_context: GitContext) -> GraphCheckContextInput {
         GraphCheckContextInput {
-            branch: git_context.branch,
-            commit: git_context.commit,
-            committer: git_context.author,
-            remote_url: git_context.remote_url,
-            message: None,
-        }
-    }
-}
-
-type SubgraphPublishContextInput =
-    subgraph::publish::publish_partial_schema_mutation::GitContextInput;
-impl From<GitContext> for SubgraphPublishContextInput {
-    fn from(git_context: GitContext) -> SubgraphPublishContextInput {
-        SubgraphPublishContextInput {
-            branch: git_context.branch,
-            commit: git_context.commit,
-            committer: git_context.author,
-            remote_url: git_context.remote_url,
-            message: None,
-        }
-    }
-}
-
-type SubgraphCheckContextInput =
-    subgraph::check::query_runner::subgraph_check_query::GitContextInput;
-impl From<GitContext> for SubgraphCheckContextInput {
-    fn from(git_context: GitContext) -> SubgraphCheckContextInput {
-        SubgraphCheckContextInput {
             branch: git_context.branch,
             commit: git_context.commit,
             committer: git_context.author,


### PR DESCRIPTION
Updates `rover subgraph publish` to conform to the new architecture.

TODO: 

- [X] make sure it's ok that we send "" for the "revision" field on the publish mutation