### PR TITLE
chore(deps): updates harmonizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "0.3.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7044c9959a4c2ad619473992e43ffd7287e7df7d0b651f830f195aa88badad34"
+checksum = "d067853682d95c6e1fa666637ec7a99c4b20c2c7935ce90ab59bd69cad2ce7ef"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ console = "0.14.0"
 crossterm = "0.20.0"
 git-url-parse = "0.3.1"
 git2 = { version = "0.13.20", default-features = false, features = ["vendored-openssl"] }
-harmonizer = { version = "0.3.1", optional = true }
+harmonizer = { version = "0.26.0", optional = true }
 heck = "0.3.3"
 humantime = "2.1.0"
 opener = "0.5.0"


### PR DESCRIPTION
Updates harmonizer to latest harmonizer version 0.26.0. This new composition algorithm includes support for `@tag` and `@inaccessible` directives.