### PR TITLE
release: v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,74 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.1.7]  2021-06-29
+
+## 🚀 Features
+
+- **Auto-decode gzipped responses - [EverlastingBugstopper], [issue/608] [pull/620]**
+
+  If your GraphQL server responds with a gzipped introspection response, it will now be decoded automatically instead of failing the command.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/620]: https://github.com/apollographql/rover/pull/620
+  [issue/608]: https://github.com/apollographql/rover/issues/608
+
+## 🐛 Fixes
+
+- **Prevent update checker from aborting commands - [EverlastingBugstopper], [pull/624]**
+
+  Previously, if there was a spurious network error when attempting to check for a newer version of Rover, the command would fail. This is no longer the case, if GitHub is down, you will still be able to run Rover commands.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/624]: https://github.com/apollographql/rover/pull/624
+
+## 🛠 Maintenance
+
+- **Address Clippy 0.1.53 warnings - [EverlastingBugstopper], [pull/621]**
+
+  Updated Rover's code to conform to the latest lints.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/621]: https://github.com/apollographql/rover/pull/621
+
+- **New `cargo xtask` command suite - [EverlastingBugstopper], [issue/388] [pull/562]**
+
+  We've replaced a decent chunk of bash scripting in GitHub actions with Rust code. This means you can locally run most commands you need for contributing to Rover with `cargo xtask`.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/562]: https://github.com/apollographql/rover/pull/562
+  [issue/388]: https://github.com/apollographql/rover/issues/388
+
+- **Additional integration tests - [EverlastingBugstopper], [pull/629]**
+
+  We've set up some integration tests that run `make ci` after cloning the [supergraph-demo].
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/629]: https://github.com/apollographql/rover/pull/629
+  [supergraph-demo]: https://github.com/apollographql/supergraph-demo
+
+## 📚 Documentation
+
+- **Extend contribution guide and create an architecture document - [EverlastingBugstopper], [JakeDawkins] & [StephenBarlow], [issue/561] [pull/594]**
+
+  Our new architecture document includes a guide on how to add a new command to Rover, and the `CONTRIBUTING.md` file at the root of the Rover repository is automatically included on our documentation site.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [JakeDawkins]: https://github.com/JakeDawkins
+  [pull/594]: https://github.com/apollographql/rover/pull/594
+  [issue/561]: https://github.com/apollographql/rover/issues/561
+
+- **Use rover@latest in BitBucket documentation - [setchy], [pull/617]**
+
+  [setchy]: https://github.com/setchy
+  [pull/617]: https://github.com/apollographql/rover/pull/617
+
+- **Small clarifications/tweaks - [StephenBarlow], [pull/619]**
+
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [pull/619]: https://github.com/apollographql/rover/pull/619
+
 # [0.1.6]  2021-06-08
 
 ## 🐛 Fixes
@@ -224,8 +292,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Previously, Rover obfuscated the information about HTTP errors that occurred. Now, if something goes wrong between your machine and any HTTP server, you'll get some more information about what exactly went wrong.
 
   [Author]: https://github.com/EverlastingBugstopper
-  [pull/PR #]: https://github.com/apollographql/rover/pull/518
-  [issue/Issue #]: https://github.com/apollographql/rover/issues/489
+  [pull/518]: https://github.com/apollographql/rover/pull/518
+  [issue/489]: https://github.com/apollographql/rover/issues/489
 
 - **Add help text to `--log` argument - [EverlastingBugstopper], [pull/486]**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,9 +1452,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "online"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdf6b557e681481348e9aaafe70d83a9fc41c4cbeed3f1073a19301574466b"
+checksum = "7680985bd550795c0161707f51f9abada87c63a5409114ed818a8618d18ec5e5"
 
 [[package]]
 name = "opaque-debug"
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.1.6"
+version = "0.1.7"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.1.6
+Rover 0.1.7
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -118,7 +118,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.7 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -136,7 +136,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.7' | iex
 ```
 
 #### npm installer

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.5 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.7 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.5' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.7' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.1.6"
+PACKAGE_VERSION="v0.1.7"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.1.6'
+$package_version = 'v0.1.7'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -476,9 +476,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "rimraf": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.1.7]  2021-06-29

## 🚀 Features

- **Auto-decode gzipped responses - [EverlastingBugstopper], [issue/608] [pull/620]**

  If your GraphQL server responds with a gzipped introspection response, it will now be decoded automatically instead of failing the command.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/620]: https://github.com/apollographql/rover/pull/620
  [issue/608]: https://github.com/apollographql/rover/issues/608

## 🐛 Fixes

- **Prevent update checker from aborting commands - [EverlastingBugstopper], [pull/624]**

  Previously, if there was a spurious network error when attempting to check for a newer version of Rover, the command would fail. This is no longer the case, if GitHub is down, you will still be able to run Rover commands.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/624]: https://github.com/apollographql/rover/pull/624

## 🛠 Maintenance

- **Address Clippy 0.1.53 warnings - [EverlastingBugstopper], [pull/621]**

  Updated Rover's code to conform to the latest lints.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/621]: https://github.com/apollographql/rover/pull/621

- **New `cargo xtask` command suite - [EverlastingBugstopper], [issue/388] [pull/562]**

  We've replaced a decent chunk of bash scripting in GitHub actions with Rust code. This means you can locally run most commands you need for contributing to Rover with `cargo xtask`.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/562]: https://github.com/apollographql/rover/pull/562
  [issue/388]: https://github.com/apollographql/rover/issues/388

- **Additional integration tests - [EverlastingBugstopper], [pull/629]**

  We've set up some integration tests that run `make ci` after cloning the [supergraph-demo].

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/629]: https://github.com/apollographql/rover/pull/629
  [supergraph-demo]: https://github.com/apollographql/supergraph-demo

## 📚 Documentation

- **Extend contribution guide and create an architecture document - [EverlastingBugstopper], [JakeDawkins] & [StephenBarlow], [issue/561] [pull/594]**

  Our new architecture document includes a guide on how to add a new command to Rover, and the `CONTRIBUTING.md` file at the root of the Rover repository is automatically included on our documentation site.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [StephenBarlow]: https://github.com/StephenBarlow
  [JakeDawkins]: https://github.com/JakeDawkins
  [pull/594]: https://github.com/apollographql/rover/pull/594
  [issue/561]: https://github.com/apollographql/rover/issues/561

- **Use rover@latest in BitBucket documentation - [setchy], [pull/617]**

  [setchy]: https://github.com/setchy
  [pull/617]: https://github.com/apollographql/rover/pull/617

- **Small clarifications/tweaks - [StephenBarlow], [pull/619]**

  [StephenBarlow]: https://github.com/StephenBarlow
  [pull/619]: https://github.com/apollographql/rover/pull/619