### PR TITLE
fix: use built-in root certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,18 +1131,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.22.1"
+name = "hyper-tls"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "futures-util",
+ "bytes",
  "hyper",
- "log",
- "rustls",
+ "native-tls",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1371,6 +1384,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1480,20 @@ checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
 dependencies = [
  "bstr",
  "winapi",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
 ]
 
 [[package]]
@@ -1828,42 +1873,26 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tokio-util",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "winreg 0.7.0",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -1969,31 +1998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
-name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rusty_v8"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,16 +2040,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sdl-encoder"
@@ -2267,12 +2261,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sputnik"
@@ -2544,14 +2532,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.22.0"
+name = "tokio-native-tls"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -2735,12 +2722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,16 +2886,6 @@ checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b6bd5df287567ffdf4ddf4d33060048e1068308e5f62d81c6f9824a045a48"
+checksum = "aa2dfc8228c6260bf620fc5a341afa8e27edcde388b19ffc5732320bfe657eb2"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -367,9 +367,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1862,6 +1862,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1873,7 +1874,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg 0.7.0",
 ]
 
@@ -2005,6 +2005,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2727,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -2939,15 +2951,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192ec435945d87bc2f70992b4d818154b5feede43c09fb7592146374eac90a6"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +117,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
 dependencies = [
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
@@ -197,6 +213,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f29919120f08613aadcd4383764e00526fc9f18b6c0895814faeed0dd78613e"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1052e1c3b8d4d80eb84a8b94f0a1498797b5fb96314c001156a1c761940ef4ec"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -674,21 +711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,19 +1131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,24 +1371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,20 +1449,6 @@ checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
 dependencies = [
  "bstr",
  "winapi",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
 ]
 
 [[package]]
@@ -1852,13 +1829,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -1867,7 +1842,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "url",
@@ -2567,16 +2541,6 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "winapi",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ humantime = "2.1.0"
 opener = "0.5.0"
 os_info = "3.0"
 prettytable-rs = "0.8.0"
-reqwest = {version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "rustls-tls-native-roots"]}
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "native-tls"]}
 regex = "1"
 semver = "1"
 serde = "1.0"
@@ -76,7 +76,7 @@ url = { version = "2.2.2", features = ["serde"] }
 assert_cmd = "1.0.5"
 assert_fs = "1.0.0"
 predicates = "1.0.8"
-reqwest = { version = "0.11.4", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
+reqwest = { version = "0.11.4", default-features = false, features = ["blocking", "native-tls-vendored"] }
 serial_test = "0.5.0"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ humantime = "2.1.0"
 opener = "0.5.0"
 os_info = "3.0"
 prettytable-rs = "0.8.0"
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "rustls-tls-native-roots"]}
 regex = "1"
 semver = "1"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ humantime = "2.1.0"
 opener = "0.5.0"
 os_info = "3.0"
 prettytable-rs = "0.8.0"
-reqwest = {version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "native-tls"]}
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "native-tls-vendored"]}
 regex = "1"
 semver = "1"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ url = { version = "2.2.2", features = ["serde"] }
 assert_cmd = "1.0.5"
 assert_fs = "1.0.0"
 predicates = "1.0.8"
-reqwest = "0.11.4"
+reqwest = { version = "0.11.4", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 serial_test = "0.5.0"
 
 [build-dependencies]

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1"
 [build-dependencies]
 camino = "1"
 online = { version = "3.0.1",  default-features = false, features = ["sync"] }
-reqwest = {version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls-native-roots"]}
+reqwest = {version = "0.11", default-features = false, features = ["json", "blocking", "native-tls-vendored"]}
 uuid = {version = "0.8", features = ["v4"]}
 
 [dev-dependencies]

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4"
 graphql_client = "0.9"
 http = "0.2"
 regex = "1.5.4"
-reqwest = {version = "0.11", default-features = false, features = ["blocking", "gzip", "json", "rustls-tls-native-roots"]}
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "json"]}
 sdl-encoder = {path = "../sdl-encoder"}
 serde = "1"
 serde_json = "1"
@@ -30,5 +30,6 @@ reqwest = {version = "0.11", default-features = false, features = ["json", "bloc
 uuid = {version = "0.8", features = ["v4"]}
 
 [dev-dependencies]
+
 indoc = "1.0.3"
 pretty_assertions = "0.7.1"

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4"
 graphql_client = "0.9"
 http = "0.2"
 regex = "1.5.4"
-reqwest = {version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls", "gzip"]}
+reqwest = {version = "0.11", default-features = false, features = ["blocking", "gzip", "json", "rustls-tls-native-roots"]}
 sdl-encoder = {path = "../sdl-encoder"}
 serde = "1"
 serde_json = "1"
@@ -26,7 +26,7 @@ tracing = "0.1"
 [build-dependencies]
 camino = "1"
 online = { version = "3.0.1",  default-features = false, features = ["sync"] }
-reqwest = {version = "0.11", default-features = false, features = ["json", "blocking", "native-tls-vendored"]}
+reqwest = {version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls-native-roots"]}
 uuid = {version = "0.8", features = ["v4"]}
 
 [dev-dependencies]

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -23,7 +23,12 @@ fn main() -> std::io::Result<()> {
     let schema_url = env::var("APOLLO_GPAPHQL_SCHEMA_URL")
         .unwrap_or_else(|_| "https://graphql.api.apollographql.com/api/schema".to_owned());
 
-    let client = Client::new();
+    let client = Client::builder()
+        .use_rustls_tls()
+        .tls_built_in_root_certs(true)
+        .build()
+        .expect("Could not create reqwest Client");
+
     let etag_path = PathBuf::from(".schema/etag.id");
 
     let should_update_schema = !(etag_path.exists()) || online::sync::check(None).is_ok();

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -23,11 +23,7 @@ fn main() -> std::io::Result<()> {
     let schema_url = env::var("APOLLO_GPAPHQL_SCHEMA_URL")
         .unwrap_or_else(|_| "https://graphql.api.apollographql.com/api/schema".to_owned());
 
-    let client = Client::builder()
-        .use_rustls_tls()
-        .tls_built_in_root_certs(true)
-        .build()
-        .expect("Could not create reqwest Client");
+    let client = Client::new();
 
     let etag_path = PathBuf::from(".schema/etag.id");
 

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -24,7 +24,6 @@ fn main() -> std::io::Result<()> {
         .unwrap_or_else(|_| "https://graphql.api.apollographql.com/api/schema".to_owned());
 
     let client = Client::new();
-
     let etag_path = PathBuf::from(".schema/etag.id");
 
     let should_update_schema = !(etag_path.exists()) || online::sync::check(None).is_ok();

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -8,27 +8,22 @@ use reqwest::{
 
 use std::collections::HashMap;
 
-pub(crate) fn get_client() -> Result<ReqwestClient, ReqwestError> {
-    ReqwestClient::builder()
-        .use_rustls_tls()
-        .tls_built_in_root_certs(true)
-        .gzip(true)
-        .build()
-}
-
 /// Represents a generic GraphQL client for making http requests.
 pub struct GraphQLClient {
-    client: ReqwestClient,
     graphql_endpoint: String,
+    client: ReqwestClient,
 }
 
 impl GraphQLClient {
     /// Construct a new [Client] from a `graphql_endpoint`.
     /// This client is used for generic GraphQL requests, such as introspection.
-    pub fn new(graphql_endpoint: &str) -> Result<GraphQLClient, ReqwestError> {
+    pub fn new(
+        graphql_endpoint: &str,
+        client: ReqwestClient,
+    ) -> Result<GraphQLClient, ReqwestError> {
         Ok(GraphQLClient {
-            client: get_client()?,
             graphql_endpoint: graphql_endpoint.to_string(),
+            client,
         })
     }
 

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -21,6 +21,7 @@ impl GraphQLClient {
         Ok(GraphQLClient {
             client: ReqwestClient::builder()
                 .use_rustls_tls()
+                .tls_built_in_root_certs(true)
                 .gzip(true)
                 .build()?,
             graphql_endpoint: graphql_endpoint.to_string(),

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -8,6 +8,14 @@ use reqwest::{
 
 use std::collections::HashMap;
 
+pub(crate) fn get_client() -> Result<ReqwestClient, ReqwestError> {
+    ReqwestClient::builder()
+        .use_rustls_tls()
+        .tls_built_in_root_certs(true)
+        .gzip(true)
+        .build()
+}
+
 /// Represents a generic GraphQL client for making http requests.
 pub struct GraphQLClient {
     client: ReqwestClient,
@@ -19,11 +27,7 @@ impl GraphQLClient {
     /// This client is used for generic GraphQL requests, such as introspection.
     pub fn new(graphql_endpoint: &str) -> Result<GraphQLClient, ReqwestError> {
         Ok(GraphQLClient {
-            client: ReqwestClient::builder()
-                .use_rustls_tls()
-                .tls_built_in_root_certs(true)
-                .gzip(true)
-                .build()?,
+            client: get_client()?,
             graphql_endpoint: graphql_endpoint.to_string(),
         })
     }

--- a/crates/rover-client/src/blocking/mod.rs
+++ b/crates/rover-client/src/blocking/mod.rs
@@ -1,5 +1,6 @@
 mod client;
 mod studio_client;
 
+pub(crate) use client::get_client;
 pub use client::GraphQLClient;
 pub use studio_client::StudioClient;

--- a/crates/rover-client/src/blocking/mod.rs
+++ b/crates/rover-client/src/blocking/mod.rs
@@ -1,6 +1,5 @@
 mod client;
 mod studio_client;
 
-pub(crate) use client::get_client;
 pub use client::GraphQLClient;
 pub use studio_client::StudioClient;

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -2,7 +2,7 @@ use crate::{blocking::GraphQLClient, headers, RoverClientError};
 use houston::Credential;
 
 use graphql_client::GraphQLQuery;
-use reqwest::Error as ReqwestError;
+use reqwest::{blocking::Client as ReqwestClient, Error as ReqwestError};
 
 /// Represents a client for making GraphQL requests to Apollo Studio.
 pub struct StudioClient {
@@ -18,10 +18,11 @@ impl StudioClient {
         credential: Credential,
         graphql_endpoint: &str,
         version: &str,
+        client: ReqwestClient,
     ) -> Result<StudioClient, ReqwestError> {
         Ok(StudioClient {
             credential,
-            client: GraphQLClient::new(graphql_endpoint)?,
+            client: GraphQLClient::new(graphql_endpoint, client)?,
             version: version.to_string(),
         })
     }

--- a/crates/rover-client/src/releases.rs
+++ b/crates/rover-client/src/releases.rs
@@ -1,12 +1,11 @@
-use crate::RoverClientError;
+use crate::{blocking::get_client, RoverClientError};
 use regex::Regex;
-use reqwest::blocking;
 
 const LATEST_RELEASE_URL: &str = "https://github.com/apollographql/rover/releases/latest";
 
 /// Looks up the latest release version, and returns it as a string
 pub fn get_latest_release() -> Result<String, RoverClientError> {
-    let res = blocking::Client::new().head(LATEST_RELEASE_URL).send()?;
+    let res = get_client()?.head(LATEST_RELEASE_URL).send()?;
 
     let release_url = res.url().to_string();
     let release_url_parts: Vec<&str> = release_url.split('/').collect();

--- a/crates/rover-client/src/releases.rs
+++ b/crates/rover-client/src/releases.rs
@@ -1,11 +1,12 @@
-use crate::{blocking::get_client, RoverClientError};
+use crate::RoverClientError;
 use regex::Regex;
+use reqwest::blocking::Client;
 
 const LATEST_RELEASE_URL: &str = "https://github.com/apollographql/rover/releases/latest";
 
 /// Looks up the latest release version, and returns it as a string
-pub fn get_latest_release() -> Result<String, RoverClientError> {
-    let res = get_client()?.head(LATEST_RELEASE_URL).send()?;
+pub fn get_latest_release(client: Client) -> Result<String, RoverClientError> {
+    let res = client.head(LATEST_RELEASE_URL).send()?;
 
     let release_url = res.url().to_string();
     let release_url_parts: Vec<&str> = release_url.split('/').collect();

--- a/crates/rover-client/tests/client.rs
+++ b/crates/rover-client/tests/client.rs
@@ -3,8 +3,6 @@ const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/ap
 
 pub(crate) fn get_client() -> Client {
     Client::builder()
-        .use_rustls_tls()
-        .tls_built_in_root_certs(true)
         .gzip(true)
         .brotli(true)
         .build()

--- a/crates/rover-client/tests/client.rs
+++ b/crates/rover-client/tests/client.rs
@@ -1,7 +1,19 @@
+use reqwest::blocking::Client;
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
+
+pub(crate) fn get_client() -> Client {
+    Client::builder()
+        .use_rustls_tls()
+        .tls_built_in_root_certs(true)
+        .gzip(true)
+        .brotli(true)
+        .build()
+        .expect("Could not create reqwest Client")
+}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use houston::{Credential, CredentialOrigin};
     use rover_client::blocking::{GraphQLClient, StudioClient};
 
@@ -9,7 +21,7 @@ mod tests {
 
     #[test]
     fn it_can_build_client() {
-        assert!(GraphQLClient::new(STUDIO_PROD_API_ENDPOINT).is_ok());
+        assert!(GraphQLClient::new(STUDIO_PROD_API_ENDPOINT, get_client()).is_ok(),);
     }
 
     #[test]
@@ -20,7 +32,8 @@ mod tests {
                 origin: CredentialOrigin::EnvVar,
             },
             "0.1.0",
-            STUDIO_PROD_API_ENDPOINT
+            STUDIO_PROD_API_ENDPOINT,
+            get_client()
         )
         .is_ok());
     }

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 camino = "1.0"
 ci_info = { version = "0.14", features = ["serde-1"] }
 git2 = "0.13"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls-native-roots"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 camino = "1.0"
 ci_info = { version = "0.14", features = ["serde-1"] }
 git2 = "0.13"
-reqwest = { version = "0.11", features = ["blocking", "rustls-tls-native-roots"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -1,4 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
+use reqwest::blocking::Client;
 use url::Url;
 use uuid::Uuid;
 
@@ -38,12 +39,15 @@ pub trait Report {
 
     /// returns the globally persistent machine identifier
     /// and writes it if it does not exist
-    /// the default implemenation uses self.machine_id_config()
+    /// the default implementation uses self.machine_id_config()
     /// as the location the machine identifier is written to.
     fn machine_id(&self) -> Result<Uuid, SputnikError> {
         let config_path = self.machine_id_config()?;
         get_or_write_machine_id(&config_path)
     }
+
+    /// returns the Client to use when sending telemetry data
+    fn client(&self) -> Client;
 }
 
 fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -125,7 +125,10 @@ impl Session {
             let body = serde_json::to_string(&self)?;
             tracing::debug!("POSTing to {}", &self.reporting_info.endpoint);
             tracing::debug!("{}", body);
-            reqwest::blocking::Client::new()
+            reqwest::blocking::Client::builder()
+                .use_rustls_tls()
+                .tls_built_in_root_certs(true)
+                .build()?
                 .post(self.reporting_info.endpoint.clone())
                 .body(body)
                 .header("User-Agent", &self.reporting_info.user_agent)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use reqwest::blocking::Client;
 use serde::Serialize;
 use structopt::{clap::AppSettings, StructOpt};
 
@@ -60,6 +61,10 @@ pub struct Rover {
     #[structopt(skip)]
     #[serde(skip_serializing)]
     pub env_store: RoverEnv,
+
+    #[structopt(skip)]
+    #[serde(skip_serializing)]
+    client: Client,
 }
 
 impl Rover {
@@ -75,7 +80,11 @@ impl Rover {
     pub(crate) fn get_client_config(&self) -> Result<StudioClientConfig> {
         let override_endpoint = self.env_store.get(RoverEnvKey::RegistryUrl)?;
         let config = self.get_rover_config()?;
-        Ok(StudioClientConfig::new(override_endpoint, config))
+        Ok(StudioClientConfig::new(
+            override_endpoint,
+            config,
+            self.get_reqwest_client(),
+        ))
     }
 
     pub(crate) fn get_install_override_path(&self) -> Result<Option<Utf8PathBuf>> {
@@ -90,6 +99,11 @@ impl Rover {
         let git_context = GitContext::try_from_rover_env(&self.env_store)?;
         tracing::debug!(?git_context);
         Ok(git_context)
+    }
+
+    pub(crate) fn get_reqwest_client(&self) -> Client {
+        // we can use clone here freely since `reqwest` uses an `Arc` under the hood
+        self.client.clone()
     }
 }
 
@@ -136,7 +150,7 @@ impl Rover {
         } else {
             let config = self.get_rover_config();
             if let Ok(config) = config {
-                let _ = version::check_for_update(config, false);
+                let _ = version::check_for_update(config, false, self.get_reqwest_client());
             }
         }
 
@@ -150,7 +164,9 @@ impl Rover {
             Command::Subgraph(command) => {
                 command.run(self.get_client_config()?, self.get_git_context()?)
             }
-            Command::Update(command) => command.run(self.get_rover_config()?),
+            Command::Update(command) => {
+                command.run(self.get_rover_config()?, self.get_reqwest_client())
+            }
             Command::Install(command) => command.run(self.get_install_override_path()?),
             Command::Info(command) => command.run(),
             Command::Explain(command) => command.run(),

--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -23,7 +23,7 @@ pub struct WhoAmI {
 
 impl WhoAmI {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         eprintln!("Checking identity of your API key against the registry.");
 
         let identity = whoami::run(whoami::who_am_i_query::Variables {}, &client)?;

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -55,7 +55,7 @@ impl Check {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let sdl = load_schema_from_flag(&self.schema, std::io::stdin())?;
         let res = check::run(
             check::check_schema_query::Variables {

--- a/src/command/graph/fetch.rs
+++ b/src/command/graph/fetch.rs
@@ -25,7 +25,7 @@ pub struct Fetch {
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
         eprintln!(
             "Fetching SDL from {} using credentials from the {} profile.",

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use reqwest::blocking::Client;
 use serde::Serialize;
 use std::collections::HashMap;
 use structopt::StructOpt;
@@ -27,8 +28,8 @@ pub struct Introspect {
 }
 
 impl Introspect {
-    pub fn run(&self) -> Result<RoverStdout> {
-        let client = GraphQLClient::new(&self.endpoint.to_string())?;
+    pub fn run(&self, client: Client) -> Result<RoverStdout> {
+        let client = GraphQLClient::new(&self.endpoint.to_string(), client)?;
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -42,7 +42,7 @@ impl Graph {
             Command::Check(command) => command.run(client_config, git_context),
             Command::Fetch(command) => command.run(client_config),
             Command::Publish(command) => command.run(client_config, git_context),
-            Command::Introspect(command) => command.run(),
+            Command::Introspect(command) => command.run(client_config.get_reqwest_client()),
         }
     }
 }

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -37,7 +37,7 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
         eprintln!(
             "Publishing SDL to {} using credentials from the {} profile.",

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -61,7 +61,7 @@ impl Check {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
 
         let sdl = load_schema_from_flag(&self.schema, std::io::stdin())?;
 

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -36,7 +36,7 @@ pub struct Delete {
 
 impl Delete {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
         eprintln!(
             "Checking for composition errors resulting from deleting subgraph {} from {} using credentials from the {} profile.",

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -30,7 +30,7 @@ pub struct Fetch {
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
         eprintln!(
             "Fetching SDL from {} (subgraph: {}) using credentials from the {} profile.",

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -1,3 +1,4 @@
+use reqwest::blocking::Client;
 use serde::Serialize;
 use std::collections::HashMap;
 use structopt::StructOpt;
@@ -32,8 +33,8 @@ pub struct Introspect {
 }
 
 impl Introspect {
-    pub fn run(&self) -> Result<RoverStdout> {
-        let client = GraphQLClient::new(&self.endpoint.to_string())?;
+    pub fn run(&self, client: Client) -> Result<RoverStdout> {
+        let client = GraphQLClient::new(&self.endpoint.to_string(), client)?;
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/subgraph/list.rs
+++ b/src/command/subgraph/list.rs
@@ -25,7 +25,7 @@ pub struct List {
 
 impl List {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
 
         eprintln!(
             "Listing subgraphs for {} using credentials from the {} profile.",

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -48,7 +48,7 @@ impl Subgraph {
     ) -> Result<RoverStdout> {
         match &self.command {
             Command::Publish(command) => command.run(client_config, git_context),
-            Command::Introspect(command) => command.run(),
+            Command::Introspect(command) => command.run(client_config.get_reqwest_client()),
             Command::Delete(command) => command.run(client_config),
             Command::Fetch(command) => command.run(client_config),
             Command::Check(command) => command.run(client_config, git_context),

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -55,7 +55,7 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let graph_ref = format!("{}:{}", &self.graph.name, &self.graph.variant);
         eprintln!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -102,7 +102,10 @@ pub(crate) fn get_subgraph_definitions(
             SchemaSource::SubgraphIntrospection { subgraph_url } => {
                 // given a federated introspection URL, use subgraph introspect to
                 // obtain SDL and add it to subgraph_definition.
-                let client = GraphQLClient::new(&subgraph_url.to_string())?;
+                let client = GraphQLClient::new(
+                    &subgraph_url.to_string(),
+                    client_config.get_reqwest_client(),
+                )?;
 
                 let introspection_response = introspect::run(&client, &HashMap::new())?;
                 let schema = introspection_response.result;
@@ -120,7 +123,7 @@ pub(crate) fn get_subgraph_definitions(
             SchemaSource::Subgraph { graphref, subgraph } => {
                 // given a graphref and subgraph, run subgraph fetch to
                 // obtain SDL and add it to subgraph_definition.
-                let client = client_config.get_client(&profile_name)?;
+                let client = client_config.get_authenticated_client(&profile_name)?;
                 let graphref = parse_graph_ref(graphref)?;
                 let schema = fetch::run(
                     fetch::fetch_subgraph_query::Variables {
@@ -153,12 +156,21 @@ mod tests {
     use assert_fs::TempDir;
     use houston as houston_config;
     use houston_config::Config;
+    use reqwest::blocking::Client;
     use std::convert::TryFrom;
 
     fn get_studio_config() -> StudioClientConfig {
         let tmp_home = TempDir::new().unwrap();
         let tmp_path = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
-        StudioClientConfig::new(None, Config::new(Some(&tmp_path), None).unwrap())
+        StudioClientConfig::new(
+            None,
+            Config::new(Some(&tmp_path), None).unwrap(),
+            Client::builder()
+                .use_rustls_tls()
+                .tls_built_in_root_certs(true)
+                .build()
+                .unwrap(),
+        )
     }
 
     #[test]

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -165,11 +165,7 @@ mod tests {
         StudioClientConfig::new(
             None,
             Config::new(Some(&tmp_path), None).unwrap(),
-            Client::builder()
-                .use_rustls_tls()
-                .tls_built_in_root_certs(true)
-                .build()
-                .unwrap(),
+            Client::new(),
         )
     }
 

--- a/src/command/supergraph/fetch.rs
+++ b/src/command/supergraph/fetch.rs
@@ -24,7 +24,7 @@ pub struct Fetch {
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverStdout> {
-        let client = client_config.get_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
         let graph_ref = self.graph.to_string();
         eprintln!(
             "Fetching supergraph SDL from {} using credentials from the {} profile.",

--- a/src/command/update/check.rs
+++ b/src/command/update/check.rs
@@ -1,3 +1,4 @@
+use reqwest::blocking::Client;
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -12,8 +13,8 @@ pub struct Check {
 }
 
 impl Check {
-    pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
-        version::check_for_update(config, true)?;
+    pub fn run(&self, config: config::Config, client: Client) -> Result<RoverStdout> {
+        version::check_for_update(config, true, client)?;
         Ok(RoverStdout::None)
     }
 }

--- a/src/command/update/mod.rs
+++ b/src/command/update/mod.rs
@@ -1,5 +1,6 @@
 mod check;
 
+use reqwest::blocking::Client;
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -21,9 +22,9 @@ pub enum Command {
 }
 
 impl Update {
-    pub fn run(&self, config: config::Config) -> Result<RoverStdout> {
+    pub fn run(&self, config: config::Config, client: Client) -> Result<RoverStdout> {
         match &self.command {
-            Command::Check(command) => command.run(config),
+            Command::Check(command) => command.run(config, client),
         }
     }
 }

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -2,19 +2,25 @@ use crate::Result;
 use crate::PKG_VERSION;
 
 use houston as config;
+use reqwest::blocking::Client;
 use rover_client::blocking::StudioClient;
 
 /// the Apollo graph registry's production API endpoint
 const STUDIO_PROD_API_ENDPOINT: &str = "https://graphql.api.apollographql.com/api/graphql";
 
 pub struct StudioClientConfig {
+    pub(crate) config: config::Config,
+    client: Client,
     uri: String,
-    pub config: config::Config,
     version: String,
 }
 
 impl StudioClientConfig {
-    pub fn new(override_endpoint: Option<String>, config: config::Config) -> StudioClientConfig {
+    pub fn new(
+        override_endpoint: Option<String>,
+        config: config::Config,
+        client: Client,
+    ) -> StudioClientConfig {
         let version = if cfg!(debug_assertions) {
             format!("{} (dev)", PKG_VERSION)
         } else {
@@ -25,11 +31,22 @@ impl StudioClientConfig {
             uri: override_endpoint.unwrap_or_else(|| STUDIO_PROD_API_ENDPOINT.to_string()),
             config,
             version,
+            client,
         }
     }
 
-    pub fn get_client(&self, profile_name: &str) -> Result<StudioClient> {
+    pub(crate) fn get_reqwest_client(&self) -> Client {
+        // we can use clone here freely since `reqwest` uses an `Arc` under the hood
+        self.client.clone()
+    }
+
+    pub fn get_authenticated_client(&self, profile_name: &str) -> Result<StudioClient> {
         let credential = config::Profile::get_credential(profile_name, &self.config)?;
-        Ok(StudioClient::new(credential, &self.uri, &self.version)?)
+        Ok(StudioClient::new(
+            credential,
+            &self.uri,
+            &self.version,
+            self.get_reqwest_client(),
+        )?)
     }
 }

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -1,4 +1,5 @@
 use camino::Utf8PathBuf;
+use reqwest::blocking::Client;
 use url::Url;
 
 use crate::utils::env::RoverEnvKey;
@@ -114,6 +115,10 @@ impl Report for Rover {
             .get_rover_config()
             .map_err(|_| SputnikError::ConfigError)?;
         Ok(config.home.join("machine.txt"))
+    }
+
+    fn client(&self) -> Client {
+        self.get_reqwest_client()
     }
 }
 

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -3,6 +3,7 @@ use std::{fs, time::SystemTime};
 use ansi_term::Colour::{Cyan, Yellow};
 use billboard::{Alignment, Billboard};
 use camino::Utf8PathBuf;
+use reqwest::blocking::Client;
 use semver::Version;
 
 use crate::{Result, PKG_VERSION};
@@ -18,7 +19,7 @@ const ONE_DAY: u64 = ONE_HOUR * 24;
 /// check for newer versions, even if we recently checked for updates.
 ///
 /// If `force` is not passed, we check for updates every day at most
-pub fn check_for_update(config: config::Config, force: bool) -> Result<()> {
+pub fn check_for_update(config: config::Config, force: bool, client: Client) -> Result<()> {
     let version_file = config.home.join("version.toml");
     let current_time = SystemTime::now();
     // if we don't end up checking, we don't want to overwrite the last checked time
@@ -28,7 +29,7 @@ pub fn check_for_update(config: config::Config, force: bool) -> Result<()> {
     let last_checked_time = get_last_checked_time_from_disk(&version_file);
 
     if force || last_checked_time.is_none() {
-        do_update_check(&mut checked, force)?;
+        do_update_check(&mut checked, force, client)?;
     } else if let Some(last_checked_time) = last_checked_time {
         let time_since_check = current_time.duration_since(last_checked_time)?.as_secs();
         tracing::trace!(
@@ -37,7 +38,7 @@ pub fn check_for_update(config: config::Config, force: bool) -> Result<()> {
         );
 
         if time_since_check > ONE_DAY {
-            do_update_check(&mut checked, force)?;
+            do_update_check(&mut checked, force, client)?;
         }
     }
 
@@ -49,8 +50,12 @@ pub fn check_for_update(config: config::Config, force: bool) -> Result<()> {
     Ok(())
 }
 
-fn do_update_check(checked: &mut bool, should_output_if_updated: bool) -> Result<()> {
-    let latest = get_latest_release()?;
+fn do_update_check(
+    checked: &mut bool,
+    should_output_if_updated: bool,
+    client: Client,
+) -> Result<()> {
+    let latest = get_latest_release(client)?;
     let pretty_latest = Cyan.normal().paint(format!("v{}", latest));
     let update_available = is_latest_newer(&latest, PKG_VERSION)?;
     if update_available {


### PR DESCRIPTION
fixes #645 by switching back to the `native-tls-vendored` SSL backend instead of `rustls`, since we want to support local CAs for certain requests.

This PR also includes changes from #650 that allows us to reuse the same instance of a `reqwest::blocking::Client` across the entire codebase 