### PR TITLE
chore: removes unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ dependencies = [
  "serial_test",
  "thiserror",
  "tracing",
- "which",
  "winapi",
  "winreg 0.9.0",
 ]
@@ -920,16 +919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphql-parser"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1abd4ce5247dfc04a03ccde70f87a048458c9356c7e41d21ad8c407b3dde6f2"
-dependencies = [
- "combine",
- "thiserror",
-]
-
-[[package]]
 name = "graphql_client"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +938,7 @@ checksum = "8e304c223c809b3bff4614018f8e6d9edb176b31d64ed9ea48b6ae8b1a03abb9"
 dependencies = [
  "failure",
  "graphql-introspection-query",
- "graphql-parser 0.2.3",
+ "graphql-parser",
  "heck",
  "lazy_static",
  "proc-macro2",
@@ -1034,7 +1023,6 @@ dependencies = [
  "assert_fs",
  "camino",
  "directories-next",
- "regex",
  "serde",
  "thiserror",
  "toml",
@@ -1947,7 +1935,6 @@ dependencies = [
  "reqwest",
  "robot-panic",
  "rover-client",
- "rustversion",
  "sdl-encoder",
  "semver 1.0.3",
  "serde",
@@ -1971,10 +1958,8 @@ dependencies = [
 name = "rover-client"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "camino",
  "chrono",
- "graphql-parser 0.3.0",
  "graphql_client",
  "houston",
  "http",
@@ -2021,12 +2006,6 @@ dependencies = [
  "sct",
  "webpki",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "rusty_v8"
@@ -2322,7 +2301,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "structopt",
  "thiserror",
  "tracing",
  "url",
@@ -2533,7 +2511,6 @@ dependencies = [
 name = "timber"
 version = "0.1.0"
 dependencies = [
- "atty",
  "serde",
  "tracing-core",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ assert_cmd = "1.0.5"
 assert_fs = "1.0.0"
 predicates = "1.0.8"
 reqwest = "0.11.4"
-rustversion = "1.0.5"
 serial_test = "0.5.0"
 
 [build-dependencies]

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -11,7 +11,6 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 toml = "0.5"
 tracing = "0.1"
-regex = "1.5"
 
 [dev-dependencies]
 assert_fs = "1"

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -11,10 +11,8 @@ version = "0.0.0"
 houston = {path = "../houston"}
 
 # crates.io deps
-anyhow = "1"
 camino = "1"
 chrono = "0.4"
-graphql-parser = "0.3.0"
 graphql_client = "0.9"
 http = "0.2"
 regex = "1.5.4"

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -13,7 +13,6 @@ semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
-structopt = "0.3"
 thiserror = "1.0"
 tracing = "0.1"
 url = "2.2"

--- a/crates/timber/Cargo.toml
+++ b/crates/timber/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 edition = "2018"
 
 [dependencies]
-atty = "0.2.14"
 serde = "1"
 tracing-core = "0.1"
 # the parking_lot feature uses a more performant mutex than std::sync::Mutex

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -10,7 +10,6 @@ camino = "1.0"
 directories-next = "2.0"
 thiserror = "1.0"
 tracing = "0.1"
-which = "4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cc = "1.0"


### PR DESCRIPTION
Found these using `rustup install nightly && cargo install --cargo-udeps --locked && cargo +nightly udeps --all-targets`.

I considered adding this to our test suite, but it relies on a nightly toolchain and claims to still be unstable. I figure we can get away with keeping this one manual for a bit, though I do wish this was built straight into cargo!