### PR TITLE
release: v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,48 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.1.8]  2021-07-07
+
+## 🚀 Features
+
+- **Adds _preview_ support for `@tag` and `@inaccessible` directives - [EverlastingBugstopper], [pull/631]**
+
+  **Preview** support for composing subgraphs with `@tag` and/or `@inaccessible` core features using `rover supergraph compose`. Note that `@apollo/gateway >= 0.33` is required when using **preview** support for these core features.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/631]: https://github.com/apollographql/rover/pull/631
+
+- **Auto-decode gzipped responses - [EverlastingBugstopper], [pull/650]**
+
+  If your GraphQL server responds with an introspection response compressed with brotli, it will now be decoded automatically instead of failing the command.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/650]: https://github.com/apollographql/rover/pull/650
+
+## 🐛 Fixes
+
+- **Use built-in root certificates and re-use HTTP connection pool - [EverlastingBugstopper], [issue/645] [pull/649]**
+
+  Rover now uses local CA Certificates along with your operating system's native TLS implementation instead of the Rust-based WebPKI implementation.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/649]: https://github.com/apollographql/rover/pull/649
+  [issue/645]: https://github.com/apollographql/rover/issues/645
+
+## 🛠 Maintenance
+
+- **Re-use HTTP connection pool - [EverlastingBugstopper], [pull/650]**
+
+  Rover will now create and reuse the same HTTP connection pool for subsequent requests, which should slightly improve performance.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/650]: https://github.com/apollographql/rover/pull/650
+
+- **Removes unused dependencies - [EverlastingBugstopper], [pull/651]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/651]: https://github.com/apollographql/rover/pull/651
+
 # [0.1.7]  2021-06-29
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.1.7"
+version = "0.1.8"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.1.7
+Rover 0.1.8
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -118,7 +118,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.7 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.8 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -136,7 +136,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.7' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.8' | iex
 ```
 
 #### npm installer

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.7 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.8 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.7' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.8' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.1.7"
+PACKAGE_VERSION="v0.1.8"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.1.7'
+$package_version = 'v0.1.8'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.1.8]  2021-07-07

## 🚀 Features

- **Adds _preview_ support for `@tag` and `@inaccessible` directives - [EverlastingBugstopper], [pull/631]**

  **Preview** support for composing subgraphs with `@tag` and/or `@inaccessible` core features using `rover supergraph compose`. Note that `@apollo/gateway >= 0.33` is required when using **preview** support for these core features.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/631]: https://github.com/apollographql/rover/pull/631

- **Auto-decode gzipped responses - [EverlastingBugstopper], [pull/650]**

  If your GraphQL server responds with an introspection response compressed with brotli, it will now be decoded automatically instead of failing the command.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/650]: https://github.com/apollographql/rover/pull/650

## 🐛 Fixes

- **Use built-in root certificates and re-use HTTP connection pool - [EverlastingBugstopper], [issue/645] [pull/649]**

  Rover now uses local CA Certificates along with your operating system's native TLS implementation instead of the Rust-based WebPKI implementation.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/649]: https://github.com/apollographql/rover/pull/649
  [issue/645]: https://github.com/apollographql/rover/issues/645

## 🛠 Maintenance

- **Re-use HTTP connection pool - [EverlastingBugstopper], [pull/650]**

  Rover will now create and reuse the same HTTP connection pool for subsequent requests, which should slightly improve performance.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/650]: https://github.com/apollographql/rover/pull/650

- **Removes unused dependencies - [EverlastingBugstopper], [pull/651]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/651]: https://github.com/apollographql/rover/pull/651