### PR TITLE
chore: update CI runner to node 16 npm 7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Node and npm
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install Rust
         if: matrix.rust


### PR DESCRIPTION
My hypothesis is that the recent update to harmonizer requires a newer version of node/npm than we are currently running.