### PR TITLE
feat: structure composition errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,6 +1971,7 @@ dependencies = [
  "indoc",
  "online",
  "pretty_assertions",
+ "prettytable-rs",
  "regex",
  "reqwest",
  "sdl-encoder",

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -18,6 +18,7 @@ git2 = { version = "0.13.20", default-features = false, features = ["vendored-op
 graphql_client = "0.9"
 http = "0.2"
 humantime = "2.1.0"
+prettytable-rs = "0.8.0"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "native-tls-vendored"] }
 regex = "1"
 sdl-encoder = {path = "../sdl-encoder"}

--- a/crates/rover-client/src/operations/graph/check/runner.rs
+++ b/crates/rover-client/src/operations/graph/check/runner.rs
@@ -1,7 +1,5 @@
 use crate::blocking::StudioClient;
-use crate::operations::graph::check::types::{
-    GraphCheckInput, MutationChangeSeverity, MutationResponseData,
-};
+use crate::operations::graph::check::types::{GraphCheckInput, MutationResponseData};
 use crate::shared::{CheckResponse, GraphRef};
 use crate::RoverClientError;
 
@@ -47,23 +45,13 @@ fn get_check_response_from_data(
 
     let operation_check_count = diff_to_previous.number_of_checked_operations.unwrap_or(0) as u64;
 
-    let change_severity = diff_to_previous.severity.into();
+    let result = diff_to_previous.severity.into();
     let mut changes = Vec::with_capacity(diff_to_previous.changes.len());
-    let mut failure_count = 0;
     for change in diff_to_previous.changes {
-        if let MutationChangeSeverity::FAILURE = change.severity {
-            failure_count += 1;
-        }
         changes.push(change.into());
     }
 
-    let check_response = CheckResponse {
-        target_url,
-        operation_check_count,
-        changes,
-        result: change_severity,
-        failure_count,
-    };
+    let check_response = CheckResponse::new(target_url, operation_check_count, changes, result);
 
     check_response.check_for_failures(graph_ref)
 }

--- a/crates/rover-client/src/operations/subgraph/delete/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/runner.rs
@@ -1,6 +1,6 @@
 use crate::blocking::StudioClient;
 use crate::operations::subgraph::delete::types::*;
-use crate::shared::{CompositionError, GraphRef};
+use crate::shared::{CompositionError, CompositionErrors, GraphRef};
 use crate::RoverClientError;
 
 use graphql_client::*;
@@ -56,7 +56,9 @@ fn build_response(response: MutationComposition) -> SubgraphDeleteResponse {
 
     // if there are no errors, just return None
     let composition_errors = if !composition_errors.is_empty() {
-        Some(composition_errors)
+        Some(CompositionErrors {
+            errors: composition_errors,
+        })
     } else {
         None
     };
@@ -136,16 +138,18 @@ mod tests {
         assert_eq!(
             parsed,
             SubgraphDeleteResponse {
-                composition_errors: Some(vec![
-                    CompositionError {
-                        message: "wow".to_string(),
-                        code: None
-                    },
-                    CompositionError {
-                        message: "boo".to_string(),
-                        code: Some("BOO".to_string())
-                    }
-                ]),
+                composition_errors: Some(CompositionErrors {
+                    errors: vec![
+                        CompositionError {
+                            message: "wow".to_string(),
+                            code: None
+                        },
+                        CompositionError {
+                            message: "boo".to_string(),
+                            code: Some("BOO".to_string())
+                        }
+                    ]
+                }),
                 updated_gateway: false,
             }
         );

--- a/crates/rover-client/src/operations/subgraph/delete/types.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/types.rs
@@ -1,6 +1,6 @@
 use crate::{
     operations::subgraph::delete::runner::subgraph_delete_mutation,
-    shared::{CompositionError, GraphRef},
+    shared::{CompositionErrors, GraphRef},
 };
 
 pub(crate) type MutationComposition = subgraph_delete_mutation::SubgraphDeleteMutationServiceRemoveImplementingServiceAndTriggerComposition;
@@ -23,7 +23,7 @@ pub struct SubgraphDeleteInput {
 #[derive(Debug, PartialEq)]
 pub struct SubgraphDeleteResponse {
     pub updated_gateway: bool,
-    pub composition_errors: Option<Vec<CompositionError>>,
+    pub composition_errors: Option<CompositionErrors>,
 }
 
 impl From<SubgraphDeleteInput> for MutationVariables {

--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -1,7 +1,7 @@
 use super::types::*;
 use crate::blocking::StudioClient;
 use crate::operations::config::is_federated::{self, IsFederatedInput};
-use crate::shared::{CompositionError, GraphRef};
+use crate::shared::{CompositionError, CompositionErrors, GraphRef};
 use crate::RoverClientError;
 use graphql_client::*;
 
@@ -73,7 +73,9 @@ fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {
 
     // if there are no errors, just return None
     let composition_errors = if !composition_errors.is_empty() {
-        Some(composition_errors)
+        Some(CompositionErrors {
+            errors: composition_errors,
+        })
     } else {
         None
     };
@@ -118,16 +120,18 @@ mod tests {
             output,
             SubgraphPublishResponse {
                 schema_hash: Some("5gf564".to_string()),
-                composition_errors: Some(vec![
-                    CompositionError {
-                        message: "[Accounts] User -> composition error".to_string(),
-                        code: None
-                    },
-                    CompositionError {
-                        message: "[Products] Product -> another one".to_string(),
-                        code: Some("ERROR".to_string())
-                    }
-                ]),
+                composition_errors: Some(CompositionErrors {
+                    errors: vec![
+                        CompositionError {
+                            message: "[Accounts] User -> composition error".to_string(),
+                            code: None
+                        },
+                        CompositionError {
+                            message: "[Products] Product -> another one".to_string(),
+                            code: Some("ERROR".to_string())
+                        }
+                    ]
+                }),
                 did_update_gateway: false,
                 subgraph_was_created: true,
             }
@@ -176,10 +180,12 @@ mod tests {
             output,
             SubgraphPublishResponse {
                 schema_hash: None,
-                composition_errors: Some(vec![CompositionError {
-                    message: "[Accounts] -> Things went really wrong".to_string(),
-                    code: None
-                }]),
+                composition_errors: Some(CompositionErrors {
+                    errors: vec![CompositionError {
+                        message: "[Accounts] -> Things went really wrong".to_string(),
+                        code: None
+                    }]
+                }),
                 did_update_gateway: false,
                 subgraph_was_created: false,
             }

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -1,6 +1,6 @@
 use super::runner::subgraph_publish_mutation;
 
-use crate::shared::{CompositionError, GitContext, GraphRef};
+use crate::shared::{CompositionErrors, GitContext, GraphRef};
 
 pub(crate) type ResponseData = subgraph_publish_mutation::ResponseData;
 pub(crate) type MutationVariables = subgraph_publish_mutation::Variables;
@@ -24,7 +24,7 @@ pub struct SubgraphPublishResponse {
     pub schema_hash: Option<String>,
     pub did_update_gateway: bool,
     pub subgraph_was_created: bool,
-    pub composition_errors: Option<Vec<CompositionError>>,
+    pub composition_errors: Option<CompositionErrors>,
 }
 
 impl From<SubgraphPublishInput> for MutationVariables {

--- a/crates/rover-client/src/operations/supergraph/fetch/runner.rs
+++ b/crates/rover-client/src/operations/supergraph/fetch/runner.rs
@@ -1,6 +1,6 @@
 use crate::blocking::StudioClient;
 use crate::operations::supergraph::fetch::SupergraphFetchInput;
-use crate::shared::{CompositionError, FetchResponse, GraphRef, Sdl, SdlType};
+use crate::shared::{CompositionError, CompositionErrors, FetchResponse, GraphRef, Sdl, SdlType};
 use crate::RoverClientError;
 
 use graphql_client::*;
@@ -77,7 +77,9 @@ fn get_supergraph_sdl_from_response_data(
             .collect();
         Err(RoverClientError::NoCompositionPublishes {
             graph_ref,
-            composition_errors,
+            source: CompositionErrors {
+                errors: composition_errors,
+            },
         })
     } else {
         let mut valid_variants = Vec::new();
@@ -190,7 +192,9 @@ mod tests {
         let output = get_supergraph_sdl_from_response_data(data, graph_ref.clone());
         let expected_error = RoverClientError::NoCompositionPublishes {
             graph_ref,
-            composition_errors,
+            source: CompositionErrors {
+                errors: composition_errors,
+            },
         }
         .to_string();
         let actual_error = output.unwrap_err().to_string();

--- a/crates/rover-client/src/shared/composition_error.rs
+++ b/crates/rover-client/src/shared/composition_error.rs
@@ -1,6 +1,11 @@
-use std::fmt::{self, Display};
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
 
-#[derive(Debug, Clone, PartialEq)]
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct CompositionError {
     pub message: String,
     pub code: Option<String>,
@@ -16,3 +21,34 @@ impl Display for CompositionError {
         write!(f, "{}", &self.message)
     }
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompositionErrors {
+    pub errors: Vec<CompositionError>,
+}
+
+impl CompositionErrors {
+    pub fn get_num_errors(&self) -> String {
+        let num_failures = self.errors.len();
+        if num_failures == 0 {
+            unreachable!("No composition errors were encountered while composing the supergraph.");
+        }
+
+        match num_failures {
+            1 => "1 composition error".to_string(),
+            _ => format!("{} composition errors", num_failures),
+        }
+    }
+}
+
+impl Display for CompositionErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for composition_error in &self.errors {
+            writeln!(f, "{}", composition_error)?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for CompositionError {}
+impl Error for CompositionErrors {}

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -7,7 +7,7 @@ mod graph_ref;
 pub use check_response::{
     ChangeSeverity, CheckConfig, CheckResponse, SchemaChange, ValidationPeriod,
 };
-pub use composition_error::CompositionError;
+pub use composition_error::{CompositionError, CompositionErrors};
 pub use fetch_response::{FetchResponse, Sdl, SdlType};
 pub use git_context::GitContext;
 pub use graph_ref::GraphRef;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -99,7 +99,8 @@ impl RoverOutput {
                 );
             }
             RoverOutput::CheckResponse(check_response) => {
-                print_check_response(check_response);
+                print_descriptor("Check Result");
+                print_content(check_response.get_table());
             }
             RoverOutput::VariantList(variants) => {
                 print_descriptor("Variants");
@@ -179,35 +180,5 @@ fn print_content(content: impl Display) {
         println!("{}", content)
     } else {
         print!("{}", content)
-    }
-}
-
-pub(crate) fn print_check_response(check_response: &CheckResponse) {
-    let num_changes = check_response.changes.len();
-
-    let msg = match num_changes {
-        0 => "There were no changes detected in the composed schema.".to_string(),
-        _ => format!(
-            "Compared {} schema changes against {} operations",
-            num_changes, check_response.operation_check_count
-        ),
-    };
-
-    eprintln!("{}", &msg);
-
-    if !check_response.changes.is_empty() {
-        let mut table = table::get_table();
-
-        // bc => sets top row to be bold and center
-        table.add_row(row![bc => "Change", "Code", "Description"]);
-        for check in &check_response.changes {
-            table.add_row(row![check.severity, check.code, check.description]);
-        }
-
-        print_content(&table);
-    }
-
-    if let Some(url) = &check_response.target_url {
-        eprintln!("View full details at {}", url);
     }
 }

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -85,14 +85,14 @@ impl Delete {
 
 fn handle_dry_run_response(response: SubgraphDeleteResponse, subgraph: &str, graph_ref: &str) {
     let warn_prefix = Red.normal().paint("WARN:");
-    if let Some(errors) = response.composition_errors {
+    if let Some(composition_errors) = response.composition_errors {
         eprintln!(
             "{} Deleting the {} subgraph from {} would result in the following composition errors:",
             warn_prefix,
             Cyan.normal().paint(subgraph),
             Cyan.normal().paint(graph_ref),
         );
-        for error in errors {
+        for error in composition_errors.errors {
             eprintln!("{}", &error);
         }
         eprintln!("{} This is only a prediction. If the graph changes before confirming, these errors could change.", warn_prefix);
@@ -129,13 +129,13 @@ fn handle_response(response: SubgraphDeleteResponse, subgraph: &str, graph_ref: 
         )
     }
 
-    if let Some(errors) = response.composition_errors {
+    if let Some(composition_errors) = response.composition_errors {
         eprintln!(
             "{} There were composition errors as a result of deleting the subgraph:",
             warn_prefix,
         );
 
-        for error in errors {
+        for error in composition_errors.errors {
             eprintln!("{}", &error);
         }
     }
@@ -144,7 +144,7 @@ fn handle_response(response: SubgraphDeleteResponse, subgraph: &str, graph_ref: 
 #[cfg(test)]
 mod tests {
     use super::{handle_response, SubgraphDeleteResponse};
-    use rover_client::shared::CompositionError;
+    use rover_client::shared::{CompositionError, CompositionErrors};
 
     #[test]
     fn handle_response_doesnt_error_with_all_successes() {
@@ -159,16 +159,18 @@ mod tests {
     #[test]
     fn handle_response_doesnt_error_with_all_failures() {
         let response = SubgraphDeleteResponse {
-            composition_errors: Some(vec![
-                CompositionError {
-                    message: "a bad thing happened".to_string(),
-                    code: None,
-                },
-                CompositionError {
-                    message: "another bad thing".to_string(),
-                    code: None,
-                },
-            ]),
+            composition_errors: Some(CompositionErrors {
+                errors: vec![
+                    CompositionError {
+                        message: "a bad thing happened".to_string(),
+                        code: None,
+                    },
+                    CompositionError {
+                        message: "another bad thing".to_string(),
+                        code: None,
+                    },
+                ],
+            }),
             updated_gateway: false,
         };
 

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -109,10 +109,10 @@ fn handle_publish_response(response: SubgraphPublishResponse, subgraph: &str, gr
         );
     }
 
-    if let Some(errors) = response.composition_errors {
+    if let Some(composition_errors) = response.composition_errors {
         let warn_prefix = Red.normal().paint("WARN:");
         eprintln!("{} The following composition errors occurred:", warn_prefix,);
-        for error in errors {
+        for error in composition_errors.errors {
             eprintln!("{}", &error);
         }
     }
@@ -121,7 +121,7 @@ fn handle_publish_response(response: SubgraphPublishResponse, subgraph: &str, gr
 #[cfg(test)]
 mod tests {
     use super::{handle_publish_response, SubgraphPublishResponse};
-    use rover_client::shared::CompositionError;
+    use rover_client::shared::{CompositionError, CompositionErrors};
 
     // this test is a bit weird, since we can't test the output. We just verify it
     // doesn't error
@@ -143,16 +143,18 @@ mod tests {
             schema_hash: None,
             did_update_gateway: false,
             subgraph_was_created: false,
-            composition_errors: Some(vec![
-                CompositionError {
-                    message: "a bad thing happened".to_string(),
-                    code: None,
-                },
-                CompositionError {
-                    message: "another bad thing".to_string(),
-                    code: None,
-                },
-            ]),
+            composition_errors: Some(CompositionErrors {
+                errors: vec![
+                    CompositionError {
+                        message: "a bad thing happened".to_string(),
+                        code: None,
+                    },
+                    CompositionError {
+                        message: "another bad thing".to_string(),
+                        code: None,
+                    },
+                ],
+            }),
         };
 
         handle_publish_response(response, "accounts", "my-graph");

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -2,21 +2,18 @@ use crate::command::supergraph::config::{self, SchemaSource, SupergraphConfig};
 use crate::utils::client::StudioClientConfig;
 use crate::{anyhow, command::RoverOutput, error::RoverError, Result, Suggestion};
 
-use ansi_term::Colour::Red;
-use camino::Utf8PathBuf;
+use rover_client::blocking::GraphQLClient;
+use rover_client::operations::subgraph::fetch::{self, SubgraphFetchInput};
+use rover_client::operations::subgraph::introspect::{self, SubgraphIntrospectInput};
+use rover_client::shared::{CompositionError, CompositionErrors, GraphRef};
+use rover_client::RoverClientError;
 
-use rover_client::operations::subgraph::fetch::SubgraphFetchInput;
-use rover_client::operations::subgraph::introspect::SubgraphIntrospectInput;
-use rover_client::shared::GraphRef;
-use rover_client::{
-    blocking::GraphQLClient,
-    operations::subgraph::{fetch, introspect},
-};
+use camino::Utf8PathBuf;
+use harmonizer::ServiceDefinition as SubgraphDefinition;
 use serde::Serialize;
-use std::{collections::HashMap, fs, str::FromStr};
 use structopt::StructOpt;
 
-use harmonizer::ServiceDefinition as SubgraphDefinition;
+use std::{collections::HashMap, fs, str::FromStr};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Compose {
@@ -43,23 +40,22 @@ impl Compose {
 
         match harmonizer::harmonize(subgraph_definitions) {
             Ok(core_schema) => Ok(RoverOutput::CoreSchema(core_schema)),
-            Err(composition_errors) => {
-                let num_failures = composition_errors.len();
-                for composition_error in composition_errors {
-                    eprintln!("{} {}", Red.bold().paint("error:"), &composition_error)
+            Err(harmonizer_composition_errors) => {
+                let mut client_composition_errors =
+                    Vec::with_capacity(harmonizer_composition_errors.len());
+                for harmonizer_composition_error in harmonizer_composition_errors {
+                    if let Some(message) = &harmonizer_composition_error.message {
+                        client_composition_errors.push(CompositionError {
+                            message: message.to_string(),
+                            code: Some(harmonizer_composition_error.code().to_string()),
+                        });
+                    }
                 }
-                match num_failures {
-                    0 => unreachable!("Composition somehow failed with no composition errors."),
-                    1 => Err(
-                        anyhow!("Encountered 1 composition error while composing the graph.")
-                            .into(),
-                    ),
-                    _ => Err(anyhow!(
-                        "Encountered {} composition errors while composing the graph.",
-                        num_failures
-                    )
-                    .into()),
-                }
+                Err(RoverError::new(RoverClientError::CompositionErrors {
+                    source: CompositionErrors {
+                        errors: client_composition_errors,
+                    },
+                }))
             }
         }
     }

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -36,7 +36,9 @@ pub enum Suggestion {
     CheckGnuVersion,
     FixSubgraphSchema {
         graph_ref: GraphRef,
+        subgraph: String,
     },
+    FixCompositionErrors,
     FixOperationsInSchema {
         graph_ref: GraphRef,
     },
@@ -137,7 +139,8 @@ impl Display for Suggestion {
             Suggestion::CheckServerConnection => "Make sure the endpoint is accepting connections and is spelled correctly".to_string(),
             Suggestion::ConvertGraphToSubgraph => "If you are sure you want to convert a non-federated graph to a subgraph, you can re-run the same command with a `--convert` flag.".to_string(),
             Suggestion::CheckGnuVersion => "This is likely an issue with your current version of `glibc`. Try running `ldd --version`, and if the version >= 2.18, we suggest installing the Rover binary built for `x86_64-unknown-linux-gnu`".to_string(),
-            Suggestion::FixSubgraphSchema { graph_ref } => format!("The changes in the schema you proposed are incompatible with graph {}. See {} for more information on resolving composition errors.", Yellow.normal().paint(graph_ref.to_string()), Cyan.normal().paint("https://www.apollographql.com/docs/federation/errors/")),
+            Suggestion::FixSubgraphSchema { graph_ref, subgraph } => format!("The changes in the schema you proposed for subgraph {} are incompatible with supergraph {}. See {} for more information on resolving composition errors.", Yellow.normal().paint(subgraph.to_string()), Yellow.normal().paint(graph_ref.to_string()), Cyan.normal().paint("https://www.apollographql.com/docs/federation/errors/")),
+            Suggestion::FixCompositionErrors => format!("The subgraph schemas you provided are incompatible with each other. See {} for more information on resolving composition errors.", Cyan.normal().paint("https://www.apollographql.com/docs/federation/errors/")),
             Suggestion::FixOperationsInSchema { graph_ref } => format!("The changes in the schema you proposed are incompatible with graph {}. See {} for more information on resolving operation check errors.", Yellow.normal().paint(graph_ref.to_string()), Cyan.normal().paint("https://www.apollographql.com/docs/studio/schema-checks/"))
         };
         write!(formatter, "{}", &suggestion)

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,9 +1,16 @@
-use prettytable::{format::consts::FORMAT_BOX_CHARS, Table};
+use prettytable::{
+    format::{consts::FORMAT_BOX_CHARS, TableFormat},
+    Table,
+};
 
 pub use prettytable::{cell, row};
 
 pub fn get_table() -> Table {
     let mut table = Table::new();
-    table.set_format(*FORMAT_BOX_CHARS);
+    table.set_format(get_table_format());
     table
+}
+
+pub fn get_table_format() -> TableFormat {
+    *FORMAT_BOX_CHARS
 }


### PR DESCRIPTION
Regular composition error output now uses proper `std::error::Error` implementations with chains of errors rather than the previous iteration where we just hacked in a bunch of calls to `eprintln!`

```
Checking the proposed schema for subgraph users against rover-supergraph-demo@current
error[E029]: Encountered 1 composition error while trying to compose subgraph "users" into supergraph "rover-supergraph-demo@current".

Caused by:
    KEY_FIELDS_SELECT_INVALID_TYPE: [users] User -> A @key selects emaillll, but User.emaillll could not be found
    
              The changes in the schema you proposed for subgraph users are incompatible with supergraph rover-supergraph-demo@current. See https://www.apollographql.com/docs/federation/errors/ for more information on resolving composition errors.
```

This PR also includes a custom serializer for our error struct that will include structured composition errors if they have occurred, whether they are detected on a `subgraph check` or a `supergraph compose`.