### PR TITLE
feat: structure sub/graph publish

### DIFF
--- a/crates/rover-client/src/operations/graph/publish/types.rs
+++ b/crates/rover-client/src/operations/graph/publish/types.rs
@@ -1,6 +1,8 @@
 use crate::operations::graph::publish::runner::graph_publish_mutation;
 use crate::shared::{GitContext, GraphRef};
 
+use serde::Serialize;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct GraphPublishInput {
     pub graph_ref: GraphRef,
@@ -33,7 +35,7 @@ impl From<GitContext> for GraphPublishContextInput {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Serialize, Debug, PartialEq)]
 pub struct GraphPublishResponse {
     pub schema_hash: String,
     pub change_summary: String,

--- a/crates/rover-client/src/operations/subgraph/check/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check/runner.rs
@@ -112,9 +112,7 @@ fn get_check_response_from_data(
         Err(RoverClientError::SubgraphCompositionErrors {
             subgraph,
             graph_ref,
-            source: CompositionErrors {
-                errors: composition_errors,
-            },
+            source: CompositionErrors { composition_errors },
         })
     }
 }

--- a/crates/rover-client/src/operations/subgraph/delete/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/runner.rs
@@ -56,9 +56,7 @@ fn build_response(response: MutationComposition) -> SubgraphDeleteResponse {
 
     // if there are no errors, just return None
     let composition_errors = if !composition_errors.is_empty() {
-        Some(CompositionErrors {
-            errors: composition_errors,
-        })
+        Some(CompositionErrors { composition_errors })
     } else {
         None
     };
@@ -139,7 +137,7 @@ mod tests {
             parsed,
             SubgraphDeleteResponse {
                 composition_errors: Some(CompositionErrors {
-                    errors: vec![
+                    composition_errors: vec![
                         CompositionError {
                             message: "wow".to_string(),
                             code: None

--- a/crates/rover-client/src/operations/subgraph/publish/publish_mutation.graphql
+++ b/crates/rover-client/src/operations/subgraph/publish/publish_mutation.graphql
@@ -5,7 +5,7 @@ mutation SubgraphPublishMutation(
   $url: String
   $revision: String!
   $schema: PartialSchemaInput!
-  $gitContext: GitContextInput!
+  $git_context: GitContextInput!
 ) {
   service(id: $graph_id) {
     upsertImplementingServiceAndTriggerComposition(
@@ -14,7 +14,7 @@ mutation SubgraphPublishMutation(
       revision: $revision
       activePartialSchema: $schema
       graphVariant: $variant
-      gitContext: $gitContext
+      gitContext: $git_context
     ) {
       compositionConfig {
         schemaHash

--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -73,9 +73,7 @@ fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {
 
     // if there are no errors, just return None
     let composition_errors = if !composition_errors.is_empty() {
-        Some(CompositionErrors {
-            errors: composition_errors,
-        })
+        Some(CompositionErrors { composition_errors })
     } else {
         None
     };
@@ -85,10 +83,11 @@ fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {
             Some(config) => Some(config.schema_hash),
             None => None,
         },
-        did_update_gateway: publish_response.did_update_gateway,
+        supergraph_was_updated: publish_response.did_update_gateway,
         subgraph_was_created: publish_response.service_was_created,
-        composition_errors: composition_errors
-            .unwrap_or_else(|| CompositionErrors { errors: vec![] }),
+        composition_errors: composition_errors.unwrap_or_else(|| CompositionErrors {
+            composition_errors: vec![],
+        }),
     }
 }
 
@@ -122,7 +121,7 @@ mod tests {
             SubgraphPublishResponse {
                 schema_hash: Some("5gf564".to_string()),
                 composition_errors: CompositionErrors {
-                    errors: vec![
+                    composition_errors: vec![
                         CompositionError {
                             message: "[Accounts] User -> composition error".to_string(),
                             code: None
@@ -133,7 +132,7 @@ mod tests {
                         }
                     ]
                 },
-                did_update_gateway: false,
+                supergraph_was_updated: false,
                 subgraph_was_created: true,
             }
         );
@@ -154,8 +153,10 @@ mod tests {
             output,
             SubgraphPublishResponse {
                 schema_hash: Some("5gf564".to_string()),
-                composition_errors: CompositionErrors { errors: vec![] },
-                did_update_gateway: true,
+                composition_errors: CompositionErrors {
+                    composition_errors: vec![]
+                },
+                supergraph_was_updated: true,
                 subgraph_was_created: true,
             }
         );
@@ -182,12 +183,12 @@ mod tests {
             SubgraphPublishResponse {
                 schema_hash: None,
                 composition_errors: CompositionErrors {
-                    errors: vec![CompositionError {
+                    composition_errors: vec![CompositionError {
                         message: "[Accounts] -> Things went really wrong".to_string(),
                         code: None
                     }]
                 },
-                did_update_gateway: false,
+                supergraph_was_updated: false,
                 subgraph_was_created: false,
             }
         );

--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -87,7 +87,8 @@ fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {
         },
         did_update_gateway: publish_response.did_update_gateway,
         subgraph_was_created: publish_response.service_was_created,
-        composition_errors,
+        composition_errors: composition_errors
+            .unwrap_or_else(|| CompositionErrors { errors: vec![] }),
     }
 }
 
@@ -120,7 +121,7 @@ mod tests {
             output,
             SubgraphPublishResponse {
                 schema_hash: Some("5gf564".to_string()),
-                composition_errors: Some(CompositionErrors {
+                composition_errors: CompositionErrors {
                     errors: vec![
                         CompositionError {
                             message: "[Accounts] User -> composition error".to_string(),
@@ -131,7 +132,7 @@ mod tests {
                             code: Some("ERROR".to_string())
                         }
                     ]
-                }),
+                },
                 did_update_gateway: false,
                 subgraph_was_created: true,
             }
@@ -153,7 +154,7 @@ mod tests {
             output,
             SubgraphPublishResponse {
                 schema_hash: Some("5gf564".to_string()),
-                composition_errors: None,
+                composition_errors: CompositionErrors { errors: vec![] },
                 did_update_gateway: true,
                 subgraph_was_created: true,
             }
@@ -180,12 +181,12 @@ mod tests {
             output,
             SubgraphPublishResponse {
                 schema_hash: None,
-                composition_errors: Some(CompositionErrors {
+                composition_errors: CompositionErrors {
                     errors: vec![CompositionError {
                         message: "[Accounts] -> Things went really wrong".to_string(),
                         code: None
                     }]
-                }),
+                },
                 did_update_gateway: false,
                 subgraph_was_created: false,
             }

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -9,6 +9,8 @@ pub(crate) type UpdateResponse = subgraph_publish_mutation::SubgraphPublishMutat
 type SchemaInput = subgraph_publish_mutation::PartialSchemaInput;
 type GitContextInput = subgraph_publish_mutation::GitContextInput;
 
+use serde::Serialize;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubgraphPublishInput {
     pub graph_ref: GraphRef,
@@ -19,12 +21,12 @@ pub struct SubgraphPublishInput {
     pub convert_to_federated_graph: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct SubgraphPublishResponse {
     pub schema_hash: Option<String>,
     pub did_update_gateway: bool,
     pub subgraph_was_created: bool,
-    pub composition_errors: Option<CompositionErrors>,
+    pub composition_errors: CompositionErrors,
 }
 
 impl From<SubgraphPublishInput> for MutationVariables {

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -24,8 +24,9 @@ pub struct SubgraphPublishInput {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct SubgraphPublishResponse {
     pub schema_hash: Option<String>,
-    pub did_update_gateway: bool,
+    pub supergraph_was_updated: bool,
     pub subgraph_was_created: bool,
+    #[serde(flatten)]
     pub composition_errors: CompositionErrors,
 }
 

--- a/crates/rover-client/src/operations/supergraph/fetch/runner.rs
+++ b/crates/rover-client/src/operations/supergraph/fetch/runner.rs
@@ -77,9 +77,7 @@ fn get_supergraph_sdl_from_response_data(
             .collect();
         Err(RoverClientError::NoCompositionPublishes {
             graph_ref,
-            source: CompositionErrors {
-                errors: composition_errors,
-            },
+            source: CompositionErrors { composition_errors },
         })
     } else {
         let mut valid_variants = Vec::new();
@@ -192,9 +190,7 @@ mod tests {
         let output = get_supergraph_sdl_from_response_data(data, graph_ref.clone());
         let expected_error = RoverClientError::NoCompositionPublishes {
             graph_ref,
-            source: CompositionErrors {
-                errors: composition_errors,
-            },
+            source: CompositionErrors { composition_errors },
         }
         .to_string();
         let actual_error = output.unwrap_err().to_string();

--- a/crates/rover-client/src/shared/composition_error.rs
+++ b/crates/rover-client/src/shared/composition_error.rs
@@ -24,12 +24,12 @@ impl Display for CompositionError {
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct CompositionErrors {
-    pub errors: Vec<CompositionError>,
+    pub composition_errors: Vec<CompositionError>,
 }
 
 impl CompositionErrors {
     pub fn get_num_errors(&self) -> String {
-        let num_failures = self.errors.len();
+        let num_failures = self.composition_errors.len();
         if num_failures == 0 {
             unreachable!("No composition errors were encountered while composing the supergraph.");
         }
@@ -43,7 +43,7 @@ impl CompositionErrors {
 
 impl Display for CompositionErrors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for composition_error in &self.errors {
+        for composition_error in &self.composition_errors {
             writeln!(f, "{}", composition_error)?;
         }
         Ok(())

--- a/crates/rover-client/src/shared/composition_error.rs
+++ b/crates/rover-client/src/shared/composition_error.rs
@@ -22,7 +22,7 @@ impl Display for CompositionError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct CompositionErrors {
     pub errors: Vec<CompositionError>,
 }

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -58,39 +58,9 @@ impl Publish {
             &client,
         )?;
 
-        let hash = handle_response(&self.graph, publish_response);
-        Ok(RoverOutput::SchemaHash(hash))
-    }
-}
-
-/// handle all output logging from operation
-fn handle_response(graph: &GraphRef, response: GraphPublishResponse) -> String {
-    eprintln!(
-        "{}#{} Published successfully {}",
-        graph, response.schema_hash, response.change_summary
-    );
-
-    response.schema_hash
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn handle_response_doesnt_err() {
-        let expected_hash = "123456".to_string();
-        let graph = GraphRef {
-            name: "harambe".to_string(),
-            variant: "inside-job".to_string(),
-        };
-        let actual_hash = handle_response(
-            &graph,
-            GraphPublishResponse {
-                schema_hash: expected_hash.clone(),
-                change_summary: "".to_string(),
-            },
-        );
-        assert_eq!(actual_hash, expected_hash);
+        Ok(RoverOutput::GraphPublishResponse {
+            graph_ref: self.graph.clone(),
+            publish_response,
+        })
     }
 }

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -2,7 +2,7 @@ use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
-use rover_client::operations::graph::publish::{self, GraphPublishInput, GraphPublishResponse};
+use rover_client::operations::graph::publish::{self, GraphPublishInput};
 use rover_client::shared::{GitContext, GraphRef};
 
 use crate::command::RoverOutput;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -99,7 +99,7 @@ impl RoverOutput {
                     );
                 }
 
-                if publish_response.did_update_gateway {
+                if publish_response.supergraph_was_updated {
                     eprintln!("The gateway for the '{}' graph was updated with a new schema, composed from the updated '{}' subgraph", graph_ref, subgraph);
                 } else {
                     eprintln!(
@@ -108,10 +108,14 @@ impl RoverOutput {
                     );
                 }
 
-                if !publish_response.composition_errors.errors.is_empty() {
+                if !publish_response
+                    .composition_errors
+                    .composition_errors
+                    .is_empty()
+                {
                     let warn_prefix = Red.normal().paint("WARN:");
                     eprintln!("{} The following composition errors occurred:", warn_prefix,);
-                    for error in &publish_response.composition_errors.errors {
+                    for error in &publish_response.composition_errors.composition_errors {
                         eprintln!("{}", &error);
                     }
                 }

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -92,7 +92,7 @@ fn handle_dry_run_response(response: SubgraphDeleteResponse, subgraph: &str, gra
             Cyan.normal().paint(subgraph),
             Cyan.normal().paint(graph_ref),
         );
-        for error in composition_errors.errors {
+        for error in composition_errors.composition_errors {
             eprintln!("{}", &error);
         }
         eprintln!("{} This is only a prediction. If the graph changes before confirming, these errors could change.", warn_prefix);
@@ -135,7 +135,7 @@ fn handle_response(response: SubgraphDeleteResponse, subgraph: &str, graph_ref: 
             warn_prefix,
         );
 
-        for error in composition_errors.errors {
+        for error in composition_errors.composition_errors {
             eprintln!("{}", &error);
         }
     }
@@ -160,7 +160,7 @@ mod tests {
     fn handle_response_doesnt_error_with_all_failures() {
         let response = SubgraphDeleteResponse {
             composition_errors: Some(CompositionErrors {
-                errors: vec![
+                composition_errors: vec![
                     CompositionError {
                         message: "a bad thing happened".to_string(),
                         code: None,

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -1,4 +1,4 @@
-use ansi_term::Colour::{Cyan, Red, Yellow};
+use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
 use structopt::StructOpt;
 
@@ -10,9 +10,7 @@ use crate::utils::{
 };
 use crate::Result;
 
-use rover_client::operations::subgraph::publish::{
-    self, SubgraphPublishInput, SubgraphPublishResponse,
-};
+use rover_client::operations::subgraph::publish::{self, SubgraphPublishInput};
 use rover_client::shared::{GitContext, GraphRef};
 
 #[derive(Debug, Serialize, StructOpt)]

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -58,10 +58,9 @@ impl Publish {
         git_context: GitContext,
     ) -> Result<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = format!("{}:{}", &self.graph.name, &self.graph.variant);
         eprintln!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
-            Cyan.normal().paint(&graph_ref),
+            Cyan.normal().paint(&self.graph.to_string()),
             Cyan.normal().paint(&self.subgraph),
             Yellow.normal().paint(&self.profile_name)
         );
@@ -82,84 +81,10 @@ impl Publish {
             &client,
         )?;
 
-        handle_publish_response(publish_response, &self.subgraph, &self.graph.name);
-        Ok(RoverOutput::None)
+        Ok(RoverOutput::SubgraphPublishResponse {
+            graph_ref: self.graph.clone(),
+            subgraph: self.subgraph.clone(),
+            publish_response,
+        })
     }
-}
-
-fn handle_publish_response(response: SubgraphPublishResponse, subgraph: &str, graph: &str) {
-    if response.subgraph_was_created {
-        eprintln!(
-            "A new subgraph called '{}' for the '{}' graph was created",
-            subgraph, graph
-        );
-    } else {
-        eprintln!(
-            "The '{}' subgraph for the '{}' graph was updated",
-            subgraph, graph
-        );
-    }
-
-    if response.did_update_gateway {
-        eprintln!("The gateway for the '{}' graph was updated with a new schema, composed from the updated '{}' subgraph", graph, subgraph);
-    } else {
-        eprintln!(
-            "The gateway for the '{}' graph was NOT updated with a new schema",
-            graph
-        );
-    }
-
-    if let Some(composition_errors) = response.composition_errors {
-        let warn_prefix = Red.normal().paint("WARN:");
-        eprintln!("{} The following composition errors occurred:", warn_prefix,);
-        for error in composition_errors.errors {
-            eprintln!("{}", &error);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{handle_publish_response, SubgraphPublishResponse};
-    use rover_client::shared::{CompositionError, CompositionErrors};
-
-    // this test is a bit weird, since we can't test the output. We just verify it
-    // doesn't error
-    #[test]
-    fn handle_response_doesnt_error_with_all_successes() {
-        let response = SubgraphPublishResponse {
-            schema_hash: Some("123456".to_string()),
-            did_update_gateway: true,
-            subgraph_was_created: true,
-            composition_errors: None,
-        };
-
-        handle_publish_response(response, "accounts", "my-graph");
-    }
-
-    #[test]
-    fn handle_response_doesnt_error_with_all_failures() {
-        let response = SubgraphPublishResponse {
-            schema_hash: None,
-            did_update_gateway: false,
-            subgraph_was_created: false,
-            composition_errors: Some(CompositionErrors {
-                errors: vec![
-                    CompositionError {
-                        message: "a bad thing happened".to_string(),
-                        code: None,
-                    },
-                    CompositionError {
-                        message: "another bad thing".to_string(),
-                        code: None,
-                    },
-                ],
-            }),
-        };
-
-        handle_publish_response(response, "accounts", "my-graph");
-    }
-
-    // TODO: test the actual output of the logs whenever we do design work
-    // for the commands :)
 }

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -53,7 +53,7 @@ impl Compose {
                 }
                 Err(RoverError::new(RoverClientError::CompositionErrors {
                     source: CompositionErrors {
-                        errors: client_composition_errors,
+                        composition_errors: client_composition_errors,
                     },
                 }))
             }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -44,7 +44,7 @@ where
             {
                 let mut data = serializer.serialize_struct(struct_name, 2)?;
                 data.serialize_field(message_field_name, &error.to_string())?;
-                data.serialize_field("composition_errors", &composition_errors.errors)?;
+                data.serialize_field("composition_errors", &composition_errors.composition_errors)?;
                 return data.end();
             }
         }


### PR DESCRIPTION
Historically, given the same input for a subgraph schema that will cause composition errors, we have different outputs for `subgraph check` and `subgraph publish`. `subgraph publish` will not hard error if there are composition errors, it will simply print as warnings.

Translating this behavior to JSON makes me think that for `subgraph publish`, `composition_errors` should be nested under the top level `data` field rather than the top level `errors` field, and for `subgraph check`, the opposite should be true, composition errors should be nested under the top level `errors` field, to correlate the behavior to what happens when you run the commands without the `--json` flag. 

To illuminate what I'm talking about, we have the following subgraph schema that incorrectly selects on a field `iddddd` instead of the correctly spelled `id`:

```graphql
                          ||||||||
                          VVVVVVVV
type Product @key(fields: "iddddd") @key(fields: "sku package") @key(fields: "sku variation { id }"){
  id: ID!
  sku: String
  package: String
  variation: ProductVariation
  dimensions: ProductDimension

  createdBy: User @provides(fields: "totalProductsCreated")
}

type ProductVariation {
  id: ID!
}

enum Color {
  BLUE
  GREEN
}

type ProductDimension {
  size: String
  weight: Float
}

extend type Query {
  allProducts: [Product]
  product(id: ID!): Product
}

extend type User @key(fields: "email") {
  email: ID! @external
  totalProductsCreated: Int @external
}
```

Running `subgraph check` provides the following output, and exits with code 1, as there are composition errors: 

```console
$ rover subgraph check rover-supergraph-demo@test --schema ../supergraph-demo/subgraphs/products/products.graphql --name products --json | jq
{
  "data": null,
  "error": {
    "message": "Encountered 3 composition errors while trying to compose subgraph \"products\" into supergraph \"rover-supergraph-demo@test\".",
    "composition_errors": [
      {
        "message": "[inventory] Product.id -> is marked as @external but is not used by a @requires, @key, or @provides directive.",
        "code": "EXTERNAL_UNUSED"
      },
      {
        "message": "[products] Product -> A @key selects iddddd, but Product.iddddd could not be found",
        "code": "KEY_FIELDS_SELECT_INVALID_TYPE"
      },
      {
        "message": "[inventory] Product -> extends from products but specifies an invalid @key directive. Valid @key directives are specified by the originating type. Available @key directives for this type are:\n\t@key(fields: \"iddddd\")\n\t@key(fields: \"sku package\")\n\t@key(fields: \"sku variation{id}\")",
        "code": "KEY_NOT_SPECIFIED"
      }
    ],
    "code": "E029"
  }
}
```

Running `subgraph publish` provides the following output, and exits with code 0, as composition errors do not prevent a new subgraph from being published since it is part of valid workflows: 

```console
$ rover subgraph publish rover-supergraph-demo@test --schema ../supergraph-demo/subgraphs/products/products.graphql --name products --json | jq
Publishing SDL to rover-supergraph-demo@test (subgraph: products) using credentials from the default profile.
{
  "data": {
    "schema_hash": null,
    "supergraph_was_updated": false,
    "subgraph_was_created": false,
    "composition_errors": [
      {
        "message": "[inventory] Product.id -> is marked as @external but is not used by a @requires, @key, or @provides directive.",
        "code": "EXTERNAL_UNUSED"
      },
      {
        "message": "[products] Product -> A @key selects iddddd, but Product.iddddd could not be found",
        "code": "KEY_FIELDS_SELECT_INVALID_TYPE"
      },
      {
        "message": "[inventory] Product -> extends from products but specifies an invalid @key directive. Valid @key directives are specified by the originating type. Available @key directives for this type are:\n\t@key(fields: \"iddddd\")\n\t@key(fields: \"sku package\")\n\t@key(fields: \"sku variation{id}\")",
        "code": "KEY_NOT_SPECIFIED"
      }
    ]
  },
  "error": null
}
```

This _may_ be confusing to some users as `jq` scripts for `publish` and `check` will need to look under a different top-level field in the JSON response, but I think that since this is how the commands/workflows are designed that this is the best way forward. 

