### PR TITLE
chore: make tests actually fail

### DIFF
--- a/src/command/supergraph/config.rs
+++ b/src/command/supergraph/config.rs
@@ -82,7 +82,7 @@ mod tests {
       file: ./films.graphql
   people:
     schema: 
-      url: https://people.example.com
+      subgraph_url: https://people.example.com
   reviews:
     schema:
       graphref: mygraph@current
@@ -93,10 +93,7 @@ mod tests {
         config_path.push("config.yaml");
         fs::write(&config_path, raw_good_yaml).unwrap();
 
-        let supergraph_config = super::parse_supergraph_config(&config_path);
-        if let Err(e) = supergraph_config {
-            panic!("{}", e)
-        }
+        super::parse_supergraph_config(&config_path).expect("Could not parse supergraph config");
     }
 
     #[test]

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -80,11 +80,36 @@ impl CargoRunner {
         if !target.composition_js() {
             args.push("--no-default-features");
         }
-        let mut env = HashMap::new();
-        env.insert("RUST_BACKTRACE".to_string(), "1".to_string());
-        self.cargo_exec(&args, Some(env))?;
 
-        Ok(())
+        let command_output = self.cargo_exec(&args, None)?;
+
+        // for some reason, cargo test doesn't actually fail if there are failed tests...????
+        // so here we manually collect all the lines including failed tests and display them
+        // as warnings for the dev.
+        let mut failed_tests = Vec::new();
+
+        for line in command_output.stdout.lines() {
+            if line.starts_with("test") && line.contains("FAILED") {
+                failed_tests.push(line);
+            }
+        }
+
+        if failed_tests.is_empty() {
+            Ok(())
+        } else {
+            for failed_test in &failed_tests {
+                let split_test: Vec<&str> = failed_test.splitn(3, ' ').collect();
+                if split_test.len() < 3 {
+                    panic!("Something went wrong with xtask's failed test detection.");
+                }
+                let exact_test = split_test[1];
+
+                // drop the result here so we can re-run the failed tests and print their output.
+                let _ =
+                    self.cargo_exec(&["test", "--", exact_test, "--exact", "--nocapture"], None);
+            }
+            Err(anyhow!("`cargo test` failed {} times.", failed_tests.len()))
+        }
     }
 
     pub(crate) fn get_bin_path(&self, target: &Target, release: bool) -> Utf8PathBuf {


### PR DESCRIPTION
Fixes the problem outlined in PR #667

Apparently it is not the default behavior of `cargo test` to... fail on failed tests? Commentors on [this issue](https://github.com/rust-lang/rust/issues/87323) make it seem like this is a deep-rooted issue in cargo, which is concerning to me!

Anyways... I've made a modification to our `cargo xtask test` runners that will go through each line reported by `cargo test` and look for failures.

It will then _rerun_ those tests and print their output so that Rover devs can actually see what's going wrong with their tests!