### PR TITLE
chore: updates harmonizer to v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067853682d95c6e1fa666637ec7a99c4b20c2c7935ce90ab59bd69cad2ce7ef"
+checksum = "b3ea09933b80c94df6cf1d23f0bbe138643437e4649332bd1ef702109abfda82"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ console = "0.14.0"
 crossterm = "0.20.0"
 git-url-parse = "0.3.1"
 git2 = { version = "0.13.20", default-features = false, features = ["vendored-openssl"] }
-harmonizer = { version = "0.26.0", optional = true }
+harmonizer = { version = "0.27.0", optional = true }
 heck = "0.3.3"
 humantime = "2.1.0"
 opener = "0.5.0"


### PR DESCRIPTION
Fixes #682

- simple merging/union rollup of `@tag` from subgraphs into a supergraph
- allow usage of `@tag` on all subgraph fields
- merge subgraph `@tag` into a supergraph
  - if _ANY_ instance is tagged, the `@tag` is union merged
    into the supergraph