### PR TITLE
feat: adds success message to subgraph publish/delete

### DIFF
--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -133,6 +133,8 @@ fn handle_response(response: DeleteServiceResponse, subgraph: &str, graph_ref: &
             warn_prefix,
             errors.join("\n")
         )
+    } else {
+        eprintln!("There were no composition errors as a result of deleting the subgraph.");
     }
 }
 

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -120,6 +120,8 @@ fn handle_publish_response(response: PublishPartialSchemaResponse, subgraph: &st
             warn_prefix,
             errors.join("\n")
         );
+    } else {
+        eprintln!("There were no composition errors as a result of publishing the subgraph.");
     }
 }
 


### PR DESCRIPTION
fixes #632 by adding success messages to both `subgraph publish` and `subgraph delete`.