### PR TITLE
release: v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,56 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+
+# [0.1.9] - 2021-07-22
+
+## 🚀 Features
+
+- **Updates `@tag`/`@inaccessible` composition algorithm in `rover supergraph compose` - [trevor-scheer]/[EverlastingBugstopper], [issue/682] [pull/684]**
+  - Includes simple merging/union rollup of `@tag` directives from subgraphs into a supergraph
+  - Allows usage of `@tag` directives on all subgraph fields
+  - Merges subgraph `@tag` directives into a supergraph
+      - if _ANY_ instance is tagged, the `@tag` is union merged
+        into the supergraph
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [trevor-scheer]: https://github.com/trevor-scheer
+  [issue/682]: https://github.com/apollographql/rover/issues/682
+  [pull/684]: https://github.com/apollographql/rover/pull/684 
+
+- **`rover subgraph publish` and `rover subgraph delete` now acknowledges operations with no composition errors. - [EverlastingBugstopper], [issue/632] [pull/685]**
+
+  Previously, if there were no composition errors on deletions/publishes of subgraphs, Rover would simply not display errors. Now, Rover will output a success message if there were no composition errors. This should make these types of successes more clear in CI workflows that may be publishing more than one subgraph at a time.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/685]: https://github.com/apollographql/rover/pull/685
+  [issue/632]: https://github.com/apollographql/rover/issues/632
+
+## 🛠 Maintenance
+
+- **Make the test process fail in CI if there are test failures - [EverlastingBugstopper], [pull/683]**
+
+  For some reason, `cargo test` was exiting with code `0` even if there were failed tests. We run tests through our own custom `xtask`, so we've added a wrapper around `cargo test` to detect and propagate the problems with our tests in our CI logs.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/683]: https://github.com/apollographql/rover/pull/683
+
+- **Updates dependencies - [EverlastingBugstopper]/[dependabot], [pull/671], [pull/672], [pull/673], and [pull/680]**
+
+  `anyhow` `1.0.41` -> `1.0.42`
+  `cc` `1.0.68` -> `1.0.69`
+  `cargo_metadata` `0.13.1` -> `0.14.0`
+  `termimad` `0.13.0` -> `0.14.0`
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [dependabot]: https://github.com/dependabot
+  [pull/671]: https://github.com/apollographql/rover/pull/671
+  [pull/672]: https://github.com/apollographql/rover/pull/672
+  [pull/673]: https://github.com/apollographql/rover/pull/673
+  [pull/680]: https://github.com/apollographql/rover/pull/680
+
+## 📚 Documentation
+
 # [0.1.8]  2021-07-07
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.1.8"
+version = "0.1.9"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.1.8
+Rover 0.1.9
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -118,7 +118,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.8 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.9 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -136,7 +136,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.8' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.9' | iex
 ```
 
 #### npm installer

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.8 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.1.9 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.8' | iex
+iwr 'https://rover.apollo.dev/win/v0.1.9' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.1.8"
+PACKAGE_VERSION="v0.1.9"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.1.8'
+$package_version = 'v0.1.9'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.1.9] - 2021-07-22

## 🚀 Features

- **Updates `@tag`/`@inaccessible` composition algorithm in `rover supergraph compose` - [trevor-scheer]/[EverlastingBugstopper], [issue/682] [pull/684]**
  - Includes simple merging/union rollup of `@tag` directives from subgraphs into a supergraph
  - Allows usage of `@tag` directives on all subgraph fields
  - Merges subgraph `@tag` directives into a supergraph
      - if _ANY_ instance is tagged, the `@tag` is union merged
        into the supergraph

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [trevor-scheer]: https://github.com/trevor-scheer
  [issue/682]: https://github.com/apollographql/rover/issues/682
  [pull/684]: https://github.com/apollographql/rover/pull/684 

- **`rover subgraph publish` and `rover subgraph delete` now acknowledges operations with no composition errors. - [EverlastingBugstopper], [issue/632] [pull/685]**

  Previously, if there were no composition errors on deletions/publishes of subgraphs, Rover would simply not display errors. Now, Rover will output a success message if there were no composition errors. This should make these types of successes more clear in CI workflows that may be publishing more than one subgraph at a time.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/685]: https://github.com/apollographql/rover/pull/685
  [issue/632]: https://github.com/apollographql/rover/issues/632

## 🛠 Maintenance

- **Make the test process fail in CI if there are test failures - [EverlastingBugstopper], [pull/683]**

  For some reason, `cargo test` was exiting with code `0` even if there were failed tests. We run tests through our own custom `xtask`, so we've added a wrapper around `cargo test` to detect and propagate the problems with our tests in our CI logs.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/683]: https://github.com/apollographql/rover/pull/683

- **Updates dependencies - [EverlastingBugstopper]/[dependabot], [pull/671], [pull/672], [pull/673], and [pull/680]**

  `anyhow` `1.0.41` -> `1.0.42`
  `cc` `1.0.68` -> `1.0.69`
  `cargo_metadata` `0.13.1` -> `0.14.0`
  `termimad` `0.13.0` -> `0.14.0`

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [dependabot]: https://github.com/dependabot
  [pull/671]: https://github.com/apollographql/rover/pull/671
  [pull/672]: https://github.com/apollographql/rover/pull/672
  [pull/673]: https://github.com/apollographql/rover/pull/673
  [pull/680]: https://github.com/apollographql/rover/pull/680