### PR TITLE
release: v0.2.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.2.0-beta.0] - 2021-07-26
+
+## 🚀 Features
+
+- **Adds structured output to Rover - [EverlastingBugstopper], [issue/285] [pull/676]**
+
+  Rover now has an `--output` parameter on every command that allows you to format Rover's output as well-structured JSON. This structure is not set in stone and will change prior to a stable release. If you write scripts around this structured output, then you should add a check in your scripts for the top level `json_version` key, and make sure to update your scripts when that version is not what you expect (the first version is `1.beta`).
+
+  We'd love your feedback on this new feature, or if you notice any bugs in your existing workflows, so please submit issues!
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/676]: https://github.com/apollographql/rover/pull/676
+  [issue/285]: https://github.com/apollographql/rover/issues/285
+
 
 # [0.1.9] - 2021-07-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.1.9"
+version = "0.2.0-beta.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.1.9"
+version = "0.2.0-beta.0"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.1.9
+Rover 0.2.0-beta.0
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -70,8 +70,10 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -l, --log <log-level>    Specify Rover's log level [possible values: error, warn, info,
-                             debug, trace]
+    -l, --log <log-level>         Specify Rover's log level [possible values: error, warn, info,
+                                  debug, trace]
+        --output <output-type>    Specify Rover's output type [default: plain]  [possible values: json,
+                                  plain]
 
 SUBCOMMANDS:
     config        Configuration profile commands

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -235,7 +235,7 @@ If you encountered this error while running introspection, you'll want to make s
 
 ### E029
 
-This error occurs when you propose a subgraph schema that could not be composed.
+This error occurs when you propose a subgraph schema that could not be built.
 
 There are many reasons why you may run into build errors. This error should include information about _why_ the proposed subgraph schema could not be composed. Error code references can be found [here](https://www.apollographql.com/docs/federation/errors/).
 

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.1.9"
+PACKAGE_VERSION="v0.2.0-beta.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.1.9'
+$package_version = 'v0.2.0-beta.0'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.9",
+  "version": "0.2.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.1.9",
+      "version": "0.2.0-beta.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.1.9",
+  "version": "0.2.0-beta.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ pub struct Rover {
     #[serde(serialize_with = "option_from_display")]
     log_level: Option<Level>,
 
-    /// Use json output
+    /// Specify Rover's output type
     #[structopt(long = "output", default_value = "plain", possible_values = &["json", "plain"], case_insensitive = true, global = true)]
     output_type: OutputType,
 


### PR DESCRIPTION
# [0.2.0-beta.0] - 2021-07-26

## 🚀 Features

- **Adds structured output to Rover - [EverlastingBugstopper], [issue/285] [pull/676]**

  Rover now has an `--output` parameter on every command that allows you to format Rover's output as well-structured JSON. This structure is not set in stone and will change prior to a stable release. If you write scripts around this structured output, then you should add a check in your scripts for the top level `json_version` key, and make sure to update your scripts when that version is not what you expect (the first version is `1.beta`).

  We'd love your feedback on this new feature, or if you notice any bugs in your existing workflows, so please submit issues!

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/676]: https://github.com/apollographql/rover/pull/676
  [issue/285]: https://github.com/apollographql/rover/issues/285