### PR TITLE
chore: upload schema.graphql as a release artifact

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[env]
+RUSTFLAGS = "--color=always"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,2 @@
 [alias]
 xtask = "run --package xtask --"
-
-[env]
-RUSTFLAGS = "--color=always"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,6 +394,16 @@ jobs:
           asset_content_type: application/gzip
           asset_name: rover-${{ needs.build.outputs.version }}-${{ env.MACOS_TARGET }}.tar.gz
 
+      - name: Upload static GraphQL Schema
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./crates/rover-client/.schema/schema.graphql
+          asset_content_type: text/plain; charset=UTF-8
+          asset_name: rover-${{ needs.build.outputs.version }}-schema.graphql
+
       - name: Set up .npmrc
         uses: actions/setup-node@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,8 @@ dependencies = [
  "cargo_metadata",
  "lazy_static",
  "regex",
+ "reqwest",
+ "semver",
  "structopt",
  "which",
 ]

--- a/README.md
+++ b/README.md
@@ -161,22 +161,14 @@ You can also [download the binary for your operating system](https://github.com/
 
 ##### Unsupported architectures
 
-If you don't see your CPU architecture supported as part of our release pipeline, you can build from source with [`cargo`](https://github.com/rust-lang/cargo). After installing `cargo`, you can set `$ROVER_VERSION` to the version you want to install, e.g. `ROVER_VERSION=v0.1.0`, and then you can run the following commands to compile and install Rover for your specific architecture
+If you don't see your CPU architecture supported as part of our release pipeline, you can build from source with [`cargo`](https://github.com/rust-lang/cargo). Clone this repo, and run `cargo xtask dist --version v0.1.3`. This will compile a released version of Rover for you, and place the binary in your `target` directory.
 
 ```
 git clone https://github.com/apollographql/rover
-cargo xtask install --version v0.1.0
+cargo xtask dist --version v0.1.3
 ```
 
-
-```
-$ export ROVER_GIT="https://github.com/apollographql/rover"
-$ export ROVER_VERSION="v0.1.0"
-$ git clone $ROVER_GIT
-$ cd rover
-$ git checkout tags/$ROVER_VERSION
-$ curl -L "$ROVER_GIT/releases/download/$ROVER_VERSION/rover-$ROVER_VERSION-schema.graphql" > ./crates/rover-client/.schema/schema.graphql cargo run --release -- --install
-```
+From here you can either place the binary in your `PATH` manually, or run `./target/release/{optional_target}/rover install`.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ Note: Unfortunately if you've installed `npm` without a version manager such as 
 
 You can also [download the binary for your operating system](https://github.com/apollographql/rover/releases) and manually add its location to your `PATH`.
 
+##### Unsupported architectures
+
+If you don't see your CPU architecture supported as part of our release pipeline, you can build from source with [`cargo`](https://github.com/rust-lang/cargo). After installing `cargo`, you can set `$ROVER_VERSION` to the version you want to install, e.g. `ROVER_VERSION=v0.1.0`, and then you can run the following command to compile and install Rover for your specific architecture
+
+```
+$ ROVER_VERSION="v0.1.0" && ROVER_GIT="https://github.com/apollographql/rover" && APOLLO_GRAPHQL_SCHEMA_URL="$ROVER_GIT/releases/download/$ROVER_VERSION/rover-$ROVER_VERSION-schema.graphql" && cargo install --git "$ROVER_GIT" --tag "$ROVER_VERSION" rover
+...
+Compiling rover v0.1.0 (/home/avery/work/rover)
+    Building [=======================> ]
+Finished in 20.51s
+```
+
 ## Contributions
 
 See [this page](https://go.apollo.dev/r/contributing) for info about contributing to Rover.

--- a/README.md
+++ b/README.md
@@ -161,14 +161,21 @@ You can also [download the binary for your operating system](https://github.com/
 
 ##### Unsupported architectures
 
-If you don't see your CPU architecture supported as part of our release pipeline, you can build from source with [`cargo`](https://github.com/rust-lang/cargo). After installing `cargo`, you can set `$ROVER_VERSION` to the version you want to install, e.g. `ROVER_VERSION=v0.1.0`, and then you can run the following command to compile and install Rover for your specific architecture
+If you don't see your CPU architecture supported as part of our release pipeline, you can build from source with [`cargo`](https://github.com/rust-lang/cargo). After installing `cargo`, you can set `$ROVER_VERSION` to the version you want to install, e.g. `ROVER_VERSION=v0.1.0`, and then you can run the following commands to compile and install Rover for your specific architecture
 
 ```
-$ ROVER_VERSION="v0.1.0" && ROVER_GIT="https://github.com/apollographql/rover" && APOLLO_GRAPHQL_SCHEMA_URL="$ROVER_GIT/releases/download/$ROVER_VERSION/rover-$ROVER_VERSION-schema.graphql" && cargo install --git "$ROVER_GIT" --tag "$ROVER_VERSION" rover
-...
-Compiling rover v0.1.0 (/home/avery/work/rover)
-    Building [=======================> ]
-Finished in 20.51s
+git clone https://github.com/apollographql/rover
+cargo xtask install --version v0.1.0
+```
+
+
+```
+$ export ROVER_GIT="https://github.com/apollographql/rover"
+$ export ROVER_VERSION="v0.1.0"
+$ git clone $ROVER_GIT
+$ cd rover
+$ git checkout tags/$ROVER_VERSION
+$ curl -L "$ROVER_GIT/releases/download/$ROVER_VERSION/rover-$ROVER_VERSION-schema.graphql" > ./crates/rover-client/.schema/schema.graphql cargo run --release -- --install
 ```
 
 ## Contributions

--- a/crates/robot-panic/src/lib.rs
+++ b/crates/robot-panic/src/lib.rs
@@ -159,7 +159,7 @@ pub fn print_msg(crash_report: &Report, meta: &Metadata) -> IoResult<()> {
          problem you can send us a crash report.\n",
     )?;
     let issue_link = if !repository.is_empty() {
-        crash_report.get_github_issue(&repository).ok()
+        crash_report.get_github_issue(repository).ok()
     } else {
         None
     };

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -50,7 +50,7 @@ fn main() -> std::io::Result<()> {
                 }
             }
         }
-        update_schema(&client, &schema_url)
+        update_schema(&client, schema_url)
     } else {
         Ok(())
     }

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs::{self, read, write};
 
 use camino::Utf8PathBuf as PathBuf;
@@ -20,8 +19,8 @@ fn main() -> std::io::Result<()> {
     write(".schema/last_run.uuid", Uuid::new_v4().to_string())
         .expect("Failed to write UUID to .schema/last_run.uuid");
 
-    let schema_url = env::var("APOLLO_GPAPHQL_SCHEMA_URL")
-        .unwrap_or_else(|_| "https://graphql.api.apollographql.com/api/schema".to_owned());
+    let schema_url = option_env!("APOLLO_GPAPHQL_SCHEMA_URL")
+        .unwrap_or_else(|| "https://graphql.api.apollographql.com/api/schema");
 
     let client = Client::new();
     let etag_path = PathBuf::from(".schema/etag.id");
@@ -37,7 +36,7 @@ fn main() -> std::io::Result<()> {
             eprintln!("current etag: {}", current_etag);
 
             let response = client
-                .head(&schema_url)
+                .head(schema_url)
                 .send()
                 .expect("Failed to get headers from Apollo's schema download url.");
 

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -1342,9 +1342,9 @@
       }
     },
     "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4220,9 +4220,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -30,6 +30,12 @@
       "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
       "dev": true
     },
+    "node_modules/@ardatan/fetch-event-source": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/fetch-event-source/-/fetch-event-source-2.0.2.tgz",
+      "integrity": "sha512-mcpz/wJ7s50PJIVz4OQ1Yim3w/AAchtYtIg0QMWiMR2cZZoI9t23hRyqeumtD5EmyJu0fxtjmQ5WY8GI86V4rQ==",
+      "dev": true
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -343,6 +349,15 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
     },
+    "node_modules/@graphql-tools/batch-execute/node_modules/value-or-promise": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@graphql-tools/code-file-loader": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-6.3.1.tgz",
@@ -375,11 +390,34 @@
         "graphql": "^14.0.0 || ^15.0.0"
       }
     },
+    "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/schema": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
+      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^7.1.2",
+        "tslib": "~2.2.0",
+        "value-or-promise": "1.0.6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/@graphql-tools/delegate/node_modules/tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
+    },
+    "node_modules/@graphql-tools/delegate/node_modules/value-or-promise": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
       "version": "6.2.7",
@@ -476,43 +514,68 @@
       "dev": true
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "6.2.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.14.tgz",
-      "integrity": "sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==",
+      "version": "6.2.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.16.tgz",
+      "integrity": "sha512-KjZ1pppzKcr2Uspgb53p8uw5yhWVuGIL+sEroar7vLsClSsuiGib8OKVICAGWjC9wrCxGaL9SjJGavfXpJMQIg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/schema": "^7.0.0",
-        "@graphql-tools/utils": "^7.7.0",
-        "tslib": "~2.2.0"
+        "@graphql-tools/schema": "^8.0.1",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+      "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "dev": true
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
-      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.0.1.tgz",
+      "integrity": "sha512-QG2HGLJjmsNc1wcj+rwZTEArgfMp7rsrb8iVq4P8ce1mDYAt6kRV6bLyPVb9q/j8Ik2zBc/B/Y1jPsnAVUHwdA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^7.1.2",
-        "tslib": "~2.2.0",
-        "value-or-promise": "1.0.6"
+        "@graphql-tools/merge": "6.2.16",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+      "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "dev": true
     },
     "node_modules/@graphql-tools/url-loader": {
@@ -587,11 +650,34 @@
         "graphql": "^14.0.0 || ^15.0.0"
       }
     },
+    "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/schema": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
+      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^7.1.2",
+        "tslib": "~2.2.0",
+        "value-or-promise": "1.0.6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/@graphql-tools/wrap/node_modules/tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
+    },
+    "node_modules/@graphql-tools/wrap/node_modules/value-or-promise": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -624,6 +710,15 @@
       "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "dev": true
+    },
+    "node_modules/@n1ru4l/graphql-live-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz",
+      "integrity": "sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^15.4.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -661,9 +756,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.4.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
+      "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -887,9 +982,9 @@
       }
     },
     "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "node_modules/callsites": {
@@ -1532,9 +1627,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
     "node_modules/form-data": {
@@ -1643,18 +1738,18 @@
       }
     },
     "node_modules/graphql-config": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.3.0.tgz",
-      "integrity": "sha512-mSQIsPMssr7QrgqhnjI+CyVH6oQgCrgS6irHsTvwf7RFDRnR2k9kqpQOQgVoOytBSn0DOYryS0w0SAg9xor/Jw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.4.0.tgz",
+      "integrity": "sha512-jnnN8wr9vkMMUHq1gOEcG9Qzd3NGgJ6k8nc3WuzsYGrQfZtQX7Mve+sHOUOfDUKsV4uhSRa/gHURA+tw5qK42g==",
       "dev": true,
       "dependencies": {
         "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
-        "@graphql-tools/graphql-file-loader": "^6.0.0",
-        "@graphql-tools/json-file-loader": "^6.0.0",
-        "@graphql-tools/load": "^6.0.0",
-        "@graphql-tools/merge": "^6.0.0",
-        "@graphql-tools/url-loader": "^6.0.0",
-        "@graphql-tools/utils": "^7.0.0",
+        "@graphql-tools/graphql-file-loader": "^7.0.0",
+        "@graphql-tools/json-file-loader": "^7.0.0",
+        "@graphql-tools/load": "^7.0.0",
+        "@graphql-tools/merge": "^6.2.15",
+        "@graphql-tools/url-loader": "^7.0.2",
+        "@graphql-tools/utils": "^8.0.0",
         "cosmiconfig": "7.0.0",
         "cosmiconfig-toml-loader": "1.0.0",
         "minimatch": "3.0.4",
@@ -1666,6 +1761,232 @@
       "peerDependencies": {
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/batch-execute": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.0.1.tgz",
+      "integrity": "sha512-39SpVo2BgcuFLp3ZNvnyPbyFBCCAQMsR/0BvSC8yQaq5AOMLU76fJCKY5RcmNY+9n6529eem8kzdN20qm2rq+g==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "8.0.1",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/delegate": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.0.3.tgz",
+      "integrity": "sha512-u6TTTqslVDna/0v9kJSqIYeqa+TdZDQMqDlwrsLi7VsATnzgv0OAYxj55XxSBJQWh0oSM+i4EoGqbwj+wU2tvg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/batch-execute": "^8.0.1",
+        "@graphql-tools/schema": "^8.0.1",
+        "@graphql-tools/utils": "8.0.1",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/graphql-file-loader": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.0.1.tgz",
+      "integrity": "sha512-gSYh+W86GcR/TP8bLCPuNdAUeV1/y3+0czM32r6VxqZNiJjiSF6k68rb4F7M6jJ/1dA/SAEZpXLd94Dokc2s/g==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/import": "^6.2.6",
+        "@graphql-tools/utils": "8.0.1",
+        "globby": "^11.0.3",
+        "is-glob": "^4.0.1",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/json-file-loader": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.0.1.tgz",
+      "integrity": "sha512-UfZ3vA37d0OG28p8GijyIo5zRMXozz9f1TBcb++k0cQKmElILrnBHD4ZiNkWTFz5VBSKSjk4gpJD89D8BKKDyg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/load": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.0.1.tgz",
+      "integrity": "sha512-TiHgGRWhHHRdhWyVlZrF9PT6NqGG0NRL0XLY6IYWzinNMuPAOyYcp6zwtPxgDbfeRQMO41/4QTIkR6mCLHrcRQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/merge": "^6.2.16",
+        "@graphql-tools/utils": "8.0.1",
+        "import-from": "4.0.0",
+        "p-limit": "3.1.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/url-loader": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.0.3.tgz",
+      "integrity": "sha512-9QhYaA6nCAleFSw5WvNgwy/ixkcJTrMfFAP3Ofsgk9Cau0iUesrgRYEYNJldf0NevP7wHzaVuWqRP/xHLqW2iw==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/fetch-event-source": "2.0.2",
+        "@graphql-tools/delegate": "8.0.3",
+        "@graphql-tools/utils": "8.0.1",
+        "@graphql-tools/wrap": "^8.0.3",
+        "@n1ru4l/graphql-live-query": "0.7.1",
+        "@types/websocket": "1.0.4",
+        "abort-controller": "3.0.0",
+        "cross-fetch": "3.1.4",
+        "extract-files": "11.0.0",
+        "form-data": "4.0.0",
+        "graphql-ws": "^5.0.0",
+        "is-promise": "4.0.0",
+        "isomorphic-ws": "4.0.1",
+        "lodash": "4.17.21",
+        "meros": "1.1.4",
+        "subscriptions-transport-ws": "^0.10.0",
+        "sync-fetch": "0.3.0",
+        "tslib": "~2.3.0",
+        "valid-url": "1.0.9",
+        "value-or-promise": "1.0.10",
+        "ws": "8.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/url-loader/node_modules/ws": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.0.0.tgz",
+      "integrity": "sha512-6AcSIXpBlS0QvCVKk+3cWnWElLsA6SzC0lkQ43ciEglgXJXiCWK3/CGFEJ+Ybgp006CMibamAsqOlxE9s4AvYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+      "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/wrap": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.0.3.tgz",
+      "integrity": "sha512-32tZiT5pEdyAzhU3jUW2ff/PS+z00jVGDvoy9m+LBG/NXMPb4JGFh3mDB91ZYnqrxvUHd2UNckxf+rg8Ej8tLg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/delegate": "8.0.3",
+        "@graphql-tools/schema": "^8.0.1",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@types/websocket": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
+      "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/graphql-config/node_modules/extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
+    "node_modules/graphql-config/node_modules/graphql-ws": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.3.0.tgz",
+      "integrity": "sha512-53MbSTOmgx5i6hf3DHVD5PrXix1drDmt2ja8MW7NG+aTpKGzkXVLyNcyNpxme4SK8jVtIV6ZIHkiwirqN0efpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=15"
+      }
+    },
+    "node_modules/graphql-config/node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphql-config/node_modules/subscriptions-transport-ws": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.10.0.tgz",
+      "integrity": "sha512-k28LhLn3abJ1mowFW+LP4QGggE0e3hrk55zXbMHyAeZkCUYtC0owepiwqMD3zX8DglQVaxnhE760pESrNSEzpg==",
+      "dev": true,
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.10.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
     },
     "node_modules/graphql-depth-limit": {
       "version": "1.1.0",
@@ -2031,21 +2352,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
       "dev": true,
       "dependencies": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.49.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2750,9 +3071,9 @@
       "dev": true
     },
     "node_modules/value-or-promise": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
-      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.10.tgz",
+      "integrity": "sha512-1OwTzvcfXkAfabk60UVr5NdjtjJ0Fg0T5+B1bhxtrOEwSH2fe8y4DnLgoksfCyd8yZCOQQHB0qLMQnwgCjbXLQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -2863,6 +3184,12 @@
           "dev": true
         }
       }
+    },
+    "@ardatan/fetch-event-source": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/fetch-event-source/-/fetch-event-source-2.0.2.tgz",
+      "integrity": "sha512-mcpz/wJ7s50PJIVz4OQ1Yim3w/AAchtYtIg0QMWiMR2cZZoI9t23hRyqeumtD5EmyJu0fxtjmQ5WY8GI86V4rQ==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -3116,6 +3443,12 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
           "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
+        },
+        "value-or-promise": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+          "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+          "dev": true
         }
       }
     },
@@ -3145,10 +3478,27 @@
         "value-or-promise": "1.0.6"
       },
       "dependencies": {
+        "@graphql-tools/schema": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
+          "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/utils": "^7.1.2",
+            "tslib": "~2.2.0",
+            "value-or-promise": "1.0.6"
+          }
+        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
           "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        },
+        "value-or-promise": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+          "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
           "dev": true
         }
       }
@@ -3239,39 +3589,58 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "6.2.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.14.tgz",
-      "integrity": "sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==",
+      "version": "6.2.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.16.tgz",
+      "integrity": "sha512-KjZ1pppzKcr2Uspgb53p8uw5yhWVuGIL+sEroar7vLsClSsuiGib8OKVICAGWjC9wrCxGaL9SjJGavfXpJMQIg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "^7.0.0",
-        "@graphql-tools/utils": "^7.7.0",
-        "tslib": "~2.2.0"
+        "@graphql-tools/schema": "^8.0.1",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0"
       },
       "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+          "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        },
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }
     },
     "@graphql-tools/schema": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
-      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.0.1.tgz",
+      "integrity": "sha512-QG2HGLJjmsNc1wcj+rwZTEArgfMp7rsrb8iVq4P8ce1mDYAt6kRV6bLyPVb9q/j8Ik2zBc/B/Y1jPsnAVUHwdA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^7.1.2",
-        "tslib": "~2.2.0",
-        "value-or-promise": "1.0.6"
+        "@graphql-tools/merge": "6.2.16",
+        "@graphql-tools/utils": "8.0.1",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
       },
       "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+          "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        },
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }
@@ -3343,10 +3712,27 @@
         "value-or-promise": "1.0.6"
       },
       "dependencies": {
+        "@graphql-tools/schema": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
+          "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/utils": "^7.1.2",
+            "tslib": "~2.2.0",
+            "value-or-promise": "1.0.6"
+          }
+        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
           "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        },
+        "value-or-promise": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+          "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
           "dev": true
         }
       }
@@ -3380,6 +3766,13 @@
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "dev": true
     },
+    "@n1ru4l/graphql-live-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz",
+      "integrity": "sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3407,9 +3800,9 @@
       }
     },
     "@types/node": {
-      "version": "16.4.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
+      "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3569,9 +3962,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "callsites": {
@@ -4074,9 +4467,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
     "form-data": {
@@ -4160,22 +4553,194 @@
       "dev": true
     },
     "graphql-config": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.3.0.tgz",
-      "integrity": "sha512-mSQIsPMssr7QrgqhnjI+CyVH6oQgCrgS6irHsTvwf7RFDRnR2k9kqpQOQgVoOytBSn0DOYryS0w0SAg9xor/Jw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.4.0.tgz",
+      "integrity": "sha512-jnnN8wr9vkMMUHq1gOEcG9Qzd3NGgJ6k8nc3WuzsYGrQfZtQX7Mve+sHOUOfDUKsV4uhSRa/gHURA+tw5qK42g==",
       "dev": true,
       "requires": {
         "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
-        "@graphql-tools/graphql-file-loader": "^6.0.0",
-        "@graphql-tools/json-file-loader": "^6.0.0",
-        "@graphql-tools/load": "^6.0.0",
-        "@graphql-tools/merge": "^6.0.0",
-        "@graphql-tools/url-loader": "^6.0.0",
-        "@graphql-tools/utils": "^7.0.0",
+        "@graphql-tools/graphql-file-loader": "^7.0.0",
+        "@graphql-tools/json-file-loader": "^7.0.0",
+        "@graphql-tools/load": "^7.0.0",
+        "@graphql-tools/merge": "^6.2.15",
+        "@graphql-tools/url-loader": "^7.0.2",
+        "@graphql-tools/utils": "^8.0.0",
         "cosmiconfig": "7.0.0",
         "cosmiconfig-toml-loader": "1.0.0",
         "minimatch": "3.0.4",
         "string-env-interpolation": "1.0.1"
+      },
+      "dependencies": {
+        "@graphql-tools/batch-execute": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.0.1.tgz",
+          "integrity": "sha512-39SpVo2BgcuFLp3ZNvnyPbyFBCCAQMsR/0BvSC8yQaq5AOMLU76fJCKY5RcmNY+9n6529eem8kzdN20qm2rq+g==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/utils": "8.0.1",
+            "dataloader": "2.0.0",
+            "tslib": "~2.3.0",
+            "value-or-promise": "1.0.10"
+          }
+        },
+        "@graphql-tools/delegate": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.0.3.tgz",
+          "integrity": "sha512-u6TTTqslVDna/0v9kJSqIYeqa+TdZDQMqDlwrsLi7VsATnzgv0OAYxj55XxSBJQWh0oSM+i4EoGqbwj+wU2tvg==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/batch-execute": "^8.0.1",
+            "@graphql-tools/schema": "^8.0.1",
+            "@graphql-tools/utils": "8.0.1",
+            "dataloader": "2.0.0",
+            "tslib": "~2.3.0",
+            "value-or-promise": "1.0.10"
+          }
+        },
+        "@graphql-tools/graphql-file-loader": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.0.1.tgz",
+          "integrity": "sha512-gSYh+W86GcR/TP8bLCPuNdAUeV1/y3+0czM32r6VxqZNiJjiSF6k68rb4F7M6jJ/1dA/SAEZpXLd94Dokc2s/g==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/import": "^6.2.6",
+            "@graphql-tools/utils": "8.0.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "tslib": "~2.3.0",
+            "unixify": "^1.0.0"
+          }
+        },
+        "@graphql-tools/json-file-loader": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.0.1.tgz",
+          "integrity": "sha512-UfZ3vA37d0OG28p8GijyIo5zRMXozz9f1TBcb++k0cQKmElILrnBHD4ZiNkWTFz5VBSKSjk4gpJD89D8BKKDyg==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/utils": "8.0.1",
+            "tslib": "~2.3.0"
+          }
+        },
+        "@graphql-tools/load": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.0.1.tgz",
+          "integrity": "sha512-TiHgGRWhHHRdhWyVlZrF9PT6NqGG0NRL0XLY6IYWzinNMuPAOyYcp6zwtPxgDbfeRQMO41/4QTIkR6mCLHrcRQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/merge": "^6.2.16",
+            "@graphql-tools/utils": "8.0.1",
+            "import-from": "4.0.0",
+            "p-limit": "3.1.0",
+            "tslib": "~2.3.0"
+          }
+        },
+        "@graphql-tools/url-loader": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.0.3.tgz",
+          "integrity": "sha512-9QhYaA6nCAleFSw5WvNgwy/ixkcJTrMfFAP3Ofsgk9Cau0iUesrgRYEYNJldf0NevP7wHzaVuWqRP/xHLqW2iw==",
+          "dev": true,
+          "requires": {
+            "@ardatan/fetch-event-source": "2.0.2",
+            "@graphql-tools/delegate": "8.0.3",
+            "@graphql-tools/utils": "8.0.1",
+            "@graphql-tools/wrap": "^8.0.3",
+            "@n1ru4l/graphql-live-query": "0.7.1",
+            "@types/websocket": "1.0.4",
+            "abort-controller": "3.0.0",
+            "cross-fetch": "3.1.4",
+            "extract-files": "11.0.0",
+            "form-data": "4.0.0",
+            "graphql-ws": "^5.0.0",
+            "is-promise": "4.0.0",
+            "isomorphic-ws": "4.0.1",
+            "lodash": "4.17.21",
+            "meros": "1.1.4",
+            "subscriptions-transport-ws": "^0.10.0",
+            "sync-fetch": "0.3.0",
+            "tslib": "~2.3.0",
+            "valid-url": "1.0.9",
+            "value-or-promise": "1.0.10",
+            "ws": "8.0.0"
+          },
+          "dependencies": {
+            "ws": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-8.0.0.tgz",
+              "integrity": "sha512-6AcSIXpBlS0QvCVKk+3cWnWElLsA6SzC0lkQ43ciEglgXJXiCWK3/CGFEJ+Ybgp006CMibamAsqOlxE9s4AvYA==",
+              "dev": true,
+              "requires": {}
+            }
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.1.tgz",
+          "integrity": "sha512-gjQk6sht4b0/hcG+QEVxfMyO8bn5tuU1nIOVhQ4whgFaUmrnb3hx2mwzz1EJzfIOAuHKE8tY0lu6jt3bGTD4yg==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        },
+        "@graphql-tools/wrap": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.0.3.tgz",
+          "integrity": "sha512-32tZiT5pEdyAzhU3jUW2ff/PS+z00jVGDvoy9m+LBG/NXMPb4JGFh3mDB91ZYnqrxvUHd2UNckxf+rg8Ej8tLg==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/delegate": "8.0.3",
+            "@graphql-tools/schema": "^8.0.1",
+            "@graphql-tools/utils": "8.0.1",
+            "tslib": "~2.3.0",
+            "value-or-promise": "1.0.10"
+          }
+        },
+        "@types/websocket": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
+          "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "extract-files": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+          "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+          "dev": true
+        },
+        "graphql-ws": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.3.0.tgz",
+          "integrity": "sha512-53MbSTOmgx5i6hf3DHVD5PrXix1drDmt2ja8MW7NG+aTpKGzkXVLyNcyNpxme4SK8jVtIV6ZIHkiwirqN0efpw==",
+          "dev": true,
+          "requires": {}
+        },
+        "import-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+          "dev": true
+        },
+        "subscriptions-transport-ws": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.10.0.tgz",
+          "integrity": "sha512-k28LhLn3abJ1mowFW+LP4QGggE0e3hrk55zXbMHyAeZkCUYtC0owepiwqMD3zX8DglQVaxnhE760pESrNSEzpg==",
+          "dev": true,
+          "requires": {
+            "backo2": "^1.0.2",
+            "eventemitter3": "^3.1.0",
+            "iterall": "^1.2.1",
+            "symbol-observable": "^1.0.4",
+            "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+          "dev": true
+        }
       }
     },
     "graphql-depth-limit": {
@@ -4453,18 +5018,18 @@
       }
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.49.0"
       }
     },
     "minimatch": {
@@ -4967,9 +5532,9 @@
       "dev": true
     },
     "value-or-promise": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
-      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.10.tgz",
+      "integrity": "sha512-1OwTzvcfXkAfabk60UVr5NdjtjJ0Fg0T5+B1bhxtrOEwSH2fe8y4DnLgoksfCyd8yZCOQQHB0qLMQnwgCjbXLQ==",
       "dev": true
     },
     "which": {

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
+      "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8",
+        "@babel/types": "^7.14.9",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -90,12 +90,12 @@
       }
     },
     "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -115,12 +115,12 @@
       }
     },
     "node_modules/@babel/helper-get-function-arity/node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -140,12 +140,12 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/parser": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
+      "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -214,12 +214,12 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -756,9 +756,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
-      "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA==",
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -1215,9 +1215,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -3201,23 +3201,23 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
+      "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8",
+        "@babel/types": "^7.14.9",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+          "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -3235,12 +3235,12 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+          "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -3256,12 +3256,12 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+          "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -3277,21 +3277,21 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+          "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
     },
     "@babel/highlight": {
@@ -3323,18 +3323,18 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-          "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
+          "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
+          "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.8",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -3800,9 +3800,9 @@
       }
     },
     "@types/node": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
-      "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA==",
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -4154,9 +4154,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -141,7 +141,7 @@ fn build_headers(header_map: &HashMap<String, String>) -> Result<HeaderMap, Rove
 
     for (key, value) in header_map {
         let header_key = HeaderName::from_bytes(key.as_bytes())?;
-        let header_value = HeaderValue::from_str(&value)?;
+        let header_value = HeaderValue::from_str(value)?;
         headers.append(header_key, header_value);
     }
 

--- a/crates/rover-client/src/operations/subgraph/check/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check/runner.rs
@@ -38,7 +38,7 @@ pub fn run(
         IsFederatedInput {
             graph_ref: graph_ref.clone(),
         },
-        &client,
+        client,
     )?;
     if !is_federated {
         return Err(RoverClientError::ExpectedFederatedGraph {

--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -33,7 +33,7 @@ pub fn run(
             IsFederatedInput {
                 graph_ref: graph_ref.clone(),
             },
-            &client,
+            client,
         )?;
 
         if !is_federated {
@@ -54,13 +54,13 @@ fn get_publish_response_from_data(
 ) -> Result<UpdateResponse, RoverClientError> {
     let service_data = data
         .service
-        .ok_or_else(|| RoverClientError::GraphNotFound { graph_ref })?;
+        .ok_or(RoverClientError::GraphNotFound { graph_ref })?;
 
-    Ok(service_data
+    service_data
         .upsert_implementing_service_and_trigger_composition
-        .ok_or_else(|| RoverClientError::MalformedResponse {
+        .ok_or(RoverClientError::MalformedResponse {
             null_field: "service.upsertImplementingServiceAndTriggerComposition".to_string(),
-        })?)
+        })
 }
 
 fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {

--- a/crates/rover-client/tests/client.rs
+++ b/crates/rover-client/tests/client.rs
@@ -35,4 +35,10 @@ mod tests {
         )
         .is_ok());
     }
+
+    #[test]
+    fn schema_at_stable_path() {
+        // this path must remain stable as we upload it as part of our release process
+        assert!(std::fs::metadata("./.schema/schema.graphql").is_ok())
+    }
 }

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.1.tgz",
-      "integrity": "sha512-GG0R7yt/CQkvG4fueXDi52Zskqxe2AyRJ+Wm54yqarnBgcX3qRIWh10qLVAAN+mlPFGTfP5UxvD3Fbi11UOTUQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
+      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -490,9 +490,9 @@
       }
     },
     "tar": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.1.tgz",
-      "integrity": "sha512-GG0R7yt/CQkvG4fueXDi52Zskqxe2AyRJ+Wm54yqarnBgcX3qRIWh10qLVAAN+mlPFGTfP5UxvD3Fbi11UOTUQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
+      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.3.tgz",
+      "integrity": "sha512-3rUqwucgVZXTeyJyL2jqtUau8/8r54SioM1xj3AmTX3HnWQdj2AydfJ2qYYayPyIIznSplcvU9mhBb7dR2XF3w==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -490,9 +490,9 @@
       }
     },
     "tar": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.3.tgz",
+      "integrity": "sha512-3rUqwucgVZXTeyJyL2jqtUau8/8r54SioM1xj3AmTX3HnWQdj2AydfJ2qYYayPyIIznSplcvU9mhBb7dR2XF3w==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -230,7 +230,7 @@ impl RoverOutput {
                 let mut skin = MadSkin::default();
                 skin.bold.add_attr(Underlined);
 
-                println!("{}", skin.inline(&explanation));
+                println!("{}", skin.inline(explanation));
             }
             RoverOutput::EmptySuccess => (),
         }

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -127,7 +127,7 @@ pub(crate) fn get_subgraph_definitions(
             } => {
                 // given a graph_ref and subgraph, run subgraph fetch to
                 // obtain SDL and add it to subgraph_definition.
-                let client = client_config.get_authenticated_client(&profile_name)?;
+                let client = client_config.get_authenticated_client(profile_name)?;
                 let result = fetch::run(
                     SubgraphFetchInput {
                         graph_ref: GraphRef::from_str(graph_ref)?,

--- a/src/utils/loaders.rs
+++ b/src/utils/loaders.rs
@@ -17,7 +17,7 @@ pub fn load_schema_from_flag(loc: &SchemaSource, mut stdin: impl Read) -> Result
             Ok(buffer)
         }
         SchemaSource::File(path) => {
-            if Utf8Path::exists(&path) {
+            if Utf8Path::exists(path) {
                 let contents = std::fs::read_to_string(path)?;
                 Ok(contents)
             } else {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,5 +12,7 @@ camino = "1.0"
 cargo_metadata = "0.14"
 lazy_static = "1.4"
 regex = "1"
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "native-tls"]}
+semver = "1"
 structopt = { version = "0.3", default-features = false }
 which = "4.1"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -4,6 +4,10 @@ Rover uses [xtask](https://github.com/matklad/cargo-xtask) to help with the auto
 
 You can run `cargo xtask --help` to see the usage. Generally we recommend that you continue to use the default cargo commands like `cargo fmt`, `cargo clippy`, and `cargo test`, but if you are debugging something that is happening in CI it can be useful to run the xtask commands that we run [in CI](../.github/workflows).
 
+## xtask test
+
+You can run `cargo xtask test` to run tests with the same configuration as our CI systems. If you are on GNU Linux, it will also run the e2e tests set up in [apollographql/supergraph-demo](https://github.com/apollographql/supergraph-demo).
+
 ## xtask prep
 
 The most important xtask command you'll need to run locally is `cargo xtask prep`. This command prepares Rover for a new release. You'll want to update the version in `Cargo.toml`, and run `cargo xtask prep` as a part of making the PR for a new release. 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -8,6 +8,10 @@ You can run `cargo xtask --help` to see the usage. Generally we recommend that y
 
 You can run `cargo xtask test` to run tests with the same configuration as our CI systems. If you are on GNU Linux, it will also run the e2e tests set up in [apollographql/supergraph-demo](https://github.com/apollographql/supergraph-demo).
 
+## xtask dist
+
+You can run `cargo xtask dist` to build Rover's binary like it would be built in CI. It will automatically build from the source that you've checked out and for your local machine's architecture. If you would like to build a specific version of Rover, you can pass `--version v0.1.5` where `v0.1.5` is the version you'd like to build.
+
 ## xtask prep
 
 The most important xtask command you'll need to run locally is `cargo xtask prep`. This command prepares Rover for a new release. You'll want to update the version in `Cargo.toml`, and run `cargo xtask prep` as a part of making the PR for a new release. 

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use structopt::StructOpt;
 
+use crate::commands::version::RoverVersion;
 use crate::target::{Target, POSSIBLE_TARGETS};
 use crate::tools::{CargoRunner, StripRunner};
 
@@ -9,13 +10,17 @@ pub struct Dist {
     /// The target to build Rover for
     #[structopt(long = "target", default_value, possible_values = &POSSIBLE_TARGETS)]
     target: Target,
+
+    // The version to check out and compile, otherwise install a local build
+    #[structopt(long)]
+    version: Option<RoverVersion>,
 }
 
 impl Dist {
     pub fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let mut cargo_runner = CargoRunner::new(verbose)?;
         let binary_path = cargo_runner
-            .build(&self.target, true)
+            .build(&self.target, true, self.version.as_ref())
             .with_context(|| "Could not build Rover.")?;
 
         if !cfg!(windows) {

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -13,9 +13,9 @@ pub struct Dist {
 
 impl Dist {
     pub fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(self.target.clone(), verbose)?;
+        let cargo_runner = CargoRunner::new(verbose)?;
         let binary_path = cargo_runner
-            .build(true)
+            .build(&self.target, true)
             .with_context(|| "Could not build Rover.")?;
 
         if !cfg!(windows) {

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -6,15 +6,16 @@ use crate::tools::{CargoRunner, StripRunner};
 
 #[derive(Debug, StructOpt)]
 pub struct Dist {
-    #[structopt(long = "target", possible_values = &POSSIBLE_TARGETS)]
+    /// The target to build Rover for
+    #[structopt(long = "target", default_value, possible_values = &POSSIBLE_TARGETS)]
     target: Target,
 }
 
 impl Dist {
     pub fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let cargo_runner = CargoRunner::new(self.target.clone(), verbose)?;
         let binary_path = cargo_runner
-            .build(&self.target, true)
+            .build(true)
             .with_context(|| "Could not build Rover.")?;
 
         if !cfg!(windows) {

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -1,19 +1,14 @@
 use anyhow::Result;
 use structopt::StructOpt;
 
-use crate::target::{Target, POSSIBLE_TARGETS};
 use crate::tools::{CargoRunner, NpmRunner};
 
 #[derive(Debug, StructOpt)]
-pub struct Lint {
-    // The target to build Rover for
-    #[structopt(long = "target", default_value, possible_values = &POSSIBLE_TARGETS)]
-    target: Target,
-}
+pub struct Lint {}
 
 impl Lint {
     pub fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(self.target.clone(), verbose)?;
+        let cargo_runner = CargoRunner::new(verbose)?;
         cargo_runner.lint()?;
         let npm_runner = NpmRunner::new(verbose)?;
         npm_runner.lint()?;

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -8,7 +8,7 @@ pub struct Lint {}
 
 impl Lint {
     pub fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let mut cargo_runner = CargoRunner::new(verbose)?;
         cargo_runner.lint()?;
         let npm_runner = NpmRunner::new(verbose)?;
         npm_runner.lint()?;

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -1,14 +1,19 @@
 use anyhow::Result;
 use structopt::StructOpt;
 
+use crate::target::{Target, POSSIBLE_TARGETS};
 use crate::tools::{CargoRunner, NpmRunner};
 
 #[derive(Debug, StructOpt)]
-pub struct Lint {}
+pub struct Lint {
+    // The target to build Rover for
+    #[structopt(long = "target", default_value, possible_values = &POSSIBLE_TARGETS)]
+    target: Target,
+}
 
 impl Lint {
     pub fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let cargo_runner = CargoRunner::new(self.target.clone(), verbose)?;
         cargo_runner.lint()?;
         let npm_runner = NpmRunner::new(verbose)?;
         npm_runner.lint()?;

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod dist;
 pub(crate) mod lint;
 pub(crate) mod prep;
 pub(crate) mod test;
+pub(crate) mod version;
 
 pub(crate) use dist::Dist;
 pub(crate) use lint::Lint;

--- a/xtask/src/commands/prep/docs.rs
+++ b/xtask/src/commands/prep/docs.rs
@@ -63,7 +63,7 @@ impl DocsRunner {
             all_descriptions.push_str(&description);
         }
 
-        self.replace_content_after_token("<!-- BUILD_CODES -->", &all_descriptions, &docs_path)
+        self.replace_content_after_token("<!-- BUILD_CODES -->", &all_descriptions, docs_path)
     }
 
     pub(crate) fn copy_contributing(&self) -> Result<()> {
@@ -78,11 +78,7 @@ impl DocsRunner {
         let source_content = source_content_with_header
             .splitn(3, '\n')
             .collect::<Vec<&str>>()[2];
-        self.replace_content_after_token(
-            "<!-- CONTRIBUTING -->",
-            &source_content,
-            &destination_path,
-        )
+        self.replace_content_after_token("<!-- CONTRIBUTING -->", source_content, &destination_path)
     }
 
     fn replace_content_after_token(
@@ -107,7 +103,7 @@ impl DocsRunner {
                 break;
             }
         }
-        new_content.push_str(&source_content);
+        new_content.push_str(source_content);
 
         fs::write(&destination_path, new_content)?;
         Ok(())

--- a/xtask/src/commands/prep/docs.rs
+++ b/xtask/src/commands/prep/docs.rs
@@ -3,7 +3,7 @@ use camino::Utf8PathBuf;
 
 use std::{convert::TryFrom, fs};
 
-use crate::utils;
+use crate::utils::{self, PKG_PROJECT_ROOT};
 
 pub(crate) struct DocsRunner {
     pub(crate) project_root: Utf8PathBuf,
@@ -12,7 +12,7 @@ pub(crate) struct DocsRunner {
 
 impl DocsRunner {
     pub(crate) fn new() -> Result<Self> {
-        let project_root = utils::project_root()?;
+        let project_root = PKG_PROJECT_ROOT.clone();
         let docs_root = project_root.join("docs");
         Ok(Self {
             project_root,

--- a/xtask/src/commands/prep/installers.rs
+++ b/xtask/src/commands/prep/installers.rs
@@ -25,7 +25,7 @@ fn update_nix_installer_version(parent: &Utf8Path) -> Result<()> {
         .context("Could not create regular expression for nix installer version replacer")?;
     let old_version = str::from_utf8(
         version_regex
-            .captures(&old_installer_contents.as_bytes())
+            .captures(old_installer_contents.as_bytes())
             .ok_or_else(|| anyhow!("Could not find PACKAGE_VERSION in nix/install.sh"))?
             .get(1)
             .ok_or_else(|| anyhow!("Could not find the version capture group in nix/install.sh"))?

--- a/xtask/src/commands/prep/installers.rs
+++ b/xtask/src/commands/prep/installers.rs
@@ -4,7 +4,7 @@ use regex::bytes::Regex;
 
 use std::{fs, str};
 
-use crate::utils::{self, PKG_VERSION};
+use crate::utils::{self, PKG_PROJECT_ROOT, PKG_VERSION};
 
 /// prepares our curl/iwr installers
 /// with the Cargo.toml version
@@ -68,7 +68,7 @@ fn update_win_installer_version(parent: &Utf8Path) -> Result<()> {
 /// gets the parent directory
 /// of our nix/windows install scripts
 fn get_binstall_scripts_root() -> Result<Utf8PathBuf> {
-    Ok(utils::project_root()?
+    Ok(PKG_PROJECT_ROOT
         .join("installers")
         .join("binstall")
         .join("scripts"))

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -14,15 +14,15 @@ pub struct Test {
 impl Test {
     pub fn run(&self, verbose: bool) -> Result<()> {
         let release = false;
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let mut cargo_runner = CargoRunner::new(verbose)?;
         let git_runner = GitRunner::new(verbose)?;
 
         cargo_runner.test(&self.target)?;
 
         if let Target::GnuLinux = self.target {
             let make_runner =
-                MakeRunner::new(verbose, cargo_runner.get_bin_path(&self.target, release))?;
-            cargo_runner.build(&self.target, release)?;
+                MakeRunner::new(verbose, cargo_runner.get_bin_path(&self.target, release)?)?;
+            cargo_runner.build(&self.target, release, None)?;
 
             let repo_path = git_runner.clone_supergraph_demo()?;
             make_runner.test_supergraph_demo(&repo_path)?;

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -14,14 +14,15 @@ pub struct Test {
 impl Test {
     pub fn run(&self, verbose: bool) -> Result<()> {
         let release = false;
-        let cargo_runner = CargoRunner::new(self.target.clone(), verbose)?;
+        let cargo_runner = CargoRunner::new(verbose)?;
         let git_runner = GitRunner::new(verbose)?;
 
-        cargo_runner.test()?;
+        cargo_runner.test(&self.target)?;
 
         if let Target::GnuLinux = self.target {
-            let make_runner = MakeRunner::new(verbose, cargo_runner.get_bin_path(release))?;
-            cargo_runner.build(release)?;
+            let make_runner =
+                MakeRunner::new(verbose, cargo_runner.get_bin_path(&self.target, release))?;
+            cargo_runner.build(&self.target, release)?;
 
             let repo_path = git_runner.clone_supergraph_demo()?;
             make_runner.test_supergraph_demo(&repo_path)?;

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -6,22 +6,22 @@ use crate::tools::{CargoRunner, GitRunner, MakeRunner};
 
 #[derive(Debug, StructOpt)]
 pub struct Test {
-    #[structopt(long = "target", possible_values = &POSSIBLE_TARGETS)]
+    // The target to build Rover for
+    #[structopt(long = "target", default_value, possible_values = &POSSIBLE_TARGETS)]
     target: Target,
 }
 
 impl Test {
     pub fn run(&self, verbose: bool) -> Result<()> {
         let release = false;
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let cargo_runner = CargoRunner::new(self.target.clone(), verbose)?;
         let git_runner = GitRunner::new(verbose)?;
 
-        cargo_runner.test(self.target.to_owned())?;
+        cargo_runner.test()?;
 
         if let Target::GnuLinux = self.target {
-            let make_runner =
-                MakeRunner::new(verbose, cargo_runner.get_bin_path(&self.target, release))?;
-            cargo_runner.build(&self.target, release)?;
+            let make_runner = MakeRunner::new(verbose, cargo_runner.get_bin_path(release))?;
+            cargo_runner.build(release)?;
 
             let repo_path = git_runner.clone_supergraph_demo()?;
             make_runner.test_supergraph_demo(&repo_path)?;

--- a/xtask/src/commands/version.rs
+++ b/xtask/src/commands/version.rs
@@ -1,0 +1,48 @@
+use anyhow::anyhow;
+use semver::Version;
+
+use crate::Result;
+
+use std::{fmt, str::FromStr};
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub(crate) struct RoverVersion {
+    inner: Version,
+}
+
+impl RoverVersion {
+    pub(crate) fn new(version: Version) -> RoverVersion {
+        RoverVersion { inner: version }
+    }
+}
+
+impl FromStr for RoverVersion {
+    type Err = anyhow::Error;
+
+    fn from_str(proposed_version: &str) -> Result<Self, Self::Err> {
+        if proposed_version.is_empty() {
+            Err(anyhow!("version cannot be empty"))
+        } else {
+            let mut version_chars = proposed_version.chars();
+
+            // check `v` prefix exists, and strip it from the input string
+            if version_chars.next().unwrap() != 'v' {
+                Err(anyhow!("version must start with `v`"))
+            } else {
+                let version = Version::parse(version_chars.as_str())?;
+                let min_supported_version = Version::new(0, 1, 3);
+                if version < min_supported_version {
+                    Err(anyhow!("version must be >= {}", min_supported_version))
+                } else {
+                    Ok(RoverVersion { inner: version })
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for RoverVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}", self.inner)
+    }
+}

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -1,43 +1,105 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context};
 use camino::Utf8PathBuf;
+use semver::{BuildMetadata, Prerelease, Version};
 
+use crate::commands::version::RoverVersion;
 use crate::target::Target;
-use crate::tools::Runner;
-use crate::utils::{self, CommandOutput};
+use crate::tools::{GitRunner, Runner};
+use crate::utils::{self, CommandOutput, PKG_PROJECT_ROOT};
+use crate::Result;
 
 use std::collections::HashMap;
+use std::convert::TryInto;
+use std::fs;
 
 pub(crate) struct CargoRunner {
     cargo_package_directory: Utf8PathBuf,
     runner: Runner,
+    env: HashMap<String, String>,
+    git_runner: Option<GitRunner>,
 }
 
 impl CargoRunner {
     pub(crate) fn new(verbose: bool) -> Result<Self> {
         let runner = Runner::new("cargo", verbose)?;
-        let cargo_package_directory = utils::project_root()?;
+        let cargo_package_directory = PKG_PROJECT_ROOT.clone();
 
         Ok(CargoRunner {
             cargo_package_directory,
             runner,
+            env: HashMap::new(),
+            git_runner: None,
         })
     }
 
-    pub(crate) fn build(&self, target: &Target, release: bool) -> Result<Utf8PathBuf> {
-        let args = vec!["build"];
-        self.cargo_exec_with_target(target, args, vec![], release)?;
-        let bin_path = self.get_bin_path(target, release);
+    pub(crate) fn set_path(&mut self, cargo_package_directory: Utf8PathBuf) {
+        self.cargo_package_directory = cargo_package_directory;
+    }
+
+    pub(crate) fn env(&mut self, key: String, value: String) -> Option<String> {
+        self.env.insert(key, value)
+    }
+
+    pub(crate) fn build(
+        &mut self,
+        target: &Target,
+        release: bool,
+        version: Option<&RoverVersion>,
+    ) -> Result<Utf8PathBuf> {
+        if let Some(version) = version {
+            let git_runner = GitRunner::new(self.runner.verbose)?;
+            let repo_path = git_runner.checkout_rover_version(version.to_string().as_str())?;
+            let versioned_schema_url = format!(
+            "https://github.com/apollographql/rover/releases/download/{0}/rover-{0}-schema.graphql",
+            &version);
+            let max_version_not_supporting_env_var = RoverVersion::new(Version {
+                major: 0,
+                minor: 2,
+                patch: 0,
+                pre: Prerelease::new("beta.0")?,
+                build: BuildMetadata::EMPTY,
+            });
+            self.set_path(repo_path.clone());
+            self.git_runner = Some(git_runner);
+
+            if version > &max_version_not_supporting_env_var {
+                self.env(
+                    "APOLLO_GRAPHQL_SCHEMA_URL".to_string(),
+                    versioned_schema_url,
+                );
+            } else {
+                utils::info(&format!(
+                    "downloading schema from {}",
+                    &versioned_schema_url
+                ));
+                let schema_response =
+                    reqwest::blocking::get(versioned_schema_url)?.error_for_status()?;
+                let schema_text = schema_response.text()?;
+                if !schema_text.contains("subgraph") {
+                    anyhow!("This schema doesn't seem to contain any references to `subgraph`s. It's probably the wrong schema.");
+                }
+                let schema_dir = repo_path
+                    .join("crates")
+                    .join("rover-client")
+                    .join(".schema");
+                let _ = self.cargo_exec_with_target(target, vec!["build"], vec![], release);
+                fs::write(schema_dir.join("schema.graphql"), schema_text)?;
+            }
+        }
+
+        self.cargo_exec_with_target(target, vec!["build"], vec![], release)?;
+        let bin_path = self.get_bin_path(target, release)?;
         utils::info(&format!("successfully compiled to `{}`", &bin_path));
         Ok(bin_path)
     }
 
-    pub(crate) fn lint(&self) -> Result<()> {
+    pub(crate) fn lint(&mut self) -> Result<()> {
         self.cargo_exec_without_target(vec!["fmt", "--all"], vec!["--check"])?;
         self.cargo_exec_without_target(vec!["clippy", "--all"], vec!["-D", "warnings"])?;
         Ok(())
     }
 
-    pub(crate) fn test(&self, target: &Target) -> Result<()> {
+    pub(crate) fn test(&mut self, target: &Target) -> Result<()> {
         let command_output = self.cargo_exec_with_target(
             target,
             vec!["test", "--workspace", "--locked"],
@@ -78,26 +140,43 @@ impl CargoRunner {
         }
     }
 
-    pub(crate) fn get_bin_path(&self, target: &Target, release: bool) -> Utf8PathBuf {
-        let mut path = self.cargo_package_directory.clone();
-        if target.is_other() {
-            path.push("target");
-            path.push(target.to_string());
+    pub(crate) fn get_bin_path(&self, target: &Target, release: bool) -> Result<Utf8PathBuf> {
+        let mut out_path = self.cargo_package_directory.clone();
+        let mut root_path = PKG_PROJECT_ROOT.clone();
+
+        out_path.push("target");
+        root_path.push("target");
+
+        if !target.is_other() {
+            out_path.push(target.to_string());
+            root_path.push(target.to_string());
         }
         if release {
-            path.push("release")
+            out_path.push("release");
+            root_path.push("release");
         } else {
-            path.push("debug")
+            out_path.push("debug");
+            root_path.push("debug");
         }
-        path.push("rover");
-        path
+
+        if out_path != root_path {
+            utils::info(&format!(
+                "copying contents of `{}` to `{}`",
+                &out_path, &root_path
+            ));
+            copy_dir_all(&out_path, &root_path)
+                .with_context(|| "Could not copy build contents to local target directory")?;
+        }
+
+        root_path.push("rover");
+
+        Ok(root_path)
     }
 
     fn _cargo_exec(
-        &self,
+        &mut self,
         cargo_args: Vec<&str>,
         extra_args: Vec<&str>,
-        env: Option<&HashMap<String, String>>,
     ) -> Result<CommandOutput> {
         let mut args = cargo_args;
         if !extra_args.is_empty() {
@@ -106,20 +185,24 @@ impl CargoRunner {
                 args.push(extra_arg);
             }
         }
-
+        let env = if self.env.is_empty() {
+            None
+        } else {
+            Some(&self.env)
+        };
         self.runner.exec(&args, &self.cargo_package_directory, env)
     }
 
     fn cargo_exec_without_target(
-        &self,
+        &mut self,
         cargo_args: Vec<&str>,
         extra_args: Vec<&str>,
     ) -> Result<CommandOutput> {
-        self._cargo_exec(cargo_args, extra_args, None)
+        self._cargo_exec(cargo_args, extra_args)
     }
 
     fn cargo_exec_with_target(
-        &self,
+        &mut self,
         target: &Target,
         cargo_args: Vec<&str>,
         extra_args: Vec<&str>,
@@ -136,7 +219,27 @@ impl CargoRunner {
         if release {
             cargo_args.push("--release");
         }
-        let env = target.get_env()?;
-        self._cargo_exec(cargo_args, extra_args, env.as_ref())
+        if let Some(env) = target.get_env()? {
+            self.env.extend(env);
+        }
+        self._cargo_exec(cargo_args, extra_args)
     }
+}
+
+fn copy_dir_all(source: &Utf8PathBuf, destination: &Utf8PathBuf) -> Result<()> {
+    fs::create_dir_all(&destination)?;
+    for entry in fs::read_dir(&source)?.flatten() {
+        if let Ok(file_type) = entry.file_type() {
+            if let Some(file_name) = entry.file_name().to_str() {
+                let this_destination = destination.join(file_name);
+                let this_source = entry.path().try_into()?;
+                if file_type.is_dir() {
+                    copy_dir_all(&this_source, &this_destination)?;
+                } else {
+                    fs::copy(this_source, this_destination)?;
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -1,6 +1,6 @@
-use crate::tools::Runner;
-
 use std::convert::TryFrom;
+
+use crate::tools::Runner;
 
 use anyhow::{Context, Result};
 use assert_fs::TempDir;
@@ -35,6 +35,23 @@ impl GitRunner {
             .exec(&["clone", &repo_url], &self.temp_dir_path, None)?;
 
         let repo_path = self.temp_dir_path.join(repo_name);
+        Ok(repo_path)
+    }
+
+    pub(crate) fn checkout_rover_version(&self, rover_version: &str) -> Result<Utf8PathBuf> {
+        let repo_name = "rover";
+        let repo_url = format!("https://github.com/apollographql/{}", repo_name);
+        self.runner
+            .exec(&["clone", &repo_url], &self.temp_dir_path, None)?;
+
+        let repo_path = self.temp_dir_path.join(repo_name);
+
+        self.runner.exec(
+            &["checkout", &format!("tags/{}", rover_version)],
+            &repo_path,
+            None,
+        )?;
+
         Ok(repo_path)
     }
 }

--- a/xtask/src/tools/make.rs
+++ b/xtask/src/tools/make.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::tools::Runner;
-use crate::utils::CommandOutput;
+use crate::utils::{self, CommandOutput};
 
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -21,9 +21,11 @@ impl MakeRunner {
     pub(crate) fn test_supergraph_demo(&self, base_dir: &Utf8Path) -> Result<()> {
         let mut env = HashMap::new();
         env.insert("ROVER_BIN".to_string(), self.rover_exe.to_string());
-        let output = self.runner.exec(&["ci"], base_dir, Some(env))?;
+        let output = self.runner.exec(&["ci"], base_dir, Some(&env))?;
         assert_demo_includes(&output)
-            .with_context(|| "There were problems with the output of 'make ci'.")
+            .with_context(|| "There were problems with the output of 'make ci'.")?;
+        utils::info("successfully ran supergraph-demo with a local binary.");
+        Ok(())
     }
 }
 

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -108,7 +108,7 @@ impl NpmRunner {
     }
 
     fn npm_exec(&self, args: &[&str], directory: &Utf8PathBuf) -> Result<CommandOutput> {
-        self.runner.exec(args, &directory, None)
+        self.runner.exec(args, directory, None)
     }
 }
 

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -5,7 +5,7 @@ use std::str;
 
 use crate::{
     tools::Runner,
-    utils::{self, CommandOutput, PKG_VERSION},
+    utils::{CommandOutput, PKG_PROJECT_ROOT, PKG_VERSION},
 };
 
 pub(crate) struct NpmRunner {
@@ -17,7 +17,7 @@ pub(crate) struct NpmRunner {
 impl NpmRunner {
     pub(crate) fn new(verbose: bool) -> Result<Self> {
         let runner = Runner::new("npm", verbose)?;
-        let project_root = utils::project_root()?;
+        let project_root = PKG_PROJECT_ROOT.clone();
 
         let npm_lint_directory = project_root.join("crates").join("rover-client");
         let npm_installer_package_directory = project_root.join("installers").join("npm");

--- a/xtask/src/tools/runner.rs
+++ b/xtask/src/tools/runner.rs
@@ -10,9 +10,9 @@ use std::process::{Command, Output, Stdio};
 use std::str;
 
 pub(crate) struct Runner {
-    verbose: bool,
-    tool_name: String,
-    tool_exe: Utf8PathBuf,
+    pub(crate) verbose: bool,
+    pub(crate) tool_name: String,
+    pub(crate) tool_exe: Utf8PathBuf,
 }
 
 impl Runner {

--- a/xtask/src/tools/runner.rs
+++ b/xtask/src/tools/runner.rs
@@ -34,10 +34,18 @@ impl Runner {
         &self,
         args: &[&str],
         directory: &Utf8Path,
-        env: Option<HashMap<String, String>>,
+        env: Option<&HashMap<String, String>>,
     ) -> Result<CommandOutput> {
         let full_command = format!("`{} {}`", &self.tool_name, args.join(" "));
         utils::info(&format!("running {} in `{}`", &full_command, directory));
+        if self.verbose {
+            if let Some(env) = env {
+                utils::info("env:");
+                for (key, value) in env {
+                    utils::info(&format!("  ${}={}", key, value));
+                }
+            }
+        }
 
         let mut command = Command::new(&self.tool_exe);
         command

--- a/xtask/src/tools/strip.rs
+++ b/xtask/src/tools/strip.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 
 use crate::tools::Runner;
-use crate::utils;
+use crate::utils::PKG_PROJECT_ROOT;
 
 pub(crate) struct StripRunner {
     runner: Runner,
@@ -19,7 +19,7 @@ impl StripRunner {
     }
 
     pub(crate) fn run(&self) -> Result<()> {
-        let project_root = utils::project_root()?;
+        let project_root = PKG_PROJECT_ROOT.clone();
         self.runner
             .exec(&[&self.rover_executable.to_string()], &project_root, None)?;
         Ok(())

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -11,6 +11,8 @@ const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 lazy_static! {
     pub(crate) static ref PKG_VERSION: String =
         rover_version().expect("Could not find Rover's version.");
+    pub(crate) static ref PKG_PROJECT_ROOT: Utf8PathBuf =
+        project_root().expect("Could not find Rover's project root.");
 }
 
 pub(crate) fn info(msg: &str) {
@@ -18,7 +20,7 @@ pub(crate) fn info(msg: &str) {
     eprintln!("{} {}", &info_prefix, msg);
 }
 
-pub(crate) fn rover_version() -> Result<String> {
+fn rover_version() -> Result<String> {
     let project_root = project_root()?;
     let metadata = MetadataCommand::new()
         .manifest_path(project_root.join("Cargo.toml"))
@@ -31,7 +33,7 @@ pub(crate) fn rover_version() -> Result<String> {
         .to_string())
 }
 
-pub(crate) fn project_root() -> Result<Utf8PathBuf> {
+fn project_root() -> Result<Utf8PathBuf> {
     let manifest_dir = Utf8PathBuf::try_from(MANIFEST_DIR)
         .with_context(|| "Could not find the root directory.")?;
     let root_dir = manifest_dir


### PR DESCRIPTION
Fixes #696 

## Situation

When we first set up builds for `rover-client`, we were manually downloading the schema and committing it periodically to the repo. Unfortunately, this was creating 7k line diffs on most PRs just from the schema changes, and it wasn't automated. This was a pain! From there, we added the schema to our `.gitignore` and started downloading the schema automatically if the builder was connected to the internet. We then set up an escape hatch for if we ever wanted to substitute a different schema at compile time. (`APOLLO_GRAPHQL_SCHEMA_URL`). 

Due to recent breaking changes in Apollo's GraphQL schema (which shouldn't actually cause issues with Rover aside from codegen), we want to start using `APOLLO_GRAPHQL_SCHEMA_URL` to build Rover with a schema that plays nicely with the types from old versions.

## Problem

Unfortunately, we never tested that using `std::env::var` would work properly in `build.rs` files, and... it turns out they don't. There is a significant difference between the `option_env!` macro, which checks for environment variables at compile time, and `std::env::var` (which is what we were using up until this PR). That means that `APOLLO_GRAPHQL_SCHEMA_URL` is never 

## Resolution

This PR does a few things:

- On every release, upload a copy of the GraphQL API Schema from the point in time when that version of Rover was built.
- Create a new `--version` parameter for `cargo xtask dist` that will go fetch that schema from the GitHub releases API if the automatically downloaded schema fails to build. It does this by cloning the repo into a temp directory, attempting to build once, and when it inevitably fails, it downloads the schema from the version's GitHub release assets and replaces the one it downloaded automatically from Apollo.
- For _newer_ versions of Rover, the `APOLLO_GRAPHQL_SCHEMA_URL` environment variable is _actually_ supported, so `cargo xtask install --version` where `version >= v0.2.0.beta.1` will go straight to GitHub releases to download the schema and we won't have to build twice.