### PR TITLE
docs: Fix link to supergraph schemas

### DIFF
--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -64,7 +64,7 @@ subgraphs:
 
 ### Output format
 
-By default, `supergraph compose` outputs a [supergraph schema](https://apollo-specs.github.io/core/draft/pre-0) document to `stdout`. This will be useful for providing the schema as input to _other_ Rover commands in the future.
+By default, `supergraph compose` outputs a [supergraph schema](https://www.apollographql.com/docs/federation/#federated-schemas) document to `stdout`. This will be useful for providing the schema as input to _other_ Rover commands in the future.
 
 You can also save the output to a local `.graphql` file like so:
 


### PR DESCRIPTION
This link was broken as it stood however rather than updating it to point
to the core schema specification, I've updated it to point to a set of definitions
of supergraph and subgraphs that lives within our Federation documentation.

Fixes https://github.com/apollographql/rover/issues/687