### PR TITLE
fix(xtask): use correct default target if not x86_64

### DIFF
--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -79,18 +79,22 @@ impl Target {
 
 impl Default for Target {
     fn default() -> Self {
-        if cfg!(target_os = "windows") {
-            Target::Windows
-        } else if cfg!(target_os = "linux") {
-            if cfg!(target_env = "gnu") {
-                Target::GnuLinux
-            } else if cfg!(target_env = "musl") {
-                Target::MuslLinux
+        if cfg!(target_arch = "x86_64") {
+            if cfg!(target_os = "windows") {
+                Target::Windows
+            } else if cfg!(target_os = "linux") {
+                if cfg!(target_env = "gnu") {
+                    Target::GnuLinux
+                } else if cfg!(target_env = "musl") {
+                    Target::MuslLinux
+                } else {
+                    Target::Other
+                }
+            } else if cfg!(target_os = "macos") {
+                Target::MacOS
             } else {
                 Target::Other
             }
-        } else if cfg!(target_os = "macos") {
-            Target::MacOS
         } else {
             Target::Other
         }


### PR DESCRIPTION
fixes the issue brought up in #582 by @a7ul - `cargo xtask dist` should now fall back to the default cargo target if it doesn't determine an officially supported x86_64 architecture 😄 