### PR TITLE
Remove root redirect

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,3 +1,1 @@
-/ /docs/rover/
-
 /docs/rover/essentials/ /docs/rover/conventions/

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,6 @@
   ignore  = "false"
 
   command = "gatsby build --prefix-paths && mkdir -p docs/rover && mv public/* docs/rover && mv docs public/ && mv public/docs/rover/_redirects public"
+
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch removes the root-level redirect in the docs and forces deploy previews to be deployed at the root to account for this change.