### PR TITLE
Deploy the prod site at the root

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
-  base    = "docs/"
-  publish = "public/"
+  base    = "docs"
+  publish = "public"
+  command = "gatsby build"
 
   # This next "ignore" setting is telling Netlify build servers to run the
   # actual "false" shell built-in or /bin/false.  It must be quoted as "false"
@@ -14,7 +15,7 @@
   #   https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds
   ignore  = "false"
 
-  command = "gatsby build --prefix-paths && mkdir -p docs/rover && mv public/* docs/rover && mv docs public/ && mv public/docs/rover/_redirects public"
-
-[context.deploy-preview]
-  command = "gatsby build"
+[context.production.environment]
+  PREFIX_PATHS = "true"
+[context.branch-deploy.environment]
+  PREFIX_PATHS = "true"


### PR DESCRIPTION
This branch changes our prod deploy to no longer put its built files in a nested directory structure. This was inspired by https://github.com/apollographql/federation/pull/964#pullrequestreview-732605899 and follows the same patterns already tested and deployed in the Community docs (more info here: https://github.com/apollographql/federation/pull/964#issuecomment-901306430) as well as the docs homepage and Studio docs.

After merging, we'll need to update the website router to reflect this change of location of the built files, but this change will uncomplicate our prod build command considerably.