### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,100 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.2.0] - 2021-08-23
+
+## 🚀 Features
+
+- **Stabilize and document structured output - [EverlastingBugstopper] & [StephenBarlow], [issue/741] & [pull/750]/[pull/752]**
+
+  Rover now has an `--output` parameter on every command that allows you to format Rover's output as well-structured JSON. Documentation for this feature can be found [here](https://www.apollographql.com/docs/rover/configuring/#--output-json).
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [pull/750]: https://github.com/apollographql/rover/pull/750
+  [pull/752]: https://github.com/apollographql/rover/pull/752
+  [issue/741]: https://github.com/apollographql/rover/issues/741
+
+- **Add an error message when an input schema is empty - [EverlastingBugstopper], [issue/724] [pull/726]**
+
+  If the input to `--schema` was ever empty, you'd get some fairly strange and unexpected error messages. Now, if you supply an empty schema via the `--schema` argument, you'll get an error message informing you as such.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/726]: https://github.com/apollographql/rover/pull/726
+  [issue/724]: https://github.com/apollographql/rover/issues/724
+
+- **Retry HTTP requests that respond with 500-599 errors - [EverlastingBugstopper], [issue/693] [pull/727]**
+
+  Now, by default, Rover will retry any requests that result in an internal server error for up to 10 seconds.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/727]: https://github.com/apollographql/rover/pull/727
+  [issue/693]: https://github.com/apollographql/rover/issues/693
+
+## 🐛 Fixes
+
+- **Fix description encodings for introspection results - [lrlna], [issue/728] [pull/742]**
+
+  Rover will now print descriptions for fields and inputs with correct spacing between triple quotes.
+
+  [Author]: https://github.com/Author
+  [pull/742]: https://github.com/apollographql/rover/pull/742
+  [issue/728]: https://github.com/apollographql/rover/issues/728
+
+- **Don't panic on git remotes without an apparent owner - [EverlastingBugstopper], [issue/670] [pull/731]**
+
+  Most git remotes include an author and a repo name, but this isn't always the case. One of Rover's dependencies assumed this _was_ always the case, and would panic if it wasn't the case. This broke workflows for people who had these types of git remotes, but it won't anymore!
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/731]: https://github.com/apollographql/rover/pull/731
+  [issue/670]: https://github.com/apollographql/rover/issues/670
+
+- **Properly send validation period as part of checks configuration - [EverlastingBugstopper], [issue/737] [pull/738]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/738]: https://github.com/apollographql/rover/pull/738
+  [issue/737]: https://github.com/apollographql/rover/issues/737
+
+- **Use correct cargo target for xtask commands - [EverlastingBugstopper], [issue/582] [pull/730]**
+
+  Any `cargo xtask` command that relies on cargo targets will now determine a correct default if building on a machine with a CPU architecture other than `x86_64`
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/730]: https://github.com/apollographql/rover/pull/730
+  [issue/582]: https://github.com/apollographql/rover/issues/582
+
+## 🛠 Maintenance
+
+- **Add `cargo update` to `cargo xtask prep` step - [EverlastingBugstopper], [issue/746] [pull/747]**
+
+  This change makes sure that our dependencies are automatically updated as part of our release process.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/747]: https://github.com/apollographql/rover/pull/747
+  [issue/746]: https://github.com/apollographql/rover/issues/746
+
+- **Further DRY StudioClient - [EverlastingBugstopper], [pull/753]**
+
+  This PR removed some small inconsistencies between HTTP requests made to Apollo Studio vs. those made for user introspection requests.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/753]: https://github.com/apollographql/rover/pull/753
+
+- **Use our GitHub bug report template for auto-generated panic reports - [EverlastingBugstopper], [issue/530] [pull/732]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/732]: https://github.com/apollographql/rover/pull/732
+  [issue/530]: https://github.com/apollographql/rover/issues/530
+
+## 📚 Documentation
+
+- **Deploy Rover's docs at the root to account for main root-level redirect - [trevorblades], [pull/744]**
+
+  This is purely a change to how Rover's docs are rolled out, no user facing changes here.
+
+  [trevorblades]: https://github.com/trevorblades
+  [pull/744]: https://github.com/apollographql/rover/pull/744
+
 
 # [0.2.0-beta.1] - 2021-08-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
  "bytes",
  "fnv",
@@ -1584,9 +1584,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "isahc"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b183576592898e9e007d41b7cf2bc8bb3f8b5d2733b9291e42618d50040e7ba"
+checksum = "431445cb4ba85a80cb1438a9ae8042dadb78ae4046ecee89ad027b614aa0ddb7"
 dependencies = [
  "async-channel",
  "crossbeam-utils",
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
@@ -1696,9 +1696,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libgit2-sys"
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.2.0-beta.1"
+version = "0.2.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2619,18 +2619,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2683,12 +2683,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039ba818c784248423789eec090aab9fb566c7b94d6ebbfa1814a9fd52c8afb2"
+checksum = "6375dbd828ed6964c3748e4ef6d18e7a175d408ffe184bca01698d0c73f915a9"
 dependencies = [
  "dtoa",
- "linked-hash-map",
+ "indexmap",
  "serde",
  "yaml-rust",
 ]
@@ -2911,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2989,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97a06798c64fce2120a9a89413c33c55e9c6ad85654774aaf7c1d279018c639"
+checksum = "d1ea6e542eaec310898d8ba84e5dbda91e95b27e5e023722f0140ca57d72136e"
 dependencies = [
  "crossbeam",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.2.0-beta.1"
+version = "0.2.0"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.2.0-beta.1
+Rover 0.2.0
 
 Rover - Your Graph Companion
 Read the getting started guide by running:

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -230,15 +230,15 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.0.1.tgz",
-      "integrity": "sha512-KxYnp6aHRXxx2B125GXGKELMvcmtJ7hkxwx/8JkZZq1VJOjgVPAxSno5zeXHg9pKVZR8DJ2aojckGg/jCiVQvg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.0.2.tgz",
+      "integrity": "sha512-E5LPCPRYNFinsDMvApuCjRE2XfZy1r1s40ncyNb2aWM2urFJndN+wLCtBPR1KkMraqCsfwavRIHvAoPLQKj43A==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/code-file-loader": "^7.0.1",
-        "@graphql-tools/graphql-tag-pluck": "^7.0.1",
+        "@graphql-tools/code-file-loader": "^7.0.2",
+        "@graphql-tools/graphql-tag-pluck": "^7.0.2",
         "@graphql-tools/import": "^6.3.1",
-        "@graphql-tools/utils": "^8.0.1",
+        "@graphql-tools/utils": "^8.0.2",
         "graphql-config": "^4.0.1",
         "graphql-depth-limit": "1.1.0"
       },
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
-      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -1572,9 +1572,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.3.0.tgz",
-      "integrity": "sha512-53MbSTOmgx5i6hf3DHVD5PrXix1drDmt2ja8MW7NG+aTpKGzkXVLyNcyNpxme4SK8jVtIV6ZIHkiwirqN0efpw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.4.0.tgz",
+      "integrity": "sha512-kxct2hGiVQJJlsfHAYoq41LY9zLkEM5SLCy+ySAOJejwYIMR290sXKzPILG3LQBEaXP9iIAiMN3nVPtOQRE8uA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -2882,15 +2882,15 @@
       }
     },
     "@graphql-eslint/eslint-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.0.1.tgz",
-      "integrity": "sha512-KxYnp6aHRXxx2B125GXGKELMvcmtJ7hkxwx/8JkZZq1VJOjgVPAxSno5zeXHg9pKVZR8DJ2aojckGg/jCiVQvg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.0.2.tgz",
+      "integrity": "sha512-E5LPCPRYNFinsDMvApuCjRE2XfZy1r1s40ncyNb2aWM2urFJndN+wLCtBPR1KkMraqCsfwavRIHvAoPLQKj43A==",
       "dev": true,
       "requires": {
-        "@graphql-tools/code-file-loader": "^7.0.1",
-        "@graphql-tools/graphql-tag-pluck": "^7.0.1",
+        "@graphql-tools/code-file-loader": "^7.0.2",
+        "@graphql-tools/graphql-tag-pluck": "^7.0.2",
         "@graphql-tools/import": "^6.3.1",
-        "@graphql-tools/utils": "^8.0.1",
+        "@graphql-tools/utils": "^8.0.2",
         "graphql-config": "^4.0.1",
         "graphql-depth-limit": "1.1.0"
       }
@@ -3156,9 +3156,9 @@
       }
     },
     "@types/node": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
-      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3927,9 +3927,9 @@
       }
     },
     "graphql-ws": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.3.0.tgz",
-      "integrity": "sha512-53MbSTOmgx5i6hf3DHVD5PrXix1drDmt2ja8MW7NG+aTpKGzkXVLyNcyNpxme4SK8jVtIV6ZIHkiwirqN0efpw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.4.0.tgz",
+      "integrity": "sha512-kxct2hGiVQJJlsfHAYoq41LY9zLkEM5SLCy+ySAOJejwYIMR290sXKzPILG3LQBEaXP9iIAiMN3nVPtOQRE8uA==",
       "dev": true,
       "requires": {}
     },

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.1.9 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.2.0 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.1.9' | iex
+iwr 'https://rover.apollo.dev/win/v0.2.0' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.2.0-beta.1"
+PACKAGE_VERSION="v0.2.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.2.0-beta.1'
+$package_version = 'v0.2.0'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.2.0-beta.1",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.2.0] - 2021-08-23

## 🚀 Features

- **Stabilize and document structured output - [EverlastingBugstopper] & [StephenBarlow], [issue/741] & [pull/750]/[pull/752]**

  Rover now has an `--output` parameter on every command that allows you to format Rover's output as well-structured JSON. Documentation for this feature can be found [here](https://www.apollographql.com/docs/rover/configuring/#--output-json).

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [StephenBarlow]: https://github.com/StephenBarlow
  [pull/750]: https://github.com/apollographql/rover/pull/750
  [pull/752]: https://github.com/apollographql/rover/pull/752
  [issue/741]: https://github.com/apollographql/rover/issues/741

- **Add an error message when an input schema is empty - [EverlastingBugstopper], [issue/724] [pull/726]**

  If the input to `--schema` was ever empty, you'd get some fairly strange and unexpected error messages. Now, if you supply an empty schema via the `--schema` argument, you'll get an error message informing you as such.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/726]: https://github.com/apollographql/rover/pull/726
  [issue/724]: https://github.com/apollographql/rover/issues/724

- **Retry HTTP requests that respond with 500-599 errors - [EverlastingBugstopper], [issue/693] [pull/727]**

  Now, by default, Rover will retry any requests that result in an internal server error for up to 10 seconds.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/727]: https://github.com/apollographql/rover/pull/727
  [issue/693]: https://github.com/apollographql/rover/issues/693

## 🐛 Fixes

- **Fix description encodings for introspection results - [lrlna], [issue/728] [pull/742]**

  Rover will now print descriptions for fields and inputs with correct spacing between triple quotes.

  [lrlna]: https://github.com/lrlna
  [pull/742]: https://github.com/apollographql/rover/pull/742
  [issue/728]: https://github.com/apollographql/rover/issues/728

- **Don't panic on git remotes without an apparent owner - [EverlastingBugstopper], [issue/670] [pull/731]**

  Most git remotes include an author and a repo name, but this isn't always the case. One of Rover's dependencies assumed this _was_ always the case, and would panic if it wasn't the case. This broke workflows for people who had these types of git remotes, but it won't anymore!

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/731]: https://github.com/apollographql/rover/pull/731
  [issue/670]: https://github.com/apollographql/rover/issues/670

- **Properly send validation period as part of checks configuration - [EverlastingBugstopper], [issue/737] [pull/738]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/738]: https://github.com/apollographql/rover/pull/738
  [issue/737]: https://github.com/apollographql/rover/issues/737

- **Use correct cargo target for xtask commands - [EverlastingBugstopper], [issue/582] [pull/730]**

  Any `cargo xtask` command that relies on cargo targets will now determine a correct default if building on a machine with a CPU architecture other than `x86_64`

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/730]: https://github.com/apollographql/rover/pull/730
  [issue/582]: https://github.com/apollographql/rover/issues/582

## 🛠 Maintenance

- **Add `cargo update` to `cargo xtask prep` step - [EverlastingBugstopper], [issue/746] [pull/747]**

  This change makes sure that our dependencies are automatically updated as part of our release process.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/747]: https://github.com/apollographql/rover/pull/747
  [issue/746]: https://github.com/apollographql/rover/issues/746

- **Further DRY StudioClient - [EverlastingBugstopper], [pull/753]**

  This PR removed some small inconsistencies between HTTP requests made to Apollo Studio vs. those made for user introspection requests.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/753]: https://github.com/apollographql/rover/pull/753

- **Use our GitHub bug report template for auto-generated panic reports - [EverlastingBugstopper], [issue/530] [pull/732]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/732]: https://github.com/apollographql/rover/pull/732
  [issue/530]: https://github.com/apollographql/rover/issues/530

## 📚 Documentation

- **Deploy Rover's docs at the root to account for main root-level redirect - [trevorblades], [pull/744]**

  This is purely a change to how Rover's docs are rolled out, no user facing changes here.

  [trevorblades]: https://github.com/trevorblades
  [pull/744]: https://github.com/apollographql/rover/pull/744