### PR TITLE
feat: adds APOLLO_FIRE_FLOWER env var

### DIFF
--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -14,6 +14,7 @@ pub struct StudioClient {
     credential: Credential,
     client: GraphQLClient,
     version: String,
+    is_sudo: bool,
 }
 
 impl StudioClient {
@@ -23,12 +24,14 @@ impl StudioClient {
         credential: Credential,
         graphql_endpoint: &str,
         version: &str,
+        is_sudo: bool,
         client: ReqwestClient,
     ) -> Result<StudioClient, ReqwestError> {
         Ok(StudioClient {
             credential,
             client: GraphQLClient::new(graphql_endpoint, client)?,
             version: version.to_string(),
+            is_sudo,
         })
     }
 
@@ -68,6 +71,10 @@ impl StudioClient {
         let mut api_key = HeaderValue::from_str(&self.credential.api_key)?;
         api_key.set_sensitive(true);
         headers.insert("x-api-key", api_key);
+
+        if self.is_sudo {
+            headers.insert("apollo-sudo", HeaderValue::from_str("true")?);
+        }
 
         Ok(headers)
     }

--- a/crates/rover-client/tests/client.rs
+++ b/crates/rover-client/tests/client.rs
@@ -31,7 +31,8 @@ mod tests {
             },
             "0.1.0",
             STUDIO_PROD_API_ENDPOINT,
-            get_client()
+            false,
+            get_client(),
         )
         .is_ok());
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,10 +177,17 @@ impl Rover {
 
     pub(crate) fn get_client_config(&self) -> Result<StudioClientConfig> {
         let override_endpoint = self.env_store.get(RoverEnvKey::RegistryUrl)?;
+        let is_sudo = if let Some(fire_flower) = self.env_store.get(RoverEnvKey::FireFlower)? {
+            let fire_flower = fire_flower.to_lowercase();
+            fire_flower == "true" || fire_flower == "1"
+        } else {
+            false
+        };
         let config = self.get_rover_config()?;
         Ok(StudioClientConfig::new(
             override_endpoint,
             config,
+            is_sudo,
             self.get_reqwest_client(),
         ))
     }

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -168,6 +168,7 @@ mod tests {
         StudioClientConfig::new(
             None,
             Config::new(Some(&tmp_path), None).unwrap(),
+            false,
             Client::new(),
         )
     }

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -13,12 +13,14 @@ pub struct StudioClientConfig {
     client: Client,
     uri: String,
     version: String,
+    is_sudo: bool,
 }
 
 impl StudioClientConfig {
     pub fn new(
         override_endpoint: Option<String>,
         config: config::Config,
+        is_sudo: bool,
         client: Client,
     ) -> StudioClientConfig {
         let version = if cfg!(debug_assertions) {
@@ -32,6 +34,7 @@ impl StudioClientConfig {
             config,
             version,
             client,
+            is_sudo,
         }
     }
 
@@ -46,6 +49,7 @@ impl StudioClientConfig {
             credential,
             &self.uri,
             &self.version,
+            self.is_sudo,
             self.get_reqwest_client(),
         )?)
     }

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -109,6 +109,7 @@ impl RoverEnv {
 #[derive(Debug, Copy, Clone)]
 pub enum RoverEnvKey {
     ConfigHome,
+    FireFlower,
     Home,
     Key,
     RegistryUrl,


### PR DESCRIPTION
fixes #577 by adding support for the `APOLLO_FIRE_FLOWER` environment variable. This variable can be set to `true` or `1` and the `apollo-sudo: true` header will be sent to the Apollo API. This header will not be sent to user infrastructure during introspection requests, and will remain undocumented as this header is for internal use only.

cc @zionts 