### PR TITLE
chore(ci): run tests with an older glibc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,12 +61,12 @@ jobs:
         enum: ["lint", "unit-test", "integration-test"]
     executor: << parameters.platform >>
     steps:
+      - checkout
       - install_system_deps:
           platform: << parameters.platform >>
           rust_channel: << parameters.rust_channel >>
       - run:
           command: ldd --version
-      - checkout
       - exec_xtask:
           command: << parameters.command >>
           platform: << parameters.platform >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,16 @@ commands:
             - rust-target-v1-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
       - when:
           condition:
+            and:
+              - equal: [ *ubuntu_executor, << parameters.platform >> ]
+              - equal: [ "integration-test", << parameters.command >> ]
+          steps:
+            - run:
+                command: ls -la
+            - attach_workspace:
+                at: target/
+      - when:
+          condition:
             # cargo xtask lint is the only xtask command that doesn't take a target
             equal: [ lint, << parameters.command >> ]
           steps:
@@ -243,4 +253,16 @@ commands:
           key: rust-target-v1-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
           paths:
             - target/
+      - when:
+          condition:
+            and:
+              - equal: [ *centos_executor, << parameters.platform >> ]
+              - equal: [ "unit-test", << parameters.command >> ]
+          steps:
+            - run:
+                command: ls -la
+            - persist_to_workspace:
+                root: workspace
+                paths:
+                  - target/
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ commands:
             - run:
                 command: ls -la
             - persist_to_workspace:
-                root: workspace
+                root: ./
                 paths:
                   - target/
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,19 +23,17 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [centos, ubuntu, musl, macos, windows]
+              platform: [centos, musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
       - xtask:
-          name: Supergraph demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
+          name: Cargo tests and supergraph demo (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
               platform: [ubuntu]
               rust_channel: [stable]
-              command: [integration-test]
-          requires:
-            - Cargo tests (<< matrix.rust_channel >> rust on ubuntu)
+              command: [test]
 
 jobs:
   xtask:
@@ -48,7 +46,7 @@ jobs:
         type: executor
       command:
         type: enum
-        enum: ["lint", "unit-test", "integration-test"]
+        enum: ["lint", "unit-test", "integration-test", "test", "dist"]
     executor: << parameters.platform >>
     steps:
       - checkout
@@ -67,6 +65,7 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
+      CHECK_GLIBC: "true"
 
   musl: &musl_executor
     docker:
@@ -216,7 +215,7 @@ commands:
     parameters:
       command:
         type: enum
-        enum: [lint, integration-test, unit-test]
+        enum: [lint, integration-test, unit-test, "test", "dist"]
       platform:
         type: executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
           name: Lint (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker]
+              platform: [centos]
               rust_channel: [stable]
               command: [lint]
   test:
@@ -23,7 +23,7 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker, buster_docker, xenial_docker, centos_docker, ubuntu_musl, macos, windows]
+              platform: [centos, musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
@@ -31,11 +31,11 @@ workflows:
           name: Supergraph demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_vm]
+              platform: [ubuntu]
               rust_channel: [stable]
               command: [integration-test]
           requires:
-            - Cargo tests (<< matrix.rust_channel >> rust on ubuntu_gnu_docker)
+            - Cargo tests (<< matrix.rust_channel >> rust on centos)
 
 jobs:
   xtask:
@@ -56,45 +56,19 @@ jobs:
           platform: << parameters.platform >>
           rust_channel: << parameters.rust_channel >>
       - exec_xtask:
-          command: << parameters.command >>
           platform: << parameters.platform >>
+          command: << parameters.command >>
 
 # The machines we use to run our workflows on
 executors:
-  ubuntu_gnu_docker: &ubuntu_gnu_docker_executor
-    docker:
-      - image: cimg/base:stable
-    resource_class: xlarge
-    environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
-  buster_docker: &buster_docker_executor
-    docker:
-      - image: circleci/buildpack-deps:buster-curl
-    resource_class: xlarge
-    environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
-  xenial_docker: &xenial_docker_executor
-    docker:
-      - image: circleci/buildpack-deps:xenial-curl
-    resource_class: xlarge
-    environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
-  centos_docker: &centos_docker_executor
+  centos: &centos_executor
     docker:
       - image: centos:7
     resource_class: xlarge
     environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
+      XTASK_TARGET: "x86_64-unknown-linux-ubuntu"
 
-  # This is only used to run supergraph-demo since you can't run Docker from Docker
-  ubuntu_gnu_vm: &ubuntu_gnu_vm_executor
-    machine:
-      image: ubuntu-1604:202104-01
-    resource_class: xlarge
-    environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
-
-  ubuntu_musl: &ubuntu_musl_executor
+  musl: &musl_executor
     docker:
       - image: cimg/base:stable
     resource_class: xlarge
@@ -116,6 +90,14 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-pc-windows-msvc"
 
+  # This is only used to run supergraph-demo since you can't run Docker from Docker
+  ubuntu: &ubuntu_executor
+    machine:
+      image: ubuntu-2004:202010-01
+    resource_class: xlarge
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-ubuntu"
+
 # reusable command snippets can be referred to in any `steps` object
 commands:
   install_system_deps:
@@ -129,12 +111,8 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
-              - equal: [ *buster_docker_executor, << parameters.platform >> ]
-              - equal: [ *xenial_docker_executor, << parameters.platform >> ]
-              - equal: [ *ubuntu_gnu_vm_executor, << parameters.platform >> ]
-              - equal: [ *ubuntu_musl_executor, << parameters.platform >> ]
-              - equal: [ *centos_docker_executor, << parameters.platform >> ]
+              - equal: [ *ubuntu_executor, << parameters.platform >> ]
+              - equal: [ *musl_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Update apt repositories
@@ -145,20 +123,21 @@ commands:
             - run:
                 name: Install OpenSSL
                 command: sudo apt-get install -y libssl-dev
-      - when:
-          condition:
-            or:
-              - equal: [ *buster_docker_executor, << parameters.platform >> ]
-              - equal: [ *xenial_docker_executor, << parameters.platform >> ]
-              - equal: [ *centos_docker_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Install build-essential and pkg-config
-                command: sudo apt-get install -y build-essential pkg-config
 
       - when:
           condition:
-            equal: [ *ubuntu_musl_executor, << parameters.platform >> ]
+            equal: [ *centos_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Upgrade yum packages
+                command: yum update
+            - run:
+                name: Check glibc version
+                command: ldd --version
+
+      - when:
+          condition:
+            equal: [ *musl_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Install musl-tools
@@ -166,7 +145,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
+              - equal: [ *ubuntu_executor, << parameters.platform >> ]
           steps:
             - node/install:
                 node-version: "14.17.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
           name: Lint (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [centos]
+              platform: [ubuntu]
               rust_channel: [stable]
               command: [lint]
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker, ubuntu_musl, macos, windows]
+              platform: [ubuntu_gnu_docker, ubuntu_gnu_docker_dind, ubuntu_musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
@@ -36,6 +36,16 @@ workflows:
               command: [integration-test]
           requires:
             - Cargo tests (<< matrix.rust_channel >> rust on ubuntu_gnu_docker)
+
+      - xtask:
+          name: Supergraph demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
+          matrix:
+            parameters:
+              platform: [ubuntu_gnu_docker_dind]
+              rust_channel: [stable]
+              command: [integration-test]
+          requires:
+            - Cargo tests (<< matrix.rust_channel >> rust on ubuntu_gnu_docker_dind)
 
 jobs:
   xtask:
@@ -51,10 +61,12 @@ jobs:
         enum: ["lint", "unit-test", "integration-test"]
     executor: << parameters.platform >>
     steps:
-      - checkout
       - install_system_deps:
           platform: << parameters.platform >>
           rust_channel: << parameters.rust_channel >>
+      - run:
+          command: ldd --version
+      - checkout
       - exec_xtask:
           command: << parameters.command >>
           platform: << parameters.platform >>
@@ -64,6 +76,12 @@ executors:
   ubuntu_gnu_docker: &ubuntu_gnu_docker_executor
     docker:
       - image: cimg/base:stable
+    resource_class: xlarge
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
+  ubuntu_gnu_docker_dind: &ubuntu_gnu_docker_dind_executor
+    docker:
+      - image: circleci/buildpack-deps:buster-curl-dind
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [centos, musl, macos, windows]
+              platform: [centos, ubuntu, musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
@@ -35,7 +35,7 @@ workflows:
               rust_channel: [stable]
               command: [integration-test]
           requires:
-            - Cargo tests (<< matrix.rust_channel >> rust on centos)
+            - Cargo tests (<< matrix.rust_channel >> rust on ubuntu)
 
 jobs:
   xtask:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,9 @@ commands:
             - run:
                 name: Install OpenSSL
                 command: sudo apt-get install -y libssl-dev
+            - run:
+                name: Install build-essential
+                command: sudo apt-get install -y build-essential
       - when:
           condition:
             equal: [ *ubuntu_musl_executor, << parameters.platform >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker, buster_docker, ubuntu_musl, macos, windows]
+              platform: [ubuntu_gnu_docker, buster_docker, xenial_docker, ubuntu_musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
@@ -73,6 +73,12 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
+  xenial_docker: &xenial_docker_executor
+    docker:
+      - image: circleci/buildpack-deps:xenial-curl
+    resource_class: xlarge
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
   # This is only used to run supergraph-demo since you can't run Docker from Docker
   ubuntu_gnu_vm: &ubuntu_gnu_vm_executor
@@ -119,6 +125,7 @@ commands:
             or:
               - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
               - equal: [ *buster_docker_executor, << parameters.platform >> ]
+              - equal: [ *xenial_docker_executor, << parameters.platform >> ]
               - equal: [ *ubuntu_gnu_vm_executor, << parameters.platform >> ]
               - equal: [ *ubuntu_musl_executor, << parameters.platform >> ]
           steps:
@@ -133,7 +140,9 @@ commands:
                 command: sudo apt-get install -y libssl-dev
       - when:
           condition:
-            equal: [ *buster_docker_executor, << parameters.platform >> ]
+            or:
+              - equal: [ *buster_docker_executor, << parameters.platform >> ]
+              - equal: [ *xenial_docker_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Install build-essential and pkg-config
@@ -150,7 +159,6 @@ commands:
           condition:
             or:
               - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
-              - equal: [ *buster_docker_executor, << parameters.platform >> ]
           steps:
             - node/install:
                 node-version: "14.17.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
-  buster_docker: &ubuntu_gnu_docker_executor
+  buster_docker: &buster_docker_executor
     docker:
       - image: circleci/buildpack-deps:buster-curl
     resource_class: xlarge
@@ -130,6 +130,7 @@ commands:
           condition:
             or:
               - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
+              - equal: [ *buster_docker_executor, << parameters.platform >> ]
               - equal: [ *ubuntu_gnu_vm_executor, << parameters.platform >> ]
               - equal: [ *ubuntu_musl_executor, << parameters.platform >> ]
           steps:
@@ -148,7 +149,9 @@ commands:
                 command: sudo apt-get install -y musl-tools
       - when:
           condition:
-            equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
+            or:
+              - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
+              - equal: [ *buster_docker_executor, << parameters.platform >> ]
           steps:
             - node/install:
                 node-version: "14.17.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,8 @@ commands:
                 name: Update and upgrade yum packages
                 command: yum -y update && yum -y upgrade
             - run:
-                name: Install cmake
-                command: yum -y install cmake
+                name: Install gcc
+                command: yum -y install gcc
             - run:
                 name: Check glibc version
                 command: ldd --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,9 @@ commands:
                 name: Update and upgrade yum packages
                 command: yum -y update && yum -y upgrade
             - run:
+                name: Install cmake
+                command: yum -y install cmake
+            - run:
                 name: Check glibc version
                 command: ldd --version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,14 @@ commands:
             - run:
                 name: Install OpenSSL
                 command: sudo apt-get install -y libssl-dev
+      - when:
+          condition:
+            equal: [ *buster_docker_executor, << parameters.platform >> ]
+          steps:
             - run:
-                name: Install build-essential
-                command: sudo apt-get install -y build-essential
+                name: Install build-essential and pkg-config
+                command: sudo apt-get install -y build-essential pkg-config
+
       - when:
           condition:
             equal: [ *ubuntu_musl_executor, << parameters.platform >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,6 @@ workflows:
           requires:
             - Cargo tests (<< matrix.rust_channel >> rust on ubuntu_gnu_docker)
 
-      - xtask:
-          name: Supergraph demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
-          matrix:
-            parameters:
-              platform: [buster_docker]
-              rust_channel: [stable]
-              command: [integration-test]
-          requires:
-            - Cargo tests (<< matrix.rust_channel >> rust on buster_docker)
-
 jobs:
   xtask:
     parameters:
@@ -178,16 +168,6 @@ commands:
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
-      - when:
-          condition:
-            or:
-              - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
-              - equal: [ *buster_docker_executor, << parameters.platform >> ]
-              - equal: [ *ubuntu_gnu_vm_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Check Rover's glibc version
-                command: ./check_glibc.sh ./target/debug/$XTASK_TARGET/rover
 
   install_rust_toolchain:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker, buster_docker, xenial_docker, ubuntu_musl, macos, windows]
+              platform: [ubuntu_gnu_docker, buster_docker, xenial_docker, centos_docker, ubuntu_musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
@@ -79,6 +79,12 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
+  centos_docker: &centos_docker_executor
+    docker:
+      - image: centos/7
+    resource_class: xlarge
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
   # This is only used to run supergraph-demo since you can't run Docker from Docker
   ubuntu_gnu_vm: &ubuntu_gnu_vm_executor
@@ -128,6 +134,7 @@ commands:
               - equal: [ *xenial_docker_executor, << parameters.platform >> ]
               - equal: [ *ubuntu_gnu_vm_executor, << parameters.platform >> ]
               - equal: [ *ubuntu_musl_executor, << parameters.platform >> ]
+              - equal: [ *centos_docker_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Update apt repositories
@@ -143,6 +150,7 @@ commands:
             or:
               - equal: [ *buster_docker_executor, << parameters.platform >> ]
               - equal: [ *xenial_docker_executor, << parameters.platform >> ]
+              - equal: [ *centos_docker_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Install build-essential and pkg-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,6 @@ jobs:
       - install_system_deps:
           platform: << parameters.platform >>
           rust_channel: << parameters.rust_channel >>
-      - run:
-          command: ldd --version
       - exec_xtask:
           command: << parameters.command >>
           platform: << parameters.platform >>
@@ -138,6 +136,9 @@ commands:
                 name: Update apt repositories
                 command: sudo apt-get update
             - run:
+                name: Check glibc version
+                command: ldd --version
+            - run:
                 name: Install OpenSSL
                 command: sudo apt-get install -y libssl-dev
       - when:
@@ -177,6 +178,16 @@ commands:
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
+      - when:
+          condition:
+            or:
+              - equal: [ *ubuntu_gnu_docker_executor, << parameters.platform >> ]
+              - equal: [ *buster_docker_executor, << parameters.platform >> ]
+              - equal: [ *ubuntu_gnu_vm_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Check Rover's glibc version
+                command: ./check_glibc.sh ./target/debug/$XTASK_TARGET/rover
 
   install_rust_toolchain:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,8 @@ commands:
                 name: Update and upgrade yum packages
                 command: yum -y update && yum -y upgrade
             - run:
-                name: Install gcc
-                command: yum -y install gcc
+                name: Install gcc and OpenSSL
+                command: yum -y install gcc openssl-devel
             - run:
                 name: Check glibc version
                 command: ldd --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ executors:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
   centos_docker: &centos_docker_executor
     docker:
-      - image: centos/7
+      - image: centos:7
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,9 @@ commands:
                 name: Update and upgrade yum packages
                 command: yum -y update && yum -y upgrade
             - run:
+                name: Install development tools
+                command: yum groupinstall -y "Development Tools"
+            - run:
                 name: Install gcc and OpenSSL
                 command: yum -y install gcc openssl-devel
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           name: Cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker, ubuntu_gnu_docker_dind, ubuntu_musl, macos, windows]
+              platform: [ubuntu_gnu_docker, buster_docker, ubuntu_musl, macos, windows]
               rust_channel: [stable]
               command: [unit-test]
 
@@ -41,11 +41,11 @@ workflows:
           name: Supergraph demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [ubuntu_gnu_docker_dind]
+              platform: [buster_docker]
               rust_channel: [stable]
               command: [integration-test]
           requires:
-            - Cargo tests (<< matrix.rust_channel >> rust on ubuntu_gnu_docker_dind)
+            - Cargo tests (<< matrix.rust_channel >> rust on buster_docker)
 
 jobs:
   xtask:
@@ -79,9 +79,9 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
-  ubuntu_gnu_docker_dind: &ubuntu_gnu_docker_dind_executor
+  buster_docker: &ubuntu_gnu_docker_executor
     docker:
-      - image: circleci/buildpack-deps:buster-curl-dind
+      - image: circleci/buildpack-deps:buster-curl
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ commands:
             equal: [ *centos_executor, << parameters.platform >> ]
           steps:
             - run:
-                name: Upgrade yum packages
-                command: yum update
+                name: Update and upgrade yum packages
+                command: yum -y update && yum -y upgrade
             - run:
                 name: Check glibc version
                 command: ldd --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,16 +225,6 @@ commands:
             - rust-target-v1-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
       - when:
           condition:
-            and:
-              - equal: [ *ubuntu_executor, << parameters.platform >> ]
-              - equal: [ "integration-test", << parameters.command >> ]
-          steps:
-            - run:
-                command: ls -la
-            - attach_workspace:
-                at: target/
-      - when:
-          condition:
             # cargo xtask lint is the only xtask command that doesn't take a target
             equal: [ lint, << parameters.command >> ]
           steps:
@@ -253,16 +243,4 @@ commands:
           key: rust-target-v1-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
           paths:
             - target/
-      - when:
-          condition:
-            and:
-              - equal: [ *centos_executor, << parameters.platform >> ]
-              - equal: [ "unit-test", << parameters.command >> ]
-          steps:
-            - run:
-                command: ls -la
-            - persist_to_workspace:
-                root: ./
-                paths:
-                  - target/
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ executors:
       - image: centos:7
     resource_class: xlarge
     environment:
-      XTASK_TARGET: "x86_64-unknown-linux-ubuntu"
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
   musl: &musl_executor
     docker:
@@ -96,7 +96,7 @@ executors:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     environment:
-      XTASK_TARGET: "x86_64-unknown-linux-ubuntu"
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
 # reusable command snippets can be referred to in any `steps` object
 commands:

--- a/check_glibc.sh
+++ b/check_glibc.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# This scripts checks if Rover's compiled executable only asks for 
+# supported versions of glibc
+
+# source: https://gist.github.com/fasterthanlime/17e002a8f5e0f189861c
+
+# usage: ./check_glibc.sh ./target/debug/rover
+
+MAX_VER=2.18
+
+SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+BINARY=$1
+
+# Version comparison function in bash
+vercomp () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+IFS="
+"
+VERS=$(objdump -T $BINARY | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -u)
+
+for VER in $VERS; do
+  vercomp $VER $MAX_VER
+  COMP=$?
+  if [[ $COMP -eq 1 ]]; then
+    echo "Error! ${BINARY} requests GLIBC ${VER}, which is higher than target ${MAX_VER}"
+    echo "Affected symbols:"
+    objdump -T $BINARY | grep GLIBC_${VER}
+    echo "Looking for symbols in libraries..."
+    for LIBRARY in $(ldd $BINARY | cut -d ' ' -f 3); do
+      echo $LIBRARY
+      objdump -T $LIBRARY | fgrep GLIBC_${VER}
+    done
+    exit 27
+  else
+    echo "Found version ${VER}"
+  fi
+done

--- a/xtask/src/commands/unit_test.rs
+++ b/xtask/src/commands/unit_test.rs
@@ -6,7 +6,7 @@ use crate::target::{Target, POSSIBLE_TARGETS};
 use crate::tools::{CargoRunner, Runner};
 use crate::utils::PKG_PROJECT_ROOT;
 
-use std::str::FromStr;
+use std::{env, str::FromStr};
 
 #[derive(Debug, StructOpt)]
 pub struct UnitTest {
@@ -20,14 +20,19 @@ impl UnitTest {
         let mut cargo_runner = CargoRunner::new(verbose)?;
         cargo_runner.test(&self.target)?;
 
-        let check_glibc_script = "./check_glibc.sh".to_string();
-        let runner = Runner {
-            verbose,
-            tool_name: check_glibc_script.clone(),
-            tool_exe: Utf8PathBuf::from_str(&check_glibc_script)?,
-        };
-        let bin_path = format!("./target/{}/debug/rover", &self.target);
-        runner.exec(&[&bin_path], &PKG_PROJECT_ROOT, None)?;
+        if let Target::GnuLinux = self.target {
+            if env::var_os("CI").is_some() {
+                let check_glibc_script = "./check_glibc.sh".to_string();
+                let runner = Runner {
+                    verbose,
+                    tool_name: check_glibc_script.clone(),
+                    tool_exe: Utf8PathBuf::from_str(&check_glibc_script)?,
+                };
+                let bin_path = format!("./target/{}/debug/rover", &self.target);
+                runner.exec(&[&bin_path], &PKG_PROJECT_ROOT, None)?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/xtask/src/commands/unit_test.rs
+++ b/xtask/src/commands/unit_test.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
+use camino::Utf8PathBuf;
 use structopt::StructOpt;
 
 use crate::target::{Target, POSSIBLE_TARGETS};
-use crate::tools::CargoRunner;
+use crate::tools::{CargoRunner, Runner};
+use crate::utils::PKG_PROJECT_ROOT;
+
+use std::str::FromStr;
 
 #[derive(Debug, StructOpt)]
 pub struct UnitTest {
@@ -15,6 +19,15 @@ impl UnitTest {
     pub fn run(&self, verbose: bool) -> Result<()> {
         let mut cargo_runner = CargoRunner::new(verbose)?;
         cargo_runner.test(&self.target)?;
+
+        let check_glibc_script = "./check_glibc.sh".to_string();
+        let runner = Runner {
+            verbose,
+            tool_name: check_glibc_script.clone(),
+            tool_exe: Utf8PathBuf::from_str(&check_glibc_script)?,
+        };
+        let bin_path = format!("./target/{}/debug/rover", &self.target);
+        runner.exec(&[&bin_path], &PKG_PROJECT_ROOT, None)?;
         Ok(())
     }
 }

--- a/xtask/src/commands/unit_test.rs
+++ b/xtask/src/commands/unit_test.rs
@@ -21,7 +21,7 @@ impl UnitTest {
         cargo_runner.test(&self.target)?;
 
         if let Target::GnuLinux = self.target {
-            if env::var_os("CI").is_some() {
+            if env::var_os("CHECK_GLIBC").is_some() {
                 let check_glibc_script = "./check_glibc.sh".to_string();
                 let runner = Runner {
                     verbose,


### PR DESCRIPTION
This PR adds a centos image to our CircleCI testing matrix, and asserts that it doesn't emit a binary that has glibc symbols that are >= 2.18, which is what we advertise you need to run Rover.