### PR TITLE
release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,61 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [0.2.1] - 2021-09-20
+
+## 🐛 Fixes
+
+- **Properly swallow unparseable git remotes - [EverlastingBugstopper], [issue/670] [pull/760]**
+
+  In v0.2.0, we fixed a crash that occurred for users with non-standard git remotes. While the crash
+  itself no longer occurred, the crash report itself was still generated - this is no longer the case.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/760]: https://github.com/apollographql/rover/pull/760
+  [issue/670]: https://github.com/apollographql/rover/issues/670
+
+## 🛠 Maintenance
+
+- **Move markdown link checker to `cargo xtask lint` - [EverlastingBugstopper], [issue/774] [pull/778]**
+
+  We now check for broken markdown links through `xtask`, meaning you can more accurately check if CI will pass locally.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/778]: https://github.com/apollographql/rover/pull/778
+  [issue/774]: https://github.com/apollographql/rover/issues/774
+
+- **Migrate lints/tests from GitHub Actions to CircleCI - [EverlastingBugstopper], [issue/774] [pull/781]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/781]: https://github.com/apollographql/rover/pull/781
+  [issue/774]: https://github.com/apollographql/rover/issues/774
+
+- **Run tests on centos 7 and ensure the binary only depends on glibc <= 2.18 - [EverlastingBugstopper], [pull/800]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/800]: https://github.com/apollographql/rover/pull/800
+
+- **Migrate release process from GitHub Actions to CircleCI - [EverlastingBugstopper], [issue/795] [pull/808]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/808]: https://github.com/apollographql/rover/pull/808
+  [issue/795]: https://github.com/apollographql/rover/issues/795
+
+## 📚 Documentation
+
+- **Clarifies setting HEAD SHA for GitHub Actions - [StephenBarlow], [pull/763]**
+
+  Extended the [section in the docs](https://www.apollographql.com/docs/rover/ci-cd/#github-actions) for configuring GitHub Actions
+  to include instructions for properly configuring the git context.
+
+  [StephenBarlow]: https://github.com/StephenBarlow
+  [pull/763]: https://github.com/apollographql/rover/pull/763
+
+- **Fix a typo in the docs - [SaintMalik], [pull/762]**
+
+  [SaintMalik]: https://github.com/SaintMalik
+  [pull/762]: https://github.com/apollographql/rover/pull/762
+
 # [0.2.0] - 2021-08-23
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.2.0"
+version = "0.2.1"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.2.0
+Rover 0.2.1
 
 Rover - Your Graph Companion
 Read the getting started guide by running:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -26,9 +26,9 @@ If you are releasing a beta or a release candidate, no official changelog is nee
 1. Make sure you have both `npm` and `cargo` installed on your machine and in your `PATH`.
 1. Create a new branch "#.#.#" where "#.#.#" is this release's version (release) or "#.#.#-rc.#" (release candidate)
 1. Update the version in `Cargo.toml`.
-1. Run `cargo xtask prep` (this will require `npm` to be installed).
-1. Run `cargo run -- help` and copy the output to the help section in `README.md`.
 1. Update the installer versions in `docs/source/getting-started.md` (eventually this should be automated).
+1. Run `cargo run -- help` and copy the output to the help section in `README.md`.
+1. Run `cargo xtask prep` (this will require `npm` to be installed).
 1. Push up a commit with the `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, and `./installers/npm` changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"
 1. Request review from the Apollo GraphQL tooling team.
 

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -32,12 +32,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -46,59 +46,59 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -131,32 +131,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.0.2.tgz",
-      "integrity": "sha512-E5LPCPRYNFinsDMvApuCjRE2XfZy1r1s40ncyNb2aWM2urFJndN+wLCtBPR1KkMraqCsfwavRIHvAoPLQKj43A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+      "integrity": "sha512-LNrXRsSNeOdVL2zTnRpJk689R1LC+Ck2xAdeYYxBB87yW8eAVS80On2bkgxVm8Y9UA23sXMdhEPfgsJPb/qH2A==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/code-file-loader": "^7.0.2",
@@ -241,139 +241,134 @@
         "@graphql-tools/import": "^6.3.1",
         "@graphql-tools/utils": "^8.0.2",
         "graphql-config": "^4.0.1",
-        "graphql-depth-limit": "1.1.0"
+        "graphql-depth-limit": "1.1.0",
+        "lodash.lowercase": "^4.3.0"
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.0.5.tgz",
-      "integrity": "sha512-Zx+zs12BLGNvrQtfESIhitzwIkrWnKyKOkAfcaMNuOLGOO2pDmhwIRzbHj+6Jtq9V1/JTaVkSnm/4ozaCRck5A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.1.0.tgz",
+      "integrity": "sha512-PPf8SZto4elBtkaV65RldkjvxCuwYV7tLYKH+w6QnsxogfjrtiwijmewtqIlfnpPRnuhmMzmOlhoDyf0I8EwHw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/utils": "^8.2.0",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/code-file-loader": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.0.6.tgz",
-      "integrity": "sha512-+xddAWyvrcW5Em3Yx+RJ7vwFMyOoS8pwqgeVr0CTZF9YbrQSPz7wQJRAVFZNJQaJOalKlPWxsmKkSyMQRG+t4A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.1.0.tgz",
+      "integrity": "sha512-1EVuKGzTDcZoPQAjJYy0Fw2vwLN1ZnWYDlCZLaqml87tCUzJcqcHlQw26SRhDEvVnJC/oCV+mH+2QE55UxqWuA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "^7.0.5",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.1.0.tgz",
-      "integrity": "sha512-jJmty2rr4k2k6pG3H0qoCH9LDezjyVe0wLNUbVQcSfWBj1VgeHX6BF4qgbT5HsDD3oOP8ruiHZgbn6EbrOwDfA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.2.1.tgz",
+      "integrity": "sha512-fvQjSrCJCfchSQlLNHPcj1TwojyV1CPtXmwtSEVKvyp9axokuP37WGyliOWUYCepfwpklklLFUeTEiWlCoxv2Q==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/batch-execute": "^8.0.5",
-        "@graphql-tools/schema": "^8.1.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/batch-execute": "^8.1.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.0.5.tgz",
-      "integrity": "sha512-hYdz/zvA2z2M6zqgTCkEiqWPIKLsFirg1ZawaKzCLN0sUi+hRrLVTc1eIlz/vfR8ojvswEq81OMtk5d+lbHiHQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.1.0.tgz",
+      "integrity": "sha512-VWGetkBuyWrUxSpMnbpzZs2yHWBFeo9nTYjc8+o+xyJKpG/CRfvQrhBRNRFfV/5C0j5/Z1FMfUgsroEAG5H3HQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/import": "^6.2.6",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/import": "^6.4.0",
+        "@graphql-tools/utils": "^8.2.0",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.0.5.tgz",
-      "integrity": "sha512-/eNFl/4gshnlgNvx1Koaey3036edcv5/Nko+px/DbkfjKedwikRWubURcCaMp/4VE6CyIUibxRrP6TzVByhVrw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.1.tgz",
+      "integrity": "sha512-p+FhiiNJi02o4Y/hnT4SSRZnDvv/UcjnZJII3F4ljlteluCAwP+hPgAmbKVwOaaGfsOmMPmiAeeTWt8i23auyg==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "7.15.3",
-        "@babel/traverse": "7.15.0",
-        "@babel/types": "7.15.0",
-        "@graphql-tools/utils": "^8.1.1",
+        "@babel/parser": "7.15.6",
+        "@babel/traverse": "7.15.4",
+        "@babel/types": "7.15.6",
+        "@graphql-tools/utils": "^8.2.0",
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.3.1.tgz",
-      "integrity": "sha512-1szR19JI6WPibjYurMLdadHKZoG9C//8I/FZ0Dt4vJSbrMdVNp8WFxg4QnZrDeMG4MzZc90etsyF5ofKjcC+jw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.0.tgz",
+      "integrity": "sha512-jfE01oPcmc4vzAcYLs6xT7XC4jJWrM1HNtIwc7HyyHTxrC3nf36XrF3txEZ2l20GT53+OWnMgYx1HhauLGdJmA==",
       "dev": true,
       "dependencies": {
         "resolve-from": "5.0.0",
-        "tslib": "~2.2.0"
+        "tslib": "~2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/import/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "dev": true
-    },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.1.2.tgz",
-      "integrity": "sha512-/CrnNBwi4WDvt4yc2PcRmQxqGIOtK84s4iI5vsHwlcK7D02WX1cza4YEblFlMQUkxR9pmwGIYXverUOiaysqRA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.2.0.tgz",
+      "integrity": "sha512-YMGjYtjYoalmGHUynypSqxm99fSBOXWqoDeDVYTHAZy970yo61yTi72owEtg7dwB4fQndL2wCoh6ZDS5ruiDDg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/utils": "^8.2.0",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.1.8.tgz",
-      "integrity": "sha512-dVl2jJon9VL0qLTC98hJH4CkQ/oat6j9TouCk69ezzWHFxiPlz6tF78BzLr86Mz+bY6QCGeNIJ75Ovyn7EutCQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.0.tgz",
+      "integrity": "sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/schema": "8.1.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/schema": "8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/merge": {
@@ -403,50 +398,52 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.1.2.tgz",
-      "integrity": "sha512-rX2pg42a0w7JLVYT+f/yeEKpnoZL5PpLq68TxC3iZ8slnNBNjfVfvzzOn8Q8Q6Xw3t17KP9QespmJEDfuQe4Rg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.2.0.tgz",
+      "integrity": "sha512-ufmI5mJQa8NJczzfkh0pUttKvspqDcT5LLakA3jUmOrrE4d4NVj6onZlazdTzF5sAepSNqanFnwhrxZpCAJMKg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/merge": "^8.0.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/merge": "^8.1.0",
+        "@graphql-tools/utils": "^8.2.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/merge": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.0.2.tgz",
-      "integrity": "sha512-li/bl6RpcZCPA0LrSxMYMcyYk+brer8QYY25jCKLS7gvhJkgzEFpCDaX43V1+X13djEoAbgay2mCr3dtfJQQRQ==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.1.2.tgz",
+      "integrity": "sha512-kFLd4kKNJXYXnKIhM8q9zgGAtbLmsy3WmGdDxYq3YHBJUogucAxnivQYyRIseUq37KGmSAIWu3pBQ23TKGsGOw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/utils": "^8.2.2",
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.0.11.tgz",
-      "integrity": "sha512-4u+h5RtjJXaQjhfBdClreNWavBZqa0U92Cx3Z+zFvIsIYRrEboy7x+cH4QD9OEca/LuUcskJ4yyWllztz/ktow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.2.0.tgz",
+      "integrity": "sha512-1HOyt89TlzINko/Sa39oNQCzvbIshAiz+ECaoJKkIfkQZzXWzRkDrU5nEIPGm/FsCHm519OiJeaLwPLbdqnrLw==",
       "dev": true,
       "dependencies": {
         "@ardatan/fetch-event-source": "2.0.2",
-        "@graphql-tools/delegate": "^8.1.0",
-        "@graphql-tools/utils": "^8.1.1",
-        "@graphql-tools/wrap": "^8.0.13",
-        "@n1ru4l/graphql-live-query": "0.7.1",
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "@graphql-tools/wrap": "^8.1.0",
+        "@n1ru4l/graphql-live-query": "0.8.1",
         "@types/websocket": "1.0.4",
+        "@types/ws": "^7.4.7",
         "abort-controller": "3.0.0",
         "cross-fetch": "3.1.4",
         "extract-files": "11.0.0",
         "form-data": "4.0.0",
-        "graphql-ws": "^5.0.0",
+        "graphql-sse": "^1.0.1",
+        "graphql-ws": "^5.4.1",
         "is-promise": "4.0.0",
         "isomorphic-ws": "4.0.1",
         "lodash": "4.17.21",
@@ -456,38 +453,38 @@
         "tslib": "~2.3.0",
         "valid-url": "1.0.9",
         "value-or-promise": "1.0.10",
-        "ws": "8.2.0"
+        "ws": "8.2.2"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.1.1.tgz",
-      "integrity": "sha512-QbFNoBmBiZ+ej4y6mOv8Ba4lNhcrTEKXAhZ0f74AhdEXi7b9xbGUH/slO5JaSyp85sGQYIPmxjRPpXBjLklbmw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.2.tgz",
+      "integrity": "sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.0.13.tgz",
-      "integrity": "sha512-GTkHbN+Zgs+D7bFniFx3/YqNIDv8ET17prM7FewmU8LNRc2P48y6d4/dkQLcwQmryy1TZF87es6yA9FMNfQtWg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.0.tgz",
+      "integrity": "sha512-WLT/bFewOIY8KJMzgOJSM/02fXJSFktFvI+JRu39wDH+hwFy1y7pFC0Bs1TP8B/hAEJ+t9+7JspX0LQWAUFjDg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "^8.1.0",
-        "@graphql-tools/schema": "^8.1.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -517,9 +514,9 @@
       "dev": true
     },
     "node_modules/@n1ru4l/graphql-live-query": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz",
-      "integrity": "sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.1.tgz",
+      "integrity": "sha512-x5SLY+L9/5s07OJprISXx4csNBPF74UZeTI01ZPSaxOtRz2Gljk652kSPf6OjMLtx5uATr35O0M3G0LYhHBLtg==",
       "dev": true,
       "peerDependencies": {
         "graphql": "^15.4.0"
@@ -561,9 +558,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
+      "version": "16.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -576,6 +573,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
       "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -640,9 +646,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -926,9 +932,9 @@
       }
     },
     "node_modules/deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "node_modules/delayed-stream": {
@@ -1376,9 +1382,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1524,9 +1530,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.0.tgz",
+      "integrity": "sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -1572,16 +1578,28 @@
         "graphql": "*"
       }
     },
+    "node_modules/graphql-sse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.4.tgz",
+      "integrity": "sha512-oB43ifRcEdElgep9jTP9qsj5cJ7Ny/1tAFyIl1W3A0hXRRg/P71tUHzMFBrRkEsJ9IA7MTp+RKSJfh52QR6PBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/graphql-ws": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.4.0.tgz",
-      "integrity": "sha512-kxct2hGiVQJJlsfHAYoq41LY9zLkEM5SLCy+ySAOJejwYIMR290sXKzPILG3LQBEaXP9iIAiMN3nVPtOQRE8uA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.0.tgz",
+      "integrity": "sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==",
       "dev": true,
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": ">=0.11 <=15"
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/has-flag": {
@@ -1828,6 +1846,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "node_modules/lodash.lowercase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz",
+      "integrity": "sha1-RlFaztSssLcJMTMzOvBo5MOxTp0=",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -2311,9 +2335,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -2396,9 +2420,9 @@
       }
     },
     "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -2468,9 +2492,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-      "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2573,9 +2597,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2659,9 +2683,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.0.tgz",
-      "integrity": "sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -2733,58 +2757,58 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true
     },
     "@babel/highlight": {
@@ -2799,43 +2823,43 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -2883,9 +2907,9 @@
       }
     },
     "@graphql-eslint/eslint-plugin": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.0.2.tgz",
-      "integrity": "sha512-E5LPCPRYNFinsDMvApuCjRE2XfZy1r1s40ncyNb2aWM2urFJndN+wLCtBPR1KkMraqCsfwavRIHvAoPLQKj43A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+      "integrity": "sha512-LNrXRsSNeOdVL2zTnRpJk689R1LC+Ck2xAdeYYxBB87yW8eAVS80On2bkgxVm8Y9UA23sXMdhEPfgsJPb/qH2A==",
       "dev": true,
       "requires": {
         "@graphql-tools/code-file-loader": "^7.0.2",
@@ -2893,112 +2917,105 @@
         "@graphql-tools/import": "^6.3.1",
         "@graphql-tools/utils": "^8.0.2",
         "graphql-config": "^4.0.1",
-        "graphql-depth-limit": "1.1.0"
+        "graphql-depth-limit": "1.1.0",
+        "lodash.lowercase": "^4.3.0"
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.0.5.tgz",
-      "integrity": "sha512-Zx+zs12BLGNvrQtfESIhitzwIkrWnKyKOkAfcaMNuOLGOO2pDmhwIRzbHj+6Jtq9V1/JTaVkSnm/4ozaCRck5A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.1.0.tgz",
+      "integrity": "sha512-PPf8SZto4elBtkaV65RldkjvxCuwYV7tLYKH+w6QnsxogfjrtiwijmewtqIlfnpPRnuhmMzmOlhoDyf0I8EwHw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/utils": "^8.2.0",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       }
     },
     "@graphql-tools/code-file-loader": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.0.6.tgz",
-      "integrity": "sha512-+xddAWyvrcW5Em3Yx+RJ7vwFMyOoS8pwqgeVr0CTZF9YbrQSPz7wQJRAVFZNJQaJOalKlPWxsmKkSyMQRG+t4A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.1.0.tgz",
+      "integrity": "sha512-1EVuKGzTDcZoPQAjJYy0Fw2vwLN1ZnWYDlCZLaqml87tCUzJcqcHlQw26SRhDEvVnJC/oCV+mH+2QE55UxqWuA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/graphql-tag-pluck": "^7.0.5",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.1.0.tgz",
-      "integrity": "sha512-jJmty2rr4k2k6pG3H0qoCH9LDezjyVe0wLNUbVQcSfWBj1VgeHX6BF4qgbT5HsDD3oOP8ruiHZgbn6EbrOwDfA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.2.1.tgz",
+      "integrity": "sha512-fvQjSrCJCfchSQlLNHPcj1TwojyV1CPtXmwtSEVKvyp9axokuP37WGyliOWUYCepfwpklklLFUeTEiWlCoxv2Q==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "^8.0.5",
-        "@graphql-tools/schema": "^8.1.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/batch-execute": "^8.1.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.0.5.tgz",
-      "integrity": "sha512-hYdz/zvA2z2M6zqgTCkEiqWPIKLsFirg1ZawaKzCLN0sUi+hRrLVTc1eIlz/vfR8ojvswEq81OMtk5d+lbHiHQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.1.0.tgz",
+      "integrity": "sha512-VWGetkBuyWrUxSpMnbpzZs2yHWBFeo9nTYjc8+o+xyJKpG/CRfvQrhBRNRFfV/5C0j5/Z1FMfUgsroEAG5H3HQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "^6.2.6",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/import": "^6.4.0",
+        "@graphql-tools/utils": "^8.2.0",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.0.5.tgz",
-      "integrity": "sha512-/eNFl/4gshnlgNvx1Koaey3036edcv5/Nko+px/DbkfjKedwikRWubURcCaMp/4VE6CyIUibxRrP6TzVByhVrw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.1.tgz",
+      "integrity": "sha512-p+FhiiNJi02o4Y/hnT4SSRZnDvv/UcjnZJII3F4ljlteluCAwP+hPgAmbKVwOaaGfsOmMPmiAeeTWt8i23auyg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "7.15.3",
-        "@babel/traverse": "7.15.0",
-        "@babel/types": "7.15.0",
-        "@graphql-tools/utils": "^8.1.1",
+        "@babel/parser": "7.15.6",
+        "@babel/traverse": "7.15.4",
+        "@babel/types": "7.15.6",
+        "@graphql-tools/utils": "^8.2.0",
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/import": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.3.1.tgz",
-      "integrity": "sha512-1szR19JI6WPibjYurMLdadHKZoG9C//8I/FZ0Dt4vJSbrMdVNp8WFxg4QnZrDeMG4MzZc90etsyF5ofKjcC+jw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.0.tgz",
+      "integrity": "sha512-jfE01oPcmc4vzAcYLs6xT7XC4jJWrM1HNtIwc7HyyHTxrC3nf36XrF3txEZ2l20GT53+OWnMgYx1HhauLGdJmA==",
       "dev": true,
       "requires": {
         "resolve-from": "5.0.0",
-        "tslib": "~2.2.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        }
+        "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.1.2.tgz",
-      "integrity": "sha512-/CrnNBwi4WDvt4yc2PcRmQxqGIOtK84s4iI5vsHwlcK7D02WX1cza4YEblFlMQUkxR9pmwGIYXverUOiaysqRA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.2.0.tgz",
+      "integrity": "sha512-YMGjYtjYoalmGHUynypSqxm99fSBOXWqoDeDVYTHAZy970yo61yTi72owEtg7dwB4fQndL2wCoh6ZDS5ruiDDg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/utils": "^8.2.0",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/load": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.1.8.tgz",
-      "integrity": "sha512-dVl2jJon9VL0qLTC98hJH4CkQ/oat6j9TouCk69ezzWHFxiPlz6tF78BzLr86Mz+bY6QCGeNIJ75Ovyn7EutCQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.0.tgz",
+      "integrity": "sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "8.1.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/schema": "8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       }
@@ -3026,46 +3043,48 @@
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.1.2.tgz",
-      "integrity": "sha512-rX2pg42a0w7JLVYT+f/yeEKpnoZL5PpLq68TxC3iZ8slnNBNjfVfvzzOn8Q8Q6Xw3t17KP9QespmJEDfuQe4Rg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.2.0.tgz",
+      "integrity": "sha512-ufmI5mJQa8NJczzfkh0pUttKvspqDcT5LLakA3jUmOrrE4d4NVj6onZlazdTzF5sAepSNqanFnwhrxZpCAJMKg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "^8.0.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/merge": "^8.1.0",
+        "@graphql-tools/utils": "^8.2.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       },
       "dependencies": {
         "@graphql-tools/merge": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.0.2.tgz",
-          "integrity": "sha512-li/bl6RpcZCPA0LrSxMYMcyYk+brer8QYY25jCKLS7gvhJkgzEFpCDaX43V1+X13djEoAbgay2mCr3dtfJQQRQ==",
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.1.2.tgz",
+          "integrity": "sha512-kFLd4kKNJXYXnKIhM8q9zgGAtbLmsy3WmGdDxYq3YHBJUogucAxnivQYyRIseUq37KGmSAIWu3pBQ23TKGsGOw==",
           "dev": true,
           "requires": {
-            "@graphql-tools/utils": "^8.1.1",
+            "@graphql-tools/utils": "^8.2.2",
             "tslib": "~2.3.0"
           }
         }
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.0.11.tgz",
-      "integrity": "sha512-4u+h5RtjJXaQjhfBdClreNWavBZqa0U92Cx3Z+zFvIsIYRrEboy7x+cH4QD9OEca/LuUcskJ4yyWllztz/ktow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.2.0.tgz",
+      "integrity": "sha512-1HOyt89TlzINko/Sa39oNQCzvbIshAiz+ECaoJKkIfkQZzXWzRkDrU5nEIPGm/FsCHm519OiJeaLwPLbdqnrLw==",
       "dev": true,
       "requires": {
         "@ardatan/fetch-event-source": "2.0.2",
-        "@graphql-tools/delegate": "^8.1.0",
-        "@graphql-tools/utils": "^8.1.1",
-        "@graphql-tools/wrap": "^8.0.13",
-        "@n1ru4l/graphql-live-query": "0.7.1",
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "@graphql-tools/wrap": "^8.1.0",
+        "@n1ru4l/graphql-live-query": "0.8.1",
         "@types/websocket": "1.0.4",
+        "@types/ws": "^7.4.7",
         "abort-controller": "3.0.0",
         "cross-fetch": "3.1.4",
         "extract-files": "11.0.0",
         "form-data": "4.0.0",
-        "graphql-ws": "^5.0.0",
+        "graphql-sse": "^1.0.1",
+        "graphql-ws": "^5.4.1",
         "is-promise": "4.0.0",
         "isomorphic-ws": "4.0.1",
         "lodash": "4.17.21",
@@ -3075,27 +3094,27 @@
         "tslib": "~2.3.0",
         "valid-url": "1.0.9",
         "value-or-promise": "1.0.10",
-        "ws": "8.2.0"
+        "ws": "8.2.2"
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.1.1.tgz",
-      "integrity": "sha512-QbFNoBmBiZ+ej4y6mOv8Ba4lNhcrTEKXAhZ0f74AhdEXi7b9xbGUH/slO5JaSyp85sGQYIPmxjRPpXBjLklbmw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.2.tgz",
+      "integrity": "sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==",
       "dev": true,
       "requires": {
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.0.13.tgz",
-      "integrity": "sha512-GTkHbN+Zgs+D7bFniFx3/YqNIDv8ET17prM7FewmU8LNRc2P48y6d4/dkQLcwQmryy1TZF87es6yA9FMNfQtWg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.0.tgz",
+      "integrity": "sha512-WLT/bFewOIY8KJMzgOJSM/02fXJSFktFvI+JRu39wDH+hwFy1y7pFC0Bs1TP8B/hAEJ+t9+7JspX0LQWAUFjDg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "^8.1.0",
-        "@graphql-tools/schema": "^8.1.2",
-        "@graphql-tools/utils": "^8.1.1",
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.10"
       }
@@ -3124,9 +3143,9 @@
       "dev": true
     },
     "@n1ru4l/graphql-live-query": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz",
-      "integrity": "sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.1.tgz",
+      "integrity": "sha512-x5SLY+L9/5s07OJprISXx4csNBPF74UZeTI01ZPSaxOtRz2Gljk652kSPf6OjMLtx5uATr35O0M3G0LYhHBLtg==",
       "dev": true,
       "requires": {}
     },
@@ -3157,9 +3176,9 @@
       }
     },
     "@types/node": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
+      "version": "16.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3172,6 +3191,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
       "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3218,9 +3246,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -3435,9 +3463,9 @@
       }
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "delayed-stream": {
@@ -3777,9 +3805,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3894,9 +3922,9 @@
       }
     },
     "graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.0.tgz",
+      "integrity": "sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ==",
       "dev": true
     },
     "graphql-config": {
@@ -3927,10 +3955,17 @@
         "arrify": "^1.0.1"
       }
     },
+    "graphql-sse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.4.tgz",
+      "integrity": "sha512-oB43ifRcEdElgep9jTP9qsj5cJ7Ny/1tAFyIl1W3A0hXRRg/P71tUHzMFBrRkEsJ9IA7MTp+RKSJfh52QR6PBQ==",
+      "dev": true,
+      "requires": {}
+    },
     "graphql-ws": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.4.0.tgz",
-      "integrity": "sha512-kxct2hGiVQJJlsfHAYoq41LY9zLkEM5SLCy+ySAOJejwYIMR290sXKzPILG3LQBEaXP9iIAiMN3nVPtOQRE8uA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.0.tgz",
+      "integrity": "sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==",
       "dev": true,
       "requires": {}
     },
@@ -4122,6 +4157,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.lowercase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz",
+      "integrity": "sha1-RlFaztSssLcJMTMzOvBo5MOxTp0=",
       "dev": true
     },
     "lodash.merge": {
@@ -4448,9 +4489,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -4517,9 +4558,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
           "dev": true,
           "requires": {}
         }
@@ -4565,9 +4606,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -4641,9 +4682,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "peer": true
     },
@@ -4705,9 +4746,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.0.tgz",
-      "integrity": "sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
       "dev": true,
       "requires": {}
     },

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.2.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.2.1 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.2.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.2.1' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.2.0"
+PACKAGE_VERSION="v0.2.1"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.2.0'
+$package_version = 'v0.2.1'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
closes #828

---

# [0.2.1] - 2021-09-20

## 🐛 Fixes

- **Properly swallow unparseable git remotes - [EverlastingBugstopper], [issue/670] [pull/760]**

  In v0.2.0, we fixed a crash that occurred for users with non-standard git remotes. While the crash
  itself no longer occurred, the crash report itself was still generated - this is no longer the case.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/760]: https://github.com/apollographql/rover/pull/760
  [issue/670]: https://github.com/apollographql/rover/issues/670

## 🛠 Maintenance

- **Move markdown link checker to `cargo xtask lint` - [EverlastingBugstopper], [issue/774] [pull/778]**

  We now check for broken markdown links through `xtask`, meaning you can more accurately check if CI will pass locally.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/778]: https://github.com/apollographql/rover/pull/778
  [issue/774]: https://github.com/apollographql/rover/issues/774

- **Migrate lints/tests from GitHub Actions to CircleCI - [EverlastingBugstopper], [issue/774] [pull/781]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/781]: https://github.com/apollographql/rover/pull/781
  [issue/774]: https://github.com/apollographql/rover/issues/774

- **Run tests on centos 7 and ensure the binary only depends on glibc <= 2.18 - [EverlastingBugstopper], [pull/800]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/800]: https://github.com/apollographql/rover/pull/800

- **Migrate release process from GitHub Actions to CircleCI - [EverlastingBugstopper], [issue/795] [pull/808]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/808]: https://github.com/apollographql/rover/pull/808
  [issue/795]: https://github.com/apollographql/rover/issues/795

## 📚 Documentation

- **Clarifies setting HEAD SHA for GitHub Actions - [StephenBarlow], [pull/763]**

  Extended the [section in the docs](https://www.apollographql.com/docs/rover/ci-cd/#github-actions) for configuring GitHub Actions
  to include instructions for properly configuring the git context.

  [StephenBarlow]: https://github.com/StephenBarlow
  [pull/763]: https://github.com/apollographql/rover/pull/763

- **Fix a typo in the docs - [SaintMalik], [pull/762]**

  [SaintMalik]: https://github.com/SaintMalik
  [pull/762]: https://github.com/apollographql/rover/pull/762