### PR TITLE
feat: updates harmonizer to v0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "0.27.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ea09933b80c94df6cf1d23f0bbe138643437e4649332bd1ef702109abfda82"
+checksum = "dde119dc39c780b7435a2b0be6601c5c1e836dc765c7f54bb84a13b74aff8245"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde119dc39c780b7435a2b0be6601c5c1e836dc765c7f54bb84a13b74aff8245"
+checksum = "985a164be21ccfe513b6df031ac69bdf611fca469452bbfb0d442cda40a646f0"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ console = "0.14"
 crossterm = "0.21"
 git-url-parse = "0.3"
 git2 = { version = "0.13", default-features = false, features = ["vendored-openssl"] }
-harmonizer = { version = "0.27.0", optional = true }
+harmonizer = { version = "0.30.0", optional = true }
 heck = "0.3"
 lazycell = "1"
 opener = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ console = "0.14"
 crossterm = "0.21"
 git-url-parse = "0.3"
 git2 = { version = "0.13", default-features = false, features = ["vendored-openssl"] }
-harmonizer = { version = "0.30.0", optional = true }
+harmonizer = { version = "0.33.0", optional = true }
 heck = "0.3"
 lazycell = "1"
 opener = "0.5"

--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -33,11 +33,11 @@ The `supergraph compose` command's `--config` option expects the path to a YAML 
 subgraphs:
   films:
     routing_url: https://films.example.com
-    schema: 
+    schema:
       file: ./films.graphql
   people:
     routing_url: https://people.example.com
-    schema: 
+    schema:
       file: ./people.graphql
 ```
 
@@ -49,17 +49,17 @@ It's also possible to pull subgraphs from various sources and specify them in th
 subgraphs:
   films:
     routing_url: https://films.example.com
-    schema: 
+    schema:
       file: ./films.graphql
   people:
     routing_url: https://example.com/people
-    schema: 
+    schema:
       subgraph_url: https://example.com/people
   actors:
     routing_url: https://localhost:4005
-    schema: 
-      graphref: mygraph@current 
-      subgraph: actors 
+    schema:
+      graphref: mygraph@current
+      subgraph: actors
 ```
 
 ### Output format
@@ -77,11 +77,11 @@ rover supergraph compose --config ./supergraph.yaml > prod-schema.graphql
 
 #### Gateway compatibility
 
-The `rover supergraph compose` command produces a supergraph by utilizing the composition functions of the [`@apollo/federation`](https://www.apollographql.com/docs/federation/api/apollo-federation/) package.  As that library is still in pre-1.0 releases (as are Rover and Apollo Gateway), some updates to Rover may result in a supergraph with new functionality and therefore necessitate complimentary updates to Apollo Gateway.
+The `rover supergraph compose` command produces a supergraph schema by using composition functions from the [`@apollo/federation`](https://www.apollographql.com/docs/federation/api/apollo-federation/) package. Because that library is still in pre-1.0 releases (as are Rover and Apollo Gateway), some updates to Rover might result in a supergraph schema with new functionality. In turn, this might require corresponding updates to your gateway.
 
-Apollo Gateway will fail to start-up if it's provided with a supergraph that it doesn't support, so it's recommended to test launching Apollo Gateway with the supergraph it will be ultimately be deployed with in a CI pipeline to ensure compatible versions.
+Apollo Gateway fails to start up if it's provided with a supergraph schema that it doesn't support. To ensure compatibility, we recommend that you test launching your gateway in a CI pipeline with the supergraph schema it will ultimately use in production.
 
-We aim to reduce the frequency at which these paired updates are necessary by making supergraph additions backwards-compatible.  We will note changes which require corresponding Apollo Gateway updates  clearly in the Rover _Release Notes_ as well as updating the compatibility table below.
+We aim to reduce the frequency at which these paired updates are necessary by making supergraph additions backwards compatible. We will note changes that require corresponding Apollo Gateway updates clearly in the Rover _Release Notes_, and we'll also update the following compatibility table.
 
 |Rover version|Gateway version|
 |---|---|

--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -87,20 +87,3 @@ We aim to reduce the frequency at which these paired updates are necessary by ma
 |---|---|
 |<= v0.2.x|<= v0.38.x|
 |>= v0.3.x|>= v0.39.x|
-
-##### `@tag` directives in newer versions of Rover/the gateway
-
-When updating to a gateway >= v0.39.x, all subgraph schemas with `@tag` directives will need to make those types repeatable not only on `FIELD_DEFINITION`, but also on `OBJECT`, `INTERFACE`, and `UNION`.
-
-Before:
-
-```graphql
-directive @tag(name: String!) repeatable on FIELD_DEFINITION
-```
-
-After:
-
-```graphql
-directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
-```
-

--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -74,3 +74,15 @@ rover supergraph compose --config ./supergraph.yaml > prod-schema.graphql
 ```
 
 > For more on passing values via `stdout`, see [Using `stdout`](./conventions#using-stdout).
+
+#### Gateway compatibility
+
+`rover supergraph compose` utilizes the composition function published in the [harmonizer]() package under the hood. Harmonizer is still under rapid development, and some breaking changes are to be expected. For now, newer versions of Rover emit supergraph schemas that are incompatible with older versions of [`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway).
+
+The following table should help you understand the compatible versions of these two pieces of software.
+
+
+|Rover version|Gateway version|
+|---|---|
+|<= v0.2|<= v0.38|
+|>= v0.3|>= v0.39|

--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -87,3 +87,20 @@ We aim to reduce the frequency at which these paired updates are necessary by ma
 |---|---|
 |<= v0.2.x|<= v0.38.x|
 |>= v0.3.x|>= v0.39.x|
+
+##### `@tag` directives in newer versions of Rover/the gateway
+
+When updating to a gateway >= v0.39.x, all subgraph schemas with `@tag` directives will need to make those types repeatable not only on `FIELD_DEFINITION`, but also on `OBJECT`, `INTERFACE`, and `UNION`.
+
+Before:
+
+```graphql
+directive @tag(name: String!) repeatable on FIELD_DEFINITION
+```
+
+After:
+
+```graphql
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+```
+

--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -77,12 +77,12 @@ rover supergraph compose --config ./supergraph.yaml > prod-schema.graphql
 
 #### Gateway compatibility
 
-`rover supergraph compose` utilizes the composition function published in the [harmonizer]() package under the hood. Harmonizer is still under rapid development, and some breaking changes are to be expected. For now, newer versions of Rover emit supergraph schemas that are incompatible with older versions of [`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway).
+`rover supergraph compose` utilizes the composition function published in the [harmonizer](https://crates.io/crates/harmonizer) package under the hood. Harmonizer is still under rapid development, and some breaking changes are to be expected. Newer versions of Rover emit supergraph schemas that are incompatible with older versions of [`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway).
 
 The following table should help you understand the compatible versions of these two pieces of software.
 
 
 |Rover version|Gateway version|
 |---|---|
-|<= v0.2|<= v0.38|
-|>= v0.3|>= v0.39|
+|<= v0.2.x|<= v0.38.x|
+|>= v0.3.x|>= v0.39.x|

--- a/docs/source/supergraphs.md
+++ b/docs/source/supergraphs.md
@@ -77,10 +77,11 @@ rover supergraph compose --config ./supergraph.yaml > prod-schema.graphql
 
 #### Gateway compatibility
 
-`rover supergraph compose` utilizes the composition function published in the [harmonizer](https://crates.io/crates/harmonizer) package under the hood. Harmonizer is still under rapid development, and some breaking changes are to be expected. Newer versions of Rover emit supergraph schemas that are incompatible with older versions of [`@apollo/gateway`](https://www.npmjs.com/package/@apollo/gateway).
+The `rover supergraph compose` command produces a supergraph by utilizing the composition functions of the [`@apollo/federation`](https://www.apollographql.com/docs/federation/api/apollo-federation/) package.  As that library is still in pre-1.0 releases (as are Rover and Apollo Gateway), some updates to Rover may result in a supergraph with new functionality and therefore necessitate complimentary updates to Apollo Gateway.
 
-The following table should help you understand the compatible versions of these two pieces of software.
+Apollo Gateway will fail to start-up if it's provided with a supergraph that it doesn't support, so it's recommended to test launching Apollo Gateway with the supergraph it will be ultimately be deployed with in a CI pipeline to ensure compatible versions.
 
+We aim to reduce the frequency at which these paired updates are necessary by making supergraph additions backwards-compatible.  We will note changes which require corresponding Apollo Gateway updates  clearly in the Rover _Release Notes_ as well as updating the compatibility table below.
 
 |Rover version|Gateway version|
 |---|---|

--- a/xtask/src/commands/integration_test.rs
+++ b/xtask/src/commands/integration_test.rs
@@ -13,6 +13,10 @@ pub struct IntegrationTest {
     // The supergraph-demo branch to check out
     #[structopt(long = "branch", default_value = "main")]
     pub(crate) branch: String,
+
+    // The supergraph-demo org to clone
+    #[structopt(long = "org", default_value = "apollographql")]
+    pub(crate) org: String,
 }
 
 impl IntegrationTest {
@@ -26,7 +30,7 @@ impl IntegrationTest {
                 MakeRunner::new(verbose, cargo_runner.get_bin_path(&self.target, release)?)?;
             cargo_runner.build(&self.target, release, None)?;
 
-            let repo_path = git_runner.clone_supergraph_demo(&self.branch)?;
+            let repo_path = git_runner.clone_supergraph_demo(&self.org, &self.branch)?;
             make_runner.test_supergraph_demo(&repo_path)?;
         } else {
             crate::info!("skipping integration tests for --target {}", &self.target);

--- a/xtask/src/commands/integration_test.rs
+++ b/xtask/src/commands/integration_test.rs
@@ -9,6 +9,10 @@ pub struct IntegrationTest {
     // The target to build Rover for
     #[structopt(long = "target", env = "XTASK_TARGET", default_value, possible_values = &[TARGET_GNU_LINUX])]
     pub(crate) target: Target,
+
+    // The supergraph-demo branch to check out
+    #[structopt(long = "branch", default_value = "main")]
+    pub(crate) branch: String,
 }
 
 impl IntegrationTest {
@@ -22,7 +26,7 @@ impl IntegrationTest {
                 MakeRunner::new(verbose, cargo_runner.get_bin_path(&self.target, release)?)?;
             cargo_runner.build(&self.target, release, None)?;
 
-            let repo_path = git_runner.clone_supergraph_demo()?;
+            let repo_path = git_runner.clone_supergraph_demo(&self.branch)?;
             make_runner.test_supergraph_demo(&repo_path)?;
         } else {
             crate::info!("skipping integration tests for --target {}", &self.target);

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -19,6 +19,7 @@ impl Test {
         unit_test_runner.run(verbose)?;
         let integration_test_runner = IntegrationTest {
             target: self.target.clone(),
+            branch: Default::default(),
         };
         integration_test_runner.run(verbose)?;
         Ok(())

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -20,6 +20,7 @@ impl Test {
         let integration_test_runner = IntegrationTest {
             target: self.target.clone(),
             branch: Default::default(),
+            org: Default::default(),
         };
         integration_test_runner.run(verbose)?;
         Ok(())

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -28,11 +28,14 @@ impl GitRunner {
         })
     }
 
-    pub(crate) fn clone_supergraph_demo(&self) -> Result<Utf8PathBuf> {
+    pub(crate) fn clone_supergraph_demo(&self, branch: &str) -> Result<Utf8PathBuf> {
         let repo_name = "supergraph-demo";
         let repo_url = format!("https://github.com/apollographql/{}", repo_name);
-        self.runner
-            .exec(&["clone", &repo_url], &self.temp_dir_path, None)?;
+        self.runner.exec(
+            &["clone", &repo_url, "--branch", branch],
+            &self.temp_dir_path,
+            None,
+        )?;
 
         let repo_path = self.temp_dir_path.join(repo_name);
         Ok(repo_path)

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -28,9 +28,9 @@ impl GitRunner {
         })
     }
 
-    pub(crate) fn clone_supergraph_demo(&self, branch: &str) -> Result<Utf8PathBuf> {
+    pub(crate) fn clone_supergraph_demo(&self, org: &str, branch: &str) -> Result<Utf8PathBuf> {
         let repo_name = "supergraph-demo";
-        let repo_url = format!("https://github.com/apollographql/{}", repo_name);
+        let repo_url = format!("https://github.com/{}/{}", org, repo_name);
         self.runner.exec(
             &["clone", &repo_url, "--branch", branch],
             &self.temp_dir_path,


### PR DESCRIPTION
fixes #801 by updating harmonizer to v0.30.0, which is a breaking change for folks using `rover supergraph compose` with versions of `@apollo/gateway` < v0.39.0. This is reflected in the docs and will also be called out in our changelog. 

cc @StephenBarlow for docs wording/structure review

cc @trevor-scheer for content review

cc @abernix for rubber stamp

cc @prasek because `supergraph-demo` fails to compose with this version bump.