### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,77 @@ All notable changes to Rover will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- # [x.x.x] (unreleased) - 2021-mm-dd
+
 > Important: X breaking changes below, indicated by **❗ BREAKING ❗**
+
 ## ❗ BREAKING ❗
+
 ## 🚀 Features
+
 ## 🐛 Fixes
+
 ## 🛠 Maintenance
+
 ## 📚 Documentation -->
+
+# [0.3.0] - 2021-09-24
+
+> Important: 1 breaking change below, indicated by **❗ BREAKING ❗**
+
+## ❗ BREAKING ❗
+
+- **`rover supergraph compose` uses a newer composition function that is incompatible with older versions of `@apollo/gateway` - [EverlastingBugstopper], [issue/801] [pull/832]**
+
+  The `rover supergraph compose` command produces a supergraph schema by using composition functions from the [`@apollo/federation`](https://www.apollographql.com/docs/federation/api/apollo-federation/) package. Because that library is still in pre-1.0 releases (as are Rover and Apollo Gateway), this update to Rover means `rover supergraph compose` will create a supergraph schema with new functionality. In turn, this requires that you update your `@apollo/gateway` version to >= v0.39.x.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/832]: https://github.com/apollographql/rover/pull/832
+  [issue/801]: https://github.com/apollographql/rover/issues/801
+
+## 🚀 Features
+
+- **Adds options to bypass TLS validation - [EverlastingBugstopper], [issue/720] [pull/837]**
+
+  In some configurations, often on internal networks, you might need Rover to communicate over encrypted channels (e.g., HTTPS) but avoid the more stringent digital certificate verifications that validate hostnames. You might even need to bypass the digital certificate validation entirely. This is generally not recommended and considered to be much less secure but for cases where it's necessary, but now there are two flags you can use to configure how Rover validates HTTPS requests:
+
+  - The `--insecure-accept-invalid-hostnames` flag disables hostname validation. If hostname verification is not used, any valid certificate for any site is trusted for use from any other. This introduces a significant vulnerability to person-in-the-middle attacks.
+
+  - The `--insecure-accept-invalid-certs` flag disables certificate validation. If invalid certificates are trusted, any certificate for any site is trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/837]: https://github.com/apollographql/rover/pull/837
+  [issue/720]: https://github.com/apollographql/rover/issues/720
+
+- **Adds option to increase rover's request timeout - [EverlastingBugstopper], [issue/792] [pull/838]**
+
+  By default, Rover times out requests to the Apollo Studio API and your graph endpoints after 30 seconds. Now, if you're executing a command that might take longer than 30 seconds to process, you can increase this timeout with the `--client-timeout` option like so:
+
+  ```sh
+  rover subgraph check my-graph --validation-period 1m --client-timeout=60
+  ```
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/838]: https://github.com/apollographql/rover/pull/838
+  [issue/792]: https://github.com/apollographql/rover/issues/792
+
+## 🛠 Maintenance
+
+- **Simplify error formatting - [EverlastingBugstopper], [pull/845]**
+
+  Now, Rover always indents the suggestion by 8 spaces instead of determining its length based on the length of the error descriptor, and the underlying cause of request errors will only be printed once.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/845]: https://github.com/apollographql/rover/pull/845
+
+## 📚 Documentation
+
+- **Clarify `--output json` support in migration guide, and provide an example `jq` script - [EverlastingBugstopper], [issue/839] [pull/840]**
+
+  The Apollo CLI migration guide now mentions Rover's support for `--output json`, and our `--output json` docs now link to an example bash script for converting a check response to markdown.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/840]: https://github.com/apollographql/rover/pull/840
+  [issue/839]: https://github.com/apollographql/rover/issues/839
 
 # [0.2.1] - 2021-09-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.47+curl-7.79.0"
+version = "0.4.48+curl-7.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab94a47d9b61f2d905beb7a3d46aba7704c9f1dfcf84e7d178998d9e95f7989"
+checksum = "a6a77a741f832116da66aeb126b4f19190ecf46144a74a9bde43c2086f38da0e"
 dependencies = [
  "cc",
  "libc",
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if",
 ]
@@ -2015,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg",
  "cc",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2945,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3138,9 +3138,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.2.1"
+version = "0.3.0"
 resolver = "2"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.2.1
+Rover 0.3.0
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -63,17 +63,21 @@ You can open the full documentation for Rover by running:
     $ rover docs open
 
 USAGE:
-    rover [OPTIONS] <SUBCOMMAND>
+    rover [FLAGS] [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+        --insecure-accept-invalid-certs        Accept invalid certificates when performing HTTPS requests
+        --insecure-accept-invalid-hostnames    Accept invalid hostnames when performing HTTPS requests
+    -h, --help                                 Prints help information
+    -V, --version                              Prints version information
 
 OPTIONS:
-    -l, --log <log-level>         Specify Rover's log level [possible values: error, warn, info,
-                                  debug, trace]
-        --output <output-type>    Specify Rover's output type [default: plain]  [possible values: json,
-                                  plain]
+        --client-timeout <client-timeout>    Configure the timeout length (in seconds) when performing HTTP(S) requests
+                                             [default: 30]
+    -l, --log <log-level>                    Specify Rover's log level [possible values: error, warn,
+                                             info, debug, trace]
+        --output <output-type>               Specify Rover's output type [default: plain]  [possible values:
+                                             json, plain]
 
 SUBCOMMANDS:
     config        Configuration profile commands

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -329,9 +329,9 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.0.tgz",
-      "integrity": "sha512-jfE01oPcmc4vzAcYLs6xT7XC4jJWrM1HNtIwc7HyyHTxrC3nf36XrF3txEZ2l20GT53+OWnMgYx1HhauLGdJmA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.1.tgz",
+      "integrity": "sha512-nFWo2dI9XXs0hsBscHnTSJNfgFq2gA1bw0qbCXyQga1PJclZViO8SxcHqCf2JmShRpTFsyzsDjKA8xGKDDs8PQ==",
       "dev": true,
       "dependencies": {
         "resolve-from": "5.0.0",
@@ -357,13 +357,13 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.0.tgz",
-      "integrity": "sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.2.tgz",
+      "integrity": "sha512-tB03MGOlgKkoP6YyzIl/saTYshuLWxQy2JebhYL6gy3XsWmSE7ae1WAL3p+G0pyfw66HaMu905omyulu1VkfXw==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/schema": "8.2.0",
-        "@graphql-tools/utils": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.3",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.2.tgz",
-      "integrity": "sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.3.tgz",
+      "integrity": "sha512-RR+aiusf2gIfnPmrDIH1uA45QuPiHB54RD+BmWyMcl88tWAjeJtqZeWPqUTq/1EXrNeocJAJQqogHV4Fbbzx3A==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.0.tgz",
-      "integrity": "sha512-WLT/bFewOIY8KJMzgOJSM/02fXJSFktFvI+JRu39wDH+hwFy1y7pFC0Bs1TP8B/hAEJ+t9+7JspX0LQWAUFjDg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.1.tgz",
+      "integrity": "sha512-Z2ylFug2iHMbpcc2Bs/avNTKmhoJrUO6l0JrQbgiZZJWBaBz6yw+fyfL/kCLQluiU5/SXsvUxxPGBQ9tqb864g==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/delegate": "^8.2.0",
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
-      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==",
+      "version": "16.9.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.6.tgz",
+      "integrity": "sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -1460,9 +1460,9 @@
       "dev": true
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2366,26 +2366,26 @@
       "dev": true
     },
     "node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -2987,9 +2987,9 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.0.tgz",
-      "integrity": "sha512-jfE01oPcmc4vzAcYLs6xT7XC4jJWrM1HNtIwc7HyyHTxrC3nf36XrF3txEZ2l20GT53+OWnMgYx1HhauLGdJmA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.1.tgz",
+      "integrity": "sha512-nFWo2dI9XXs0hsBscHnTSJNfgFq2gA1bw0qbCXyQga1PJclZViO8SxcHqCf2JmShRpTFsyzsDjKA8xGKDDs8PQ==",
       "dev": true,
       "requires": {
         "resolve-from": "5.0.0",
@@ -3009,13 +3009,13 @@
       }
     },
     "@graphql-tools/load": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.0.tgz",
-      "integrity": "sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.2.tgz",
+      "integrity": "sha512-tB03MGOlgKkoP6YyzIl/saTYshuLWxQy2JebhYL6gy3XsWmSE7ae1WAL3p+G0pyfw66HaMu905omyulu1VkfXw==",
       "dev": true,
       "requires": {
         "@graphql-tools/schema": "8.2.0",
-        "@graphql-tools/utils": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.3",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       }
@@ -3098,18 +3098,18 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.2.tgz",
-      "integrity": "sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.3.tgz",
+      "integrity": "sha512-RR+aiusf2gIfnPmrDIH1uA45QuPiHB54RD+BmWyMcl88tWAjeJtqZeWPqUTq/1EXrNeocJAJQqogHV4Fbbzx3A==",
       "dev": true,
       "requires": {
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.0.tgz",
-      "integrity": "sha512-WLT/bFewOIY8KJMzgOJSM/02fXJSFktFvI+JRu39wDH+hwFy1y7pFC0Bs1TP8B/hAEJ+t9+7JspX0LQWAUFjDg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.1.tgz",
+      "integrity": "sha512-Z2ylFug2iHMbpcc2Bs/avNTKmhoJrUO6l0JrQbgiZZJWBaBz6yw+fyfL/kCLQluiU5/SXsvUxxPGBQ9tqb864g==",
       "dev": true,
       "requires": {
         "@graphql-tools/delegate": "^8.2.0",
@@ -3176,9 +3176,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
-      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==",
+      "version": "16.9.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.6.tgz",
+      "integrity": "sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3871,9 +3871,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4519,23 +4519,23 @@
       "dev": true
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-json-comments": {

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -9,7 +9,7 @@ The Rover CLI is available for Linux, Mac, and Windows.
 
 ### `curl | sh` installer for Linux / MacOS
 
-To install the latest release of Rover: 
+To install the latest release of Rover:
 
 ```bash
 curl -sSL https://rover.apollo.dev/nix/latest | sh
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.2.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.3.0 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.2.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.3.0' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -16,7 +16,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.2.1"
+PACKAGE_VERSION="v0.3.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -9,7 +9,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.2.1'
+$package_version = 'v0.3.0'
 
 function Install-Binary() {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -153,9 +153,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -406,9 +406,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.3.0] - 2021-09-24

> Important: 1 breaking change below, indicated by **❗ BREAKING ❗**
## ❗ BREAKING ❗

- **`rover supergraph compose` uses a newer composition function that is incompatible with older versions of `@apollo/gateway` - [EverlastingBugstopper], [issue/801] [pull/832]**

  The `rover supergraph compose` command produces a supergraph schema by using composition functions from the [`@apollo/federation`](https://www.apollographql.com/docs/federation/api/apollo-federation/) package. Because that library is still in pre-1.0 releases (as are Rover and Apollo Gateway), this update to Rover means `rover supergraph compose` will create a supergraph schema with new functionality. In turn, this requires that you update your `@apollo/gateway` version to >= v0.39.x.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/832]: https://github.com/apollographql/rover/pull/832
  [issue/801]: https://github.com/apollographql/rover/issues/801

## 🚀 Features

- **Adds options to bypass TLS validation - [EverlastingBugstopper], [issue/720] [pull/837]**

  In some configurations, often on internal networks, you might need Rover to communicate over encrypted channels (e.g., HTTPS) but avoid the more stringent digital certificate verifications that validate hostnames. You might even need to bypass the digital certificate validation entirely. This is generally not recommended and considered to be much less secure but for cases where it's necessary, but now there are two flags you can use to configure how Rover validates HTTPS requests:

  - The `--insecure-accept-invalid-hostnames` flag disables hostname validation. If hostname verification is not used, any valid certificate for any site is trusted for use from any other. This introduces a significant vulnerability to person-in-the-middle attacks.

  - The `--insecure-accept-invalid-certs` flag disables certificate validation. If invalid certificates are trusted, any certificate for any site is trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/837]: https://github.com/apollographql/rover/pull/837
  [issue/720]: https://github.com/apollographql/rover/issues/720

- **Adds option to increase rover's request timeout - [EverlastingBugstopper], [issue/792] [pull/838]**

  By default, Rover times out requests to the Apollo Studio API and your graph endpoints after 30 seconds. Now, if you're executing a command that might take longer than 30 seconds to process, you can increase this timeout with the `--client-timeout` option like so:

  ```sh
  rover subgraph check my-graph --validation-period 1m --client-timeout=60
  ```

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/838]: https://github.com/apollographql/rover/pull/838
  [issue/792]: https://github.com/apollographql/rover/issues/792

## 🛠 Maintenance

- **Simplify error formatting - [EverlastingBugstopper], [pull/845]**

  Now, Rover always indents the suggestion by 8 spaces instead of determining its length based on the length of the error descriptor, and the underlying cause of request errors will only be printed once.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/845]: https://github.com/apollographql/rover/pull/845

## 📚 Documentation

- **Clarify `--output json` support in migration guide, and provide an example `jq` script - [EverlastingBugstopper], [issue/839] [pull/840]**

  The Apollo CLI migration guide now mentions Rover's support for `--output json`, and our `--output json` docs now link to an example bash script for converting a check response to markdown.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/840]: https://github.com/apollographql/rover/pull/840
  [issue/839]: https://github.com/apollographql/rover/issues/839