### PR TITLE
chore(ci): install volta in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ commands:
           name: Install volta
           command: |
             curl https://get.volta.sh | bash -s -- --skip-setup
-            echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
+            echo 'export VOLTA_HOME=$HOME/.volta/bin' >> $BASH_ENV
             echo 'export PATH=$VOLTA_HOME:$PATH' >> $BASH_ENV
 
   install_rust_toolchain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,20 +272,13 @@ commands:
           platform: << parameters.platform >>
 
   install_volta:
-    parameters:
-      platform:
-        type: executor
     steps:
-      - unless:
-          condition:
-            equal: [ *windows_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Install volta
-                command: |
-                  curl https://get.volta.sh | bash -s -- --skip-setup
-                  echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
-                  echo 'export PATH=$VOLTA_HOME:$PATH' >> $BASH_ENV
+      - run:
+          name: Install volta
+          command: |
+            curl https://get.volta.sh | bash -s -- --skip-setup
+            echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
+            echo 'export PATH=$VOLTA_HOME:$PATH' >> $BASH_ENV
 
   install_rust_toolchain:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,7 @@ workflows:
               rust_channel: [stable]
               command: [lint]
           pre-steps:
-            - node/install:
-                node-version: "14.17.1"
-                npm-version: "7.21.1"
+            - install_volta
   test:
     jobs:
       - xtask:
@@ -149,9 +147,10 @@ jobs:
 
   publish_release:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/base:lts
     resource_class: small
     steps:
+      - install_volta
       - checkout
       - attach_workspace:
           at: artifacts
@@ -176,7 +175,7 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-musl"
-  
+
   macos: &macos_executor
     macos:
       xcode: "11.4"
@@ -271,6 +270,22 @@ commands:
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
+
+  install_volta:
+    parameters:
+      platform:
+        type: executor
+    steps:
+      - unless:
+          condition:
+            equal: [ *windows_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Install volta
+                command: |
+                  curl https://get.volta.sh | bash -s -- --skip-setup
+                  echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
+                  echo 'export PATH=$VOLTA_HOME:$PATH' >> $BASH_ENV
 
   install_rust_toolchain:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ executors:
   # This is used for any xtask command that needs volta installed
   volta: &volta_executor
     docker:
-      - image: cimg/base:lts
+      - image: cimg/base:stable
     resource_class: small
 
 # reusable command snippets can be referred to in any `steps` object

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,8 @@ executors:
     docker:
       - image: cimg/base:stable
     resource_class: small
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
 # reusable command snippets can be referred to in any `steps` object
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,12 @@ commands:
             curl https://get.volta.sh | bash -s -- --skip-setup
             echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
             echo 'export PATH=$VOLTA_HOME/bin:$PATH' >> $BASH_ENV
+      - run:
+          name: Install default versions of npm and node
+          command: |
+            volta install node@16
+            volta install npm@7
+
 
   install_rust_toolchain:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
           name: Lint
           matrix:
             parameters:
-              platform: [ubuntu]
+              platform: [volta]
               rust_channel: [stable]
               command: [lint]
           pre-steps:
@@ -94,20 +94,22 @@ workflows:
               rust_channel: [stable]
               command: [package]
               options: ["--verbose --rebuild"]
-          requires: 
+          requires:
             - "Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)"
             - "Run supergraph-demo tests (stable rust on ubuntu)"
           <<: *run_release
 
       - publish_release:
           name: Publish GitHub release and release to npm
-          requires: 
+          matrix:
+            parameters:
+              platform: [volta]
+          requires:
             - "Build and bundle release artifacts (centos)"
             - "Build and bundle release artifacts (musl)"
             - "Build and bundle release artifacts (macos)"
             - "Build and bundle release artifacts (windows)"
           <<: *run_release
-          
 
 jobs:
   xtask:
@@ -146,9 +148,10 @@ jobs:
                 options: << parameters.options >>
 
   publish_release:
-    docker:
-      - image: cimg/base:lts
-    resource_class: small
+    parameters:
+      platform:
+        type: executor
+    executor: << parameters.platform >>
     steps:
       - install_volta
       - checkout
@@ -201,6 +204,12 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
+
+  # This is used for any xtask command that needs volta installed
+  volta: &volta_executor
+    docker:
+      - image: cimg/base:lts
+    resource_class: small
 
 # reusable command snippets can be referred to in any `steps` object
 commands:
@@ -368,7 +377,7 @@ commands:
           condition: << pipeline.git.tag >>
           steps:
             - exec_gh_release
-      
+
   exec_gh_release:
     parameters:
       release_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,8 +288,8 @@ commands:
           name: Install volta
           command: |
             curl https://get.volta.sh | bash -s -- --skip-setup
-            echo 'export VOLTA_HOME=$HOME/.volta/bin' >> $BASH_ENV
-            echo 'export PATH=$VOLTA_HOME:$PATH' >> $BASH_ENV
+            echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
+            echo 'export PATH=$VOLTA_HOME/bin:$PATH' >> $BASH_ENV
 
   install_rust_toolchain:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ commands:
             or:
               - equal: [ *ubuntu_executor, << parameters.platform >> ]
               - equal: [ *musl_executor, << parameters.platform >> ]
+              - equal: [ *volta_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Update apt repositories

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -14,6 +14,8 @@ You can run `cargo xtask dist` to build Rover's binary like it would be built in
 
 ## xtask prep
 
-The most important xtask command you'll need to run locally is `cargo xtask prep`. This command prepares Rover for a new release. You'll want to update the version in `Cargo.toml`, and run `cargo xtask prep` as a part of making the PR for a new release. 
+The most important xtask command you'll need to run locally is `cargo xtask prep`. This command prepares Rover for a new release. You'll want to update the version in `Cargo.toml`, and run `cargo xtask prep` as a part of making the PR for a new release.
+
+You must have `volta` [installed](https://docs.volta.sh/guide/getting-started) in order to ensure the proper node versions are used for the multiple packages in this repo.
 
 These steps are outlined in more detail in the [release checklist](../RELEASE_CHECKLIST.md).

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
+use which::which;
 
 use std::{convert::TryFrom, fs, str};
 
@@ -44,10 +45,11 @@ impl NpmRunner {
     }
 
     /// prepares our npm installer package for release
-    /// by default this runs on every build and does all the steps
-    /// if the machine has npm installed.
-    /// these steps are only _required_ when running in release mode
+    /// you must have volta installed to run this command
     pub(crate) fn prepare_package(&self) -> Result<()> {
+        self.require_volta()
+            .with_context(|| "You must have `volta` installed to run this command.")?;
+
         self.update_dependency_tree()
             .with_context(|| "Could not update the dependency tree.")?;
 
@@ -89,6 +91,12 @@ impl NpmRunner {
         }
 
         Ok(())
+    }
+
+    fn require_volta(&self) -> Result<()> {
+        which("volta")
+            .map(|_| ())
+            .map_err(|_| anyhow!("You must have `volta` installed to run this command."))
     }
 
     fn update_dependency_tree(&self) -> Result<()> {

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -47,8 +47,7 @@ impl NpmRunner {
     /// prepares our npm installer package for release
     /// you must have volta installed to run this command
     pub(crate) fn prepare_package(&self) -> Result<()> {
-        self.require_volta()
-            .with_context(|| "You must have `volta` installed to run this command.")?;
+        self.require_volta()?;
 
         self.update_dependency_tree()
             .with_context(|| "Could not update the dependency tree.")?;
@@ -71,6 +70,7 @@ impl NpmRunner {
     }
 
     pub(crate) fn lint(&self) -> Result<()> {
+        self.require_volta()?;
         self.npm_exec(&["install"], &self.rover_client_lint_directory)?;
         self.npm_exec(&["run", "lint"], &self.rover_client_lint_directory)?;
 


### PR DESCRIPTION
Use volta to quickly install and switch between the proper node/npm versions

- `cargo xtask prep` now requires `volta` to be installed to run (none of the other commands require it)
- We now use `volta` to manage our node/npm versions in CircleCI instead of relying on their bespoke installations