### PR TITLE
docs: Replace 'data graph' with 'graph'

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -8,7 +8,7 @@ import { Button } from '@apollo/space-kit/Button';
 import { Link } from 'gatsby';
 import { colors } from 'gatsby-theme-apollo-core';
 
-**Rover** is a CLI for managing and maintaining data graphs with [Apollo Studio](https://www.apollographql.com/docs/studio/):
+**Rover** is a CLI for managing and maintaining graphs with [Apollo Studio](https://www.apollographql.com/docs/studio/):
 
 ```shell:title=Examples
 # Publish your graph's schema to Apollo


### PR DESCRIPTION
This branch replaces instances of 'data graph' in our docs with 'graph' to be more in line with the language that we use in our marketing these days.

cc @jchesterman