### PR TITLE
feat: adds `rover graph delete`

### DIFF
--- a/crates/rover-client/src/operations/graph/delete/delete_mutation.graphql
+++ b/crates/rover-client/src/operations/graph/delete/delete_mutation.graphql
@@ -1,0 +1,10 @@
+mutation GraphDeleteMutation(
+  $graph_id: ID!,
+  $variant: String!
+) {
+  service(id: $graph_id) {
+    deleteSchemaTag(tag: $variant) {
+      deleted
+    }
+  }
+}

--- a/crates/rover-client/src/operations/graph/delete/mod.rs
+++ b/crates/rover-client/src/operations/graph/delete/mod.rs
@@ -1,0 +1,5 @@
+mod runner;
+mod types;
+
+pub use runner::run;
+pub use types::GraphDeleteInput;

--- a/crates/rover-client/src/operations/graph/delete/runner.rs
+++ b/crates/rover-client/src/operations/graph/delete/runner.rs
@@ -1,0 +1,52 @@
+use crate::blocking::StudioClient;
+use crate::operations::graph::{
+    delete::GraphDeleteInput,
+    variant::{self, VariantListInput},
+};
+use crate::RoverClientError;
+
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/graph/delete/delete_mutation.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+/// This struct is used to generate the module containing `Variables` and
+/// `ResponseData` structs.
+/// Snake case of this name is the mod name. i.e. graph_delete_mutation
+pub(crate) struct GraphDeleteMutation;
+
+/// The main function to be used from this module.
+/// This function deletes a single graph variant from the graph registry
+pub fn run(input: GraphDeleteInput, client: &StudioClient) -> Result<(), RoverClientError> {
+    let graph_ref = input.graph_ref.clone();
+    let response_data = client
+        .post::<GraphDeleteMutation>(input.into())
+        .map_err(|e| {
+            if e.to_string().contains("Variant not found") {
+                if let Err(no_variant_err) = variant::run(
+                    VariantListInput {
+                        graph_ref: graph_ref.clone(),
+                    },
+                    client,
+                ) {
+                    return no_variant_err;
+                }
+            }
+            e
+        })?;
+    let service_data = response_data
+        .service
+        .ok_or(RoverClientError::GraphNotFound { graph_ref })?;
+
+    if service_data.delete_schema_tag.deleted {
+        Ok(())
+    } else {
+        Err(RoverClientError::AdhocError {
+            msg: "An unknown error occurred while deleting your graph.".to_string(),
+        })
+    }
+}

--- a/crates/rover-client/src/operations/graph/delete/types.rs
+++ b/crates/rover-client/src/operations/graph/delete/types.rs
@@ -1,0 +1,17 @@
+use crate::operations::graph::delete::runner::graph_delete_mutation;
+use crate::shared::GraphRef;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphDeleteInput {
+    pub graph_ref: GraphRef,
+}
+
+type MutationVariables = graph_delete_mutation::Variables;
+impl From<GraphDeleteInput> for MutationVariables {
+    fn from(input: GraphDeleteInput) -> Self {
+        Self {
+            graph_id: input.graph_ref.name,
+            variant: input.graph_ref.variant,
+        }
+    }
+}

--- a/crates/rover-client/src/operations/graph/mod.rs
+++ b/crates/rover-client/src/operations/graph/mod.rs
@@ -9,3 +9,9 @@ pub mod check;
 
 /// "graph introspect" command execution
 pub mod introspect;
+
+/// "graph delete" command execution
+pub mod delete;
+
+/// internal module for getting info about variants
+pub(crate) mod variant;

--- a/crates/rover-client/src/operations/graph/variant/mod.rs
+++ b/crates/rover-client/src/operations/graph/variant/mod.rs
@@ -1,0 +1,5 @@
+mod runner;
+mod types;
+
+pub(crate) use runner::run;
+pub(crate) use types::VariantListInput;

--- a/crates/rover-client/src/operations/graph/variant/runner.rs
+++ b/crates/rover-client/src/operations/graph/variant/runner.rs
@@ -1,0 +1,45 @@
+use crate::blocking::StudioClient;
+use crate::operations::graph::variant::VariantListInput;
+use crate::RoverClientError;
+
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/graph/variant/variant_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+/// This struct is used to generate the module containing `Variables` and
+/// `ResponseData` structs.
+/// Snake case of this name is the mod name. i.e. variant_list_query
+pub(crate) struct VariantListQuery;
+
+/// The main function to be used from this module.
+/// This function lists all the variants for a given graph ref
+pub fn run(input: VariantListInput, client: &StudioClient) -> Result<(), RoverClientError> {
+    let graph_ref = input.graph_ref.clone();
+    let response_data = client.post::<VariantListQuery>(input.into())?;
+    let service_data = response_data
+        .service
+        .ok_or(RoverClientError::GraphNotFound {
+            graph_ref: graph_ref.clone(),
+        })?;
+
+    let mut valid_variants = Vec::new();
+
+    for variant in service_data.variants {
+        valid_variants.push(variant.name)
+    }
+
+    if !valid_variants.contains(&graph_ref.variant) {
+        Err(RoverClientError::NoSchemaForVariant {
+            graph_ref,
+            valid_variants,
+            frontend_url_root: response_data.frontend_url_root,
+        })
+    } else {
+        Ok(())
+    }
+}

--- a/crates/rover-client/src/operations/graph/variant/types.rs
+++ b/crates/rover-client/src/operations/graph/variant/types.rs
@@ -1,0 +1,16 @@
+use crate::operations::graph::variant::runner::variant_list_query;
+use crate::shared::GraphRef;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VariantListInput {
+    pub graph_ref: GraphRef,
+}
+
+type MutationVariables = variant_list_query::Variables;
+impl From<VariantListInput> for MutationVariables {
+    fn from(input: VariantListInput) -> Self {
+        Self {
+            graph_id: input.graph_ref.name,
+        }
+    }
+}

--- a/crates/rover-client/src/operations/graph/variant/variant_query.graphql
+++ b/crates/rover-client/src/operations/graph/variant/variant_query.graphql
@@ -1,0 +1,8 @@
+query VariantListQuery($graph_id: ID!) {
+  frontendUrlRoot,
+  service(id: $graph_id) {
+    variants {
+      name
+    }
+  }
+}

--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -1,6 +1,10 @@
 use super::types::*;
 use crate::blocking::StudioClient;
-use crate::operations::config::is_federated::{self, IsFederatedInput};
+use crate::operations::graph::variant::VariantListInput;
+use crate::operations::{
+    config::is_federated::{self, IsFederatedInput},
+    graph::variant,
+};
 use crate::shared::{BuildError, BuildErrors, GraphRef};
 use crate::RoverClientError;
 use graphql_client::*;
@@ -29,18 +33,38 @@ pub fn run(
     // Error here if no --convert flag is passed _and_ the current context
     // is non-federated. Add a suggestion to require a --convert flag.
     if !input.convert_to_federated_graph {
-        let is_federated = is_federated::run(
-            IsFederatedInput {
+        // first, check if the variant exists _at all_
+        // if it doesn't exist, there is no graph schema to "convert"
+        // so don't require --convert in this case, just publish the subgraph
+        let variant_exists = variant::run(
+            VariantListInput {
                 graph_ref: graph_ref.clone(),
             },
             client,
-        )?;
+        )
+        .is_ok();
 
-        if !is_federated {
-            return Err(RoverClientError::ExpectedFederatedGraph {
-                graph_ref,
-                can_operation_convert: true,
-            });
+        if variant_exists {
+            // check if subgraphs have ever been published to this graph ref
+            let is_federated = is_federated::run(
+                IsFederatedInput {
+                    graph_ref: graph_ref.clone(),
+                },
+                client,
+            )?;
+
+            if !is_federated {
+                return Err(RoverClientError::ExpectedFederatedGraph {
+                    graph_ref,
+                    can_operation_convert: true,
+                });
+            }
+        } else {
+            tracing::debug!(
+                "Publishing new subgraph {} to {}",
+                &input.subgraph,
+                &input.graph_ref
+            );
         }
     }
     let data = client.post::<SubgraphPublishMutation>(variables)?;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3840,15 +3840,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -8241,12 +8232,6 @@
         "strtok3": "^6.2.4",
         "token-types": "^4.1.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "filesize": {
       "version": "3.5.11",
@@ -13714,12 +13699,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/name-all-modules-plugin/-/name-all-modules-plugin-1.0.1.tgz",
       "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
-    },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "optional": true
     },
     "nano-css": {
       "version": "5.3.4",
@@ -20078,11 +20057,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -20760,11 +20735,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/docs/source/graphs.md
+++ b/docs/source/graphs.md
@@ -79,6 +79,8 @@ The argument `my-graph@my-variant` in the example above specifies the ID of the 
 
 > You can omit `@` and the variant name. If you do, Rover publishes the schema to the default variant, named `current`.
 
+If the graph exists in the graph registry, but the variant does not, a new variant will be created on publish.
+
 ### Providing the schema
 
 You provide your schema to Rover commands via the `--schema` option. The value is usually the path to a local `.graphql` or `.gql` file in [SDL format](https://www.apollographql.com/docs/resources/graphql-glossary/#schema-definition-language-sdl).
@@ -112,3 +114,9 @@ rover graph introspect http://localhost:4000 | rover graph check my-graph --sche
 As shown, arguments and options are similar to [`graph publish`](#publishing-a-schema-to-apollo-studio).
 
 To configure the behavior of schema checks (such as the time range of past operations to check against), see the [documentation for schema checks](https://www.apollographql.com/docs/studio/check-configurations/#using-apollo-studio-recommended).
+
+## Deleting a variant
+
+> This requires first [authenticating Rover with Apollo Studio](./configuring/#authenticating-with-apollo-studio).
+
+You can delete a single variant of a graph by running `rover graph delete`. If this graph is federated, it will also delete all of the subgraphs, meaning any of Rover's `fetch` commands will no longer work with this variant. This command will prompt you for confirmation before deletion since the action is irreversible. You can bypass this confirmation by passing the `--confirm` flag.

--- a/docs/source/graphs.md
+++ b/docs/source/graphs.md
@@ -119,4 +119,13 @@ To configure the behavior of schema checks (such as the time range of past opera
 
 > This requires first [authenticating Rover with Apollo Studio](./configuring/#authenticating-with-apollo-studio).
 
-You can delete a single variant of a graph by running `rover graph delete`. If this graph is federated, it will also delete all of the subgraphs, meaning any of Rover's `fetch` commands will no longer work with this variant. This command will prompt you for confirmation before deletion since the action is irreversible. You can bypass this confirmation by passing the `--confirm` flag.
+You can delete a single variant of a graph by running `rover graph delete`:
+
+```bash
+# ⚠️ This action is irreversible!
+rover graph delete my-graph@variant-to-delete
+```
+
+This command prompts you for confirmation because the action is irreversible. You can bypass confirmation by passing the `--confirm` flag.
+
+If you delete a federated variant with this command, it _also_ deletes all of that variant's subgraphs. To delete a single subgraph while preserving the variant, see [Deleting a subgraph](./subgraphs/#deleting-a-subgraph).

--- a/docs/source/subgraphs.md
+++ b/docs/source/subgraphs.md
@@ -125,14 +125,16 @@ Use the `subgraph publish` command, like so:
 
 ```bash
 rover subgraph publish my-supergraph@my-variant \
-  --schema ./accounts/schema.graphql\
-  --name accounts\
-  --routing-url https://my-running-subgraph.com/api
+  --schema "./accounts/schema.graphql" \
+  --name accounts \
+  --routing-url "https://my-running-subgraph.com/api"
 ```
 
-The argument `my-graph@my-variant` in the example above is a [graph ref](./conventions/#graph-refs) that specifies the ID of the Studio graph you're publishing to, along with which [variant](https://www.apollographql.com/docs/studio/org/graphs/#managing-variants) you're publishing to.
+The argument `my-supergraph@my-variant` in the example above is a [graph ref](./conventions/#graph-refs) that specifies the ID of the Studio graph you're publishing to, along with which [variant](https://www.apollographql.com/docs/studio/org/graphs/#managing-variants) you're publishing to.
 
 > You can omit `@` and the variant name. If you do, Rover publishes the schema to the default variant, named `current`.
+
+If the graph exists in the graph registry, but the variant does not, a new variant will be created on publish.
 
 Options include:
 
@@ -190,6 +192,23 @@ The URL that your gateway uses to communicate with the subgraph in a [managed fe
 
 </td>
 </tr>
+<tr class="required">
+<td>
+
+###### `--convert`
+
+</td>
+
+<td>
+
+If a monolithic schema for this variant already exists in the graph registry instead of multiple subgraph schemas, you will need to run `rover subgraph publish` with the `--convert` flag in order to convert this variant to be a federated graph with one or more subgraphs. This will _permanently_ delete the existing schema from this variant and replace it with a single subgraph. You will likely need to run multiple `subgraph publish` multiple times in order to successfully compose a supergraph.
+
+**Required** if you are converting an existing monolithic graph variant to a federated graph variant with one or more subgraphs.
+
+**Optional** if the graph variant already has one or more subgraphs.
+
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -215,3 +234,7 @@ rover subgraph introspect http://localhost:4000 \
 As shown, arguments and options are similar to [`subgraph publish`](#publishing-a-subgraph-schema-to-apollo-studio).
 
 To configure the behavior of schema checks (such as the time range of past operations to check against), see the [documentation for schema checks](https://www.apollographql.com/docs/studio/check-configurations/#using-apollo-studio-recommended).
+
+## Deleting a subgraph
+
+You can delete a single subgraph by running `rover subgraph delete`. Note that this command will error if any other subgraph references types specified by the subgraph you're deleting. If you'd rather delete all of the subgraphs for a variant, see the docs for [`graph delete`](./graphs/#deleting-a-variant).

--- a/docs/source/subgraphs.md
+++ b/docs/source/subgraphs.md
@@ -134,7 +134,7 @@ The argument `my-supergraph@my-variant` in the example above is a [graph ref](./
 
 > You can omit `@` and the variant name. If you do, Rover publishes the schema to the default variant, named `current`.
 
-If the graph exists in the graph registry, but the variant does not, a new variant will be created on publish.
+If the graph exists in the graph registry but the variant does _not_, a new variant is created on publish.
 
 Options include:
 
@@ -237,4 +237,17 @@ To configure the behavior of schema checks (such as the time range of past opera
 
 ## Deleting a subgraph
 
-You can delete a single subgraph by running `rover subgraph delete`. Note that this command will error if any other subgraph references types specified by the subgraph you're deleting. If you'd rather delete all of the subgraphs for a variant, see the docs for [`graph delete`](./graphs/#deleting-a-variant).
+> This requires first [authenticating Rover with Apollo Studio](./configuring/#authenticating-with-apollo-studio).
+
+You can delete a single subgraph from a federated graph by running `rover subgraph delete`:
+
+```bash
+# ⚠️ This action is irreversible!
+rover subgraph delete my-graph@my-variant --name subgraph-to-delete
+```
+
+This command prompts you for confirmation because the action is irreversible. You can bypass confirmation by passing the `--confirm` flag.
+
+This command fails with an error if any _other_ subgraph references types that originate in this subgraph.
+
+To delete an entire federated graph instead of a single subgraph, see [Deleting a variant](./graphs/#deleting-a-variant).

--- a/src/command/graph/delete.rs
+++ b/src/command/graph/delete.rs
@@ -1,0 +1,46 @@
+use ansi_term::Colour::{Cyan, Yellow};
+use serde::Serialize;
+use structopt::StructOpt;
+
+use rover_client::operations::graph::delete::{self, GraphDeleteInput};
+use rover_client::shared::GraphRef;
+
+use crate::command::RoverOutput;
+use crate::utils::client::StudioClientConfig;
+use crate::Result;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Delete {
+    /// <NAME>@<VARIANT> of graph in Apollo Studio to fetch from.
+    /// @<VARIANT> may be left off, defaulting to @current
+    #[structopt(name = "GRAPH_REF")]
+    #[serde(skip_serializing)]
+    graph: GraphRef,
+
+    /// Name of configuration profile to use
+    #[structopt(long = "profile", default_value = "default")]
+    #[serde(skip_serializing)]
+    profile_name: String,
+}
+
+impl Delete {
+    pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
+        let client = client_config.get_authenticated_client(&self.profile_name)?;
+        let graph_ref = self.graph.to_string();
+        eprintln!(
+            "Deleting {} using credentials from the {} profile.",
+            Cyan.normal().paint(&graph_ref),
+            Yellow.normal().paint(&self.profile_name)
+        );
+
+        delete::run(
+            GraphDeleteInput {
+                graph_ref: self.graph.clone(),
+            },
+            &client,
+        )?;
+
+        eprintln!("Successfully deleted {}.", Cyan.normal().paint(&graph_ref));
+        Ok(RoverOutput::EmptySuccess)
+    }
+}

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -1,4 +1,5 @@
 mod check;
+mod delete;
 mod fetch;
 mod introspect;
 mod publish;
@@ -24,6 +25,9 @@ pub enum Command {
     /// against a graph schema in the Apollo graph registry
     Check(check::Check),
 
+    /// Delete a graph schema from the Apollo graph registry
+    Delete(delete::Delete),
+
     /// Fetch a graph schema from the Apollo graph registry
     Fetch(fetch::Fetch),
 
@@ -42,6 +46,7 @@ impl Graph {
     ) -> Result<RoverOutput> {
         match &self.command {
             Command::Check(command) => command.run(client_config, git_context),
+            Command::Delete(command) => command.run(client_config),
             Command::Fetch(command) => command.run(client_config),
             Command::Publish(command) => command.run(client_config, git_context),
             Command::Introspect(command) => command.run(client_config.get_reqwest_client()),

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverOutput;
-use crate::utils::client::StudioClientConfig;
+use crate::utils::{self, client::StudioClientConfig};
 use crate::Result;
 
 use rover_client::operations::subgraph::delete::{self, SubgraphDeleteInput};
@@ -67,7 +67,7 @@ impl Delete {
             .print();
 
             // I chose not to error here, since this is a perfectly valid path
-            if !confirm_delete()? {
+            if !utils::confirm_delete()? {
                 eprintln!("Delete cancelled by user");
                 return Ok(RoverOutput::EmptySuccess);
             }
@@ -90,16 +90,5 @@ impl Delete {
             dry_run,
             delete_response,
         })
-    }
-}
-
-fn confirm_delete() -> Result<bool> {
-    eprintln!("Would you like to continue [y/n]");
-    let term = console::Term::stdout();
-    let confirm = term.read_line()?;
-    if confirm.to_lowercase() == *"y" {
-        Ok(true)
-    } else {
-        Ok(false)
     }
 }

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -82,7 +82,11 @@ impl Display for Suggestion {
                 "Try running the command on a valid federated graph, or use the appropriate `rover graph` command instead of `rover subgraph`.".to_string()
             }
             Suggestion::CheckGraphNameAndAuth => {
-                "Make sure your graph name is typed correctly, and that your API key is valid. (Are you using the right profile?)".to_string()
+                format!(
+                    "Make sure your graph name is typed correctly, and that your API key is valid.\n        You can run {} to check if you are authenticated.\n        If you are trying to create a new graph, you must do so online at {}, by clicking \"New Graph\".",
+                    Yellow.normal().paint("`rover config whoami`"),
+                    Cyan.normal().paint("https://studio.apollographql.com")
+                )
             }
             Suggestion::ProvideValidSubgraph(valid_subgraphs) => {
                 format!(
@@ -97,7 +101,7 @@ impl Display for Suggestion {
                     let num_valid_variants = valid_variants.len();
                     let color_graph_name = Cyan.normal().paint(&graph_ref.name);
                     match num_valid_variants {
-                        0 => format!("Graph {} exists, but has no variants. You can create a new variant by running {}.", &color_graph_name, Yellow.normal().paint("`rover graph publish`")),
+                        0 => format!("Graph {} exists, but has no variants. You can create a new monolithic variant by running {} for your graph schema, or a new federated variant by running {} for all of your subgraph schemas.", &color_graph_name, Yellow.normal().paint("`rover graph publish`"), Yellow.normal().paint("`rover subgraph publish`")),
                         1 => format!("The only existing variant for graph {} is {}.", &color_graph_name, Cyan.normal().paint(&valid_variants[0])),
                         2 => format!("The existing variants for graph {} are {} and {}.", &color_graph_name, Cyan.normal().paint(&valid_variants[0]), Cyan.normal().paint(&valid_variants[1])),
                         3 ..= 10 => {

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -95,26 +95,27 @@ impl Display for Suggestion {
                     format!("Did you mean \"{}@{}\"?", graph_ref.name, maybe_variant)
                 } else {
                     let num_valid_variants = valid_variants.len();
+                    let color_graph_name = Cyan.normal().paint(&graph_ref.name);
                     match num_valid_variants {
-                        0 => unreachable!(&format!("Graph \"{}\" exists but has no variants.", graph_ref.name)),
-                        1 => format!("The only existing variant for graph \"{}\" is \"{}\".", graph_ref.name, valid_variants[0]),
-                        2 => format!("The existing variants for graph \"{}\" are \"{}\" and \"{}\".", graph_ref.name, valid_variants[0], valid_variants[1]),
+                        0 => format!("Graph {} exists, but has no variants. You can create a new variant by running {}.", &color_graph_name, Yellow.normal().paint("`rover graph publish`")),
+                        1 => format!("The only existing variant for graph {} is {}.", &color_graph_name, Cyan.normal().paint(&valid_variants[0])),
+                        2 => format!("The existing variants for graph {} are {} and {}.", &color_graph_name, Cyan.normal().paint(&valid_variants[0]), Cyan.normal().paint(&valid_variants[1])),
                         3 ..= 10 => {
                             let mut valid_variants_msg = "".to_string();
                             for (i, variant) in valid_variants.iter().enumerate() {
                                 if i == num_valid_variants - 1 {
                                     valid_variants_msg.push_str("and ");
                                 }
-                                valid_variants_msg.push_str(&format!("\"{}\"", variant));
+                                valid_variants_msg.push_str(&format!("{}", Cyan.normal().paint(variant)));
                                 if i < num_valid_variants - 1 {
                                     valid_variants_msg.push_str(", ");
                                 }
                             }
-                            format!("The existing variants for graph \"{}\" are {}.", &graph_ref.name, &valid_variants_msg)
+                            format!("The existing variants for graph {} are {}.", &color_graph_name, &valid_variants_msg)
                         }
                         _ => {
-                            let graph_url = format!("{}/graph/{}/settings", &frontend_url_root, &graph_ref.name);
-                            format!("You can view the variants for graph \"{}\" by visiting {}", graph_ref.name, Cyan.normal().paint(&graph_url))
+                            let graph_url = format!("{}/graph/{}/settings", &frontend_url_root, &color_graph_name);
+                            format!("You can view the variants for graph \"{}\" by visiting {}", &color_graph_name, Cyan.normal().paint(&graph_url))
                         }
                     }
                 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,3 +7,14 @@ pub mod stringify;
 pub mod table;
 pub mod telemetry;
 pub mod version;
+
+pub fn confirm_delete() -> std::io::Result<bool> {
+    eprintln!("Would you like to continue? [y/n]");
+    let term = console::Term::stdout();
+    let confirm = term.read_line()?;
+    if confirm.to_lowercase() == *"y" {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}


### PR DESCRIPTION
starts to fix #722 by adding the `rover graph delete` command.

`rover graph delete` allows you to delete a single variant from your graph.
It will never fully delete the graph, only the specified variant.

If you delete all the variants from a graph, you still retain ownership over the graph ref and graph title, and it will show in Studio as an "unconfigured" graph:

<img width="851" alt="image" src="https://user-images.githubusercontent.com/9408157/136253472-6cee8758-abf4-43d3-846e-79859a9c3034.png">

This PR also updates quite a few error messages to make them more clear, and handles a few more cases than it did previously, taking in some work I had on a local branch for #729 


TODO:

- [x] Don't require `--convert` for `subgraph publish` on a variant with no schema
- [x] Print [y/N] prompt on `graph delete`
- [x] Add `--confirm` flag to bypass `[y/N]` prompt
- [x] Update the docs for graph provisioning