### PR TITLE
feat: adds ability to run third party subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bf633f7ad4e022f63c4197085047af9606a08a3df17badbb7bd3644dc7faeb"
+dependencies = [
+ "anyhow",
+ "core-foundation",
+ "crypto-hash",
+ "filetime",
+ "hex 0.4.3",
+ "jobserver",
+ "libc",
+ "log",
+ "miow",
+ "same-file",
+ "shell-escape",
+ "tempfile",
+ "walkdir",
+ "winapi",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +616,24 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "commoncrypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+dependencies = [
+ "commoncrypto-sys",
+]
+
+[[package]]
+name = "commoncrypto-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -758,6 +798,18 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-hash"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
+dependencies = [
+ "commoncrypto",
+ "hex 0.3.2",
+ "openssl",
+ "winapi",
+]
 
 [[package]]
 name = "csv"
@@ -1421,6 +1473,18 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "houston"
@@ -2475,6 +2539,7 @@ dependencies = [
  "billboard",
  "binstall",
  "camino",
+ "cargo-util",
  "chrono",
  "console",
  "crossterm",
@@ -2506,6 +2571,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -2770,6 +2836,12 @@ checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ anyhow = "1"
 atty = "0.2"
 billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
 camino = { version = "1", features = ["serde1"] }
+cargo-util = "0.1"
 chrono = "0.4"
 console = "0.14"
 crossterm = "0.21"
@@ -69,6 +70,7 @@ termimad = "0.16"
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
+which = "4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ SUBCOMMANDS:
     update        Commands related to updating rover
 ```
 
+## External Subcommands
+
+Rover is designed to be extensible with new subcommands without having to modify Rover itself. This is achieved by translating a `rover` invocation of the form `rover (?<command>[^ ]+)` into an invocation of an external tool `rover-${command}` that then needs to be present in the user's `$PATH`.
+
+## Code Organization
+
 This repo is organized as a [`cargo` workspace], containing several related projects:
 
 - `rover`: Apollo's suite of GraphQL developer productivity tools


### PR DESCRIPTION
This PR introduces the ability to run external third party subcommands, just like [cargo](https://github.com/rust-lang/cargo/wiki/Third-party-cargo-subcommands).

New README section:

> Rover is designed to be extensible with new subcommands without having to modify Rover itself. This is achieved by translating a `rover` invocation of the form `rover (?<command>[^ ]+)` into an invocation of an external tool `rover-${command}` that then needs to be present in the user's `$PATH`.

So, if you want `rover other` to work, you must make a binary called `rover-other`, add it to your `PATH`, and make it accept an `other` argument, since we pass the arguments unchanged. 

The docs on the `exec_replace` function we're using:

> /// Replaces the current process with the target process.
> ///
> /// On Unix, this executes the process using the Unix syscall `execvp`, which will block
> /// this process, and will only return if there is an error.
> ///
> /// On Windows this isn't technically possible. Instead we emulate it to the best of our
> /// ability. One aspect we fix here is that we specify a handler for the Ctrl-C handler.
> /// In doing so (and by effectively ignoring it) we should emulate proxying Ctrl-C
> /// handling to the application at hand, which will either terminate or handle it itself.
> /// According to Microsoft's documentation at
> /// <https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals>.
> /// the Ctrl-C signal is sent to all processes attached to a terminal, which should
> /// include our child process. If the child terminates then we'll reap them in Cargo
> /// pretty quickly, and if the child handles the signal then we won't terminate
> /// (and we shouldn't!) until the process itself later exits.