### PR TITLE
feat(composition): default to routing url from graph registry

### DIFF
--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -1172,18 +1172,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.11.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
@@ -1338,6 +1326,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1449,15 +1449,15 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
@@ -3438,15 +3438,6 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "glob-parent": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.3"
-          }
-        },
         "globals": {
           "version": "13.11.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
@@ -3588,6 +3579,17 @@
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
@@ -3683,12 +3685,12 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "requires": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       }
     },
     "globals": {

--- a/crates/rover-client/src/operations/subgraph/fetch/fetch_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/fetch/fetch_query.graphql
@@ -5,6 +5,7 @@ query SubgraphFetchQuery($graph_id: ID!, $variant: String!) {
       ... on FederatedImplementingServices {
         services {
           name
+          url
           activePartialSchema {
             sdl
           }

--- a/crates/rover-client/src/shared/fetch_response.rs
+++ b/crates/rover-client/src/shared/fetch_response.rs
@@ -16,6 +16,6 @@ pub struct Sdl {
 #[serde(rename_all(serialize = "lowercase"))]
 pub enum SdlType {
     Graph,
-    Subgraph,
+    Subgraph { routing_url: Option<String> },
     Supergraph,
 }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -75,7 +75,7 @@ impl RoverOutput {
             }
             RoverOutput::FetchResponse(fetch_response) => {
                 match fetch_response.sdl.r#type {
-                    SdlType::Graph | SdlType::Subgraph => print_descriptor("SDL"),
+                    SdlType::Graph | SdlType::Subgraph { .. } => print_descriptor("SDL"),
                     SdlType::Supergraph => print_descriptor("Supergraph SDL"),
                 }
                 print_content(&fetch_response.sdl.contents);
@@ -469,7 +469,9 @@ mod tests {
         let mock_fetch_response = FetchResponse {
             sdl: Sdl {
                 contents: "sdl contents".to_string(),
-                r#type: SdlType::Subgraph,
+                r#type: SdlType::Subgraph {
+                    routing_url: Some("http://localhost:8000/graphql".to_string()),
+                },
             },
         };
         let actual_json: JsonOutput = RoverOutput::FetchResponse(mock_fetch_response).into();


### PR DESCRIPTION
Back in #519 we had a `TODO` to default to the routing URL in the graph registry for a subgraph when doing `supergraph compose` locally. This PR makes that happen - might be considered a breaking change? maybe? if you like, somehow relied on leaving `routing_url` blank and had something in the graph registry, that url will now be used. quick workaround is to just set `routing_url = ""` if for some reason you really must omit URLs from your supergraph SDL. 

In all reality this is more like a "fixing" change where we'll just "do the right thing" by getting the url from the registry, or errors will show up rather than producing invalid supergraph SDL without the URLs.