### PR TITLE
chore: updates workspace to rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,13 @@ description = """
 Rover is a tool for working with the Apollo GraphQL Registry.
 """
 documentation = "https://go.apollo.dev/r/docs"
-edition = "2018"
+edition = "2021"
 keywords = ["graphql", "cli", "apollo", "graph", "registry"]
 license = "MIT"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
 version = "0.3.0"
-resolver = "2"
 
 [[bin]]
 name = "rover"

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -2,7 +2,7 @@
 name = "houston"
 version = "0.0.0"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 camino = "1"

--- a/crates/robot-panic/Cargo.toml
+++ b/crates/robot-panic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "robot-panic"
 version = "1.0.3"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 backtrace = "0.3"

--- a/crates/robot-panic/src/report.rs
+++ b/crates/robot-panic/src/report.rs
@@ -171,13 +171,10 @@ impl Report {
                         "body",
                         &format!(
                             "<!--\n  Please add some additional information about what you were trying to \
-                            do before submitting this report\n --> \n\n\
-                            
-                            ## Description\n\
-
-                            Describe the issue that you're seeing.\n\n\
-
-                            **Crash Report**\n \
+                            do before submitting this report\n --> \n\n\n
+                            ## Description\n\n
+                            Describe the issue that you're seeing.\n\n\n
+                            **Crash Report**\n\n
                             ```toml\n{}\n```\n",
                             &crash_report
                         ),

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 description = "an http client for making graphql requests for the rover CLI"
-edition = "2018"
+edition = "2021"
 name = "rover-client"
 version = "0.0.0"
 

--- a/crates/sdl-encoder/Cargo.toml
+++ b/crates/sdl-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["lrlna <shestak.irina@gmail.com>"]
-edition = "2018"
+edition = "2021"
 name = "sdl-encoder"
 version = "0.1.0"
 

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sputnik"
 version = "0.0.0"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 camino = "1"

--- a/crates/timber/Cargo.toml
+++ b/crates/timber/Cargo.toml
@@ -2,7 +2,7 @@
 name = "timber"
 version = "0.1.0"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = "1"

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -2,7 +2,7 @@
 name = "binstall"
 version = "0.1.0"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 atty = "0.2"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 ansi_term = "0.12"

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -9,6 +9,14 @@ pub struct Test {
     // The target to build Rover for
     #[structopt(long = "target", env = "XTASK_TARGET", default_value, possible_values = &POSSIBLE_TARGETS)]
     target: Target,
+
+    // The supergraph-demo branch to check out
+    #[structopt(long = "branch", default_value = "main")]
+    pub(crate) branch: String,
+
+    // The supergraph-demo org to clone
+    #[structopt(long = "org", default_value = "apollographql")]
+    pub(crate) org: String,
 }
 
 impl Test {
@@ -19,8 +27,8 @@ impl Test {
         unit_test_runner.run(verbose)?;
         let integration_test_runner = IntegrationTest {
             target: self.target.clone(),
-            branch: Default::default(),
-            org: Default::default(),
+            branch: self.branch.clone(),
+            org: self.org.clone(),
         };
         integration_test_runner.run(verbose)?;
         Ok(())


### PR DESCRIPTION
notable changes:

- some strange escaped newlines had new warnings, those have been removed.
- the default feature resolver for the 2021 edition is 2, so we no longer need to specify it in the manifest.
- `cargo xtask test` wasn't ever really working properly and I never noticed since we don't run it in CI