### PR TITLE
fix: properly build rover-fed artifacts

### DIFF
--- a/crates/rover-fed/README.md
+++ b/crates/rover-fed/README.md
@@ -1,0 +1,9 @@
+<div align="center">
+  <h1><code>rover-fed</code></h1>
+
+  <p>
+    <strong>The composition plugin used in Apollo's Rover CLI</strong>
+  </p>
+</div>
+
+This binary is typically invoked through Rover rather than being called directly.

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use structopt::StructOpt;
 
-use crate::utils::{PKG_PROJECT_NAME, PKG_PROJECT_ROOT, PKG_VERSION, RELEASE_BIN};
+use crate::utils::{PKG_PROJECT_ROOT, PKG_VERSION};
 
 const ENTITLEMENTS: &str = "macos-entitlements.plist";
 
@@ -41,7 +41,7 @@ pub struct PackageMacos {
 }
 
 impl PackageMacos {
-    pub fn run(&self, release_path: impl AsRef<Path>) -> Result<()> {
+    pub fn run(&self, release_path: impl AsRef<Path>, bin_name: &str) -> Result<()> {
         let release_path = release_path.as_ref();
         let temp = tempfile::tempdir().context("could not create temporary directory")?;
 
@@ -185,14 +185,14 @@ impl PackageMacos {
         crate::info!("Zipping dist...");
         let dist_zip = temp
             .path()
-            .join(format!("{}-{}.zip", PKG_PROJECT_NAME, *PKG_VERSION));
+            .join(format!("{}-{}.zip", bin_name, *PKG_VERSION));
         let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(
             std::fs::File::create(&dist_zip).context("could not create file")?,
         ));
         let options = zip::write::FileOptions::default()
             .compression_method(zip::CompressionMethod::Stored)
             .unix_permissions(0o755);
-        let path = Path::new("dist").join(RELEASE_BIN);
+        let path = Path::new("dist").join(bin_name);
         crate::info!("Adding {} as {}...", release_path.display(), path.display());
         zip.start_file(path.to_str().unwrap(), options)?;
         std::io::copy(

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -6,10 +6,6 @@ use lazy_static::lazy_static;
 use std::{convert::TryFrom, env, process::Output, str};
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
-#[cfg(not(windows))]
-pub const RELEASE_BIN: &str = "rover";
-#[cfg(windows)]
-pub const RELEASE_BIN: &str = "rover.exe";
 #[allow(dead_code)]
 pub const PKG_PROJECT_NAME: &str = "rover";
 
@@ -19,7 +15,7 @@ lazy_static! {
     pub(crate) static ref PKG_PROJECT_ROOT: Utf8PathBuf =
         project_root().expect("Could not find Rover's project root.");
     pub(crate) static ref TARGET_DIR: Utf8PathBuf =
-        target_dir().expect("Could not find Router's target dir.");
+        target_dir().expect("Could not find Rover's target dir.");
 }
 
 #[macro_export]


### PR DESCRIPTION
this PR makes sure that we're including the proper README and LICENSE when building `rover-fed` with `cargo xtask package`