### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,89 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.4.0] - 2021-11-02
+
+## 🚀 Features
+
+<!-- TODO: add in the PRs that we merge tomorrow and get buy-in on wording. -->
+
+- **Federation 2 Support - [EverlastingBugstopper], [pull/887]**
+
+  The alpha version of Federation 2 [has been released](https://www.apollographql.com/docs/federation/v2/)!
+
+  In Rover, you can use the Federation 2 composition model by running `rover fed2 supergraph compose --config <supergraph.yaml>` after [installing](https://www.apollographql.com/docs/federation/v2/federation-2/moving-to-federation-2/) the `rover-fed2` binary.. You _must_ install `rover-fed2` before you can run `rover fed2 supergraph compose`, and they _must_ be the same version in order to be compatible with each other.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/887]: https://github.com/apollographql/rover/pull/887
+
+- **Graph lifecycle management - [EverlastingBugstopper], [issue/722] [pull/861]**
+
+  Rover now supports the `rover graph delete` command, which will delete all subgraphs in a federated variant, or delete the schema for a non-federated variant.
+
+  There is also new documentation on how [`rover graph publish`](https://www.apollographql.com/docs/rover/graphs/#publishing-a-schema-to-apollo-studio) and [`rover subgraph publish`](https://www.apollographql.com/docs/rover/subgraphs/#publishing-a-subgraph-schema-to-apollo-studio) create new variants.
+
+  Additionally, you no longer need to pass `--convert` to `subgraph publish` when publishing a subgraph to a new variant, though you will still need it when converting a non-federated variant to a federated variant.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/861]: https://github.com/apollographql/rover/pull/861
+  [issue/722]: https://github.com/apollographql/rover/issues/722
+
+- **Fetch the subgraph's `routing_url` from the graph registry if it isn't specified in a `supergraph.yaml` file - [EverlastingBugstopper], [pull/873]**
+
+  Now, whenever `routing_url` is not specified for a subgraph in `supergraph.yaml` and the source is a `graphref` (which fetches a subgraph from the graph registry), the composed supergraph will use the routing URL from the graph registry for that subgraph instead of an empty string.
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/873]: https://github.com/apollographql/rover/pull/873
+
+## 🐛 Fixes
+
+- **Output enum descriptions in introspection results - [lrlna], [issue/878] [pull/879]**
+
+  Now, any introspection result that contains descriptions for enums will include them in the output.
+
+  [lrlna]: https://github.com/lrlna
+  [pull/879]: https://github.com/apollographql/rover/pull/879
+  [issue/878]: https://github.com/apollographql/rover/issues/878
+
+- **Output directive arguments in introspection results - [lrlna], [pull/858]**
+
+  Now, any introspection results that contain directive arguments will include them in the output.
+
+  [lrlna]: https://github.com/lrlna
+  [pull/858]: https://github.com/apollographql/rover/pull/858
+
+## 🛠 Maintenance
+
+- **Refactor HTTP client configuration - [ptondereau], [issue/844] [pull/890]**
+
+  When Rover first introduced options to configure the HTTP client, there was a function that took configuration arguments, and returned a client. This has now been refactored to use a more idiomatic [builder](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html) approach. Thanks @ptondereau!
+
+  [ptondereau]: https://github.com/ptondereau
+  [pull/890]: https://github.com/apollographql/rover/pull/890
+  [issue/844]: https://github.com/apollographql/rover/issues/844
+
+- **Updates workspace to the 2021 Rust edition - [EverlastingBugstopper], [pull/886]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/886]: https://github.com/apollographql/rover/pull/886
+
+## 📚 Documentation
+
+- **Replace 'data graph' with 'graph' in all of the docs - [trevorblades], [pull/860]**
+
+  [trevorblades]: https://github.com/trevorblades
+  [pull/860]: https://github.com/apollographql/rover/pull/860
+
+- **Add a missing backtick to `$PATH` in the CI install docs - [EverlastingBugstopper], [pull/874]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/874]: https://github.com/apollographql/rover/pull/874
+
+- **Clarify the drawbacks of publishing introspection results to the graph registry - [EverlastingBugstopper], [pull/866]**
+
+  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
+  [pull/866]: https://github.com/apollographql/rover/pull/866
+
 # [0.3.0] - 2021-09-24
 
 > Important: 1 breaking change below, indicated by **❗ BREAKING ❗**

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.3.0
+Rover 0.4.0
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -66,23 +66,43 @@ USAGE:
     rover [FLAGS] [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
-        --insecure-accept-invalid-certs        Accept invalid certificates when performing HTTPS requests
-        --insecure-accept-invalid-hostnames    Accept invalid hostnames when performing HTTPS requests
-    -h, --help                                 Prints help information
-    -V, --version                              Prints version information
+        --insecure-accept-invalid-certs
+            Accept invalid certificates when performing HTTPS requests.
+
+            You should think very carefully before using this flag.
+
+            If invalid certificates are trusted, any certificate for any site will be trusted for use. This includes
+            expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+        --insecure-accept-invalid-hostnames
+            Accept invalid hostnames when performing HTTPS requests.
+
+            You should think very carefully before using this flag.
+
+            If hostname verification is not used, any valid certificate for any site will be trusted for use from any
+            other. This introduces a significant vulnerability to man-in-the-middle attacks.
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
-        --client-timeout <client-timeout>    Configure the timeout length (in seconds) when performing HTTP(S) requests
-                                             [default: 30]
-    -l, --log <log-level>                    Specify Rover's log level [possible values: error, warn,
-                                             info, debug, trace]
-        --output <output-type>               Specify Rover's output type [default: plain]  [possible values:
-                                             json, plain]
+        --client-timeout <client-timeout>
+            Configure the timeout length (in seconds) when performing HTTP(S) requests [default: 30]
+
+    -l, --log <log-level>
+            Specify Rover's log level [possible values: error, warn, info, debug,
+            trace]
+        --output <output-type>
+            Specify Rover's output type [default: plain]  [possible values: json, plain]
+
 
 SUBCOMMANDS:
     config        Configuration profile commands
     docs          Interact with Rover's documentation
     explain       Explain error codes
+    fed2          Federation 2 Alpha commands
     graph         Graph API schema commands
     help          Prints this message or the help of the given subcommand(s)
     subgraph      Subgraph schema commands

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -18,24 +18,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -43,51 +43,116 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity/node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -103,12 +168,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -200,14 +265,39 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "7.16.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -366,12 +456,12 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/@graphql-tools/import": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.7.tgz",
-      "integrity": "sha512-E892M7WF8a1vCcDENP/ODmwg5zwUCSZlGExsFpWhgemmbNN6HaXHiJglL2kfp3sWGD8/ayjMcj+f9fX7PLDytg==",
+      "version": "6.5.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.8.tgz",
+      "integrity": "sha512-G0/PRf7tY3FZ8QzCeI+XH+CMye1Gd5JHw1G8RvhELxKG0l94xMAih/y7n8FgYp1Q2NgjsY2hFhUpdqgvF/WU3w==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.5.1",
+        "@graphql-tools/utils": "8.5.2",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -380,9 +470,9 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/@graphql-tools/utils": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-      "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.2.tgz",
+      "integrity": "sha512-wxA51td/759nQziPYh+HxE0WbURRufrp1lwfOYMgfK4e8Aa6gCa1P1p6ERogUIm423NrIfOVau19Q/BBpHdolw==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -392,18 +482,18 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.0.2.tgz",
-      "integrity": "sha512-O8De/OscAaD4Kwe70Ik3BKg2DQRKh8J5Bq5HsMKWb9OtzVU+t/zoPD8wh7sNNxFNG8sLjT4cCP/9UorQpHTdeQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.1.0.tgz",
+      "integrity": "sha512-Myqay6pmdcmX3KqoH+bMbeKZ1cTODpHS2CxF1ZzNnfTE+YUpGTcp01bOw6LpzamRb0T/WTYtGFbZeXGo9Hab2Q==",
       "dev": true,
       "dependencies": {
         "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
-        "@graphql-tools/graphql-file-loader": "^7.0.1",
-        "@graphql-tools/json-file-loader": "^7.0.1",
-        "@graphql-tools/load": "^7.1.0",
-        "@graphql-tools/merge": "^6.2.16 || ^7.0.0 || ^8.0.0",
-        "@graphql-tools/url-loader": "^7.0.3",
-        "@graphql-tools/utils": "^8.0.1",
+        "@graphql-tools/graphql-file-loader": "^7.3.2",
+        "@graphql-tools/json-file-loader": "^7.3.2",
+        "@graphql-tools/load": "^7.4.1",
+        "@graphql-tools/merge": "^8.2.1",
+        "@graphql-tools/url-loader": "^7.4.2",
+        "@graphql-tools/utils": "^8.5.1",
         "cosmiconfig": "7.0.1",
         "cosmiconfig-toml-loader": "1.0.0",
         "minimatch": "3.0.4",
@@ -413,7 +503,7 @@
         "node": ">= 10.0.0"
       },
       "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/graphql-file-loader": {
@@ -491,27 +581,25 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/url-loader": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.4.2.tgz",
-      "integrity": "sha512-dS/cTux3Xw5flM9KHCwPzq7S0Yy7ff8mOmvq2quDfYmn0OawhccyEcjGnrgQ896ujwg+qYQqEyB62hv4A5962w==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.5.0.tgz",
+      "integrity": "sha512-itSxMZs0/Qy89uzC8ncR9dWewspLympWLaI1pA7oEcz3sMiO/TslA86SG2CzIp76KdQMd5HsPpsz6w3jfhhYnQ==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/delegate": "^8.4.1",
         "@graphql-tools/utils": "^8.5.1",
         "@graphql-tools/wrap": "^8.3.1",
-        "@n1ru4l/graphql-live-query": "0.8.1",
+        "@n1ru4l/graphql-live-query": "0.8.2",
         "@types/websocket": "1.0.4",
         "@types/ws": "^8.0.0",
-        "abort-controller": "3.0.0",
-        "cross-fetch": "3.1.4",
+        "cross-undici-fetch": "0.0.19",
         "dset": "^3.1.0",
         "extract-files": "11.0.0",
-        "form-data": "4.0.0",
         "graphql-sse": "^1.0.1",
         "graphql-ws": "^5.4.1",
         "isomorphic-ws": "4.0.1",
         "meros": "1.1.4",
-        "subscriptions-transport-ws": "^0.10.0",
+        "subscriptions-transport-ws": "^0.11.0",
         "sync-fetch": "0.3.1",
         "tslib": "~2.3.0",
         "valid-url": "1.0.9",
@@ -601,18 +689,18 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/url-loader/node_modules/@n1ru4l/graphql-live-query": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.1.tgz",
-      "integrity": "sha512-x5SLY+L9/5s07OJprISXx4csNBPF74UZeTI01ZPSaxOtRz2Gljk652kSPf6OjMLtx5uATr35O0M3G0LYhHBLtg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.2.tgz",
+      "integrity": "sha512-StBuj5gxoVbFx2axvJF6ArnHVqVnibYeekRjO2T1KbUWyR+SbxaqDg9E3Ch9XkJnQAb+7HKW2JSUc+jnuqsXxQ==",
       "dev": true,
       "peerDependencies": {
         "graphql": "^15.4.0"
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/url-loader/node_modules/graphql-sse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.4.tgz",
-      "integrity": "sha512-oB43ifRcEdElgep9jTP9qsj5cJ7Ny/1tAFyIl1W3A0hXRRg/P71tUHzMFBrRkEsJ9IA7MTp+RKSJfh52QR6PBQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.5.tgz",
+      "integrity": "sha512-x7HpPtbODImc20YfpKea++8Tj2ruKb1oLWNxd4xxa62BASxZRdm+uIq5bYGv7TwENeckgi/MjELtj2dZrTkQ8A==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -622,9 +710,9 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/url-loader/node_modules/graphql-ws": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.4.tgz",
-      "integrity": "sha512-t8NfKc4pz7F4f1prqa/BVopRDPtykEtiLUk8A2ByB+9F8FUDoshYxQHVaZhDVaQ+NMULiILiAblkF/bcwYW6yg==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
+      "integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -634,9 +722,9 @@
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/url-loader/node_modules/subscriptions-transport-ws": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.10.0.tgz",
-      "integrity": "sha512-k28LhLn3abJ1mowFW+LP4QGggE0e3hrk55zXbMHyAeZkCUYtC0owepiwqMD3zX8DglQVaxnhE760pESrNSEzpg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
       "dev": true,
       "dependencies": {
         "backo2": "^1.0.2",
@@ -646,7 +734,7 @@
         "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependencies": {
-        "graphql": ">=0.10.0"
+        "graphql": "^15.7.2 || ^16.0.0"
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin/node_modules/graphql-config/node_modules/@graphql-tools/url-loader/node_modules/subscriptions-transport-ws/node_modules/ws": {
@@ -709,9 +797,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "node_modules/@iarna/toml": {
@@ -1079,15 +1167,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1100,6 +1179,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cross-undici-fetch": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.0.19.tgz",
+      "integrity": "sha512-6FToDMNXfNQvnyhXBtjPvNujeHBzwCSXcljFB+MKws8tEmDQvSBU3hyiZVSulQIEpsxn9vIlNh71qmOEmH7fzA==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.5",
+        "undici": "^4.9.3"
       }
     },
     "node_modules/dataloader": {
@@ -1607,9 +1698,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1948,10 +2039,13 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -2370,6 +2464,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "node_modules/ts-node": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
@@ -2440,6 +2540,15 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.9.3.tgz",
+      "integrity": "sha512-9WbSy4Y2At64gXTOclOjkEgkVrQj09DoH3sgyUYP6e8XCMU/VN8UbjIl+Syd084JgLnlYslgJ0jFM+3hx1ClvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/unixify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -2480,6 +2589,22 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -2572,61 +2697,121 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-validator-identifier": {
@@ -2636,12 +2821,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -2711,14 +2896,32 @@
       "dev": true
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
@@ -2848,38 +3051,38 @@
           }
         },
         "@graphql-tools/import": {
-          "version": "6.5.7",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.7.tgz",
-          "integrity": "sha512-E892M7WF8a1vCcDENP/ODmwg5zwUCSZlGExsFpWhgemmbNN6HaXHiJglL2kfp3sWGD8/ayjMcj+f9fX7PLDytg==",
+          "version": "6.5.8",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.5.8.tgz",
+          "integrity": "sha512-G0/PRf7tY3FZ8QzCeI+XH+CMye1Gd5JHw1G8RvhELxKG0l94xMAih/y7n8FgYp1Q2NgjsY2hFhUpdqgvF/WU3w==",
           "dev": true,
           "requires": {
-            "@graphql-tools/utils": "8.5.1",
+            "@graphql-tools/utils": "8.5.2",
             "resolve-from": "5.0.0",
             "tslib": "~2.3.0"
           }
         },
         "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
+          "version": "8.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.2.tgz",
+          "integrity": "sha512-wxA51td/759nQziPYh+HxE0WbURRufrp1lwfOYMgfK4e8Aa6gCa1P1p6ERogUIm423NrIfOVau19Q/BBpHdolw==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
           }
         },
         "graphql-config": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.0.2.tgz",
-          "integrity": "sha512-O8De/OscAaD4Kwe70Ik3BKg2DQRKh8J5Bq5HsMKWb9OtzVU+t/zoPD8wh7sNNxFNG8sLjT4cCP/9UorQpHTdeQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.1.0.tgz",
+          "integrity": "sha512-Myqay6pmdcmX3KqoH+bMbeKZ1cTODpHS2CxF1ZzNnfTE+YUpGTcp01bOw6LpzamRb0T/WTYtGFbZeXGo9Hab2Q==",
           "dev": true,
           "requires": {
             "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
-            "@graphql-tools/graphql-file-loader": "^7.0.1",
-            "@graphql-tools/json-file-loader": "^7.0.1",
-            "@graphql-tools/load": "^7.1.0",
-            "@graphql-tools/merge": "^6.2.16 || ^7.0.0 || ^8.0.0",
-            "@graphql-tools/url-loader": "^7.0.3",
-            "@graphql-tools/utils": "^8.0.1",
+            "@graphql-tools/graphql-file-loader": "^7.3.2",
+            "@graphql-tools/json-file-loader": "^7.3.2",
+            "@graphql-tools/load": "^7.4.1",
+            "@graphql-tools/merge": "^8.2.1",
+            "@graphql-tools/url-loader": "^7.4.2",
+            "@graphql-tools/utils": "^8.5.1",
             "cosmiconfig": "7.0.1",
             "cosmiconfig-toml-loader": "1.0.0",
             "minimatch": "3.0.4",
@@ -2948,27 +3151,25 @@
               }
             },
             "@graphql-tools/url-loader": {
-              "version": "7.4.2",
-              "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.4.2.tgz",
-              "integrity": "sha512-dS/cTux3Xw5flM9KHCwPzq7S0Yy7ff8mOmvq2quDfYmn0OawhccyEcjGnrgQ896ujwg+qYQqEyB62hv4A5962w==",
+              "version": "7.5.0",
+              "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.5.0.tgz",
+              "integrity": "sha512-itSxMZs0/Qy89uzC8ncR9dWewspLympWLaI1pA7oEcz3sMiO/TslA86SG2CzIp76KdQMd5HsPpsz6w3jfhhYnQ==",
               "dev": true,
               "requires": {
                 "@graphql-tools/delegate": "^8.4.1",
                 "@graphql-tools/utils": "^8.5.1",
                 "@graphql-tools/wrap": "^8.3.1",
-                "@n1ru4l/graphql-live-query": "0.8.1",
+                "@n1ru4l/graphql-live-query": "0.8.2",
                 "@types/websocket": "1.0.4",
                 "@types/ws": "^8.0.0",
-                "abort-controller": "3.0.0",
-                "cross-fetch": "3.1.4",
+                "cross-undici-fetch": "0.0.19",
                 "dset": "^3.1.0",
                 "extract-files": "11.0.0",
-                "form-data": "4.0.0",
                 "graphql-sse": "^1.0.1",
                 "graphql-ws": "^5.4.1",
                 "isomorphic-ws": "4.0.1",
                 "meros": "1.1.4",
-                "subscriptions-transport-ws": "^0.10.0",
+                "subscriptions-transport-ws": "^0.11.0",
                 "sync-fetch": "0.3.1",
                 "tslib": "~2.3.0",
                 "valid-url": "1.0.9",
@@ -3044,30 +3245,30 @@
                   }
                 },
                 "@n1ru4l/graphql-live-query": {
-                  "version": "0.8.1",
-                  "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.1.tgz",
-                  "integrity": "sha512-x5SLY+L9/5s07OJprISXx4csNBPF74UZeTI01ZPSaxOtRz2Gljk652kSPf6OjMLtx5uATr35O0M3G0LYhHBLtg==",
+                  "version": "0.8.2",
+                  "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.8.2.tgz",
+                  "integrity": "sha512-StBuj5gxoVbFx2axvJF6ArnHVqVnibYeekRjO2T1KbUWyR+SbxaqDg9E3Ch9XkJnQAb+7HKW2JSUc+jnuqsXxQ==",
                   "dev": true,
                   "requires": {}
                 },
                 "graphql-sse": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.4.tgz",
-                  "integrity": "sha512-oB43ifRcEdElgep9jTP9qsj5cJ7Ny/1tAFyIl1W3A0hXRRg/P71tUHzMFBrRkEsJ9IA7MTp+RKSJfh52QR6PBQ==",
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.5.tgz",
+                  "integrity": "sha512-x7HpPtbODImc20YfpKea++8Tj2ruKb1oLWNxd4xxa62BASxZRdm+uIq5bYGv7TwENeckgi/MjELtj2dZrTkQ8A==",
                   "dev": true,
                   "requires": {}
                 },
                 "graphql-ws": {
-                  "version": "5.5.4",
-                  "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.4.tgz",
-                  "integrity": "sha512-t8NfKc4pz7F4f1prqa/BVopRDPtykEtiLUk8A2ByB+9F8FUDoshYxQHVaZhDVaQ+NMULiILiAblkF/bcwYW6yg==",
+                  "version": "5.5.5",
+                  "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
+                  "integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==",
                   "dev": true,
                   "requires": {}
                 },
                 "subscriptions-transport-ws": {
-                  "version": "0.10.0",
-                  "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.10.0.tgz",
-                  "integrity": "sha512-k28LhLn3abJ1mowFW+LP4QGggE0e3hrk55zXbMHyAeZkCUYtC0owepiwqMD3zX8DglQVaxnhE760pESrNSEzpg==",
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+                  "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
                   "dev": true,
                   "requires": {
                     "backo2": "^1.0.2",
@@ -3119,9 +3320,9 @@
       }
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "@iarna/toml": {
@@ -3398,15 +3599,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3416,6 +3608,18 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "cross-undici-fetch": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.0.19.tgz",
+      "integrity": "sha512-6FToDMNXfNQvnyhXBtjPvNujeHBzwCSXcljFB+MKws8tEmDQvSBU3hyiZVSulQIEpsxn9vIlNh71qmOEmH7fzA==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.5",
+        "undici": "^4.9.3"
       }
     },
     "dataloader": {
@@ -3800,9 +4004,9 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
           "dev": true
         }
       }
@@ -4057,10 +4261,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -4341,6 +4548,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "ts-node": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
@@ -4383,6 +4596,12 @@
       "dev": true,
       "peer": true
     },
+    "undici": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.9.3.tgz",
+      "integrity": "sha512-9WbSy4Y2At64gXTOclOjkEgkVrQj09DoH3sgyUYP6e8XCMU/VN8UbjIl+Syd084JgLnlYslgJ0jFM+3hx1ClvQ==",
+      "dev": true
+    },
     "unixify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -4418,6 +4637,22 @@
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
       "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -20,7 +20,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.3.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.0 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.3.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.0' | iex
 ```
 
 ### `npm` installer

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
       "funding": [
         {
           "type": "individual",
@@ -392,9 +392,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "fs-minipass": {
       "version": "2.1.0",

--- a/xtask/src/commands/prep/installers.rs
+++ b/xtask/src/commands/prep/installers.rs
@@ -20,8 +20,8 @@ pub(crate) fn update_versions() -> Result<()> {
 
 /// updates our curl installer with the Cargo.toml version
 fn update_nix_installer_version(parent: &Utf8Path, script_name: &str) -> Result<()> {
-    crate::info!("updating nix installer version.");
     let installer = Utf8PathBuf::from(parent).join("nix").join(script_name);
+    crate::info!("updating $PACKAGE_VERSION in `{}`.", &installer);
     let old_installer_contents = fs::read_to_string(installer.as_path())
         .with_context(|| format!("Could not read contents of {} to a String", &installer))?;
     let version_regex = Regex::new(r#"(?:PACKAGE_VERSION="v){1}(.*)"{1}"#)
@@ -43,8 +43,8 @@ fn update_nix_installer_version(parent: &Utf8Path, script_name: &str) -> Result<
 
 /// updates our windows installer with the Cargo.toml version
 fn update_win_installer_version(parent: &Utf8Path, script_name: &str) -> Result<()> {
-    crate::info!("updating windows installer version.");
     let installer = Utf8PathBuf::from(parent).join("windows").join(script_name);
+    crate::info!("updating $package_version in `{}`.", &installer);
     let old_installer_contents = fs::read_to_string(installer.as_path())
         .with_context(|| format!("Could not read contents of {} to a String", &installer))?;
     let version_regex = Regex::new(r#"(?:\$package_version = 'v){1}(.*)'{1}"#)

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -101,6 +101,7 @@ impl CargoRunner {
 
     pub(crate) fn update_deps(&mut self) -> Result<()> {
         self.cargo_exec_without_target(vec!["update"], vec![])?;
+        self.cargo_exec_without_target(vec!["update"], vec![])?;
         Ok(())
     }
 


### PR DESCRIPTION
## 🚀 Features

<!-- TODO: add in the PRs that we merge tomorrow and get buy-in on wording. -->

- **Federation 2 Support - [EverlastingBugstopper], [pull/887]**

  The alpha version of Federation 2 [has been released](https://www.apollographql.com/docs/federation/v2/)!

  In Rover, you can use the Federation 2 composition model by running `rover fed2 supergraph compose --config <supergraph.yaml>` after [installing](https://www.apollographql.com/docs/federation/v2/federation-2/moving-to-federation-2/) the `rover-fed2` binary.. You _must_ install `rover-fed2` before you can run `rover fed2 supergraph compose`, and they _must_ be the same version in order to be compatible with each other.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/887]: https://github.com/apollographql/rover/pull/887

- **Graph lifecycle management - [EverlastingBugstopper], [issue/722] [pull/861]**

  Rover now supports the `rover graph delete` command, which will delete all subgraphs in a federated variant, or delete the schema for a non-federated variant.

  There is also new documentation on how [`rover graph publish`](https://www.apollographql.com/docs/rover/graphs/#publishing-a-schema-to-apollo-studio) and [`rover subgraph publish`](https://www.apollographql.com/docs/rover/subgraphs/#publishing-a-subgraph-schema-to-apollo-studio) create new variants.

  Additionally, you no longer need to pass `--convert` to `subgraph publish` when publishing a subgraph to a new variant, though you will still need it when converting a non-federated variant to a federated variant.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/861]: https://github.com/apollographql/rover/pull/861
  [issue/722]: https://github.com/apollographql/rover/issues/722

- **Fetch the subgraph's `routing_url` from the graph registry if it isn't specified in a `supergraph.yaml` file - [EverlastingBugstopper], [pull/873]**

  Now, whenever `routing_url` is not specified for a subgraph in `supergraph.yaml` and the source is a `graphref` (which fetches a subgraph from the graph registry), the composed supergraph will use the routing URL from the graph registry for that subgraph instead of an empty string.

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/873]: https://github.com/apollographql/rover/pull/873

## 🐛 Fixes

- **Output enum descriptions in introspection results - [lrlna], [issue/878] [pull/879]**

  Now, any introspection result that contains descriptions for enums will include them in the output.

  [lrlna]: https://github.com/lrlna
  [pull/879]: https://github.com/apollographql/rover/pull/879
  [issue/878]: https://github.com/apollographql/rover/issues/878

- **Output directive arguments in introspection results - [lrlna], [pull/858]**

  Now, any introspection results that contain directive arguments will include them in the output.

  [lrlna]: https://github.com/lrlna
  [pull/858]: https://github.com/apollographql/rover/pull/858

## 🛠 Maintenance

- **Refactor HTTP client configuration - [ptondereau], [issue/844] [pull/890]**

  When Rover first introduced options to configure the HTTP client, there was a function that took configuration arguments, and returned a client. This has now been refactored to use a more idiomatic [builder](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html) approach. Thanks @ptondereau!

  [ptondereau]: https://github.com/ptondereau
  [pull/890]: https://github.com/apollographql/rover/pull/890
  [issue/844]: https://github.com/apollographql/rover/issues/844

- **Updates workspace to the 2021 Rust edition - [EverlastingBugstopper], [pull/886]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/886]: https://github.com/apollographql/rover/pull/886

## 📚 Documentation

- **Replace 'data graph' with 'graph' in all of the docs - [trevorblades], [pull/860]**

  [trevorblades]: https://github.com/trevorblades
  [pull/860]: https://github.com/apollographql/rover/pull/860

- **Add a missing backtick to `$PATH` in the CI install docs - [EverlastingBugstopper], [pull/874]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/874]: https://github.com/apollographql/rover/pull/874

- **Clarify the drawbacks of publishing introspection results to the graph registry - [EverlastingBugstopper], [pull/866]**

  [EverlastingBugstopper]: https://github.com/EverlastingBugstopper
  [pull/866]: https://github.com/apollographql/rover/pull/866