### PR TITLE
feat: adds support for SOCKS proxies and documents existing proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,9 +1608,9 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpmock"
@@ -2630,6 +2630,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tokio-util",
  "url",
  "wasm-bindgen",
@@ -3388,6 +3389,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -27,7 +27,7 @@ graphql_client = "0.10"
 http = "0.2"
 humantime = "2.1.0"
 prettytable-rs = "0.8.0"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "native-tls-vendored"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "brotli", "gzip", "json", "native-tls-vendored", "socks"] }
 regex = "1"
 sdl-encoder = {path = "../sdl-encoder"}
 semver = "1"

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 camino = "1"
 ci_info = { version = "0.14", features = ["serde-1"] }
 git2 = "0.13"
-reqwest = { version = "0.11", default-features = false, features = ["blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "socks"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -19,6 +19,7 @@ module.exports = {
             'index',
             'getting-started',
             'configuring',
+            'proxy',
             'ci-cd',
             'conventions',
             'privacy',

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -96,6 +96,26 @@ The Apollo CLI reads an `apollo.config.js` file to load certain configuration op
 </tbody>
 </table>
 
+### With a Proxy Server
+
+Rover support natively and without extra dependencies a proxy server usage.
+
+Previously, you had to use `global-agent` like this to achieve your goal:
+
+```shell
+GLOBAL_AGENT_HTTP_PROXY=http://proxy-hostname:proxy-port \
+  npx -n '-r global-agent/bootstrap' \
+    apollo client:download-schema …
+```
+
+and now, you need to set `HTTP_PROXY` environment variable like this:
+```shell
+HTTP_PROXY=http://proxy-hostname:proxy-port \
+  rover graph fetch …
+```
+
+Find more about proxy server usage with Rover [here](./proxy)
+
 ## Introspection
 
 In the Apollo CLI, introspection of running services happens behind the scenes when you pass an `--endpoint` option to commands like `service:push`, `service:check`, and `service:download`. In Rover, you instead run the `graph introspect` command and pipe its result to the similar `graph/subgraph push` and `graph/subgraph check` commands.

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -96,11 +96,9 @@ The Apollo CLI reads an `apollo.config.js` file to load certain configuration op
 </tbody>
 </table>
 
-### With a Proxy Server
+### Using a Proxy Server
 
-Rover support natively and without extra dependencies a proxy server usage.
-
-Previously, you had to use `global-agent` like this to achieve your goal:
+With the `apollo` CLI, you had to configure `global-agent` in order to route your traffic through an HTTP proxy:
 
 ```shell
 GLOBAL_AGENT_HTTP_PROXY=http://proxy-hostname:proxy-port \
@@ -108,10 +106,9 @@ GLOBAL_AGENT_HTTP_PROXY=http://proxy-hostname:proxy-port \
     apollo client:download-schema …
 ```
 
-and now, you need to set `HTTP_PROXY` environment variable like this:
+With Rover, you can set the `HTTP_PROXY` and/or the `HTTPS_PROXY` environment variable and all of Rover's traffic will be routed through the specified proxy:
 ```shell
-HTTP_PROXY=http://proxy-hostname:proxy-port \
-  rover graph fetch …
+HTTP_PROXY=http://proxy-hostname:proxy-port rover graph fetch mygraph
 ```
 
 Find more about proxy server usage with Rover [here](./proxy)

--- a/docs/source/proxy.md
+++ b/docs/source/proxy.md
@@ -1,13 +1,13 @@
 ---
 title: "Using Rover with a Proxy Server"
-sidebar_title: "With a Proxy Server"
+sidebar_title: "Proxy Configuration"
 ---
 
 ## Overview
 
-If you have an HTTP or SOCKS5 proxy server on your network between a host running Rover and Apollo's endpoints, you must set `HTTP_PROXY` or `http_proxy` with the hostname or IP address of the proxy server. If you are using a secure proxy server, you can set instead `HTTPS_PROXY` or `https_proxy`.
+If you have an HTTP or SOCKS5 proxy server on your network between a host running Rover and Apollo's endpoints, you must set the `HTTP_PROXY` environment variable to the hostname or IP address of the proxy server. If you are using a secure proxy server, you can instead set `HTTPS_PROXY`.
 
-`http(s)_proxy` is a standard environment variable. Like any environment variable, the specific steps you use to set it depends on your operating system.
+`HTTP(S)_PROXY` is a standard environment variable. Like any environment variable, the specific steps you use to set it depends on your operating system.
 
 ## Example
 
@@ -20,10 +20,10 @@ HTTPS_PROXY=socks5://127.0.0.1:1086 \
 or
 
 ```shell
-export HTTPS_PROXY=socks5://127.0.0.1:1086 
+export HTTPS_PROXY=socks5://127.0.0.1:1086
 rover graph check my-company@prod --profile work
 ```
 
 ## Force bypass proxy
 
-If you have `http(s)_proxy` environment variable initialised but you want to bypass your proxy server, set `NO_PROXY` environment variable to `true`.
+If you have the `HTTP(S)_PROXY` environment variable set in your environment but you Rover to bypass the proxy, set the `NO_PROXY` environment variable to `true`.

--- a/docs/source/proxy.md
+++ b/docs/source/proxy.md
@@ -26,4 +26,4 @@ rover graph check my-company@prod --profile work
 
 ## Force bypass proxy
 
-If you have the `HTTP(S)_PROXY` environment variable set in your environment but you Rover to bypass the proxy, set the `NO_PROXY` environment variable to `true`.
+If you have the `HTTP(S)_PROXY` environment variable set in your environment, but you want Rover to bypass the proxy, set the `NO_PROXY` environment variable to `true`.

--- a/docs/source/proxy.md
+++ b/docs/source/proxy.md
@@ -1,0 +1,29 @@
+---
+title: "Using Rover with a Proxy Server"
+sidebar_title: "With a Proxy Server"
+---
+
+## Overview
+
+If you have an HTTP or SOCKS5 proxy server on your network between a host running Rover and Apollo's endpoints, you must set `HTTP_PROXY` or `http_proxy` with the hostname or IP address of the proxy server. If you are using a secure proxy server, you can set instead `HTTPS_PROXY` or `https_proxy`.
+
+`http(s)_proxy` is a standard environment variable. Like any environment variable, the specific steps you use to set it depends on your operating system.
+
+## Example
+
+On the same line:
+```shell
+HTTPS_PROXY=socks5://127.0.0.1:1086 \
+    rover graph check my-company@prod --profile work
+```
+
+or
+
+```shell
+export HTTPS_PROXY=socks5://127.0.0.1:1086 
+rover graph check my-company@prod --profile work
+```
+
+## Force bypass proxy
+
+If you have `http(s)_proxy` environment variable initialised but you want to bypass your proxy server, set `NO_PROXY` environment variable to `true`.

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -11,7 +11,7 @@ atty = "0.2"
 camino = "1"
 directories-next = "2.0"
 flate2 = "1"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "native-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "native-tls", "socks"] }
 thiserror = "1.0"
 tar = "0.4"
 tempdir = "0.3"


### PR DESCRIPTION
fixes #836 - 

thanks to @ptondereau for getting the ball rolling on this - this PR takes the docs from #922 and makes them true by adding support for SOCKS proxies in Rover (also changed just a bit of the wording of the docs themselves)