### PR TITLE
sdl-encoder: encode string values with single quotes (")

### DIFF
--- a/crates/rover-client/src/operations/graph/introspect/schema.rs
+++ b/crates/rover-client/src/operations/graph/introspect/schema.rs
@@ -379,10 +379,10 @@ mod tests {
             schema.encode(),
             indoc! { r#"
         directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
-        """Exposes a URL that specifies the behaviour of this scalar."""
-        directive @specifiedBy("""The URL that specifies the behaviour of this scalar.""" url: String!) on SCALAR
+        "Exposes a URL that specifies the behaviour of this scalar."
+        directive @specifiedBy("The URL that specifies the behaviour of this scalar." url: String!) on SCALAR
         type Query {
-          """A simple type for getting started!"""
+          "A simple type for getting started!"
           hello: String
           cats(cat: [String]! = ["Nori"]): [String]!
         }
@@ -396,7 +396,7 @@ mod tests {
           PUBLIC
           PRIVATE
         }
-        """The `Upload` scalar type represents a file upload."""
+        "The `Upload` scalar type represents a file upload."
         scalar Upload
     "#}
         )
@@ -428,14 +428,14 @@ mod tests {
           starship(id: ID, starshipID: ID): Starship
           allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
           vehicle(id: ID, vehicleID: ID): Vehicle
-          """Fetches an object given its ID"""
-          node("""The ID of an object""" id: ID!): Node
+          "Fetches an object given its ID"
+          node("The ID of an object" id: ID!): Node
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type FilmsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [FilmsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -454,60 +454,60 @@ mod tests {
           """
           films: [Film]
         }
-        """Information about pagination in a connection."""
+        "Information about pagination in a connection."
         type PageInfo {
-          """When paginating forwards, are there more items?"""
+          "When paginating forwards, are there more items?"
           hasNextPage: Boolean!
-          """When paginating backwards, are there more items?"""
+          "When paginating backwards, are there more items?"
           hasPreviousPage: Boolean!
-          """When paginating backwards, the cursor to continue."""
+          "When paginating backwards, the cursor to continue."
           startCursor: String
-          """When paginating forwards, the cursor to continue."""
+          "When paginating forwards, the cursor to continue."
           endCursor: String
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type FilmsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Film
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A single film."""
+        "A single film."
         type Film implements Node {
-          """The title of this film."""
+          "The title of this film."
           title: String
-          """The episode number of this film."""
+          "The episode number of this film."
           episodeID: Int
-          """The opening paragraphs at the beginning of this film."""
+          "The opening paragraphs at the beginning of this film."
           openingCrawl: String
-          """The name of the director of this film."""
+          "The name of the director of this film."
           director: String
-          """The name(s) of the producer(s) of this film."""
+          "The name(s) of the producer(s) of this film."
           producers: [String]
-          """The ISO 8601 date format of film release at original creator country."""
+          "The ISO 8601 date format of film release at original creator country."
           releaseDate: String
           speciesConnection(after: String, first: Int, before: String, last: Int): FilmSpeciesConnection
           starshipConnection(after: String, first: Int, before: String, last: Int): FilmStarshipsConnection
           vehicleConnection(after: String, first: Int, before: String, last: Int): FilmVehiclesConnection
           characterConnection(after: String, first: Int, before: String, last: Int): FilmCharactersConnection
           planetConnection(after: String, first: Int, before: String, last: Int): FilmPlanetsConnection
-          """The ISO 8601 date format of the time that this resource was created."""
+          "The ISO 8601 date format of the time that this resource was created."
           created: String
-          """The ISO 8601 date format of the time that this resource was edited."""
+          "The ISO 8601 date format of the time that this resource was edited."
           edited: String
-          """The ID of an object"""
+          "The ID of an object"
           id: ID!
         }
-        """An object with an ID"""
+        "An object with an ID"
         interface Node {
-          """The id of the object."""
+          "The id of the object."
           id: ID!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type FilmSpeciesConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [FilmSpeciesEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -526,16 +526,16 @@ mod tests {
           """
           species: [Species]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type FilmSpeciesEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Species
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A type of person or character within the Star Wars Universe."""
+        "A type of person or character within the Star Wars Universe."
         type Species implements Node {
-          """The name of this species."""
+          "The name of this species."
           name: String
           """
           The classification of this species, such as "mammal" or "reptile".
@@ -545,9 +545,9 @@ mod tests {
           The designation of this species, such as "sentient".
           """
           designation: String
-          """The average height of this species in centimeters."""
+          "The average height of this species in centimeters."
           averageHeight: Float
-          """The average lifespan of this species in years, null if unknown."""
+          "The average lifespan of this species in years, null if unknown."
           averageLifespan: Int
           """
           Common eye colors for this species, null if this species does not typically
@@ -564,29 +564,29 @@ mod tests {
           have skin.
           """
           skinColors: [String]
-          """The language commonly spoken by this species."""
+          "The language commonly spoken by this species."
           language: String
-          """A planet that this species originates from."""
+          "A planet that this species originates from."
           homeworld: Planet
           personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
           filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
-          """The ISO 8601 date format of the time that this resource was created."""
+          "The ISO 8601 date format of the time that this resource was created."
           created: String
-          """The ISO 8601 date format of the time that this resource was edited."""
+          "The ISO 8601 date format of the time that this resource was edited."
           edited: String
-          """The ID of an object"""
+          "The ID of an object"
           id: ID!
         }
-        """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point)."""
+        "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point)."
         scalar Float
         """
         A large mass, planet or planetoid in the Star Wars Universe, at the time of
         0 ABY.
         """
         type Planet implements Node {
-          """The name of this planet."""
+          "The name of this planet."
           name: String
-          """The diameter of this planet in kilometers."""
+          "The diameter of this planet in kilometers."
           diameter: Int
           """
           The number of standard hours it takes for this planet to complete a single
@@ -603,11 +603,11 @@ mod tests {
           G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
           """
           gravity: String
-          """The average population of sentient beings inhabiting this planet."""
+          "The average population of sentient beings inhabiting this planet."
           population: Float
-          """The climates of this planet."""
+          "The climates of this planet."
           climates: [String]
-          """The terrains of this planet."""
+          "The terrains of this planet."
           terrains: [String]
           """
           The percentage of the planet surface that is naturally occuring water or bodies
@@ -616,18 +616,18 @@ mod tests {
           surfaceWater: Float
           residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
           filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
-          """The ISO 8601 date format of the time that this resource was created."""
+          "The ISO 8601 date format of the time that this resource was created."
           created: String
-          """The ISO 8601 date format of the time that this resource was edited."""
+          "The ISO 8601 date format of the time that this resource was edited."
           edited: String
-          """The ID of an object"""
+          "The ID of an object"
           id: ID!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PlanetResidentsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PlanetResidentsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -646,16 +646,16 @@ mod tests {
           """
           residents: [Person]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PlanetResidentsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Person
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """An individual person or character within the Star Wars universe."""
+        "An individual person or character within the Star Wars universe."
         type Person implements Node {
-          """The name of this person."""
+          "The name of this person."
           name: String
           """
           The birth year of the person, using the in-universe standard of BBY or ABY -
@@ -678,31 +678,31 @@ mod tests {
           person does not have hair.
           """
           hairColor: String
-          """The height of the person in centimeters."""
+          "The height of the person in centimeters."
           height: Int
-          """The mass of the person in kilograms."""
+          "The mass of the person in kilograms."
           mass: Float
-          """The skin color of this person."""
+          "The skin color of this person."
           skinColor: String
-          """A planet that this person was born on or inhabits."""
+          "A planet that this person was born on or inhabits."
           homeworld: Planet
           filmConnection(after: String, first: Int, before: String, last: Int): PersonFilmsConnection
-          """The species that this person belongs to, or null if unknown."""
+          "The species that this person belongs to, or null if unknown."
           species: Species
           starshipConnection(after: String, first: Int, before: String, last: Int): PersonStarshipsConnection
           vehicleConnection(after: String, first: Int, before: String, last: Int): PersonVehiclesConnection
-          """The ISO 8601 date format of the time that this resource was created."""
+          "The ISO 8601 date format of the time that this resource was created."
           created: String
-          """The ISO 8601 date format of the time that this resource was edited."""
+          "The ISO 8601 date format of the time that this resource was edited."
           edited: String
-          """The ID of an object"""
+          "The ID of an object"
           id: ID!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PersonFilmsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PersonFilmsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -721,18 +721,18 @@ mod tests {
           """
           films: [Film]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PersonFilmsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Film
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PersonStarshipsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PersonStarshipsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -751,14 +751,14 @@ mod tests {
           """
           starships: [Starship]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PersonStarshipsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Starship
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A single transport craft that has hyperdrive capability."""
+        "A single transport craft that has hyperdrive capability."
         type Starship implements Node {
           """
           The name of this starship. The common name, such as "Death Star".
@@ -774,22 +774,22 @@ mod tests {
           Battlestation"
           """
           starshipClass: String
-          """The manufacturers of this starship."""
+          "The manufacturers of this starship."
           manufacturers: [String]
-          """The cost of this starship new, in galactic credits."""
+          "The cost of this starship new, in galactic credits."
           costInCredits: Float
-          """The length of this starship in meters."""
+          "The length of this starship in meters."
           length: Float
-          """The number of personnel needed to run or pilot this starship."""
+          "The number of personnel needed to run or pilot this starship."
           crew: String
-          """The number of non-essential people this starship can transport."""
+          "The number of non-essential people this starship can transport."
           passengers: String
           """
           The maximum speed of this starship in atmosphere. null if this starship is
           incapable of atmosphering flight.
           """
           maxAtmospheringSpeed: Int
-          """The class of this starships hyperdrive."""
+          "The class of this starships hyperdrive."
           hyperdriveRating: Float
           """
           The Maximum number of Megalights this starship can travel in a standard hour.
@@ -799,7 +799,7 @@ mod tests {
           distance between our Sun (Sol) and Earth.
           """
           MGLT: Int
-          """The maximum number of kilograms that this starship can transport."""
+          "The maximum number of kilograms that this starship can transport."
           cargoCapacity: Float
           """
           The maximum length of time that this starship can provide consumables for its
@@ -808,18 +808,18 @@ mod tests {
           consumables: String
           pilotConnection(after: String, first: Int, before: String, last: Int): StarshipPilotsConnection
           filmConnection(after: String, first: Int, before: String, last: Int): StarshipFilmsConnection
-          """The ISO 8601 date format of the time that this resource was created."""
+          "The ISO 8601 date format of the time that this resource was created."
           created: String
-          """The ISO 8601 date format of the time that this resource was edited."""
+          "The ISO 8601 date format of the time that this resource was edited."
           edited: String
-          """The ID of an object"""
+          "The ID of an object"
           id: ID!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type StarshipPilotsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [StarshipPilotsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -838,18 +838,18 @@ mod tests {
           """
           pilots: [Person]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type StarshipPilotsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Person
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type StarshipFilmsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [StarshipFilmsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -868,18 +868,18 @@ mod tests {
           """
           films: [Film]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type StarshipFilmsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Film
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PersonVehiclesConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PersonVehiclesEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -898,14 +898,14 @@ mod tests {
           """
           vehicles: [Vehicle]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PersonVehiclesEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Vehicle
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A single transport craft that does not have hyperdrive capability"""
+        "A single transport craft that does not have hyperdrive capability"
         type Vehicle implements Node {
           """
           The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
@@ -921,19 +921,19 @@ mod tests {
           The class of this vehicle, such as "Wheeled" or "Repulsorcraft".
           """
           vehicleClass: String
-          """The manufacturers of this vehicle."""
+          "The manufacturers of this vehicle."
           manufacturers: [String]
-          """The cost of this vehicle new, in Galactic Credits."""
+          "The cost of this vehicle new, in Galactic Credits."
           costInCredits: Float
-          """The length of this vehicle in meters."""
+          "The length of this vehicle in meters."
           length: Float
-          """The number of personnel needed to run or pilot this vehicle."""
+          "The number of personnel needed to run or pilot this vehicle."
           crew: String
-          """The number of non-essential people this vehicle can transport."""
+          "The number of non-essential people this vehicle can transport."
           passengers: String
-          """The maximum speed of this vehicle in atmosphere."""
+          "The maximum speed of this vehicle in atmosphere."
           maxAtmospheringSpeed: Int
-          """The maximum number of kilograms that this vehicle can transport."""
+          "The maximum number of kilograms that this vehicle can transport."
           cargoCapacity: Float
           """
           The maximum length of time that this vehicle can provide consumables for its
@@ -942,18 +942,18 @@ mod tests {
           consumables: String
           pilotConnection(after: String, first: Int, before: String, last: Int): VehiclePilotsConnection
           filmConnection(after: String, first: Int, before: String, last: Int): VehicleFilmsConnection
-          """The ISO 8601 date format of the time that this resource was created."""
+          "The ISO 8601 date format of the time that this resource was created."
           created: String
-          """The ISO 8601 date format of the time that this resource was edited."""
+          "The ISO 8601 date format of the time that this resource was edited."
           edited: String
-          """The ID of an object"""
+          "The ID of an object"
           id: ID!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type VehiclePilotsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [VehiclePilotsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -972,18 +972,18 @@ mod tests {
           """
           pilots: [Person]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type VehiclePilotsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Person
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type VehicleFilmsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [VehicleFilmsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1002,18 +1002,18 @@ mod tests {
           """
           films: [Film]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type VehicleFilmsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Film
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PlanetFilmsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PlanetFilmsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1032,18 +1032,18 @@ mod tests {
           """
           films: [Film]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PlanetFilmsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Film
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type SpeciesPeopleConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [SpeciesPeopleEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1062,18 +1062,18 @@ mod tests {
           """
           people: [Person]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type SpeciesPeopleEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Person
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type SpeciesFilmsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [SpeciesFilmsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1092,18 +1092,18 @@ mod tests {
           """
           films: [Film]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type SpeciesFilmsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Film
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type FilmStarshipsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [FilmStarshipsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1122,18 +1122,18 @@ mod tests {
           """
           starships: [Starship]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type FilmStarshipsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Starship
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type FilmVehiclesConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [FilmVehiclesEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1152,18 +1152,18 @@ mod tests {
           """
           vehicles: [Vehicle]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type FilmVehiclesEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Vehicle
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type FilmCharactersConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [FilmCharactersEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1182,18 +1182,18 @@ mod tests {
           """
           characters: [Person]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type FilmCharactersEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Person
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type FilmPlanetsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [FilmPlanetsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1212,18 +1212,18 @@ mod tests {
           """
           planets: [Planet]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type FilmPlanetsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Planet
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PeopleConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PeopleEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1242,18 +1242,18 @@ mod tests {
           """
           people: [Person]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PeopleEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Person
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type PlanetsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [PlanetsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1272,18 +1272,18 @@ mod tests {
           """
           planets: [Planet]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type PlanetsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Planet
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type SpeciesConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [SpeciesEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1302,18 +1302,18 @@ mod tests {
           """
           species: [Species]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type SpeciesEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Species
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type StarshipsConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [StarshipsEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1332,18 +1332,18 @@ mod tests {
           """
           starships: [Starship]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type StarshipsEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Starship
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
-        """A connection to a list of items."""
+        "A connection to a list of items."
         type VehiclesConnection {
-          """Information to aid in pagination."""
+          "Information to aid in pagination."
           pageInfo: PageInfo!
-          """A list of edges."""
+          "A list of edges."
           edges: [VehiclesEdge]
           """
           A count of the total number of objects in this connection, ignoring pagination.
@@ -1362,11 +1362,11 @@ mod tests {
           """
           vehicles: [Vehicle]
         }
-        """An edge in a connection."""
+        "An edge in a connection."
         type VehiclesEdge {
-          """The item at the end of the edge"""
+          "The item at the end of the edge"
           node: Vehicle
-          """A cursor for use in pagination"""
+          "A cursor for use in pagination"
           cursor: String!
         }
     "#}
@@ -1384,9 +1384,9 @@ mod tests {
             schema.encode(),
             indoc! { r#"
         type Query {
-          """Fetch a simple list of products with an offset"""
+          "Fetch a simple list of products with an offset"
           topProducts(first: Int = 5): [Product] @deprecated(reason: "Use `products` instead")
-          """Fetch a paginated list of products based on a filter type."""
+          "Fetch a paginated list of products based on a filter type."
           products(first: Int = 5, after: Int = 0, type: ProductType): ProductConnection
           """
           The currently authenticated user root. All nodes off of this
@@ -1394,17 +1394,17 @@ mod tests {
           """
           me: User
         }
-        """The Product type represents all products within the system"""
+        "The Product type represents all products within the system"
         interface Product {
-          """The primary identifier of products in the graph"""
+          "The primary identifier of products in the graph"
           upc: String!
-          """The display name of the product"""
+          "The display name of the product"
           name: String
-          """A simple integer price of the product in US dollars"""
+          "A simple integer price of the product in US dollars"
           price: Int
-          """How much the product weighs in kg"""
+          "How much the product weighs in kg"
           weight: Int @deprecated(reason: "Not all product's have a weight")
-          """A simple list of all reviews for a product"""
+          "A simple list of all reviews for a product"
           reviews: [Review] @deprecated(reason: "The `reviews` field on product is deprecated to roll over the return
         type from a simple list to a paginated list. The easiest way to fix your
         operations is to alias the new field `reviewList` to `review`:
@@ -1443,32 +1443,32 @@ mod tests {
           """
           reviewList(first: Int = 5, after: Int = 0): ReviewConnection
         }
-        """A review is any feedback about products across the graph"""
+        "A review is any feedback about products across the graph"
         type Review {
           id: ID!
-          """The plain text version of the review"""
+          "The plain text version of the review"
           body: String
-          """The user who authored the review"""
+          "The user who authored the review"
           author: User
-          """The product which this review is about"""
+          "The product which this review is about"
           product: Product
         }
-        """The base User in Acephei"""
+        "The base User in Acephei"
         type User {
-          """A globally unique id for the user"""
+          "A globally unique id for the user"
           id: ID!
-          """The users full name as provided"""
+          "The users full name as provided"
           name: String
-          """The account username of the user"""
+          "The account username of the user"
           username: String
-          """A list of all reviews by the user"""
+          "A list of all reviews by the user"
           reviews: [Review]
         }
-        """A connection wrapper for lists of reviews"""
+        "A connection wrapper for lists of reviews"
         type ReviewConnection {
-          """Helpful metadata about the connection"""
+          "Helpful metadata about the connection"
           pageInfo: PageInfo
-          """List of reviews returned by the search"""
+          "List of reviews returned by the search"
           edges: [ReviewEdge]
         }
         """
@@ -1476,40 +1476,40 @@ mod tests {
         if more data can be fetched from the list
         """
         type PageInfo {
-          """More items exist in the list"""
+          "More items exist in the list"
           hasNextPage: Boolean
-          """Items earlier in the list exist"""
+          "Items earlier in the list exist"
           hasPreviousPage: Boolean
         }
-        """A connection edge for the Review type"""
+        "A connection edge for the Review type"
         type ReviewEdge {
           review: Review
         }
-        """An enum of product types"""
+        "An enum of product types"
         enum ProductType {
           LATEST
           TRENDING
         }
-        """A connection wrapper for lists of products"""
+        "A connection wrapper for lists of products"
         type ProductConnection {
-          """Helpful metadata about the connection"""
+          "Helpful metadata about the connection"
           pageInfo: PageInfo
-          """List of products returned by the search"""
+          "List of products returned by the search"
           edges: [ProductEdge]
         }
-        """A connection edge for the Product type"""
+        "A connection edge for the Product type"
         type ProductEdge {
           product: Product
         }
-        """The basic book in the graph"""
+        "The basic book in the graph"
         type Book implements Product {
-          """All books can be found by an isbn"""
+          "All books can be found by an isbn"
           isbn: String!
-          """The title of the book"""
+          "The title of the book"
           title: String
-          """The year the book was published"""
+          "The year the book was published"
           year: Int
-          """A simple list of similar books"""
+          "A simple list of similar books"
           similarBooks: [Book]
           reviews: [Review]
           reviewList(first: Int = 5, after: Int = 0): ReviewConnection
@@ -1518,23 +1518,23 @@ mod tests {
           service to return related reviews that may be of interest to the user
           """
           relatedReviews(first: Int = 5, after: Int = 0): ReviewConnection
-          """Since books are now products, we can also use their upc as a primary id"""
+          "Since books are now products, we can also use their upc as a primary id"
           upc: String!
-          """The name of a book is the book's title + year published"""
+          "The name of a book is the book's title + year published"
           name(delimeter: String = " "): String
           price: Int
           weight: Int
         }
-        """Information about the brand Amazon"""
+        "Information about the brand Amazon"
         type Amazon {
-          """The url of a referrer for a product"""
+          "The url of a referrer for a product"
           referrer: String
         }
-        """A union of all brands represented within the store"""
+        "A union of all brands represented within the store"
         union Brand = Ikea | Amazon
-        """Information about the brand Ikea"""
+        "Information about the brand Ikea"
         type Ikea {
-          """Which asile to find an item"""
+          "Which asile to find an item"
           asile: Int
         }
         """
@@ -1542,13 +1542,13 @@ mod tests {
         of furniture.
         """
         type Furniture implements Product {
-          """The modern primary identifier for furniture"""
+          "The modern primary identifier for furniture"
           upc: String!
-          """The SKU field is how furniture was previously stored, and still exists in some legacy systems"""
+          "The SKU field is how furniture was previously stored, and still exists in some legacy systems"
           sku: String!
           name: String
           price: Int
-          """The brand of furniture"""
+          "The brand of furniture"
           brand: Brand
           weight: Int
           reviews: [Review]

--- a/crates/sdl-encoder/src/description.rs
+++ b/crates/sdl-encoder/src/description.rs
@@ -32,7 +32,7 @@ impl Display for Description {
                     if is_block_string_character(description) {
                         writeln!(f, "\"\"\"\n{}\n\"\"\"", description)?
                     } else {
-                        writeln!(f, "\"\"\"{}\"\"\"", description)?
+                        writeln!(f, "\"{}\"", description)?
                     }
                 }
             }
@@ -45,7 +45,7 @@ impl Display for Description {
                         }
                         writeln!(f, "\n  \"\"\"")?;
                     } else {
-                        writeln!(f, "  \"\"\"{}\"\"\"", description)?
+                        writeln!(f, "  \"{}\"", description)?
                     }
                 }
             }
@@ -54,7 +54,7 @@ impl Display for Description {
                     if is_block_string_character(description) {
                         write!(f, "\"\"\"\n{}\n\"\"\" ", description)?
                     } else {
-                        write!(f, "\"\"\"{}\"\"\" ", description)?
+                        write!(f, "\"{}\" ", description)?
                     }
                 }
             }
@@ -81,7 +81,7 @@ mod test {
 
         assert_eq!(
             desc.to_string(),
-            r#""""Favourite cat nap spots include: plant corner, pile of clothes."""
+            r#""Favourite cat nap spots include: plant corner, pile of clothes."
 "#
         );
     }

--- a/crates/sdl-encoder/src/directive_def.rs
+++ b/crates/sdl-encoder/src/directive_def.rs
@@ -114,7 +114,7 @@ mod tests {
 
         assert_eq!(
             directive.to_string(),
-            r#""""Infer field types from field values."""
+            r#""Infer field types from field values."
 directive @infer on OBJECT
 "#
         );
@@ -155,7 +155,7 @@ directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
         assert_eq!(
             directive.to_string(),
-            r#""""Infer field types from field values."""
+            r#""Infer field types from field values."
 directive @infer(cat: [SpaceProgram]) on OBJECT
 "#
         );

--- a/crates/sdl-encoder/src/enum_def.rs
+++ b/crates/sdl-encoder/src/enum_def.rs
@@ -26,9 +26,9 @@ use std::fmt::{self, Display};
 ///
 /// assert_eq!(
 ///     enum_.to_string(),
-///     r#""""Favourite cat nap spots."""
+///     r#""Favourite cat nap spots."
 /// enum NapSpots {
-///   """Top bunk of a cat tree."""
+///   "Top bunk of a cat tree."
 ///   CAT_TREE
 ///   BED
 ///   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")
@@ -123,9 +123,9 @@ mod tests {
 
         assert_eq!(
             enum_.to_string(),
-            r#""""Favourite cat nap spots."""
+            r#""Favourite cat nap spots."
 enum NapSpots {
-  """Top bunk of a cat tree."""
+  "Top bunk of a cat tree."
   CAT_TREE
   BED
   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")

--- a/crates/sdl-encoder/src/enum_value.rs
+++ b/crates/sdl-encoder/src/enum_value.rs
@@ -19,7 +19,7 @@ use crate::Description;
 ///
 /// assert_eq!(
 ///     enum_ty.to_string(),
-///     r#"  """Box nap spot."""
+///     r#"  "Box nap spot."
 ///   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")"#
 /// );
 /// ```
@@ -95,7 +95,7 @@ mod tests {
         enum_ty.description(Some("Top bunk of a cat tree.".to_string()));
         assert_eq!(
             enum_ty.to_string(),
-            r#"  """Top bunk of a cat tree."""
+            r#"  "Top bunk of a cat tree."
   CAT_TREE"#
         );
     }

--- a/crates/sdl-encoder/src/field.rs
+++ b/crates/sdl-encoder/src/field.rs
@@ -139,7 +139,7 @@ mod tests {
 
         assert_eq!(
             field.to_string(),
-            r#"  """Very good cats"""
+            r#"  "Very good cats"
   cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
         );
     }
@@ -158,7 +158,7 @@ mod tests {
 
         assert_eq!(
             field.to_string(),
-            r#"  """Very good space cats"""
+            r#"  "Very good space cats"
   spaceCat: [SpaceProgram!]!"#
         );
     }
@@ -188,7 +188,7 @@ mod tests {
 
         assert_eq!(
             field.to_string(),
-            r#"  """Very good space cats"""
+            r#"  "Very good space cats"
   spaceCat(cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")): [SpaceProgram!]!"#
         );
     }

--- a/crates/sdl-encoder/src/input_object_def.rs
+++ b/crates/sdl-encoder/src/input_object_def.rs
@@ -38,10 +38,10 @@ use std::fmt::{self, Display};
 /// assert_eq!(
 ///     input_def.to_string(),
 ///     indoc! { r#"
-///         """Cat playtime input"""
+///         "Cat playtime input"
 ///         input PlayTime {
 ///           toys: [DanglerPoleToys] = "Cat Dangler Pole Bird"
-///           """Best playime spots, e.g. tree, bed."""
+///           "Best playime spots, e.g. tree, bed."
 ///           playSpot: FavouriteSpots
 ///         }
 ///     "#}
@@ -124,7 +124,7 @@ mod tests {
             indoc! { r#"
                 input PlayTime {
                   toys: [DanglerPoleToys] = "Cat Dangler Pole Bird"
-                  """Best playime spots, e.g. tree, bed."""
+                  "Best playime spots, e.g. tree, bed."
                   playSpot: FavouriteSpots
                 }
             "#}
@@ -154,10 +154,10 @@ mod tests {
         assert_eq!(
             input_def.to_string(),
             indoc! { r#"
-                """Cat playtime input"""
+                "Cat playtime input"
                 input PlayTime {
                   toys: [DanglerPoleToys] = "Cat Dangler Pole Bird"
-                  """Best playime spots, e.g. tree, bed."""
+                  "Best playime spots, e.g. tree, bed."
                   playSpot: FavouriteSpots
                 }
             "#}

--- a/crates/sdl-encoder/src/input_value.rs
+++ b/crates/sdl-encoder/src/input_value.rs
@@ -29,7 +29,7 @@ use std::fmt::{self, Display};
 ///
 /// assert_eq!(
 ///     value.to_string(),
-///     r#""""Very good cats""" cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
+///     r#""Very good cats" cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
 /// );
 /// ```
 #[derive(Debug, PartialEq, Clone)]
@@ -153,7 +153,7 @@ mod tests {
 
         assert_eq!(
             value.to_string(),
-            r#""""Very good cats""" cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
+            r#""Very good cats" cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
         );
     }
 
@@ -171,7 +171,7 @@ mod tests {
 
         assert_eq!(
             value.to_string(),
-            r#""""Very good space cats""" spaceCat: [SpaceProgram!]!"#
+            r#""Very good space cats" spaceCat: [SpaceProgram!]!"#
         );
     }
 }

--- a/crates/sdl-encoder/src/interface_def.rs
+++ b/crates/sdl-encoder/src/interface_def.rs
@@ -45,7 +45,7 @@ use std::fmt::{self, Display};
 /// // a schema definition
 /// let mut interface = InterfaceDef::new("Meal".to_string());
 /// interface.description(Some(
-///     "Meal interface for various meals during the day.".to_string(),
+///     "Meal interface for various\nmeals during the day.".to_string(),
 /// ));
 /// interface.field(field_1);
 /// interface.field(field_2);
@@ -54,13 +54,16 @@ use std::fmt::{self, Display};
 /// assert_eq!(
 ///     interface.to_string(),
 ///     indoc! { r#"
-///     """Meal interface for various meals during the day."""
+///     """
+///     Meal interface for various
+///     meals during the day.
+///     """
 ///     interface Meal {
-///       """Cat's main dish of a meal."""
+///       "Cat's main dish of a meal."
 ///       main: String
-///       """Cat's post meal snack."""
+///       "Cat's post meal snack."
 ///       snack: [String!]!
-///       """Does cat get a pat after meal?"""
+///       "Does cat get a pat after meal?"
 ///       pats: Boolean
 ///     }
 ///     "# }
@@ -164,7 +167,7 @@ mod tests {
         // a schema definition
         let mut interface = InterfaceDef::new("Meal".to_string());
         interface.description(Some(
-            "Meal interface for various meals during the day.".to_string(),
+            "Meal interface for various\nmeals during the day.".to_string(),
         ));
         interface.field(field_1);
         interface.field(field_2);
@@ -173,11 +176,14 @@ mod tests {
         assert_eq!(
             interface.to_string(),
             indoc! { r#"
-            """Meal interface for various meals during the day."""
+            """
+            Meal interface for various
+            meals during the day.
+            """
             interface Meal {
-              """Cat's main dish of a meal."""
+              "Cat's main dish of a meal."
               main: String
-              """Cat's post meal snack."""
+              "Cat's post meal snack."
               snack: [String!]!
               """
               Does cat get a pat

--- a/crates/sdl-encoder/src/lib.rs
+++ b/crates/sdl-encoder/src/lib.rs
@@ -26,7 +26,7 @@
 //! enum_ty_3.deprecated(Some("Box was recycled.".to_string()));
 //!
 //! let mut enum_def = EnumDef::new("NapSpots".to_string());
-//! enum_def.description(Some("Favourite cat nap spots.".to_string()));
+//! enum_def.description(Some("Favourite cat\nnap spots.".to_string()));
 //! enum_def.value(enum_ty_1);
 //! enum_def.value(enum_ty_2);
 //! enum_def.value(enum_ty_3);
@@ -43,16 +43,19 @@
 //! assert_eq!(
 //!     schema.finish(),
 //!     indoc! { r#"
-//!         """Ensures cats get treats."""
+//!         "Ensures cats get treats."
 //!         directive @provideTreat on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-//!         """Favourite cat nap spots."""
+//!         """
+//!         Favourite cat
+//!         nap spots.
+//!         """
 //!         enum NapSpots {
-//!           """Top bunk of a cat tree."""
+//!           "Top bunk of a cat tree."
 //!           CatTree
 //!           Bed
 //!           CardboardBox @deprecated(reason: "Box was recycled.")
 //!         }
-//!         """A union of all cats represented within a household."""
+//!         "A union of all cats represented within a household."
 //!         union Cat = NORI | CHASHU
 //!     "# }
 //! );

--- a/crates/sdl-encoder/src/object_def.rs
+++ b/crates/sdl-encoder/src/object_def.rs
@@ -44,7 +44,7 @@ use std::fmt::{self, Display};
 ///     indoc! { r#"
 ///         type PetStoreTrip implements ShoppingTrip {
 ///           toys: [DanglerPoleToys] @deprecated(reason: "Cats are too spoiled")
-///           """Dry or wet food?"""
+///           "Dry or wet food?"
 ///           food: FoodType
 ///           catGrass: Boolean
 ///         }
@@ -135,7 +135,7 @@ mod tests {
         assert_eq!(
             object_def.to_string(),
             indoc! { r#"
-                """What to get at Fressnapf?"""
+                "What to get at Fressnapf?"
                 type PetStoreTrip {
                   toys: [DanglerPoleToys]
                 }
@@ -167,14 +167,16 @@ mod tests {
         object_def.field(field);
         object_def.field(field_2);
         object_def.field(field_3);
+        object_def.description(Some("Shopping list for cats at the pet store.".to_string()));
         object_def.interface("ShoppingTrip".to_string());
 
         assert_eq!(
             object_def.to_string(),
             indoc! { r#"
+                "Shopping list for cats at the pet store."
                 type PetStoreTrip implements ShoppingTrip {
                   toys: [DanglerPoleToys] @deprecated(reason: "Cats are too spoiled")
-                  """Dry or wet food?"""
+                  "Dry or wet food?"
                   food: FoodType
                   catGrass: Boolean
                 }

--- a/crates/sdl-encoder/src/scalar_def.rs
+++ b/crates/sdl-encoder/src/scalar_def.rs
@@ -20,7 +20,7 @@ use crate::Description;
 ///
 /// assert_eq!(
 ///     scalar.to_string(),
-///     r#""""Int representing number of treats received."""
+///     r#""Int representing number of treats received."
 /// scalar NumberOfTreatsPerDay
 /// "#
 /// );
@@ -81,7 +81,7 @@ mod tests {
 
         assert_eq!(
             scalar.to_string(),
-            r#""""Int representing number of treats received."""
+            r#""Int representing number of treats received."
 scalar NumberOfTreatsPerDay
 "#
         );

--- a/crates/sdl-encoder/src/schema.rs
+++ b/crates/sdl-encoder/src/schema.rs
@@ -25,7 +25,7 @@ use crate::*;
 /// assert_eq!(
 ///     schema.finish(),
 ///     indoc! { r#"
-///         """A union of all cats represented within a household."""
+///         "A union of all cats represented within a household."
 ///         union Cat = NORI | CHASHU
 ///     "# }
 /// );
@@ -203,7 +203,9 @@ mod tests {
             name: "FavouriteSpots".to_string(),
         };
         let mut input_value_2 = InputField::new("playSpot".to_string(), input_value_3);
-        input_value_2.description(Some("Best playime spots, e.g. tree, bed.".to_string()));
+        input_value_2.description(Some(
+            "Best playime spots, e.g. \"tree\", \"bed\".".to_string(),
+        ));
 
         let mut input_def = InputObjectDef::new("PlayTime".to_string());
         input_def.field(input_field);
@@ -213,31 +215,33 @@ mod tests {
         assert_eq!(
             schema.finish(),
             indoc! { r#"
-                """Ensures cats get treats."""
+                "Ensures cats get treats."
                 directive @provideTreat on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
                 schema {
                   query: TryingToFindCatQuery
                 }
-                """A union of all animals in a household."""
+                "A union of all animals in a household."
                 union Pet = Cat | Dog
                 type PetStoreTrip implements ShoppingTrip {
                   toys: [DanglerPoleToys] @deprecated(reason: "Cats are too spoiled")
-                  """Dry or wet food?"""
+                  "Dry or wet food?"
                   food: FoodType
                   catGrass: Boolean
                 }
-                """Favourite cat nap spots."""
+                "Favourite cat nap spots."
                 enum NapSpots {
-                  """Top bunk of a cat tree."""
+                  "Top bunk of a cat tree."
                   CAT_TREE
                   BED
                   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")
                 }
-                """Int representing number of treats received."""
+                "Int representing number of treats received."
                 scalar NumberOfTreatsPerDay
                 input PlayTime {
                   toys: [DanglerPoleToys] = "Cat Dangler Pole Bird"
-                  """Best playime spots, e.g. tree, bed."""
+                  """
+                  Best playime spots, e.g. "tree", "bed".
+                  """
                   playSpot: FavouriteSpots
                 }
             "# }

--- a/crates/sdl-encoder/src/union_def.rs
+++ b/crates/sdl-encoder/src/union_def.rs
@@ -88,7 +88,7 @@ mod tests {
 
         assert_eq!(
             union_.to_string(),
-            r#""""A union of all animals in a household."""
+            r#""A union of all animals in a household."
 union Pet = Cat | Dog
 "#
         );


### PR DESCRIPTION
We've been encoding all BlockStringValues and StringValues by surrounding them with `"""`. StringValue is meant to be encoded with just a single `"`. If a description does not include a line break or a `"`, we assume it's a StringValue.

This means that instead of printing this:
```graphql
"""Shopping list for cats at the pet store"""
type PetStoreTrip implements ShoppingTrip {
  toys: [DanglerPoleToys] @deprecated(reason: "Cats are too spoiled")
  """Dry or wet food?"""
  food: FoodType
  catGrass: Boolean
}
```

we encode this:
```graphql
"Shopping list for cats at the pet store"
type PetStoreTrip implements ShoppingTrip {
  toys: [DanglerPoleToys] @deprecated(reason: "Cats are too spoiled")
  "Dry or wet food?"
  food: FoodType
  catGrass: Boolean
}
```