### PR TITLE
fix: handle pipe errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "calm_io"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f"
+dependencies = [
+ "calmio_filters",
+]
+
+[[package]]
+name = "calmio_filters"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "camino"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2677,7 @@ dependencies = [
  "atty",
  "billboard",
  "binstall",
+ "calm_io",
  "camino",
  "chrono",
  "console 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ ansi_term = "0.12"
 anyhow = "1"
 atty = "0.2"
 billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
+calm_io = "0.1"
 camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
 console = "0.15"

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -2,7 +2,8 @@ use robot_panic::setup_panic;
 use rover::cli::Rover;
 use structopt::StructOpt;
 
-fn main() {
+#[calm_io::pipefail]
+fn main() -> std::io::Result<()> {
     setup_panic!(Metadata {
         name: rover::PKG_NAME.into(),
         version: rover::PKG_VERSION.into(),
@@ -11,5 +12,5 @@ fn main() {
         repository: rover::PKG_REPOSITORY.into()
     });
     let app = Rover::from_args();
-    app.run();
+    app.run()
 }

--- a/src/command/info.rs
+++ b/src/command/info.rs
@@ -1,6 +1,8 @@
 use crate::command::RoverOutput;
 use crate::Result;
 use crate::PKG_VERSION;
+
+use calm_io::stderrln;
 use serde::Serialize;
 use std::env;
 use structopt::StructOpt;
@@ -23,10 +25,13 @@ impl Info {
             Err(_) => "Unknown".to_string(),
         };
 
-        eprintln!(
+        stderrln!(
             "Rover Info:\nVersion: {}\nInstall Location: {}\nOS: {}\nShell: {}",
-            PKG_VERSION, location, os, shell
-        );
+            PKG_VERSION,
+            location,
+            os,
+            shell
+        )?;
 
         Ok(RoverOutput::EmptySuccess)
     }

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -64,7 +64,7 @@ impl Delete {
                 dry_run,
                 delete_response: delete_dry_run_response,
             }
-            .print();
+            .print()?;
 
             // I chose not to error here, since this is a perfectly valid path
             if !utils::confirm_delete()? {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use metadata::Metadata;
 pub type Result<T> = std::result::Result<T, RoverError>;
 
 use ansi_term::Colour::Red;
+use calm_io::{stderrln, stdoutln};
 use rover_client::RoverClientError;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
@@ -14,6 +15,7 @@ use serde_json::{json, Value};
 use std::borrow::BorrowMut;
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
+use std::io;
 
 use crate::command::output::JsonVersion;
 
@@ -95,16 +97,17 @@ impl RoverError {
         &self.metadata.suggestion
     }
 
-    pub fn print(&self) {
+    pub fn print(&self) -> io::Result<()> {
         if let Some(RoverClientError::OperationCheckFailure {
             graph_ref: _,
             check_response,
         }) = self.error.downcast_ref::<RoverClientError>()
         {
-            println!("{}", check_response.get_table());
+            stdoutln!("{}", check_response.get_table())?;
         }
 
-        eprintln!("{}", self);
+        stderrln!("{}", self)?;
+        Ok(())
     }
 
     pub(crate) fn get_internal_data_json(&self) -> Value {


### PR DESCRIPTION
This PR fixes #842 by simply terminating the process early in the case of a pipe failure. 

before: 

```console
$ rover --help | grep
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
Houston, we have a problem. Rover crashed!
To help us diagnose the problem you can send us a crash report.

You can submit an issue with the crash report at this link: https://github.com/apollographql/rover/issues/new?title=bug%3A+crashed+while+%3Cinsert+description+here%3E&body=%3C%21--%0A++Please+add+some+additional+information+about+what+you+were+trying+to+do+before+submitting+this+report%0A+--%3E+%0A%0A%23%23+Description%0ADescribe+the+issue+that+you%27re+seeing.%0A%0A**Crash+Report**%0A+%60%60%60toml%0Aname+%3D+%27rover%27%0Aoperating_system+%3D+%27unix%3AUbuntu%27%0Acrate_version+%3D+%270.2.0%27%0Aexplanation+%3D+%27%27%27%0APanic+occurred+in+file+%27%2Fhome%2Frunner%2F.cargo%2Fregistry%2Fsrc%2Fgithub.com-1ecc6299db9ec823%2Fclap-2.33.3%2Fsrc%2Ferrors.rs%27+at+line+401%0A%27%27%27%0Acause+%3D+%27Error+writing+Error+to+stdout%3A+Os+%7B+code%3A+32%2C+kind%3A+BrokenPipe%2C+message%3A+%22Broken+pipe%22+%7D%27%0Amethod+%3D+%27Panic%27%0Abacktrace+%3D+%27%27%27%0A%0A+++0%3A+0x55f3e442e703+-+core%3A%3Aresult%3A%3Aunwrap_failed%3A%3Ah6160d2b4bfbb0e87%0A+++1%3A+0x55f3e533e7c4+-+%3Cunresolved%3E%0A+++2%3A+0x55f3e533f0ac+-+clap%3A%3Aerrors%3A%3AError%3A%3Aexit%3A%3Ah6da8512269a47591%0A+++3%3A+0x55f3e5324ac2+-+%3Cunresolved%3E%0A+++4%3A+0x55f3e5324868+-+clap%3A%3Aapp%3A%3AApp%3A%3Aget_matches%3A%3Ah6d975bc6e8135bff%0A+++5%3A+0x55f3e4430337+-+%3Cunresolved%3E%0A+++6%3A+0x55f3e442f973+-+%3Cunresolved%3E%0A+++7%3A+0x55f3e442f989+-+%3Cunresolved%3E%0A+++8%3A+0x55f3e5746e99+-+std%3A%3Art%3A%3Alang_start_internal%3A%3Ah22ac7383c516f93e%0A+++9%3A+0x55f3e4430602+-+%3Cunresolved%3E%0A++10%3A+0x7f6af977b0b3+-+__libc_start_main%0A++11%3A+0x55f3e442f3c9+-+%3Cunresolved%3E%0A++12%3A++++++++0x0+-+%3Cunresolved%3E%27%27%27%0A%0A%60%60%60%0A&labels=bug+%F0%9F%90%9E%2C+triage&template=bug_report.md

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thanks for your patience!
```

after:

```console
$ rover --help | grep
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
```