### PR TITLE
fix: add new unused input type to check mutations

### DIFF
--- a/crates/rover-client/src/operations/graph/check/types.rs
+++ b/crates/rover-client/src/operations/graph/check/types.rs
@@ -38,6 +38,7 @@ impl From<CheckConfig> for MutationConfig {
             to,
             // we don't support configuring these, but we can't leave them out
             excludedClients: None,
+            excludedOperationNames: None,
             ignoredOperations: None,
             includedVariants: None,
         }

--- a/crates/rover-client/src/operations/subgraph/check/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check/types.rs
@@ -75,6 +75,7 @@ impl From<CheckConfig> for MutationConfig {
             to,
             // we don't support configuring these, but we can't leave them out
             excludedClients: None,
+            excludedOperationNames: None,
             ignoredOperations: None,
             includedVariants: None,
         }

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -67,7 +67,7 @@ impl RoverEnv {
             value.to_string()
         };
 
-        format!("environment variable ${} = {}", key.to_string(), value)
+        format!("environment variable ${} = {}", key, value)
     }
 
     /// sets an environment variable to a value


### PR DESCRIPTION
fixes #967 by updating the inputs to check mutations to include the new nullable `excludedOperationNames` field. this change was _not_ actually a breaking change as far as the GraphQL spec is concerned (and the Studio API team is concerned), the only reason this change made rover fail to compile was because the rust graphql client we use requires that all inputs be specified even if they are nullable. 