### PR TITLE
fix: build with versioned schemas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ workflows:
               platform: [centos, musl, macos, windows]
               rust_channel: [stable]
               command: [package]
-              options: ["--verbose --rebuild"]
+              options: ["--verbose --rebuild --copy-schema"]
           requires:
             - "Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)"
             - "Run supergraph-demo tests (stable rust on ubuntu)"

--- a/xtask/src/commands/version.rs
+++ b/xtask/src/commands/version.rs
@@ -10,12 +10,6 @@ pub(crate) struct RoverVersion {
     inner: Version,
 }
 
-impl RoverVersion {
-    pub(crate) fn new(version: Version) -> RoverVersion {
-        RoverVersion { inner: version }
-    }
-}
-
 impl FromStr for RoverVersion {
     type Err = anyhow::Error;
 


### PR DESCRIPTION
fixes #967 

this commit removes the usage of `APOLLO_GRAPHQL_SCHEMA_URL` by
`cargo xtask dist --version` since it just didn't work.

now, all versions are built by downloading their schema from the GitHub
repository if the first build fails.

additionally, schemas are now built and versioned with the `cargo xtask package --copy-schema`
command, which is now executed properly in CircleCI, meaning future releases should include the schema as part of the build process, and running `cargo xtask dist --version` should work for future releases.

