### PR TITLE
Update Renovate to support Gatsby v3 for docs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -44,13 +44,13 @@
       "matchPackageNames": ["react", "react-dom"],
       "allowedVersions": "16.x",
     },
-    // The current Apollo Gatsby version is pinned to v2
+    // The current Apollo Gatsby version is pinned to v3
     {
       "matchPaths": [
         "docs/package.json"
       ],
       "matchPackageNames": ["gatsby"],
-      "allowedVersions": "2.x",
+      "allowedVersions": "3.x",
     }
   ],
   "pathRules": [


### PR DESCRIPTION
This PR updates Renovate following the recent changes to the docs Gatsby theme to now support v3 (but not Gatsby v4).