### PR TITLE
Improve messaging for `rover subgraph check`

### DIFF
--- a/crates/rover-client/src/operations/graph/check/runner.rs
+++ b/crates/rover-client/src/operations/graph/check/runner.rs
@@ -51,11 +51,19 @@ fn get_check_response_from_data(
         changes.push(change.into());
     }
 
+    // The `graph` check response does not return this field
+    // only `subgraph` check does. Since `CheckResponse` is shared
+    // between `graph` and `subgraph` checks, defaulting this
+    // to false for now since its currently only used in
+    // `check_response.rs` to format better console messages.
+    let core_schema_modified = false;
+
     CheckResponse::try_new(
         target_url,
         operation_check_count,
         changes,
         result,
         graph_ref,
+        core_schema_modified,
     )
 }

--- a/crates/rover-client/src/operations/subgraph/check/check_mutation.graphql
+++ b/crates/rover-client/src/operations/subgraph/check/check_mutation.graphql
@@ -36,6 +36,7 @@
           }
           targetUrl
         }
+        coreSchemaModified
       }
     }
   }

--- a/crates/rover-client/src/operations/subgraph/check/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check/runner.rs
@@ -93,12 +93,15 @@ fn get_check_response_from_data(
             });
         }
 
+        let core_schema_modified = service.check_partial_schema.core_schema_modified;
+
         CheckResponse::try_new(
             check_schema_result.target_url,
             operation_check_count,
             changes,
             result,
             graph_ref,
+            core_schema_modified,
         )
     } else {
         let num_failures = query_composition_errors.len();

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -766,6 +766,7 @@ mod tests {
             ],
             ChangeSeverity::PASS,
             graph_ref,
+            true,
         );
         if let Ok(mock_check_response) = mock_check_response {
             let actual_json: JsonOutput = RoverOutput::CheckResponse(mock_check_response).into();
@@ -819,7 +820,9 @@ mod tests {
                     severity: ChangeSeverity::FAIL,
                 }
             ],
-            ChangeSeverity::FAIL, graph_ref);
+            ChangeSeverity::FAIL, graph_ref,
+            false,
+        );
 
         if let Err(operation_check_failure) = check_response {
             let actual_json: JsonOutput = RoverError::new(operation_check_failure).into();

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -790,6 +790,7 @@ mod tests {
                     ],
                     "failure_count": 0,
                     "success": true,
+                    "core_schema_modified": true,
                 },
                 "error": null
             });
@@ -846,6 +847,7 @@ mod tests {
                     ],
                     "failure_count": 2,
                     "success": false,
+                    "core_schema_modified": false,
                 },
                 "error": {
                     "message": "This operation check has encountered 2 schema changes that would break operations from existing client traffic.",


### PR DESCRIPTION
## Motivation

The current message outputted by rover when running a `subgraph check` only tells you if the API schema changed not the core schema.

This can sometimes lead to a confusing experience. For example when adding metadata directives such as `@key`, `@tag` etc. which get removed during composition and then seeing that rover detected zero changes.

The proposed improvement is the following.

If the Core schema changed but the API schema did not change:

`There were no changes detected in the composed API schema, but the core schema was modified.`

If the Core and API schema did not change:

`There were no changes detected in the composed schema.`