### PR TITLE
fix: proper configuration error messages

### DIFF
--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -26,7 +26,7 @@ pub enum HoustonProblem {
     ProfileNotFound(String),
 
     /// NoProfilesFound occurs when there are no profiles at all, often for new users
-    #[error("No configuration profiles found")]
+    #[error("No configuration profiles were found, and this command requires one.")]
     NoConfigProfiles,
 
     /// NoNonSensitiveConfigFound occurs when non-sensitive config can't be found for a profile.

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -115,10 +115,10 @@ impl Profile {
             ))
         } else {
             let profiles_base_dir = Profile::base_dir(config);
-            if let Ok(mut base_dir) = fs::read_dir(profiles_base_dir) {
-                if base_dir.next().is_none() {
-                    return Err(HoustonProblem::NoConfigProfiles);
-                }
+            let mut base_dir_contents =
+                fs::read_dir(profiles_base_dir).map_err(|_| HoustonProblem::NoConfigProfiles)?;
+            if base_dir_contents.next().is_none() {
+                return Err(HoustonProblem::NoConfigProfiles);
             }
             Err(HoustonProblem::ProfileNotFound(profile_name.to_string()))
         }

--- a/src/error/metadata/codes/E020.md
+++ b/src/error/metadata/codes/E020.md
@@ -2,4 +2,4 @@ This error occurs when trying to run a command that needs to use a configuration
 
 This is likely because you haven't set up a configuration profile yet or your `APOLLO_KEY` has been removed.
 
-Run `apollo config auth` to set up a new configuration profile or check out Rover's [configuration docs](https://go.apollo.dev/r/configuring) for more on how to set up and use Rover.
+Run `rover config auth` to set up a new configuration profile or check out Rover's [configuration docs](https://go.apollo.dev/r/configuring) for more on how to set up and use Rover.

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -137,8 +137,8 @@ impl Display for Suggestion {
                 "When trying to compose with a local .graphql file, make sure you supply a `routing_url` in your config YAML.".to_string()
             }
             Suggestion::NewUserNoProfiles => {
-                format!("It looks like you may be new here (we couldn't find any existing config profiles). To authenticate with Apollo Studio, run {}",
-                    Yellow.normal().paint("`rover config auth`")
+                format!("It looks like you may be new here. Welcome! To authenticate with Apollo Studio, run {}, or set {} to a valid Apollo Studio API key.",
+                    Yellow.normal().paint("`rover config auth`"), Cyan.normal().paint(format!("`${}`", RoverEnvKey::Key))
                 )
             }
             Suggestion::Adhoc(msg) => msg.to_string(),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use metadata::Metadata;
 pub type Result<T> = std::result::Result<T, RoverError>;
 
 use ansi_term::Colour::Red;
-use calm_io::{stderrln, stdoutln};
+use calm_io::{stderr, stdoutln};
 use rover_client::RoverClientError;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
@@ -106,7 +106,7 @@ impl RoverError {
             stdoutln!("{}", check_response.get_table())?;
         }
 
-        stderrln!("{}", self)?;
+        stderr!("{}", self)?;
         Ok(())
     }
 

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -81,7 +81,7 @@ impl Report for Rover {
     }
 
     fn is_telemetry_enabled(&self) -> Result<bool, SputnikError> {
-        let value = self.env_store.get(RoverEnvKey::TelemetryDisabled)?;
+        let value = self.get_env_var(RoverEnvKey::TelemetryDisabled)?;
         let is_telemetry_disabled = value.is_some();
         if is_telemetry_disabled {
             tracing::info!("Telemetry has been disabled.");
@@ -96,8 +96,7 @@ impl Report for Rover {
 
     fn endpoint(&self) -> Result<Url, SputnikError> {
         let url = self
-            .env_store
-            .get(RoverEnvKey::TelemetryUrl)?
+            .get_env_var(RoverEnvKey::TelemetryUrl)?
             .unwrap_or_else(|| TELEMETRY_URL.to_string());
         Ok(Url::parse(&url)?)
     }
@@ -172,8 +171,8 @@ mod tests {
         let args = vec![PKG_NAME, "config", "list"];
         let mut rover = Rover::from_iter(args);
         rover
-            .env_store
-            .insert(RoverEnvKey::TelemetryUrl, apollo_telemetry_url);
+            .insert_env_var(RoverEnvKey::TelemetryUrl, apollo_telemetry_url)
+            .unwrap();
         let actual_endpoint = rover
             .endpoint()
             .expect("could not parse telemetry URL")
@@ -187,7 +186,9 @@ mod tests {
     fn it_can_be_disabled() {
         let args = vec![PKG_NAME, "config", "list"];
         let mut rover = Rover::from_iter(args);
-        rover.env_store.insert(RoverEnvKey::TelemetryDisabled, "1");
+        rover
+            .insert_env_var(RoverEnvKey::TelemetryDisabled, "1")
+            .unwrap();
         let expect_enabled = false;
         let is_telemetry_enabled = rover.is_telemetry_enabled().unwrap();
 


### PR DESCRIPTION
This PR does two things:

1) Use `$APOLLO_KEY` when there are no profiles
 - to achieve this, we now only parse environment variables at startup and store them on first load in a `LazyCell`
2) Correctly print error E020 when there are no profiles on the machine, fixes #783 