### PR TITLE
release: v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Rover will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- # [x.x.x] (unreleased) - 2021-mm-dd
+<!-- # [x.x.x] (unreleased) - 2022-mm-dd
 
 > Important: X breaking changes below, indicated by **❗ BREAKING ❗**
 
@@ -17,6 +17,66 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 
 ## 📚 Documentation -->
+
+# [0.4.2] - 2022-02-11
+
+## 🚀 Features
+
+- **Adds launch URL feedback to `rover subgraph publish` - @Y-Guo, #989**
+
+  If a `rover subgraph publish` invocation kicks off a [launch](https://www.apollographql.com/docs/studio/launches/), it will now output the URL associated with the launch so you can go right to it in Studio.
+
+- **Improve messaging for `rover subgraph check` - @david-castaneda, #980**
+
+  In the case where the API schema does not change after a `subgraph check` but the core schema was modified, you are now notified as such rather than being displayed a confusing "there were no changes detected" message.
+
+## 🐛 Fixes
+
+- **Omit Float scalars from introspection result - @lrlna, #988 fixes #985**
+
+  Since `Float` is a built-in GraphQL scalar type, it is no longer included in Rover's introspection results.
+
+- **Fix configuration error messages when there are no profiles - @EverlastingBugstopper, #995 fixes #783**
+
+  Rover had a hard time detecting when there were no configured profiles, so it never actually emitted error `E020`. Now it does, and we also get some performance improvements by only parsing environment variables on startup rather than on every time they are needed.
+
+- **No longer panic when printing large output - @EverlastingBugstopper, #955 fixes #842**
+
+  Migrate away from the `println` and `eprintln` macros that can cause panics from time to time and instead use calm_io to gracefully handle output.
+
+- **Lowers the maximum required `glibc` version from 2.18 to 2.17 - @EverlastingBugstopper, #990 fixes #992**
+
+  We build Rover in Docker with the `centos:7` base image, which has `glibc` `v2.17` installed. This means we can lower our installer requirements to 2.17, allowing folks on older machines like centos to install Rover. Thanks to @theJC for the report and help with testing!
+
+- **Removes unused `--profile` argument from `rover subgraph introspect` - @EverlastingBugstopper, #950 fixes #948**
+
+## 🛠 Maintenance
+
+- **Use `apollo-encoder` in `rover-client` - @lrlna, #939**
+
+  `sdl-encoder` has been replaced with the official `apollo-encoder` from the [`apollo-rs`](https://github.com/apollographql/apollo-rs) ecosystem.
+
+- **Add PR template - @EverlastingBugstopper, #488**
+
+  Now folks who are kind enough to contribute pull requests to Rover's repository will have a helpful template to fill out.
+
+- **Fix mechanism for building old versions of Rover - @EverlastingBugstopper, #973 fixes #967**
+
+  If a build is executed via `cargo xtask dist --version vx.x.x`, it will now _actually_ download the schema it needs from the GitHub release artifacts page in order to build for the exact types that were built at that tagged version.
+
+- **Allow Rover to be installed alongside Node.js v17 - @EverlastingBugstopper, #999 fixes #993**
+
+- **Run plugin tests and lints in xtask - @EverlastingBugstopper, #977 fixes #909**
+
+- **Adds new unused input type to check mutations - @EverlastingBugstopper, #969 fixes #967**
+
+  Update the inputs to our check mutations to always send `null` for the `excludedOperationNames` field.
+
+## 📚 Documentation
+
+- **Add docs for `rover supergraph fetch` - @StephenBarlow, #971 fixes #952**
+
+- **Miscellaneous documentation polish - @StephenBarlow, #965, #963**
 
 # [0.4.1] - 2021-11-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "rover-fed2"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "apollo-federation-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.4.1"
+version = "0.4.2"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.4.1
+Rover 0.4.2
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -66,37 +66,18 @@ USAGE:
     rover [FLAGS] [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
-        --insecure-accept-invalid-certs        
-            Accept invalid certificates when performing HTTPS requests.
-            
-            You should think very carefully before using this flag.
-            
-            If invalid certificates are trusted, any certificate for any site will be trusted for use. This includes
-            expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
-        --insecure-accept-invalid-hostnames    
-            Accept invalid hostnames when performing HTTPS requests.
-            
-            You should think very carefully before using this flag.
-            
-            If hostname verification is not used, any valid certificate for any site will be trusted for use from any
-            other. This introduces a significant vulnerability to man-in-the-middle attacks.
-    -h, --help                                 
-            Prints help information
-
-    -V, --version                              
-            Prints version information
-
+        --insecure-accept-invalid-certs        Accept invalid certificates when performing HTTPS requests
+        --insecure-accept-invalid-hostnames    Accept invalid hostnames when performing HTTPS requests
+    -h, --help                                 Prints help information
+    -V, --version                              Prints version information
 
 OPTIONS:
-        --client-timeout <client-timeout>    
-            Configure the timeout length (in seconds) when performing HTTP(S) requests [default: 30]
-
-    -l, --log <log-level>                    
-            Specify Rover's log level [possible values: error, warn, info, debug,
-            trace]
-        --output <output-type>               
-            Specify Rover's output type [default: plain]  [possible values: json, plain]
-
+        --client-timeout <client-timeout>    Configure the timeout length (in seconds) when performing HTTP(S) requests
+                                             [default: 30]
+    -l, --log <log-level>                    Specify Rover's log level [possible values: error, warn,
+                                             info, debug, trace]
+        --output <output-type>               Specify Rover's output type [default: plain]  [possible values:
+                                             json, plain]
 
 SUBCOMMANDS:
     config        Configuration profile commands
@@ -142,7 +123,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.2 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -160,7 +141,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.4.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.2' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.12.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -310,6 +310,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@graphql-eslint/eslint-plugin": {
@@ -329,18 +338,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/@graphql-tools/utils": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.1.tgz",
-      "integrity": "sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
@@ -375,14 +372,14 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.2.tgz",
-      "integrity": "sha512-CjggOhiL4WtyG2I3kux+1/p8lQxSFHBj0gwa0NxnQ6Vsnpw7Ig5VP1ovPnitFuBv2k4QdC37Nj2xv2n7DRn8fw==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
+      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/batch-execute": "^8.3.1",
         "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.3",
+        "@graphql-tools/utils": "^8.5.4",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
@@ -424,12 +421,12 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.1.tgz",
-      "integrity": "sha512-i9WA6k+erJMci822o9w9DoX+uncVBK60LGGYW8mdbhX0l7wEubUpA000thJ1aarCusYh0u+ZT9qX0HyVPXu25Q==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.5.tgz",
+      "integrity": "sha512-w0/cYuhrr2apn+iGoTToCqt65x2NN2iHQyqRNk/Zw1NJ+e8/C3eKVw0jmW4pYQvSocuPxL4UCSI56SdKO7m3+Q==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.5.3",
+        "@graphql-tools/utils": "8.6.1",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -453,13 +450,13 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.4.1.tgz",
-      "integrity": "sha512-UvBodW5hRHpgBUBVz5K5VIhJDOTFIbRRAGD6sQ2l9J5FDKBEs3u/6JjZDzbdL96br94D5cEd2Tk6auaHpTn7mQ==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.1.tgz",
+      "integrity": "sha512-j9XcLYZPZdl/TzzqA83qveJmwcCxgGizt5L1+C1/Z68brTEmQHLdQCOR3Ma3ewESJt6DU05kSTu2raKaunkjRg==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/schema": "8.3.1",
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.0",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
@@ -468,9 +465,9 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.1.tgz",
-      "integrity": "sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.2.tgz",
+      "integrity": "sha512-2DyqhIOMUMKbCPqo8p6xSdll2OBcBxGdOrxlJJlFQvinsSaYqp/ct3dhAxNtzaIcvSVgXvttQqfD7O2ziFtE7Q==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^8.5.1",
@@ -496,39 +493,39 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.5.3.tgz",
-      "integrity": "sha512-VKMRJ4TOeVIdulkCLGSBUr4stRRwOGcVRXDeoUF+86K32Ufo0H2V0lz7QwS/bCl8GXV19FMgHZCDl4BMJyOXEA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.1.tgz",
+      "integrity": "sha512-K/5amdeHtKYI976HVd/AXdSNvLL7vx5QVjMlwN0OHeYyxSgC+UOH+KkS7cshYgL13SekGu0Mxbg9ABfgQ34ECA==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/delegate": "^8.4.1",
         "@graphql-tools/utils": "^8.5.1",
         "@graphql-tools/wrap": "^8.3.1",
-        "@n1ru4l/graphql-live-query": "0.9.0",
-        "@types/websocket": "1.0.4",
+        "@n1ru4l/graphql-live-query": "^0.9.0",
+        "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
-        "cross-undici-fetch": "^0.0.26",
+        "cross-undici-fetch": "^0.1.19",
         "dset": "^3.1.0",
-        "extract-files": "11.0.0",
+        "extract-files": "^11.0.0",
         "graphql-sse": "^1.0.1",
         "graphql-ws": "^5.4.1",
-        "isomorphic-ws": "4.0.1",
-        "meros": "1.1.4",
+        "isomorphic-ws": "^4.0.1",
+        "meros": "^1.1.4",
         "subscriptions-transport-ws": "^0.11.0",
-        "sync-fetch": "0.3.1",
-        "tslib": "~2.3.0",
-        "valid-url": "1.0.9",
-        "value-or-promise": "1.0.11",
-        "ws": "8.3.0"
+        "sync-fetch": "^0.3.1",
+        "tslib": "^2.3.0",
+        "valid-url": "^1.0.9",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.3.tgz",
-      "integrity": "sha512-HDNGWFVa8QQkoQB0H1lftvaO1X5xUaUDk1zr1qDe0xN1NL0E/CrQdJ5UKLqOvH4hkqVUPxQsyOoAZFkaH6rLHg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.1.tgz",
+      "integrity": "sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -538,9 +535,9 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.2.tgz",
-      "integrity": "sha512-7DcOBFB+Dd84x9dxSm7qS4iJONMyfLnCJb8A19vGPffpu4SMJ3sFcgwibKFu5l6mMUiigKgXna2RRgWI+02bKQ==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.3.tgz",
+      "integrity": "sha512-TpXN1S4Cv+oMA1Zsg9Nu4N9yrFxLuJkX+CTtSRrrdfETGHIxqfyDkm5slPDCckxP+RILA00g8ny2jzsYyNvX1w==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/delegate": "^8.4.2",
@@ -554,9 +551,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -624,9 +621,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
-      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.17.tgz",
+      "integrity": "sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -636,18 +633,18 @@
       "dev": true
     },
     "node_modules/@types/websocket": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
-      "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
+      "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.1.tgz",
-      "integrity": "sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -755,12 +752,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
     },
     "node_modules/backo2": {
       "version": "1.0.2",
@@ -889,18 +880,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -953,15 +932,17 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.0.26.tgz",
-      "integrity": "sha512-aMDRrLbWr0TGXfY92stlV+XOGpskeqFmWmrKSWsnc8w6gK5LPE83NBh7O7N6gCb2xjwHcm1Yn2nBXMEVH2RBcA==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.23.tgz",
+      "integrity": "sha512-PxSFKt7owZrL/WWowlOXVyD86HcUXePQ0853p/6DGktaONK10hVixV9RmqPaEsdrCTJkeBDlnXFT2tp6db0K0g==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.5",
-        "undici": "^4.9.3"
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^4.9.3",
+        "web-streams-polyfill": "^3.2.0"
       }
     },
     "node_modules/dataloader": {
@@ -992,15 +973,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -1181,15 +1153,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/espree": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
@@ -1280,9 +1243,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1292,7 +1255,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
@@ -1366,23 +1329,37 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+    "node_modules/form-data-encoder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
+      "dev": true
+    },
+    "node_modules/formdata-node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
+      "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
       "dev": true,
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
+      "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fs.realpath": {
@@ -1439,16 +1416,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1456,15 +1433,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/graphql": {
@@ -1499,6 +1467,18 @@
       },
       "peerDependencies": {
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/graphql-depth-limit": {
@@ -1570,9 +1550,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1815,31 +1795,10 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.51.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1860,16 +1819,43 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/normalize-path": {
@@ -1983,9 +1969,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -2212,9 +2198,9 @@
       }
     },
     "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -2356,9 +2342,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2370,9 +2356,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.11.0.tgz",
-      "integrity": "sha512-gofXRqAdm81rzaZgPbMf98qvrNGd3ptJ26+mCcF3EXoC817p//MtL8XcDpTvHUXxdW27rAM2jvTae+KyAchorw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
+      "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
       "dev": true,
       "engines": {
         "node": ">=12.18"
@@ -2418,6 +2404,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -2467,9 +2462,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -2736,13 +2731,19 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+          "version": "13.12.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         }
       }
     },
@@ -2760,17 +2761,6 @@
         "graphql-config": "4.1.0",
         "graphql-depth-limit": "1.1.0",
         "lodash.lowercase": "4.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.1.tgz",
-          "integrity": "sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/batch-execute": {
@@ -2799,14 +2789,14 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.2.tgz",
-      "integrity": "sha512-CjggOhiL4WtyG2I3kux+1/p8lQxSFHBj0gwa0NxnQ6Vsnpw7Ig5VP1ovPnitFuBv2k4QdC37Nj2xv2n7DRn8fw==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
+      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
       "dev": true,
       "requires": {
         "@graphql-tools/batch-execute": "^8.3.1",
         "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.3",
+        "@graphql-tools/utils": "^8.5.4",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
@@ -2839,12 +2829,12 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.1.tgz",
-      "integrity": "sha512-i9WA6k+erJMci822o9w9DoX+uncVBK60LGGYW8mdbhX0l7wEubUpA000thJ1aarCusYh0u+ZT9qX0HyVPXu25Q==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.5.tgz",
+      "integrity": "sha512-w0/cYuhrr2apn+iGoTToCqt65x2NN2iHQyqRNk/Zw1NJ+e8/C3eKVw0jmW4pYQvSocuPxL4UCSI56SdKO7m3+Q==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.5.3",
+        "@graphql-tools/utils": "8.6.1",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       }
@@ -2862,21 +2852,21 @@
       }
     },
     "@graphql-tools/load": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.4.1.tgz",
-      "integrity": "sha512-UvBodW5hRHpgBUBVz5K5VIhJDOTFIbRRAGD6sQ2l9J5FDKBEs3u/6JjZDzbdL96br94D5cEd2Tk6auaHpTn7mQ==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.1.tgz",
+      "integrity": "sha512-j9XcLYZPZdl/TzzqA83qveJmwcCxgGizt5L1+C1/Z68brTEmQHLdQCOR3Ma3ewESJt6DU05kSTu2raKaunkjRg==",
       "dev": true,
       "requires": {
         "@graphql-tools/schema": "8.3.1",
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.0",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.1.tgz",
-      "integrity": "sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.2.tgz",
+      "integrity": "sha512-2DyqhIOMUMKbCPqo8p6xSdll2OBcBxGdOrxlJJlFQvinsSaYqp/ct3dhAxNtzaIcvSVgXvttQqfD7O2ziFtE7Q==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "^8.5.1",
@@ -2896,45 +2886,45 @@
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.5.3.tgz",
-      "integrity": "sha512-VKMRJ4TOeVIdulkCLGSBUr4stRRwOGcVRXDeoUF+86K32Ufo0H2V0lz7QwS/bCl8GXV19FMgHZCDl4BMJyOXEA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.1.tgz",
+      "integrity": "sha512-K/5amdeHtKYI976HVd/AXdSNvLL7vx5QVjMlwN0OHeYyxSgC+UOH+KkS7cshYgL13SekGu0Mxbg9ABfgQ34ECA==",
       "dev": true,
       "requires": {
         "@graphql-tools/delegate": "^8.4.1",
         "@graphql-tools/utils": "^8.5.1",
         "@graphql-tools/wrap": "^8.3.1",
-        "@n1ru4l/graphql-live-query": "0.9.0",
-        "@types/websocket": "1.0.4",
+        "@n1ru4l/graphql-live-query": "^0.9.0",
+        "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
-        "cross-undici-fetch": "^0.0.26",
+        "cross-undici-fetch": "^0.1.19",
         "dset": "^3.1.0",
-        "extract-files": "11.0.0",
+        "extract-files": "^11.0.0",
         "graphql-sse": "^1.0.1",
         "graphql-ws": "^5.4.1",
-        "isomorphic-ws": "4.0.1",
-        "meros": "1.1.4",
+        "isomorphic-ws": "^4.0.1",
+        "meros": "^1.1.4",
         "subscriptions-transport-ws": "^0.11.0",
-        "sync-fetch": "0.3.1",
-        "tslib": "~2.3.0",
-        "valid-url": "1.0.9",
-        "value-or-promise": "1.0.11",
-        "ws": "8.3.0"
+        "sync-fetch": "^0.3.1",
+        "tslib": "^2.3.0",
+        "valid-url": "^1.0.9",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.3.0"
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.3.tgz",
-      "integrity": "sha512-HDNGWFVa8QQkoQB0H1lftvaO1X5xUaUDk1zr1qDe0xN1NL0E/CrQdJ5UKLqOvH4hkqVUPxQsyOoAZFkaH6rLHg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.1.tgz",
+      "integrity": "sha512-uxcfHCocp4ENoIiovPxUWZEHOnbXqj3ekWc0rm7fUhW93a1xheARNHcNKhwMTR+UKXVJbTFQdGI1Rl5XdyvDBg==",
       "dev": true,
       "requires": {
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.2.tgz",
-      "integrity": "sha512-7DcOBFB+Dd84x9dxSm7qS4iJONMyfLnCJb8A19vGPffpu4SMJ3sFcgwibKFu5l6mMUiigKgXna2RRgWI+02bKQ==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.3.tgz",
+      "integrity": "sha512-TpXN1S4Cv+oMA1Zsg9Nu4N9yrFxLuJkX+CTtSRrrdfETGHIxqfyDkm5slPDCckxP+RILA00g8ny2jzsYyNvX1w==",
       "dev": true,
       "requires": {
         "@graphql-tools/delegate": "^8.4.2",
@@ -2945,9 +2935,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -3001,9 +2991,9 @@
       }
     },
     "@types/node": {
-      "version": "16.11.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
-      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.17.tgz",
+      "integrity": "sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3013,18 +3003,18 @@
       "dev": true
     },
     "@types/websocket": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
-      "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
+      "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/ws": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.1.tgz",
-      "integrity": "sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3101,12 +3091,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "backo2": {
@@ -3193,15 +3177,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3248,15 +3223,17 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.0.26.tgz",
-      "integrity": "sha512-aMDRrLbWr0TGXfY92stlV+XOGpskeqFmWmrKSWsnc8w6gK5LPE83NBh7O7N6gCb2xjwHcm1Yn2nBXMEVH2RBcA==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.23.tgz",
+      "integrity": "sha512-PxSFKt7owZrL/WWowlOXVyD86HcUXePQ0853p/6DGktaONK10hVixV9RmqPaEsdrCTJkeBDlnXFT2tp6db0K0g==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.5",
-        "undici": "^4.9.3"
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^4.9.3",
+        "web-streams-polyfill": "^3.2.0"
       }
     },
     "dataloader": {
@@ -3278,12 +3255,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "diff": {
@@ -3382,12 +3353,6 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
-        },
-        "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-          "dev": true
         }
       }
     },
@@ -3490,9 +3455,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3563,20 +3528,33 @@
       }
     },
     "flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+    "form-data-encoder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
+      "dev": true
+    },
+    "formdata-node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
+      "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.1"
+      },
+      "dependencies": {
+        "web-streams-polyfill": {
+          "version": "4.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
+          "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
+          "dev": true
+        }
       }
     },
     "fs.realpath": {
@@ -3621,25 +3599,17 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.9",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
-          "dev": true
-        }
       }
     },
     "graphql": {
@@ -3665,6 +3635,17 @@
         "cosmiconfig-toml-loader": "1.0.0",
         "minimatch": "3.0.4",
         "string-env-interpolation": "1.0.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "graphql-depth-limit": {
@@ -3703,9 +3684,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "import-fresh": {
@@ -3896,25 +3877,10 @@
         "picomatch": "^2.2.3"
       }
     },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.51.0"
-      }
-    },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -3932,10 +3898,16 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
+    },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -4022,9 +3994,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "prelude-ls": {
@@ -4167,9 +4139,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.5.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
           "dev": true,
           "requires": {}
         }
@@ -4263,16 +4235,16 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "peer": true
     },
     "undici": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.11.0.tgz",
-      "integrity": "sha512-gofXRqAdm81rzaZgPbMf98qvrNGd3ptJ26+mCcF3EXoC817p//MtL8XcDpTvHUXxdW27rAM2jvTae+KyAchorw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
+      "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
       "dev": true
     },
     "unixify": {
@@ -4309,6 +4281,12 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
       "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "dev": true
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
       "dev": true
     },
     "webidl-conversions": {
@@ -4349,9 +4327,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "requires": {}
     },

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -167,7 +167,7 @@ This error occurs when trying to run a command that needs to use a configuration
 
 This is likely because you haven't set up a configuration profile yet or your `APOLLO_KEY` has been removed.
 
-Run `apollo config auth` to set up a new configuration profile or check out Rover's [configuration docs](https://go.apollo.dev/r/configuring) for more on how to set up and use Rover.
+Run `rover config auth` to set up a new configuration profile or check out Rover's [configuration docs](https://go.apollo.dev/r/configuring) for more on how to set up and use Rover.
 
 ### E021
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -19,7 +19,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.2 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.4.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.2' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.1"
+PACKAGE_VERSION="v0.4.2"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/nix/install_rover_fed2.sh
+++ b/installers/binstall/scripts/nix/install_rover_fed2.sh
@@ -118,7 +118,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.1"
+PACKAGE_VERSION="v0.4.2"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.1'
+$package_version = 'v0.4.2'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/binstall/scripts/windows/install_rover_fed2.ps1
+++ b/installers/binstall/scripts/windows/install_rover_fed2.ps1
@@ -112,7 +112,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.1'
+$package_version = 'v0.4.2'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -187,9 +187,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -389,9 +389,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -434,17 +434,17 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "requires": {
         "yallist": "^4.0.0"
       }

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rover-fed2"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license-file = "./LICENSE"
 

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -17,6 +17,8 @@ lazy_static! {
     pub(crate) static ref PKG_PROJECT_ROOT: Utf8PathBuf =
         project_root().expect("Could not find Rover's project root.");
     pub(crate) static ref TARGET_DIR: Utf8PathBuf = CARGO_METADATA.clone().target_directory;
+    static ref CARGO_METADATA_WITHOUT_DEPS: Metadata =
+        cargo_metadata_without_deps().expect("Could not run `cargo metadata`");
     static ref CARGO_METADATA: Metadata = cargo_metadata().expect("Could not run `cargo metadata`");
 }
 
@@ -49,6 +51,13 @@ fn project_root() -> Result<Utf8PathBuf> {
 fn cargo_metadata() -> Result<Metadata> {
     let metadata = MetadataCommand::new()
         .manifest_path(PKG_PROJECT_ROOT.join("Cargo.toml"))
+        .exec()?;
+    Ok(metadata)
+}
+
+fn cargo_metadata_without_deps() -> Result<Metadata> {
+    let metadata = MetadataCommand::new()
+        .manifest_path(PKG_PROJECT_ROOT.join("Cargo.toml"))
         .no_deps()
         .exec()?;
     Ok(metadata)
@@ -56,7 +65,7 @@ fn cargo_metadata() -> Result<Metadata> {
 
 pub(crate) fn get_bin_paths(crate_target: &Target, release: bool) -> HashMap<String, Utf8PathBuf> {
     let mut bin_paths = HashMap::new();
-    for package in &CARGO_METADATA.packages {
+    for package in &CARGO_METADATA_WITHOUT_DEPS.packages {
         for target in &package.targets {
             for kind in &target.kind {
                 if kind == "bin" && target.name != "xtask" {


### PR DESCRIPTION
# [0.4.2] - 2022-02-11

## 🚀 Features

- **Adds launch URL feedback to `rover subgraph publish` - @Y-Guo, #989**

  If a `rover subgraph publish` invocation kicks off a [launch](https://www.apollographql.com/docs/studio/launches/), it will now output the URL associated with the launch so you can go right to it in Studio.

- **Improve messaging for `rover subgraph check` - @david-castaneda, #980**

  In the case where the API schema does not change after a `subgraph check` but the core schema was modified, you are now notified as such rather than being displayed a confusing "there were no changes detected" message.

## 🐛 Fixes

- **Omit Float scalars from introspection result - @lrlna, #988 fixes #985**

  Since `Float` is a built-in GraphQL scalar type, it is no longer included in Rover's introspection results.

- **Fix configuration error messages when there are no profiles - @EverlastingBugstopper, #995 fixes #783**

  Rover had a hard time detecting when there were no configured profiles, so it never actually emitted error `E020`. Now it does, and we also get some performance improvements by only parsing environment variables on startup rather than on every time they are needed.

- **No longer panic when printing large output - @EverlastingBugstopper, #955 fixes #842**

  Migrate away from the `println` and `eprintln` macros that can cause panics from time to time and instead use calm_io to gracefully handle output.

- **Lowers the maximum required `glibc` version from 2.18 to 2.17 - @EverlastingBugstopper, #990 fixes #992**

  We build Rover in Docker with the `centos:7` base image, which has `glibc` `v2.17` installed. This means we can lower our installer requirements to 2.17, allowing folks on older machines like centos to install Rover. Thanks to @theJC for the report and help with testing!

- **Removes unused `--profile` argument from `rover subgraph introspect` - @EverlastingBugstopper, #950 fixes #948**

## 🛠 Maintenance

- **Use `apollo-encoder` in `rover-client` - @lrlna, #939**

  `sdl-encoder` has been replaced with the official `apollo-encoder` from the [`apollo-rs`](https://github.com/apollographql/apollo-rs) ecosystem.

- **Add PR template - @EverlastingBugstopper, #488**

  Now folks who are kind enough to contribute pull requests to Rover's repository will have a helpful template to fill out.

- **Fix mechanism for building old versions of Rover - @EverlastingBugstopper, #973 fixes #967**

  If a build is executed via `cargo xtask dist --version vx.x.x`, it will now _actually_ download the schema it needs from the GitHub release artifacts page in order to build for the exact types that were built at that tagged version.

- **Allow Rover to be installed alongside Node.js v17 - @EverlastingBugstopper, #999 fixes #993**

- **Run plugin tests and lints in xtask - @EverlastingBugstopper, #977 fixes #909**

- **Adds new unused input type to check mutations - @EverlastingBugstopper, #969 fixes #967**

  Update the inputs to our check mutations to always send `null` for the `excludedOperationNames` field.

## 📚 Documentation

- **Add docs for `rover supergraph fetch` - @StephenBarlow, #971 fixes #952**

- **Miscellaneous documentation polish - @StephenBarlow, #965, #963**