### PR TITLE
feat: build universal macos binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,6 @@ commands:
             volta install node@16
             volta install npm@7
 
-
   install_rust_toolchain:
     parameters:
       rust_channel:
@@ -306,15 +305,33 @@ commands:
       platform:
         type: executor
     steps:
-      - unless:
+      - when:
           condition:
-            equal: [ *windows_executor, << parameters.platform >> ]
+            or:
+              - equal: [ *centos_executor, << parameters.platform >> ]
+              - equal: [ *musl_executor, << parameters.platform >> ]
+              - equal: [ *ubuntu_executor, << parameters.platform >> ]
+              - equal: [ *volta_executor, << parameters.platform >> ]
           steps:
             - rust/install:
                 version: << parameters.rust_channel >>
             - run:
                 name: Install specific rust toolchain
                 command: rustup target add $XTASK_TARGET
+                
+      - when:
+          condition:
+            equal: [ *macos_executor, << parameters.platform >> ]
+          steps:
+            - rust/install:
+                version: << parameters.rust_channel>>
+            - run:
+                name: Install ARM toolchain
+                command: rustup target add aarch64-apple-darwin
+            - run:
+                name: Install standard toolchain
+                command: rustup target add x86_64-apple-darwin
+
       - when:
           condition:
             equal: [ *windows_executor, << parameters.platform >> ]
@@ -354,6 +371,16 @@ commands:
       - restore_cache:
           keys:
             - rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+      
+      - when:
+          condition:
+            and:
+              - equal: [ package, << parameters.command >> ]
+              - equal: [ *macos_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Build a universal MacOS binary
+                command: export XTASK_TARGET="unknown-apple-darwin"
 
       - run:
           command: cargo xtask << parameters.command >> << parameters.options >>

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -67,7 +67,7 @@ impl Package {
         );
 
         #[cfg(target_os = "macos")]
-        self.macos.run(&release_path, &bin_name)?;
+        self.macos.run(&release_path, bin_name)?;
 
         if !self.output.exists() {
             std::fs::create_dir_all(&self.output).context("Couldn't create output directory")?;

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -8,14 +8,18 @@ use crate::Result;
 pub(crate) const TARGET_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
 pub(crate) const TARGET_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
 pub(crate) const TARGET_WINDOWS: &str = "x86_64-pc-windows-msvc";
-pub(crate) const TARGET_MACOS: &str = "x86_64-apple-darwin";
+pub(crate) const TARGET_X86_64_MACOS: &str = "x86_64-apple-darwin";
+pub(crate) const TARGET_ARM_MACOS: &str = "aarch64-apple-darwin";
+pub(crate) const TARGET_UNIVERSAL_MACOS: &str = "unknown-apple-darwin";
 const BREW_OPT: &[&str] = &["/usr/local/opt", "/opt/homebrew/Cellar"];
 
-pub(crate) const POSSIBLE_TARGETS: [&str; 4] = [
+pub(crate) const POSSIBLE_TARGETS: [&str; 6] = [
     TARGET_MUSL_LINUX,
     TARGET_GNU_LINUX,
     TARGET_WINDOWS,
-    TARGET_MACOS,
+    TARGET_UNIVERSAL_MACOS,
+    TARGET_X86_64_MACOS,
+    TARGET_ARM_MACOS,
 ];
 
 #[derive(Debug, PartialEq, Clone)]
@@ -23,22 +27,32 @@ pub(crate) enum Target {
     MuslLinux,
     GnuLinux,
     Windows,
-    MacOS,
+    ArmMacOS,
+    NotArmMacOS,
+    UniversalMacOS,
     Other,
 }
 
 impl Target {
-    pub(crate) fn get_args(&self) -> Vec<String> {
-        let mut args = vec![];
-
-        if let Self::MuslLinux | Self::GnuLinux | Self::Windows | Self::MacOS = self {
-            args.push("--target".to_string());
-            args.push(self.to_string());
+    /// This function will return all of the options needed
+    /// to build for a specific target. It is a Vec<Vec<String>>
+    /// because sometimes you need more than one cargo build
+    /// to be run for an architecture (namely universal MacOS binaries)
+    pub(crate) fn get_all_cargo_args(&self) -> Vec<Vec<String>> {
+        let mut cargo_args = vec![];
+        for cargo_target in self.cargo_targets() {
+            let mut current_args = vec![];
+    
+            if !self.is_other() {
+                current_args.push("--target".to_string());
+                current_args.push(cargo_target.to_string());
+            }
+            if !self.composition_js() {
+                current_args.push("--no-default-features".to_string());
+            }
+            cargo_args.push(current_args);
         }
-        if !self.composition_js() {
-            args.push("--no-default-features".to_string());
-        }
-        args
+        cargo_args
     }
 
     pub(crate) fn is_other(&self) -> bool {
@@ -51,7 +65,7 @@ impl Target {
             Target::GnuLinux | Target::MuslLinux => {
                 env.insert("OPENSSL_STATIC".to_string(), "1".to_string());
             }
-            Target::MacOS => {
+            Target::UniversalMacOS | Target::ArmMacOS | Target::NotArmMacOS => {
                 let openssl_path = BREW_OPT
                     .iter()
                     .map(|x| Utf8Path::new(x).join("openssl@1.1"))
@@ -71,10 +85,22 @@ impl Target {
                     "RUSTFLAGS".to_string(),
                     "-Ctarget-feature=+crt-static".to_string(),
                 );
-            }
+            },
             _ => {}
         };
         Ok(env)
+    }
+
+    fn cargo_targets(&self) -> Vec<String> {
+        match &self {
+            Self::UniversalMacOS => vec![TARGET_X86_64_MACOS.to_string(), TARGET_ARM_MACOS.to_string()],
+            Self::ArmMacOS => vec![TARGET_ARM_MACOS.to_string()],
+            Self::NotArmMacOS => vec![TARGET_X86_64_MACOS.to_string()],
+            Self::Windows => vec![TARGET_WINDOWS.to_string()],
+            Self::GnuLinux => vec![TARGET_GNU_LINUX.to_string()],
+            Self::MuslLinux => vec![TARGET_MUSL_LINUX.to_string()],
+            Self::Other => vec![]
+        }
     }
 
     fn composition_js(&self) -> bool {
@@ -84,25 +110,27 @@ impl Target {
 
 impl Default for Target {
     fn default() -> Self {
-        if cfg!(target_arch = "x86_64") {
-            if cfg!(target_os = "windows") {
-                Target::Windows
-            } else if cfg!(target_os = "linux") {
-                if cfg!(target_env = "gnu") {
-                    Target::GnuLinux
-                } else if cfg!(target_env = "musl") {
-                    Target::MuslLinux
-                } else {
-                    Target::Other
-                }
-            } else if cfg!(target_os = "macos") {
-                Target::MacOS
+        let mut target = Target::Other;
+
+        if cfg!(target_os = "macos") {
+            if cfg!(target_arch = "x86_64") {
+                target = Target::NotArmMacOS
             } else {
-                Target::Other
+                target = Target::ArmMacOS
             }
-        } else {
-            Target::Other
+        } else if cfg!(target_os = "windows") {
+            target = Target::Windows
+        } else if cfg!(target_os = "linux") {
+            if cfg!(target_arch = "x86_64") {
+                if cfg!(target_env = "gnu") {
+                    target = Target::GnuLinux
+                } else if cfg!(target_env = "musl") {
+                    target = Target::MuslLinux
+                }
+            }
         }
+
+        target
     }
 }
 
@@ -114,7 +142,9 @@ impl FromStr for Target {
             TARGET_MUSL_LINUX => Ok(Self::MuslLinux),
             TARGET_GNU_LINUX => Ok(Self::GnuLinux),
             TARGET_WINDOWS => Ok(Self::Windows),
-            TARGET_MACOS => Ok(Self::MacOS),
+            TARGET_UNIVERSAL_MACOS => Ok(Self::UniversalMacOS),
+            TARGET_ARM_MACOS => Ok(Self::ArmMacOS),
+            TARGET_X86_64_MACOS => Ok(Self::NotArmMacOS),
             _ => Ok(Self::Other),
         }
     }
@@ -126,7 +156,9 @@ impl fmt::Display for Target {
             Target::MuslLinux => TARGET_MUSL_LINUX,
             Target::GnuLinux => TARGET_GNU_LINUX,
             Target::Windows => TARGET_WINDOWS,
-            Target::MacOS => TARGET_MACOS,
+            Target::UniversalMacOS => TARGET_UNIVERSAL_MACOS,
+            Target::ArmMacOS => TARGET_ARM_MACOS,
+            Target::NotArmMacOS => TARGET_X86_64_MACOS,
             Target::Other => "unknown-target",
         };
         write!(f, "{}", msg)


### PR DESCRIPTION
possibly fixes #260, assuming my machine is any indication of what circle ci can do.

it seems like you can cross compile for m1 machines and create a universal binary. i recently installed qemu emulation for a _different_ investigation, so i'm not sure if that is a requirement for cross-compiling, but this should tell us. 