### PR TITLE
feat: rover supergraph generate

### DIFF
--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -11,6 +11,7 @@ use ansi_term::{
 };
 use atty::Stream;
 use calm_io::{stderr, stderrln, stdout, stdoutln};
+use camino::Utf8PathBuf;
 use crossterm::style::Attribute::Underlined;
 use rover_client::operations::graph::publish::GraphPublishResponse;
 use rover_client::operations::subgraph::delete::SubgraphDeleteResponse;
@@ -41,6 +42,10 @@ pub enum RoverOutput {
     },
     SubgraphList(SubgraphListResponse),
     CheckResponse(CheckResponse),
+    SupergraphGenerate {
+        repository_url: String,
+        directory: Utf8PathBuf,
+    },
     GraphPublishResponse {
         graph_ref: GraphRef,
         publish_response: GraphPublishResponse,
@@ -85,6 +90,16 @@ impl RoverOutput {
                     SdlType::Supergraph => print_descriptor("Supergraph SDL")?,
                 }
                 print_content(&fetch_response.sdl.contents)?;
+            }
+            RoverOutput::SupergraphGenerate {
+                repository_url,
+                directory,
+            } => {
+                stderrln!(
+                    "Created supergraph project from {} in {}",
+                    repository_url,
+                    directory
+                )?;
             }
             RoverOutput::GraphPublishResponse {
                 graph_ref,
@@ -301,6 +316,10 @@ impl RoverOutput {
             } => {
                 json!(delete_response)
             }
+            RoverOutput::SupergraphGenerate {
+                repository_url,
+                directory,
+            } => json!({"repository_url": repository_url, "directory": directory}),
             RoverOutput::SubgraphList(list_response) => json!(list_response),
             RoverOutput::CheckResponse(check_response) => check_response.get_json(),
             RoverOutput::Profiles(profiles) => json!({ "profiles": profiles }),

--- a/src/command/supergraph/generate.rs
+++ b/src/command/supergraph/generate.rs
@@ -1,0 +1,27 @@
+use camino::Utf8PathBuf;
+use serde::Serialize;
+use structopt::StructOpt;
+
+use crate::command::supergraph::Template;
+use crate::command::RoverOutput;
+use crate::error::RoverError;
+
+#[derive(Debug, Serialize, StructOpt)]
+pub struct Generate {
+    #[structopt(long = "template", possible_values = &Template::possible_templates())]
+    template: Template,
+
+    #[structopt(long = "directory", default_value = "./supergraph")]
+    directory: Utf8PathBuf,
+}
+
+impl Generate {
+    pub fn run(&self) -> Result<RoverOutput, RoverError> {
+        let repository_url = self.template.get_repository_url().to_string();
+        self.template.clone_repo(&self.directory)?;
+        Ok(RoverOutput::SupergraphGenerate {
+            repository_url,
+            directory: self.directory.clone(),
+        })
+    }
+}

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -1,5 +1,9 @@
 pub(crate) mod compose;
 mod fetch;
+mod generate;
+mod template;
+
+pub(crate) use template::Template;
 
 mod resolve_config;
 pub(crate) use resolve_config::get_subgraph_definitions;
@@ -24,6 +28,9 @@ pub enum Command {
 
     /// Fetch supergraph SDL from the graph registry
     Fetch(fetch::Fetch),
+
+    /// Generate a starter supergraph project
+    Generate(generate::Generate),
 }
 
 impl Supergraph {
@@ -31,6 +38,7 @@ impl Supergraph {
         match &self.command {
             Command::Fetch(command) => command.run(client_config),
             Command::Compose(command) => command.run(client_config),
+            Command::Generate(command) => command.run(),
         }
     }
 }

--- a/src/command/supergraph/template.rs
+++ b/src/command/supergraph/template.rs
@@ -1,0 +1,84 @@
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+use anyhow::Context;
+use camino::Utf8PathBuf;
+use serde::Serialize;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+use crate::anyhow;
+use crate::error::RoverError;
+
+#[derive(Debug, Clone, Serialize, EnumIter)]
+pub(crate) enum Template {
+    Rust,
+    Typescript,
+}
+
+impl Template {
+    pub(crate) fn clone_repo(&self, directory: &Utf8PathBuf) -> Result<(), RoverError> {
+        if directory.exists() {
+            return Err(RoverError::new(anyhow!(
+                "`{}` already exists, please select a different directory for your project, or remove it.",
+                directory
+            )));
+        }
+
+        let repo_url = self.get_repository_url();
+
+        std::process::Command::new("git")
+            .args(&["clone", repo_url, directory.as_str()])
+            .output()
+            .with_context(|| format!("Could not clone `{}` into `{}`", repo_url, directory))?;
+        Ok(())
+        // Ok(Repository::clone(repo_url, directory)
+        //     .with_context(|| format!("Could not clone `{}` into `{}`", repo_url, directory))?)
+    }
+    pub(crate) fn get_repository_url(&self) -> &str {
+        match self {
+            Self::Rust => "https://github.com/apollographql/supergraph-rs",
+            Self::Typescript => "https://github.com/apollographql/fed-day-1",
+        }
+    }
+}
+
+impl Template {
+    pub(crate) fn possible_templates() -> Vec<&'static str> {
+        let mut res = Vec::new();
+        for lang in Self::iter() {
+            res.push(lang.as_str());
+        }
+        res
+    }
+
+    pub(crate) fn as_str(&self) -> &'static str {
+        match &self {
+            Self::Rust => "rust",
+            Self::Typescript => "typescript",
+        }
+    }
+}
+
+impl FromStr for Template {
+    type Err = RoverError;
+    fn from_str(lang: &str) -> Result<Self, Self::Err> {
+        match lang.to_lowercase().as_str() {
+            "rust" => Ok(Self::Rust),
+            "typescript" => Ok(Self::Typescript),
+            _ => Err(RoverError::new(anyhow!(
+                "Could not find a template for language `{}`.",
+                lang
+            ))),
+        }
+    }
+}
+
+impl Display for Template {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let template = self.as_str();
+        write!(f, "{}", template)
+    }
+}


### PR DESCRIPTION
proof of concept for `rover supergraph generate` - 

```console
$ rover supergraph generate --help
rover-supergraph-generate 0.4.3
Generate a starter supergraph project

USAGE:
    rover supergraph generate [FLAGS] [OPTIONS] --template <template>

FLAGS:
    -h, --help                                 
            Prints help information

OPTIONS:
        --directory <directory>              
             [default: ./supergraph]

    -l, --log <log-level>                    
            Specify Rover's log level [possible values: error, warn, info, debug,
            trace]
        --output <output-type>               
            Specify Rover's output type [default: plain]  [possible values: json, plain]

        --template <template>                
             [possible values: rust, typescript]
```

```console
$ rover supergraph generate --template typescript
Created supergraph project from https://github.com/apollographql/fed-day-1 in ./supergraph
```
