### PR TITLE
fix rust version with rust-toolchain file, and fix lint errors for rust 1.59

### DIFF
--- a/crates/houston/src/config.rs
+++ b/crates/houston/src/config.rs
@@ -82,6 +82,6 @@ mod tests {
         let config = Config::new(Some(&tmp_path), None).unwrap();
         assert!(config.home.exists());
         config.clear().unwrap();
-        assert_eq!(config.home.exists(), false);
+        assert!(!config.home.exists());
     }
 }

--- a/crates/rover-client/src/operations/graph/introspect/schema.rs
+++ b/crates/rover-client/src/operations/graph/introspect/schema.rs
@@ -126,11 +126,11 @@ impl Schema {
     fn encode_full_type(type_: SchemaType, sdl: &mut SDL) {
         match type_.kind {
             __TypeKind::OBJECT => {
-                let mut object_def = ObjectDef::new(type_.name.unwrap_or_else(String::new));
+                let mut object_def = ObjectDef::new(type_.name.unwrap_or_default());
                 object_def.description(type_.description);
                 if let Some(interfaces) = type_.interfaces {
                     for interface in interfaces {
-                        object_def.interface(interface.name.unwrap_or_else(String::new));
+                        object_def.interface(interface.name.unwrap_or_default());
                     }
                 }
                 if let Some(field) = type_.fields {
@@ -142,7 +142,7 @@ impl Schema {
                 }
             }
             __TypeKind::INPUT_OBJECT => {
-                let mut input_def = InputObjectDef::new(type_.name.unwrap_or_else(String::new));
+                let mut input_def = InputObjectDef::new(type_.name.unwrap_or_default());
                 input_def.description(type_.description);
                 if let Some(field) = type_.input_fields {
                     for f in field {
@@ -153,11 +153,11 @@ impl Schema {
                 }
             }
             __TypeKind::INTERFACE => {
-                let mut interface_def = InterfaceDef::new(type_.name.unwrap_or_else(String::new));
+                let mut interface_def = InterfaceDef::new(type_.name.unwrap_or_default());
                 interface_def.description(type_.description);
                 if let Some(interfaces) = type_.interfaces {
                     for interface in interfaces {
-                        interface_def.interface(interface.name.unwrap_or_else(String::new));
+                        interface_def.interface(interface.name.unwrap_or_default());
                     }
                 }
                 if let Some(field) = type_.fields {
@@ -169,22 +169,22 @@ impl Schema {
                 }
             }
             __TypeKind::SCALAR => {
-                let mut scalar_def = ScalarDef::new(type_.name.unwrap_or_else(String::new));
+                let mut scalar_def = ScalarDef::new(type_.name.unwrap_or_default());
                 scalar_def.description(type_.description);
                 sdl.scalar(scalar_def);
             }
             __TypeKind::UNION => {
-                let mut union_def = UnionDef::new(type_.name.unwrap_or_else(String::new));
+                let mut union_def = UnionDef::new(type_.name.unwrap_or_default());
                 union_def.description(type_.description);
                 if let Some(possible_types) = type_.possible_types {
                     for possible_type in possible_types {
-                        union_def.member(possible_type.name.unwrap_or_else(String::new));
+                        union_def.member(possible_type.name.unwrap_or_default());
                     }
                 }
                 sdl.union(union_def);
             }
             __TypeKind::ENUM => {
-                let mut enum_def = EnumDef::new(type_.name.unwrap_or_else(String::new));
+                let mut enum_def = EnumDef::new(type_.name.unwrap_or_default());
                 enum_def.description(type_.description);
                 if let Some(enums) = type_.enum_values {
                     for enum_ in enums {

--- a/crates/rover-client/src/operations/supergraph/fetch/runner.rs
+++ b/crates/rover-client/src/operations/supergraph/fetch/runner.rs
@@ -269,7 +269,7 @@ mod tests {
         let data: supergraph_fetch_query::ResponseData =
             serde_json::from_value(json_response).unwrap();
         let graph_ref = mock_graph_ref();
-        let output = get_supergraph_sdl_from_response_data(data, graph_ref.clone());
+        let output = get_supergraph_sdl_from_response_data(data, graph_ref);
         let expected_error = RoverClientError::MalformedResponse {
             null_field: "supergraphSdl".to_string(),
         }

--- a/crates/rover-client/src/shared/git_context.rs
+++ b/crates/rover-client/src/shared/git_context.rs
@@ -91,9 +91,7 @@ impl GitContext {
         } else {
             None
         };
-        remote_url
-            .map(|r| GitContext::sanitize_remote_url(&r))
-            .flatten()
+        remote_url.and_then(|r| GitContext::sanitize_remote_url(&r))
     }
 
     // Parses and sanitizes git remote urls according to the same rules as

--- a/crates/timber/src/lib.rs
+++ b/crates/timber/src/lib.rs
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn it_parses_all_possible_levels() -> Result<(), ParseLevelError> {
         for level in &LEVELS {
-            Level::from_str(&level)?;
+            Level::from_str(level)?;
         }
         Ok(())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.59.0"
+components = [ "rustfmt", "clippy" ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -286,7 +286,7 @@ impl Rover {
 
     #[cfg(test)]
     pub(crate) fn insert_env_var(&mut self, key: RoverEnvKey, value: &str) -> io::Result<()> {
-        Ok(if let Some(env_store) = self.env_store.borrow_mut() {
+        if let Some(env_store) = self.env_store.borrow_mut() {
             env_store.insert(key, value)
         } else {
             let mut env_store = RoverEnv::new()?;
@@ -294,7 +294,8 @@ impl Rover {
             self.env_store
                 .fill(env_store)
                 .expect("Could not overwrite the existing environment variable store");
-        })
+        };
+        Ok(())
     }
 }
 

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -58,10 +58,8 @@ pub(crate) fn get_subgraph_definitions(
             SchemaSource::SubgraphIntrospection { subgraph_url } => {
                 // given a federated introspection URL, use subgraph introspect to
                 // obtain SDL and add it to subgraph_definition.
-                let client = GraphQLClient::new(
-                    &subgraph_url.to_string(),
-                    client_config.get_reqwest_client(),
-                )?;
+                let client =
+                    GraphQLClient::new(subgraph_url.as_ref(), client_config.get_reqwest_client())?;
 
                 let introspection_response = introspect::run(
                     SubgraphIntrospectInput {

--- a/src/utils/loaders.rs
+++ b/src/utils/loaders.rs
@@ -68,7 +68,7 @@ mod tests {
         let loc = SchemaSource::File(Utf8PathBuf::from(empty_path));
 
         let schema = load_schema_from_flag(&loc, std::io::stdin());
-        assert_eq!(schema.is_err(), true);
+        assert!(schema.is_err());
     }
 
     #[test]

--- a/tests/config/profile.rs
+++ b/tests/config/profile.rs
@@ -17,7 +17,7 @@ fn it_can_list_no_profiles() {
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd
         .arg("config")
-        .env(RoverEnvKey::ConfigHome.to_string(), temp_dir.to_string())
+        .env(RoverEnvKey::ConfigHome.to_string(), &temp_dir)
         .arg("list")
         .assert();
     result.stderr(predicate::str::contains("No profiles"));
@@ -31,7 +31,7 @@ fn it_can_list_one_profile() {
 
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd
-        .env(RoverEnvKey::ConfigHome.to_string(), temp_dir.to_string())
+        .env(RoverEnvKey::ConfigHome.to_string(), &temp_dir)
         .arg("config")
         .arg("list")
         .assert();


### PR DESCRIPTION
Related to the recent new rust release (1.59). It's better to fix the rust version into the rust-toolchain file because for example if I'm on the rust v1.58 all the lint errors in the CI won't appear. The main goal is to always keep the same rust version between our dev env and CI env. 