### PR TITLE
replace chrono with time 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,20 +609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "ci_info"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,16 +2072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
  "libc",
 ]
 
@@ -2659,7 +2644,6 @@ dependencies = [
  "binstall",
  "calm_io",
  "camino",
- "chrono",
  "console 0.15.0",
  "crossterm",
  "git-url-parse",
@@ -2687,6 +2671,7 @@ dependencies = [
  "tempdir",
  "termimad",
  "timber",
+ "time",
  "toml",
  "tracing",
  "url",
@@ -2701,7 +2686,6 @@ dependencies = [
  "apollo-federation-types",
  "backoff",
  "camino",
- "chrono",
  "git-url-parse",
  "git2",
  "graphql_client",
@@ -2719,6 +2703,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
  "tracing",
  "uuid",
 ]
@@ -3321,12 +3306,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
+ "itoa 1.0.1",
  "libc",
- "winapi",
+ "num_threads",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ atty = "0.2"
 billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
 calm_io = "0.1"
 camino = { version = "1", features = ["serde1"] }
-chrono = "0.4"
 console = "0.15"
 crossterm = "0.22"
 git-url-parse = "0.4"
@@ -89,6 +88,7 @@ strum = "0.23"
 strum_macros = "0.23"
 termimad = "0.20"
 tempdir = "0.3"
+time = { version = "0.3.7", features = ["formatting"] }
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
@@ -104,3 +104,4 @@ reqwest = { version = "0.11", default-features = false, features = [
     "native-tls-vendored",
 ] }
 serial_test = "0.5"
+time = { version = "0.3.7", features = ["local-offset"] }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -19,7 +19,6 @@ apollo-federation-types = "0.1"
 # crates.io deps
 backoff = "0.4"
 camino = "1"
-chrono = { version = "0.4", features = ["serde"] }
 git-url-parse = "0.4.0"
 git2 = { version = "0.13", default-features = false, features = [
     "vendored-openssl",
@@ -43,6 +42,7 @@ serde = "1"
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
+time = { version = "0.3.7", features = ["parsing", "serde"] }
 
 [build-dependencies]
 camino = "1"

--- a/crates/rover-client/src/operations/subgraph/list/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/list/runner.rs
@@ -4,6 +4,8 @@ use crate::shared::GraphRef;
 use crate::RoverClientError;
 
 use graphql_client::*;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 type Timestamp = String;
 #[derive(GraphQLQuery)]
@@ -79,8 +81,8 @@ fn format_subgraphs(subgraphs: &[QuerySubgraphInfo]) -> Vec<SubgraphInfo> {
             name: subgraph.name.clone(),
             url: subgraph.url.clone(),
             updated_at: SubgraphUpdatedAt {
-                local: subgraph.updated_at.clone().parse().ok(),
-                utc: subgraph.updated_at.clone().parse().ok(),
+                local: OffsetDateTime::parse(&subgraph.updated_at, &Rfc3339).ok(),
+                utc: OffsetDateTime::parse(&subgraph.updated_at, &Rfc3339).ok(),
             },
         })
         .collect();

--- a/crates/rover-client/src/operations/subgraph/list/types.rs
+++ b/crates/rover-client/src/operations/subgraph/list/types.rs
@@ -6,8 +6,8 @@ pub(crate) type QueryGraphType = subgraph_list_query::SubgraphListQueryServiceIm
 
 type QueryVariables = subgraph_list_query::Variables;
 
-use chrono::{DateTime, Local, Utc};
 use serde::Serialize;
+use time::OffsetDateTime;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct SubgraphListInput {
@@ -43,6 +43,6 @@ pub struct SubgraphInfo {
 
 #[derive(Clone, Serialize, PartialEq, Debug)]
 pub struct SubgraphUpdatedAt {
-    pub local: Option<DateTime<Local>>,
-    pub utc: Option<DateTime<Utc>>,
+    pub local: Option<OffsetDateTime>,
+    pub utc: Option<OffsetDateTime>,
 }


### PR DESCRIPTION
this will avoid the currently reported vulnerability in chrono and time 0.1

time 0.1: https://rustsec.org/advisories/RUSTSEC-2020-0071.html
chrono: https://rustsec.org/advisories/RUSTSEC-2020-0159.html