### PR TITLE
release: v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.4.4] - 2022-03-09
+
+## 🛠 Maintenance
+
+- **Updates the version of the underlying composition packages - @EverlastingBugstopper, #1025**
+
+  `rover supergraph compose` now uses `harmonizer@v0.35.3`/`@apollo/federation@v0.35.4` and `rover fed2 supergraph compose` now uses `harmonizer@v2.0.0-preview.2`/`@apollo/composition@v2.0.0-preview.2`.
+
+- **Updates README badges - @EverlastingBugstopper, #1016**
+
+  Replaced the `stability: experimental` badge with a badge showing Rover's total download count, and replaced the outdated GitHub workflow badge with the appropriate CircleCI badge.
+
 # [0.4.3] - 2022-02-14
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "apollo-encoder"
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
 dependencies = [
  "event-listener",
 ]
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
@@ -343,7 +343,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "instant",
  "rand 0.8.5",
 ]
@@ -506,9 +506,9 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 
 [[package]]
 name = "byteorder"
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -586,9 +586,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -855,8 +855,8 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
- "parking_lot",
+ "mio 0.7.14",
+ "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -879,11 +879,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -961,7 +962,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project",
  "serde",
  "serde_json",
@@ -984,9 +985,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -1094,9 +1095,9 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "eyre"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc225d8f637923fe585089fcf03e705c222131232d2c1fb622e84ecf725d0eb8"
+checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1141,7 +1142,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall 0.2.11",
  "winapi",
 ]
 
@@ -1355,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1495,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1529,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "2.0.0-preview.1"
+version = "2.0.0-preview.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c714bd536a82b967ee458883d61c300afbfe5edd24e41193f3627f7a3224d624"
+checksum = "2a291f1024a2f72a5318236ad0934e3bcaf4e7c43008ef5c67df3f43adba0806"
 dependencies = [
  "apollo-federation-types",
  "deno_core",
@@ -1737,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
 dependencies = [
  "unindent",
 ]
@@ -1755,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "isahc"
@@ -1895,9 +1896,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libgit2-sys"
@@ -1939,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
 dependencies = [
  "cc",
  "libc",
@@ -2025,6 +2026,19 @@ name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -2233,7 +2247,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2245,9 +2269,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall 0.2.11",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.11",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2497,7 +2534,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -2517,9 +2554,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -2541,15 +2578,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.4",
- "redox_syscall 0.2.10",
+ "getrandom 0.2.5",
+ "redox_syscall 0.2.11",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2618,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a374af9a0e5fdcdd98c1c7b64f05004f9ea2555b6c75f211daa81268a3c50f1"
+checksum = "e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6"
 dependencies = [
  "bytemuck",
 ]
@@ -2641,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2720,12 +2757,12 @@ dependencies = [
 
 [[package]]
 name = "rover-fed2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "apollo-federation-types",
  "camino",
- "harmonizer 2.0.0-preview.1",
+ "harmonizer 2.0.0-preview.2",
  "serde",
  "serde_json",
  "structopt",
@@ -2812,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 dependencies = [
  "serde",
 ]
@@ -2918,7 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -2935,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2970,7 +3007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.14",
  "signal-hook",
 ]
 
@@ -2991,9 +3028,9 @@ checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
@@ -3056,7 +3093,7 @@ checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.11.2",
  "phf_shared",
  "precomputed-hash",
 ]
@@ -3187,7 +3224,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall 0.2.11",
  "remove_dir_all",
  "winapi",
 ]
@@ -3226,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -3307,7 +3344,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "tracing-core",
- "tracing-subscriber 0.3.8",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -3346,18 +3383,19 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.0",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -3438,9 +3476,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "log",
@@ -3451,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3462,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3514,12 +3552,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
- "parking_lot",
+ "parking_lot 0.12.0",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3574,9 +3612,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unindent"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
+checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
 
 [[package]]
 name = "unreachable"
@@ -3606,7 +3644,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "serde",
 ]
 
@@ -3837,6 +3875,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.4.3"
+version = "0.4.4"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.4.3
+Rover 0.4.4
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -123,7 +123,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.4.3 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.4 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -141,7 +141,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.4.3' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.4' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0",
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -226,18 +226,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -341,15 +341,27 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
-      "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.2.tgz",
+      "integrity": "sha512-ICWqM+MvEkIPHm18Q0cmkvm134zeQMomBKmTRxyxMNhL/ouz6Nqld52/brSlaHnzA3fczupeRJzZ0YatruGBcQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.2",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -372,15 +384,16 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.4.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
-      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
+      "integrity": "sha512-/YPmVxitt57F8sH50pnfXASzOOjEfaUDkX48eF5q6f16+JBncej2zeu+Zm2c68q8MbIxhPlEGfpd0QZeqTvAxw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/batch-execute": "^8.3.1",
-        "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.4",
+        "@graphql-tools/batch-execute": "^8.3.2",
+        "@graphql-tools/schema": "^8.3.2",
+        "@graphql-tools/utils": "^8.6.2",
         "dataloader": "2.0.0",
+        "graphql-executor": "0.0.18",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -388,17 +401,41 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.3.tgz",
-      "integrity": "sha512-6kUJZiNpYKVhum9E5wfl5PyLLupEDYdH7c8l6oMrk6c7EPEVs6iSUyB7yQoWrtJccJLULBW2CRQ5IHp5JYK0mA==",
+    "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/import": "^6.5.7",
-        "@graphql-tools/utils": "^8.5.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-file-loader": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.4.tgz",
+      "integrity": "sha512-Q0/YtDq0APR6syRclsQMNguWKRlchd8nFTOpLhfc7Xeiy21VhEEi4Ik+quRySfb7ubDfJGhiUq4MQW43FhWJvg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/import": "^6.6.6",
+        "@graphql-tools/utils": "^8.6.2",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -421,12 +458,12 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.5.tgz",
-      "integrity": "sha512-w0/cYuhrr2apn+iGoTToCqt65x2NN2iHQyqRNk/Zw1NJ+e8/C3eKVw0jmW4pYQvSocuPxL4UCSI56SdKO7m3+Q==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.6.tgz",
+      "integrity": "sha512-a0aVajxqu1MsL8EwavA44Osw20lBOIhq8IM2ZIHFPP62cPAcOB26P+Sq57DHMsSyX5YQ0ab9XPM2o4e1dQhs0w==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.1",
+        "@graphql-tools/utils": "8.6.2",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -434,13 +471,25 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.3.tgz",
-      "integrity": "sha512-CN2Qk9rt+Gepa3rb3X/mpxYA5MIYLwZBPj2Njw6lbZ6AaxG+O1ArDCL5ACoiWiBimn1FCOM778uhRM9znd0b3Q==",
+    "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.5.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.4.tgz",
+      "integrity": "sha512-1AROMFh8Lyorf2gTWXgVaUbU3ic84gzAgpRmJCsCla/Nnvn6JiCs4aWHsalk4ZWVXCaK04c8gk8Px1uNQUj02Q==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.6.2",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
@@ -449,14 +498,26 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/load": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.1.tgz",
-      "integrity": "sha512-j9XcLYZPZdl/TzzqA83qveJmwcCxgGizt5L1+C1/Z68brTEmQHLdQCOR3Ma3ewESJt6DU05kSTu2raKaunkjRg==",
+    "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/schema": "8.3.1",
-        "@graphql-tools/utils": "^8.6.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/load": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.2.tgz",
+      "integrity": "sha512-URPqVP77mYxdZxT895DzrWf2C23S3yC/oAmXD4D4YlxR5eVVH/fxu0aZR78WcEKF331fWSiFwWy9j7BZWvkj7g==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "8.3.2",
+        "@graphql-tools/utils": "^8.6.2",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
@@ -464,13 +525,37 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/merge": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.2.tgz",
-      "integrity": "sha512-2DyqhIOMUMKbCPqo8p6xSdll2OBcBxGdOrxlJJlFQvinsSaYqp/ct3dhAxNtzaIcvSVgXvttQqfD7O2ziFtE7Q==",
+    "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.5.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.3.tgz",
+      "integrity": "sha512-XCSmL6/Xg8259OTWNp69B57CPWiVL69kB7pposFrufG/zaAlI9BS68dgzrxmmSqZV5ZHU4r/6Tbf6fwnEJGiSw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.6.2",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
@@ -478,13 +563,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.1.tgz",
-      "integrity": "sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.2.tgz",
+      "integrity": "sha512-77feSmIuHdoxMXRbRyxE8rEziKesd/AcqKV6fmxe7Zt+PgIQITxNDew2XJJg7qFTMNM43W77Ia6njUSBxNOkwg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/merge": "^8.2.1",
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/merge": "^8.2.3",
+        "@graphql-tools/utils": "^8.6.2",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -492,15 +577,27 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/url-loader": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.1.tgz",
-      "integrity": "sha512-K/5amdeHtKYI976HVd/AXdSNvLL7vx5QVjMlwN0OHeYyxSgC+UOH+KkS7cshYgL13SekGu0Mxbg9ABfgQ34ECA==",
+    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "^8.4.1",
-        "@graphql-tools/utils": "^8.5.1",
-        "@graphql-tools/wrap": "^8.3.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.8.0.tgz",
+      "integrity": "sha512-4j5X40hpYInM5J7KbURSspEJCi6tPqvEE2kyBOyP0C0YIOYtKgUJTAryjbBXqr+HWGyEwJ2zuQ2cQdVMn8l78A==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/delegate": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/wrap": "^8.4.2",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
@@ -522,6 +619,18 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/@graphql-tools/utils": {
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.1.tgz",
@@ -535,14 +644,14 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.3.tgz",
-      "integrity": "sha512-TpXN1S4Cv+oMA1Zsg9Nu4N9yrFxLuJkX+CTtSRrrdfETGHIxqfyDkm5slPDCckxP+RILA00g8ny2jzsYyNvX1w==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.3.tgz",
+      "integrity": "sha512-2bd3GtlqV72idEphLTM8SRiSxEDrMPGE556faW8N5Q2qK7qlCEu9AQK0HNKWKdtEPTHqahndZtIPcdpNN6xGig==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "^8.4.2",
-        "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.3",
+        "@graphql-tools/delegate": "^8.5.1",
+        "@graphql-tools/schema": "^8.3.2",
+        "@graphql-tools/utils": "^8.6.2",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -550,10 +659,22 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -621,9 +742,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.17.tgz",
-      "integrity": "sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -642,9 +763,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+      "integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -932,9 +1053,9 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.24.tgz",
-      "integrity": "sha512-83KDV6+8pYCn51zSM2cFAwqQ5UQtDaPm89RkUwHxEMDq/cdqYgqo1q+2eM/Xhmd8HeAsGTtecsC4crrQkCn0zg==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.25.tgz",
+      "integrity": "sha512-KS6hm/VuRO+3jIrg4uidz3mQ8NWvCbiTTOg3yoH30zuGVUvjqZlnXw66h0kuzyfP21hDkrdIbufXCW6BAQdSNw==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -1496,10 +1617,22 @@
         "graphql": "*"
       }
     },
+    "node_modules/graphql-executor": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.18.tgz",
+      "integrity": "sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/graphql-sse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.6.tgz",
-      "integrity": "sha512-y2mVBN2KwNrzxX2KBncQ6kzc6JWvecxuBernrl0j65hsr6MAS3+Yn8PTFSOgRmtolxugepxveyZVQEuaNEbw3w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.1.0.tgz",
+      "integrity": "sha512-xE8AGPJa5X+g7iFmRQw/8H+7lXIDJvSkW6lou/XSSq17opPQl+dbKOMiqraHMx52VrDgS061ZVx90OSuqS6ykA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -1509,9 +1642,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
-      "integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.2.tgz",
+      "integrity": "sha512-TsjovINNEGfv52uKWYSVCOLX9LFe6wAhf9n7hIsV3zjflky1dv/mAP+kjXAXsnzV1jH5Sx0S73CtBFNvxus+SQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1766,9 +1899,9 @@
       }
     },
     "node_modules/meros": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
-      "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.2.0.tgz",
+      "integrity": "sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -1796,9 +1929,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2185,6 +2318,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
       "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
       "dev": true,
       "dependencies": {
         "backo2": "^1.0.2",
@@ -2342,9 +2476,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2356,9 +2490,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
-      "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.1.tgz",
+      "integrity": "sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==",
       "dev": true,
       "engines": {
         "node": ">=12.18"
@@ -2524,9 +2658,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.17.0",
@@ -2657,9 +2791,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true
     },
     "@babel/template": {
@@ -2674,18 +2808,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2714,9 +2848,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -2764,15 +2898,26 @@
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
-      "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.2.tgz",
+      "integrity": "sha512-ICWqM+MvEkIPHm18Q0cmkvm134zeQMomBKmTRxyxMNhL/ouz6Nqld52/brSlaHnzA3fczupeRJzZ0YatruGBcQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.2",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/code-file-loader": {
@@ -2789,30 +2934,53 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.4.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
-      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
+      "integrity": "sha512-/YPmVxitt57F8sH50pnfXASzOOjEfaUDkX48eF5q6f16+JBncej2zeu+Zm2c68q8MbIxhPlEGfpd0QZeqTvAxw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "^8.3.1",
-        "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.4",
+        "@graphql-tools/batch-execute": "^8.3.2",
+        "@graphql-tools/schema": "^8.3.2",
+        "@graphql-tools/utils": "^8.6.2",
         "dataloader": "2.0.0",
+        "graphql-executor": "0.0.18",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.3.tgz",
-      "integrity": "sha512-6kUJZiNpYKVhum9E5wfl5PyLLupEDYdH7c8l6oMrk6c7EPEVs6iSUyB7yQoWrtJccJLULBW2CRQ5IHp5JYK0mA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.4.tgz",
+      "integrity": "sha512-Q0/YtDq0APR6syRclsQMNguWKRlchd8nFTOpLhfc7Xeiy21VhEEi4Ik+quRySfb7ubDfJGhiUq4MQW43FhWJvg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "^6.5.7",
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/import": "^6.6.6",
+        "@graphql-tools/utils": "^8.6.2",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
@@ -2829,71 +2997,126 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.5.tgz",
-      "integrity": "sha512-w0/cYuhrr2apn+iGoTToCqt65x2NN2iHQyqRNk/Zw1NJ+e8/C3eKVw0jmW4pYQvSocuPxL4UCSI56SdKO7m3+Q==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.6.tgz",
+      "integrity": "sha512-a0aVajxqu1MsL8EwavA44Osw20lBOIhq8IM2ZIHFPP62cPAcOB26P+Sq57DHMsSyX5YQ0ab9XPM2o4e1dQhs0w==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.1",
+        "@graphql-tools/utils": "8.6.2",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.3.tgz",
-      "integrity": "sha512-CN2Qk9rt+Gepa3rb3X/mpxYA5MIYLwZBPj2Njw6lbZ6AaxG+O1ArDCL5ACoiWiBimn1FCOM778uhRM9znd0b3Q==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.4.tgz",
+      "integrity": "sha512-1AROMFh8Lyorf2gTWXgVaUbU3ic84gzAgpRmJCsCla/Nnvn6JiCs4aWHsalk4ZWVXCaK04c8gk8Px1uNQUj02Q==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.2",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/load": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.1.tgz",
-      "integrity": "sha512-j9XcLYZPZdl/TzzqA83qveJmwcCxgGizt5L1+C1/Z68brTEmQHLdQCOR3Ma3ewESJt6DU05kSTu2raKaunkjRg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.2.tgz",
+      "integrity": "sha512-URPqVP77mYxdZxT895DzrWf2C23S3yC/oAmXD4D4YlxR5eVVH/fxu0aZR78WcEKF331fWSiFwWy9j7BZWvkj7g==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "8.3.1",
-        "@graphql-tools/utils": "^8.6.0",
+        "@graphql-tools/schema": "8.3.2",
+        "@graphql-tools/utils": "^8.6.2",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.2.tgz",
-      "integrity": "sha512-2DyqhIOMUMKbCPqo8p6xSdll2OBcBxGdOrxlJJlFQvinsSaYqp/ct3dhAxNtzaIcvSVgXvttQqfD7O2ziFtE7Q==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.3.tgz",
+      "integrity": "sha512-XCSmL6/Xg8259OTWNp69B57CPWiVL69kB7pposFrufG/zaAlI9BS68dgzrxmmSqZV5ZHU4r/6Tbf6fwnEJGiSw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.2",
         "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.1.tgz",
-      "integrity": "sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.2.tgz",
+      "integrity": "sha512-77feSmIuHdoxMXRbRyxE8rEziKesd/AcqKV6fmxe7Zt+PgIQITxNDew2XJJg7qFTMNM43W77Ia6njUSBxNOkwg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "^8.2.1",
-        "@graphql-tools/utils": "^8.5.1",
+        "@graphql-tools/merge": "^8.2.3",
+        "@graphql-tools/utils": "^8.6.2",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.1.tgz",
-      "integrity": "sha512-K/5amdeHtKYI976HVd/AXdSNvLL7vx5QVjMlwN0OHeYyxSgC+UOH+KkS7cshYgL13SekGu0Mxbg9ABfgQ34ECA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.8.0.tgz",
+      "integrity": "sha512-4j5X40hpYInM5J7KbURSspEJCi6tPqvEE2kyBOyP0C0YIOYtKgUJTAryjbBXqr+HWGyEwJ2zuQ2cQdVMn8l78A==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "^8.4.1",
-        "@graphql-tools/utils": "^8.5.1",
-        "@graphql-tools/wrap": "^8.3.1",
+        "@graphql-tools/delegate": "^8.5.1",
+        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/wrap": "^8.4.2",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
@@ -2910,6 +3133,17 @@
         "valid-url": "^1.0.9",
         "value-or-promise": "^1.0.11",
         "ws": "^8.3.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@graphql-tools/utils": {
@@ -2922,22 +3156,33 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.3.tgz",
-      "integrity": "sha512-TpXN1S4Cv+oMA1Zsg9Nu4N9yrFxLuJkX+CTtSRrrdfETGHIxqfyDkm5slPDCckxP+RILA00g8ny2jzsYyNvX1w==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.3.tgz",
+      "integrity": "sha512-2bd3GtlqV72idEphLTM8SRiSxEDrMPGE556faW8N5Q2qK7qlCEu9AQK0HNKWKdtEPTHqahndZtIPcdpNN6xGig==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "^8.4.2",
-        "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.3",
+        "@graphql-tools/delegate": "^8.5.1",
+        "@graphql-tools/schema": "^8.3.2",
+        "@graphql-tools/utils": "^8.6.2",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
+          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        }
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -2991,9 +3236,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.17.tgz",
-      "integrity": "sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3012,9 +3257,9 @@
       }
     },
     "@types/ws": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+      "integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3223,9 +3468,9 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.24.tgz",
-      "integrity": "sha512-83KDV6+8pYCn51zSM2cFAwqQ5UQtDaPm89RkUwHxEMDq/cdqYgqo1q+2eM/Xhmd8HeAsGTtecsC4crrQkCn0zg==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.25.tgz",
+      "integrity": "sha512-KS6hm/VuRO+3jIrg4uidz3mQ8NWvCbiTTOg3yoH30zuGVUvjqZlnXw66h0kuzyfP21hDkrdIbufXCW6BAQdSNw==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -3657,17 +3902,24 @@
         "arrify": "^1.0.1"
       }
     },
+    "graphql-executor": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.18.tgz",
+      "integrity": "sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==",
+      "dev": true,
+      "requires": {}
+    },
     "graphql-sse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.0.6.tgz",
-      "integrity": "sha512-y2mVBN2KwNrzxX2KBncQ6kzc6JWvecxuBernrl0j65hsr6MAS3+Yn8PTFSOgRmtolxugepxveyZVQEuaNEbw3w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.1.0.tgz",
+      "integrity": "sha512-xE8AGPJa5X+g7iFmRQw/8H+7lXIDJvSkW6lou/XSSq17opPQl+dbKOMiqraHMx52VrDgS061ZVx90OSuqS6ykA==",
       "dev": true,
       "requires": {}
     },
     "graphql-ws": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
-      "integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.2.tgz",
+      "integrity": "sha512-TsjovINNEGfv52uKWYSVCOLX9LFe6wAhf9n7hIsV3zjflky1dv/mAP+kjXAXsnzV1jH5Sx0S73CtBFNvxus+SQ==",
       "dev": true,
       "requires": {}
     },
@@ -3861,9 +4113,9 @@
       "dev": true
     },
     "meros": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
-      "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.2.0.tgz",
+      "integrity": "sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==",
       "dev": true,
       "requires": {}
     },
@@ -3878,9 +4130,9 @@
       }
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -4235,16 +4487,16 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "peer": true
     },
     "undici": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.14.1.tgz",
-      "integrity": "sha512-WJ+g+XqiZcATcBaUeluCajqy4pEDcQfK1vy+Fo+bC4/mqXI9IIQD/XWHLS70fkGUT6P52Drm7IFslO651OdLPQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.1.tgz",
+      "integrity": "sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==",
       "dev": true
     },
     "unixify": {

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -19,7 +19,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.4.3 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.4 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.4.3' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.4' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.3"
+PACKAGE_VERSION="v0.4.4"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/nix/install_rover_fed2.sh
+++ b/installers/binstall/scripts/nix/install_rover_fed2.sh
@@ -118,7 +118,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.3"
+PACKAGE_VERSION="v0.4.4"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.3'
+$package_version = 'v0.4.4'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/binstall/scripts/windows/install_rover_fed2.ps1
+++ b/installers/binstall/scripts/windows/install_rover_fed2.ps1
@@ -112,7 +112,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.3'
+$package_version = 'v0.4.4'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -187,9 +187,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -389,9 +389,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -434,9 +434,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rover-fed2"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 license-file = "./LICENSE"
 
@@ -21,7 +21,7 @@ composition-js = ["harmonizer_fed_two"]
 [dependencies]
 # https://github.com/apollographql/federation-rs dependencies
 apollo-federation-types = "0.2"
-harmonizer_fed_two = { package = "harmonizer", version = "2.0.0-preview.1", optional = true }
+harmonizer_fed_two = { package = "harmonizer", version = "2.0.0-preview.2", optional = true }
 
 # crates.io dependencies
 anyhow = "1"

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -44,7 +44,7 @@ impl CargoRunner {
                 reqwest::blocking::get(versioned_schema_url)?.error_for_status()?;
             let schema_text = schema_response.text()?;
             if !schema_text.contains("subgraph") {
-                anyhow!("This schema doesn't seem to contain any references to `subgraph`s. It's probably the wrong schema.");
+                return Err(anyhow!("This schema doesn't seem to contain any references to `subgraph`s. It's probably the wrong schema."));
             }
             let schema_dir = repo_path
                 .join("crates")


### PR DESCRIPTION
# [0.4.4] - 2022-03-09

## 🛠 Maintenance

- **Updates the version of the underlying composition packages - @EverlastingBugstopper, #1025**

  `rover supergraph compose` now uses `harmonizer@v0.35.3`/`@apollo/federation@v0.35.4` and `rover fed2 supergraph compose` now uses `harmonizer@v2.0.0-preview.2`/`@apollo/composition@v2.0.0-preview.2`.

- **Updates README badges - @EverlastingBugstopper, #1016**

  Replaced the `stability: experimental` badge with a badge showing Rover's total download count, and replaced the outdated GitHub workflow badge with the appropriate CircleCI badge.