### PR TITLE
chore: bumps harmonizer to 2.0.0-preview.4-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ checksum = "c1da9c412262c1dd533a84c9b867dcb4e68ab852a0936e235d75242585dda631"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b122541fb4105259bdcef9a1906f21be72e3c3a86028cdd0963668f39a64dcd9"
+checksum = "d9703972c1d79af11e3d551df5a00f8cf605440465558127b4ec5ac31382d3bb"
 dependencies = [
  "camino",
  "log",
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "2.0.0-preview.2"
+version = "2.0.0-preview.4-1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a291f1024a2f72a5318236ad0934e3bcaf4e7c43008ef5c67df3f43adba0806"
+checksum = "b657c80ce15e0ba151230da14a0e30db2eead77a308bcc3bfc588b628a5a9eeb"
 dependencies = [
  "apollo-federation-types",
  "deno_core",
@@ -2762,7 +2762,7 @@ dependencies = [
  "anyhow",
  "apollo-federation-types",
  "camino",
- "harmonizer 2.0.0-preview.2",
+ "harmonizer 2.0.0-preview.4-1",
  "serde",
  "serde_json",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ composition-js = ["harmonizer_fed_one"]
 
 [dependencies]
 # https://github.com/apollographql/federation-rs dependencies
-apollo-federation-types = "0.2"
+apollo-federation-types = "0.2.1"
 harmonizer_fed_one = { package = "harmonizer", version = "0.35.3", optional = true }
 
 # workspace dependencies

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 houston = { path = "../houston" }
 
 # https://github.com/apollographql/federation-rs dependencies
-apollo-federation-types = "0.2"
+apollo-federation-types = "0.2.1"
 
 # crates.io deps
 backoff = "0.4"

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -20,8 +20,8 @@ composition-js = ["harmonizer_fed_two"]
 
 [dependencies]
 # https://github.com/apollographql/federation-rs dependencies
-apollo-federation-types = "0.2"
-harmonizer_fed_two = { package = "harmonizer", version = "2.0.0-preview.2", optional = true }
+apollo-federation-types = "0.2.1"
+harmonizer_fed_two = { package = "harmonizer", version = "2.0.0-preview.4-1", optional = true }
 
 # crates.io dependencies
 anyhow = "1"

--- a/plugins/rover-fed2/src/cli.rs
+++ b/plugins/rover-fed2/src/cli.rs
@@ -10,47 +10,19 @@ use structopt::StructOpt;
 pub struct RoverFed {
     #[structopt(subcommand)]
     command: Command,
-
-    /// Print output as JSON.
-    #[structopt(long, global = true)]
-    json: bool,
 }
 
 impl RoverFed {
     #[cfg(feature = "composition-js")]
     pub fn run(&self) -> ! {
-        let composition_result = match &self.command {
+        let build_result = match &self.command {
             Command::Compose(command) => command.run(),
         };
-        match composition_result {
-            Ok(composition_output) => {
-                if self.json {
-                    print!("{}", serde_json::json!(composition_output));
-                } else {
-                    for hint in composition_output.hints {
-                        eprintln!("WARN: {}", hint.message);
-                    }
-                    println!("{}", composition_output.supergraph_sdl)
-                }
-                std::process::exit(0);
-            }
-            Err(composition_err) => {
-                if self.json {
-                    if let Some(build_errors) = composition_err
-                        .downcast_ref::<apollo_federation_types::build::BuildErrors>(
-                    ) {
-                        print!("{}", serde_json::json!(build_errors));
-                    } else {
-                        println!(
-                            "{}",
-                            serde_json::json!({"message": composition_err.to_string()})
-                        )
-                    }
-                } else {
-                    println!("{}", composition_err);
-                }
-                std::process::exit(1);
-            }
+        print!("{}", serde_json::json!(build_result));
+        if build_result.is_ok() {
+            std::process::exit(0)
+        } else {
+            std::process::exit(1);
         }
     }
 

--- a/plugins/rover-fed2/src/command/compose/do_compose.rs
+++ b/plugins/rover-fed2/src/command/compose/do_compose.rs
@@ -1,4 +1,4 @@
-use apollo_federation_types::{build::BuildOutput, config::SupergraphConfig};
+use apollo_federation_types::{build::BuildResult, config::SupergraphConfig};
 use camino::Utf8PathBuf;
 use harmonizer_fed_two::harmonize;
 use structopt::StructOpt;
@@ -13,9 +13,9 @@ pub struct Compose {
 }
 
 impl Compose {
-    pub fn run(&self) -> Result<BuildOutput, anyhow::Error> {
+    pub fn run(&self) -> BuildResult {
         let supergraph_config = SupergraphConfig::new_from_yaml_file(&self.config_file)?;
         let subgraph_definitions = supergraph_config.get_subgraph_definitions()?;
-        Ok(harmonize(subgraph_definitions)?)
+        harmonize(subgraph_definitions)
     }
 }

--- a/src/command/fed2/supergraph/compose.rs
+++ b/src/command/fed2/supergraph/compose.rs
@@ -3,6 +3,7 @@ use crate::{anyhow, command::RoverOutput, error::RoverError, Context, Result};
 use crate::{Suggestion, PKG_VERSION};
 
 use apollo_federation_types::{build::BuildResult, config::SupergraphConfig};
+use rover_client::RoverClientError;
 
 use camino::Utf8PathBuf;
 use serde::Serialize;
@@ -101,7 +102,10 @@ impl Compose {
                     hints: build_output.hints,
                     supergraph_sdl: build_output.supergraph_sdl,
                 }),
-                Err(build_errors) => Err(RoverError::new(build_errors)),
+                Err(build_errors) => Err(RoverError::from(RoverClientError::BuildErrors {
+                    source: build_errors,
+                })
+                .into()),
             },
             Err(bad_json) => Err(anyhow!("{}", bad_json))
                 .with_context(|| anyhow!("{} compose output: {}", FEDERATION_PLUGIN, stdout))

--- a/src/command/fed2/supergraph/compose.rs
+++ b/src/command/fed2/supergraph/compose.rs
@@ -104,8 +104,7 @@ impl Compose {
                 }),
                 Err(build_errors) => Err(RoverError::from(RoverClientError::BuildErrors {
                     source: build_errors,
-                })
-                .into()),
+                })),
             },
             Err(bad_json) => Err(anyhow!("{}", bad_json))
                 .with_context(|| anyhow!("{} compose output: {}", FEDERATION_PLUGIN, stdout))

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -9,6 +9,7 @@ use ansi_term::{
     Colour::{Cyan, Red, Yellow},
     Style,
 };
+use apollo_federation_types::build::BuildHint;
 use atty::Stream;
 use calm_io::{stderr, stderrln, stdout, stdoutln};
 use crossterm::style::Attribute::Underlined;
@@ -37,7 +38,7 @@ pub enum RoverOutput {
     CoreSchema(String),
     CompositionResult {
         supergraph_sdl: String,
-        hints: Vec<String>,
+        hints: Vec<BuildHint>,
     },
     SubgraphList(SubgraphListResponse),
     CheckResponse(CheckResponse),
@@ -194,7 +195,7 @@ impl RoverOutput {
             } => {
                 let warn_prefix = Red.normal().paint("WARN:");
                 for hint in hints {
-                    stderrln!("{} {}", warn_prefix, hint)?;
+                    stderrln!("{} {}", warn_prefix, hint.message)?;
                 }
                 stdoutln!()?;
                 print_descriptor("CoreSchema")?;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -35,12 +35,6 @@ pub struct RoverError {
     metadata: Metadata,
 }
 
-#[derive(Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
-enum RoverDetails {
-    BuildErrors(BuildErrors),
-}
-
 fn serialize_anyhow<S>(error: &anyhow::Error, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -54,10 +48,7 @@ where
             if let Some(build_errors) = rover_client_error_source.downcast_ref::<BuildErrors>() {
                 let mut top_level_data = serializer.serialize_struct(top_level_struct, 2)?;
                 top_level_data.serialize_field(message_field_name, &error.to_string())?;
-                top_level_data.serialize_field(
-                    details_struct,
-                    &RoverDetails::BuildErrors(build_errors.clone()),
-                )?;
+                top_level_data.serialize_field(details_struct, &build_errors)?;
                 return top_level_data.end();
             }
         }


### PR DESCRIPTION
chore: bumps harmonizer to 2.0.0-preview.4-1, fixing the deserialization bugs we were encountering with rover 0.4.4