### PR TITLE
release: v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.4.5] - 2022-03-11
+
+## 🐛 Fixes
+
+- **Fixes "output from `rover-fed2` was malformed" serialization errors - @EverlastingBugstopper, #1030**
+
+  Federation 2 was broken in 0.4.4, every `rover fed2 supergraph compose` command would return "output from `rover-fed2` was malformed" which was not helpful.
+
+  `rover fed2 supergraph compose` now uses `harmonizer@v2.0.0-preview.4-1`/`@apollo/composition@v2.0.0-preview.4` under the hood and the data passed between rover and rover-fed2 is matched up properly. Happy federating!
+
 # [0.4.4] - 2022-03-09
 
 ## 🛠 Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,14 +2036,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2413,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d5b548b725018ab5496482b45cb8bef21e9fed1858a6d674e3a8a0f0bb5d50"
+checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
 dependencies = [
  "ansi_term",
  "ctor",
@@ -2678,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2757,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "rover-fed2"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "apollo-federation-types",
@@ -3390,7 +3391,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.0",
+ "mio 0.8.1",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
@@ -3748,6 +3749,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.4.4"
+version = "0.4.5"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.4.4
+Rover 0.4.5
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -123,7 +123,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.4.4 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.5 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -141,7 +141,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.4.4' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.5' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
-      "integrity": "sha512-/YPmVxitt57F8sH50pnfXASzOOjEfaUDkX48eF5q6f16+JBncej2zeu+Zm2c68q8MbIxhPlEGfpd0QZeqTvAxw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.2.tgz",
+      "integrity": "sha512-M7d1jY4orPUC7MBoSKZEP21HTVqVGX+mS0AL6UGxg1L7GCRtaYQeopyKXmnnEmBi5FNZ9KduJgHRtxkS4Hc6uA==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/batch-execute": "^8.3.2",
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.8.0.tgz",
-      "integrity": "sha512-4j5X40hpYInM5J7KbURSspEJCi6tPqvEE2kyBOyP0C0YIOYtKgUJTAryjbBXqr+HWGyEwJ2zuQ2cQdVMn8l78A==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.1.tgz",
+      "integrity": "sha512-UYKc0f8jw+MODDb79XKOG8wyvRCG/7KBYtRUfUKed4LBjftjZfF5VovAbF3axiTuzt2FSyPRu8YMEQ7kypkc8g==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/delegate": "^8.5.1",
@@ -611,7 +611,6 @@
         "subscriptions-transport-ws": "^0.11.0",
         "sync-fetch": "^0.3.1",
         "tslib": "^2.3.0",
-        "valid-url": "^1.0.9",
         "value-or-promise": "^1.0.11",
         "ws": "^8.3.0"
       },
@@ -2525,12 +2524,6 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
-      "dev": true
-    },
     "node_modules/value-or-promise": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
@@ -2934,9 +2927,9 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
-      "integrity": "sha512-/YPmVxitt57F8sH50pnfXASzOOjEfaUDkX48eF5q6f16+JBncej2zeu+Zm2c68q8MbIxhPlEGfpd0QZeqTvAxw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.2.tgz",
+      "integrity": "sha512-M7d1jY4orPUC7MBoSKZEP21HTVqVGX+mS0AL6UGxg1L7GCRtaYQeopyKXmnnEmBi5FNZ9KduJgHRtxkS4Hc6uA==",
       "dev": true,
       "requires": {
         "@graphql-tools/batch-execute": "^8.3.2",
@@ -3109,9 +3102,9 @@
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.8.0.tgz",
-      "integrity": "sha512-4j5X40hpYInM5J7KbURSspEJCi6tPqvEE2kyBOyP0C0YIOYtKgUJTAryjbBXqr+HWGyEwJ2zuQ2cQdVMn8l78A==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.1.tgz",
+      "integrity": "sha512-UYKc0f8jw+MODDb79XKOG8wyvRCG/7KBYtRUfUKed4LBjftjZfF5VovAbF3axiTuzt2FSyPRu8YMEQ7kypkc8g==",
       "dev": true,
       "requires": {
         "@graphql-tools/delegate": "^8.5.1",
@@ -3130,7 +3123,6 @@
         "subscriptions-transport-ws": "^0.11.0",
         "sync-fetch": "^0.3.1",
         "tslib": "^2.3.0",
-        "valid-url": "^1.0.9",
         "value-or-promise": "^1.0.11",
         "ws": "^8.3.0"
       },
@@ -4521,12 +4513,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
-    },
-    "valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
       "dev": true
     },
     "value-or-promise": {

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -19,7 +19,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.4.4 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.5 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -38,7 +38,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.4.4' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.5' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.4"
+PACKAGE_VERSION="v0.4.5"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/nix/install_rover_fed2.sh
+++ b/installers/binstall/scripts/nix/install_rover_fed2.sh
@@ -118,7 +118,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.4"
+PACKAGE_VERSION="v0.4.5"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.4'
+$package_version = 'v0.4.5'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/binstall/scripts/windows/install_rover_fed2.ps1
+++ b/installers/binstall/scripts/windows/install_rover_fed2.ps1
@@ -112,7 +112,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.4'
+$package_version = 'v0.4.5'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rover-fed2"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 license-file = "./LICENSE"
 


### PR DESCRIPTION
# [0.4.5] - 2022-03-11

## 🐛 Fixes

- **Fixes "output from `rover-fed2` was malformed" serialization errors - @EverlastingBugstopper, #1030**

  Federation 2 was broken in 0.4.4, every `rover fed2 supergraph compose` command would return "output from `rover-fed2` was malformed" which was not helpful.

  `rover fed2 supergraph compose` now uses `harmonizer@v2.0.0-preview.4-1`/`@apollo/composition@v2.0.0-preview.4` under the hood and the data passed between rover and rover-fed2 is matched up properly. Happy federating!