### PR TITLE
release: v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.4.7] - 2022-03-15
+
+## 🐛 Maintenance
+
+- **Bumps harmonizer to v2.0.0-preview.7 - @EverlastingBugstopper, #1037**
+
+  `rover fed2 supergraph compose` now uses rust: `harmonizer@v2.0.0-preview.7` and js: `@apollo/composition@v2.0.0-preview.7`.
+
 # [0.4.6] - 2022-03-14
 
 ## 🐛 Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "2.0.0-preview.7"
+version = "2.0.0-preview.4-1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6e8ceb8dcdb4ffdac0d964d18693a113285f32b6713fe1f8e41cdb40ca7c87"
+checksum = "b657c80ce15e0ba151230da14a0e30db2eead77a308bcc3bfc588b628a5a9eeb"
 dependencies = [
  "apollo-federation-types",
  "deno_core",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2734,12 +2734,12 @@ dependencies = [
 
 [[package]]
 name = "rover-fed2"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "apollo-federation-types",
  "camino",
- "harmonizer 2.0.0-preview.7",
+ "harmonizer 2.0.0-preview.4-1",
  "serde",
  "serde_json",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.4.6"
+version = "0.4.7"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.4.6
+Rover 0.4.7
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -123,7 +123,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.4.6 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.7 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -141,7 +141,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.4.6' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.7' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1250,9 +1250,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2849,9 +2849,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.12.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -3568,9 +3568,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.12.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -236,18 +236,18 @@ If you encountered this error while running introspection, you'll want to make s
 
 This error occurs when you propose a subgraph schema that could not be built.
 
-There are many reasons why you may run into build errors. This error should include information about _why_ the proposed subgraph schema could not be composed. Error code references can be found [here](/federation/errors/).
+There are many reasons why you may run into build errors. This error should include information about _why_ the proposed subgraph schema could not be composed. Error code references can be found [here](https://www.apollographql.com/docs/federation/errors/).
 
-Some build errors are part of normal workflows. For instance, you may need to publish a subgraph that does not compose if you are trying to [migrate an entity or field](/federation/entities/#migrating-entities-and-fields-advanced).
+Some build errors are part of normal workflows. For instance, you may need to publish a subgraph that does not compose if you are trying to [migrate an entity or field](https://www.apollographql.com/docs/federation/entities/#migrating-entities-and-fields-advanced).
 
 
 ### E030
 
-This error occurs when an operation check fails. This means that you proposed a schema that would break operations in use by existing clients. You can configure this behavior in the Checks -> Configuration view in [Apollo Studio](https://studio.apollographql.com/), and you can read more about client checks [here](/studio/schema-checks/).
+This error occurs when an operation check fails. This means that you proposed a schema that would break operations in use by existing clients. You can configure this behavior in the Checks -> Configuration view in [Apollo Studio](https://studio.apollographql.com/), and you can read more about client checks [here](https://www.apollographql.com/docs/studio/schema-checks/).
 
 ### E031
 
 This error occurs when Rover made an HTTP request and it timed out.
 
-The client timeout that Rover sets is configurable. You can [increase Rover's request timeout](./configuring/#bypassing-tlsssl-validation), but it's also possible that you've made a request for too much data from the Studio API, or that the Studio API is experiencing degraded performance. You can check for known performance issues on our [status page](https://status.apollographql.com).
+The client timeout that Rover sets is configurable. You can [increase Rover's request timeout](https://www.apollographql.com/docs/rover/configuring/#bypass-tlsssl-validation), but it's also possible that you've made a request for too much data from the Studio API, or that the Studio API is experiencing degraded performance. You can check for known performance issues on our [status page](https://status.apollographql.com).
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.4.6 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.7 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.4.6' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.7' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.6"
+PACKAGE_VERSION="v0.4.7"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/nix/install_rover_fed2.sh
+++ b/installers/binstall/scripts/nix/install_rover_fed2.sh
@@ -118,7 +118,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.6"
+PACKAGE_VERSION="v0.4.7"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.6'
+$package_version = 'v0.4.7'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/binstall/scripts/windows/install_rover_fed2.ps1
+++ b/installers/binstall/scripts/windows/install_rover_fed2.ps1
@@ -112,7 +112,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.6'
+$package_version = 'v0.4.7'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rover-fed2"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 license-file = "./LICENSE"
 


### PR DESCRIPTION
# [0.4.7] - 2022-03-15

## 🐛 Maintenance

- **Bumps harmonizer to v2.0.0-preview.7 - @EverlastingBugstopper, #1037**

  `rover fed2 supergraph compose` now uses rust: `harmonizer@v2.0.0-preview.7` and js: `@apollo/composition@v2.0.0-preview.7`.