### PR TITLE
pins harmonizer properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "harmonizer"
-version = "2.0.0-preview.4-1"
+version = "2.0.0-preview.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b657c80ce15e0ba151230da14a0e30db2eead77a308bcc3bfc588b628a5a9eeb"
+checksum = "aa6e8ceb8dcdb4ffdac0d964d18693a113285f32b6713fe1f8e41cdb40ca7c87"
 dependencies = [
  "apollo-federation-types",
  "deno_core",
@@ -2739,7 +2739,7 @@ dependencies = [
  "anyhow",
  "apollo-federation-types",
  "camino",
- "harmonizer 2.0.0-preview.4-1",
+ "harmonizer 2.0.0-preview.7",
  "serde",
  "serde_json",
  "structopt",

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -21,7 +21,7 @@ composition-js = ["harmonizer_fed_two"]
 [dependencies]
 # https://github.com/apollographql/federation-rs dependencies
 apollo-federation-types = "0.2.1"
-harmonizer_fed_two = { package = "harmonizer", version = "2.0.0-preview.7", optional = true }
+harmonizer_fed_two = { package = "harmonizer", version = "=2.0.0-preview.7", optional = true }
 
 # crates.io dependencies
 anyhow = "1"


### PR DESCRIPTION
we need an `=` in `Cargo.toml` to pin harmonizer properly, the lockfile was including `preview.4-1` because it thought it was a greater version than preview.7. 🤕 