### PR TITLE
release: v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.4.8] - 2022-03-15
+
+## 🐛 Fixes
+
+- **Properly pin harmonizer versions - @EverlastingBugstopper, #1039**
+
+  0.4.7 accidentally released harmonizer@v2.0.0-preview.4-1 instead of preview.7 because of semver. Versions are now pinned properly.
+
 # [0.4.7] - 2022-03-15
 
 ## 🐛 Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "rover-fed2"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "apollo-federation-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.4.7"
+version = "0.4.8"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.4.7 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.8 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -141,7 +141,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.4.7' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.8' | iex
 ```
 
 #### npm installer

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.4.7 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.4.8 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.4.7' | iex
+iwr 'https://rover.apollo.dev/win/v0.4.8' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.7"
+PACKAGE_VERSION="v0.4.8"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/nix/install_rover_fed2.sh
+++ b/installers/binstall/scripts/nix/install_rover_fed2.sh
@@ -118,7 +118,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.7"
+PACKAGE_VERSION="v0.4.8"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.7'
+$package_version = 'v0.4.8'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/binstall/scripts/windows/install_rover_fed2.ps1
+++ b/installers/binstall/scripts/windows/install_rover_fed2.ps1
@@ -112,7 +112,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.7'
+$package_version = 'v0.4.8'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rover-fed2"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 license-file = "./LICENSE"
 


### PR DESCRIPTION
# [0.4.8] - 2022-03-15

## 🐛 Fixes

- **Properly pin harmonizer versions - @EverlastingBugstopper, #1039**

  0.4.7 accidentally released harmonizer@v2.0.0-preview.4-1 instead of preview.7 because of semver. Versions are now pinned properly.