### PR TITLE
chore: prove that federation-rs git deps work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,8 +65,7 @@ checksum = "f0f3d4a3fab912bb8d19416f9149b04d9689f8c063b0c06cf5aa97c1385ca3de"
 [[package]]
 name = "apollo-federation-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9703972c1d79af11e3d551df5a00f8cf605440465558127b4ec5ac31382d3bb"
+source = "git+https://github.com/apollographql/federation-rs?branch=avery/destroy-the-stage#4212c39ffe9ecfe509497b6837c74b4989581f07"
 dependencies = [
  "camino",
  "log",
@@ -1501,8 +1500,7 @@ dependencies = [
 [[package]]
 name = "harmonizer"
 version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79eda1d20d288d1fd13b6510a7c784c41950855f8f5b8e4568024999787a8230"
+source = "git+https://github.com/apollographql/federation-rs?branch=avery/destroy-the-stage#4212c39ffe9ecfe509497b6837c74b4989581f07"
 dependencies = [
  "apollo-federation-types",
  "deno_core",
@@ -1516,8 +1514,7 @@ dependencies = [
 [[package]]
 name = "harmonizer"
 version = "2.0.0-preview.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6e8ceb8dcdb4ffdac0d964d18693a113285f32b6713fe1f8e41cdb40ca7c87"
+source = "git+https://github.com/apollographql/federation-rs?branch=avery/destroy-the-stage#4212c39ffe9ecfe509497b6837c74b4989581f07"
 dependencies = [
  "apollo-federation-types",
  "deno_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ composition-js = ["harmonizer_fed_one"]
 
 [dependencies]
 # https://github.com/apollographql/federation-rs dependencies
-apollo-federation-types = "0.2.1"
-harmonizer_fed_one = { package = "harmonizer", version = "=0.35.3", optional = true }
+apollo-federation-types = { version = "=0.2.1", git = "https://github.com/apollographql/federation-rs", branch = "avery/destroy-the-stage" }
+harmonizer_fed_one = { package = "harmonizer", version = "=0.35.3", git = "https://github.com/apollographql/federation-rs", branch = "avery/destroy-the-stage", optional = true }
 
 # workspace dependencies
 binstall = { path = "./installers/binstall" }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 houston = { path = "../houston" }
 
 # https://github.com/apollographql/federation-rs dependencies
-apollo-federation-types = "0.2.1"
+apollo-federation-types = { version = "=0.2.1", git = "https://github.com/apollographql/federation-rs", branch = "avery/destroy-the-stage" }
 
 # crates.io deps
 backoff = "0.4"

--- a/plugins/rover-fed2/Cargo.toml
+++ b/plugins/rover-fed2/Cargo.toml
@@ -20,8 +20,8 @@ composition-js = ["harmonizer_fed_two"]
 
 [dependencies]
 # https://github.com/apollographql/federation-rs dependencies
-apollo-federation-types = "0.2.1"
-harmonizer_fed_two = { package = "harmonizer", version = "=2.0.0-preview.7", optional = true }
+apollo-federation-types = { version = "=0.2.1", git = "https://github.com/apollographql/federation-rs", branch = "avery/destroy-the-stage" }
+harmonizer_fed_two = { package = "harmonizer", version = "=2.0.0-preview.7", git = "https://github.com/apollographql/federation-rs", branch = "avery/destroy-the-stage", optional = true }
 
 # crates.io dependencies
 anyhow = "1"


### PR DESCRIPTION
this won't ever get merged but it pairs with https://github.com/apollographql/federation-rs/pull/79, proving that you can now refer to both versions of `harmonizer` via `git` dependency which was impossible previously with our bespoke "stage" implementation.