### PR TITLE
chore: simplify `rover subgraph fetch` query

### DIFF
--- a/crates/rover-client/src/operations/subgraph/fetch/fetch_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/fetch/fetch_query.graphql
@@ -1,15 +1,15 @@
-query SubgraphFetchQuery($graph_id: ID!, $variant: String!) {
-  service(id: $graph_id) {
-    implementingServices(graphVariant: $variant) {
-      __typename
-      ... on FederatedImplementingServices {
-        services {
-          name
-          url
-          activePartialSchema {
-            sdl
-          }
+query SubgraphFetchQuery($graph_ref: ID!, $subgraph_name: ID!) {
+  variant(ref: $graph_ref) {
+    __typename
+    ... on GraphVariant {
+      subgraph(name: $subgraph_name) {
+        url,
+        activePartialSchema {
+          sdl
         }
+      }
+      subgraphs {
+        name
       }
     }
   }

--- a/crates/rover-client/src/operations/subgraph/fetch/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch/types.rs
@@ -2,22 +2,21 @@ use crate::shared::GraphRef;
 
 use super::runner::subgraph_fetch_query;
 
-pub(crate) type ServiceList = Vec<subgraph_fetch_query::SubgraphFetchQueryServiceImplementingServicesOnFederatedImplementingServicesServices>;
 pub(crate) type SubgraphFetchResponseData = subgraph_fetch_query::ResponseData;
-pub(crate) type Services = subgraph_fetch_query::SubgraphFetchQueryServiceImplementingServices;
+pub(crate) type SubgraphFetchGraphVariant = subgraph_fetch_query::SubgraphFetchQueryVariant;
 pub(crate) type QueryVariables = subgraph_fetch_query::Variables;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubgraphFetchInput {
     pub graph_ref: GraphRef,
-    pub subgraph: String,
+    pub subgraph_name: String,
 }
 
 impl From<SubgraphFetchInput> for QueryVariables {
     fn from(input: SubgraphFetchInput) -> Self {
         Self {
-            graph_id: input.graph_ref.name,
-            variant: input.graph_ref.variant,
+            graph_ref: input.graph_ref.to_string(),
+            subgraph_name: input.subgraph_name,
         }
     }
 }

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -42,7 +42,7 @@ impl Fetch {
         let fetch_response = fetch::run(
             SubgraphFetchInput {
                 graph_ref: self.graph.clone(),
-                subgraph: self.subgraph.clone(),
+                subgraph_name: self.subgraph.clone(),
             },
             &client,
         )?;

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -90,7 +90,7 @@ pub(crate) fn get_subgraph_definitions(
                 let result = fetch::run(
                     SubgraphFetchInput {
                         graph_ref: GraphRef::from_str(graph_ref)?,
-                        subgraph: subgraph.clone(),
+                        subgraph_name: subgraph.clone(),
                     },
                     &client,
                 )?;


### PR DESCRIPTION
fixes #992 - @lennyburdette tipped me off that the studio api now has official support for fetching a single subgraph by name, so we're no longer exponentially increasing query sizes when adding new subgraphs to variants. there's still some improvements to make around `rover supergraph compose` but this is a step in the right direction.

thanks to @jsegaran for the tip on `cargo expand` - really helped me debug the type errors i was running into.