### PR TITLE
release: v0.5.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,52 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.5.0-rc.0] - 2022-04-05
+
+> Important: X breaking changes below, indicated by **❗ BREAKING ❗**
+
+## ❗ BREAKING ❗
+
+- **`rover-fed2` has been deprecated - @EverlastingBugstopper, #1058**
+
+  `rover fed2 supergraph compose` has been deprecated. You should instead set `federation_version: 2` in your `supergraph.yaml` to use Federation 2 with the `rover supergraph compose` command.
+
+## 🚀 Features
+
+- **`rover supergraph compose` optionally updates automatically - @EverlastingBugstopper, #1058 fixes #2046**
+
+  When running `rover supergraph compose`, Rover will automatically download the correct version of composition to use. When you first install Rover, it will automatically download the latest composition function for Federation 1 and Federation 2. In your `supergraph.yaml` files, you can specify `federation_version: 1` or `federation_version: 2` to always get the latest updates. You can pass the `--skip-update` flag to skip checking for an update. You can also specify an exact version if you'd like to pin your composition function, like so: `federation_version: =2.0.0-preview.9`.
+
+  Additionally, you can run `rover install --plugin supergraph@latest-2` or `rover install --plugin supergraph@v2.0.0-preview.9` to install a plugin ahead of time, which may be helpful in CI.
+
+- **Adds `--insecure-unmask-key` to `rover config whoami` - @EverlastingBugstopper, #1043 fixes #1023**
+
+  Previously, running `rover config whoami` would output your entire API key to the terminal. This is not the documented behavior, and it is insecure because someone could be sharing their screen while trying to debug and accidentally leak their API key.
+
+  Now, `rover config whoami` will mask your API key when it prints to the terminal. You can override this behavior by passing the `--insecure-unmask-key` flag.
+
+- **Retry on timeouts and connection errors - @ptondereau, #1014 fixes #790**
+
+  Rover will now automatically retry HTTP requests that fail due to timeouts or initial connection errors.
+
+## 🐛 Fixes
+
+- **Fixed a dead link in ARCHITECTURE.md - @ptondereau, #1053**
+
+## 🛠 Maintenance
+
+- **Simplify `rover subgraph fetch` query - @EverlastingBugstopper, #1056 fixes #992**
+
+  `rover subgraph fetch` now uses a much more efficient query that only requests a single subgraph at a time rather than all of them. Yay GraphQL!
+
+- **Upgrades `apollo-encoder` - @bnjjj, #1017 fixes #1010**
+
+## 📚 Documentation
+
+- **Set up new docs infrastructure - @trevorblades, #1051, #1052**
+
+  @trevorblades has done an awesome job setting up new docs for Apollo, including Rover! Check out the [shiny new repo](https://github.com/apollographql/docs).
+
 # [0.4.8] - 2022-03-15
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "apollo-encoder"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f3d4a3fab912bb8d19416f9149b04d9689f8c063b0c06cf5aa97c1385ca3de"
+checksum = "c2ae23d8a1f5cc1a4e33ec9b1f0d4d626f9e4736619b4c1a4f1482a594ac2e13"
 
 [[package]]
 name = "apollo-federation-types"
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
+checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
 dependencies = [
  "async-channel",
  "async-global-executor",
@@ -298,9 +298,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -336,7 +336,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "instant",
  "rand 0.8.5",
 ]
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.3"
+version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -748,9 +748,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbfe11fe19ff083c48923cf179540e8cd0535903dc35e178a1fdeeb59aef51f"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -1032,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.0",
+ "redox_users 0.4.3",
  "winapi",
 ]
 
@@ -1071,9 +1071,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
 ]
@@ -1096,9 +1096,9 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "eyre"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1143,7 +1143,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "winapi",
 ]
 
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1471,7 +1471,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -1588,9 +1588,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1666,9 +1666,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1834,9 +1834,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
@@ -1896,18 +1896,19 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
  "value-bag",
@@ -1974,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
@@ -1997,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2074,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "online"
@@ -2116,9 +2117,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.17.0+1.1.1m"
+version = "111.18.0+1.1.1n"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 dependencies = [
  "cc",
 ]
@@ -2196,7 +2197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -2208,20 +2209,20 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "smallvec",
  "windows-sys",
 ]
@@ -2291,9 +2292,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
@@ -2352,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
 dependencies = [
  "ansi_term",
  "ctor",
@@ -2411,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -2473,7 +2474,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -2493,9 +2494,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -2513,12 +2514,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.5",
- "redox_syscall 0.2.11",
+ "getrandom 0.2.6",
+ "redox_syscall 0.2.13",
+ "thiserror",
 ]
 
 [[package]]
@@ -2584,7 +2586,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-socks",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2608,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.4.8"
+version = "0.5.0-rc.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2766,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 dependencies = [
  "serde",
 ]
@@ -2945,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.7.14",
@@ -2977,9 +2979,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "sluice"
@@ -3030,13 +3032,13 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
 dependencies = [
- "lazy_static",
  "new_debug_unreachable",
- "parking_lot 0.11.2",
+ "once_cell",
+ "parking_lot 0.12.0",
  "phf_shared",
  "precomputed-hash",
 ]
@@ -3116,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd69e719f31e88618baa1eaa6ee2de5c9a1c004f1e9ecdb58e8352a13f20a01"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3167,7 +3169,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "remove_dir_all",
  "winapi",
 ]
@@ -3287,7 +3289,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "tracing-core",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.10",
 ]
 
 [[package]]
@@ -3333,7 +3335,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.1",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
@@ -3391,6 +3393,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3495,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term",
  "parking_lot 0.12.0",
@@ -3587,7 +3603,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "serde",
 ]
 
@@ -3772,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.4"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
  "lazy_static",
@@ -3814,9 +3830,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -3827,33 +3843,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.4.8"
+version = "0.5.0-rc.0"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.4.7
+Rover 0.5.0-rc.0
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -66,18 +66,37 @@ USAGE:
     rover [FLAGS] [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
-        --insecure-accept-invalid-certs        Accept invalid certificates when performing HTTPS requests
-        --insecure-accept-invalid-hostnames    Accept invalid hostnames when performing HTTPS requests
-    -h, --help                                 Prints help information
-    -V, --version                              Prints version information
+        --insecure-accept-invalid-certs        
+            Accept invalid certificates when performing HTTPS requests.
+            
+            You should think very carefully before using this flag.
+            
+            If invalid certificates are trusted, any certificate for any site will be trusted for use. This includes
+            expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+        --insecure-accept-invalid-hostnames    
+            Accept invalid hostnames when performing HTTPS requests.
+            
+            You should think very carefully before using this flag.
+            
+            If hostname verification is not used, any valid certificate for any site will be trusted for use from any
+            other. This introduces a significant vulnerability to man-in-the-middle attacks.
+    -h, --help                                 
+            Prints help information
+
+    -V, --version                              
+            Prints version information
+
 
 OPTIONS:
-        --client-timeout <client-timeout>    Configure the timeout length (in seconds) when performing HTTP(S) requests
-                                             [default: 30]
-    -l, --log <log-level>                    Specify Rover's log level [possible values: error, warn,
-                                             info, debug, trace]
-        --output <output-type>               Specify Rover's output type [default: plain]  [possible values:
-                                             json, plain]
+        --client-timeout <client-timeout>    
+            Configure the timeout length (in seconds) when performing HTTP(S) requests [default: 30]
+
+    -l, --log <log-level>                    
+            Specify Rover's log level [possible values: error, warn, info, debug,
+            trace]
+        --output <output-type>               
+            Specify Rover's output type [default: plain]  [possible values: json, plain]
+
 
 SUBCOMMANDS:
     config        Configuration profile commands
@@ -123,7 +142,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.4.8 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.0 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -141,7 +160,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.4.8' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.0-rc.0' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
-      "integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -334,12 +334,12 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.2.tgz",
-      "integrity": "sha512-ICWqM+MvEkIPHm18Q0cmkvm134zeQMomBKmTRxyxMNhL/ouz6Nqld52/brSlaHnzA3fczupeRJzZ0YatruGBcQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.1.tgz",
+      "integrity": "sha512-63+lNWrwXmofjZVa7ML+n9CBviClF3K+RP3Xx3hxGQ8BrhvB1pWS1yzaUZqrkiiKdTu1v3mJGVfmooHwzlyPwQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -377,16 +377,16 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.3.tgz",
-      "integrity": "sha512-e65cEmAccodc3tlVskU0JgEbHgJUGB4sbd/dk2v15nOFzjj9izBTsTdvebI1Bm28Mip10vBJj9G0jJcTeOIyhg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.1.tgz",
+      "integrity": "sha512-e98/NRaOH5wQy624bRd5i5qUKz5tCs8u4xBmxW89d7t6V6CveXj7pvAgmnR9DbwOkO6IA3P799p/aa/YG/pWTA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/batch-execute": "^8.3.2",
-        "@graphql-tools/schema": "^8.3.2",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/batch-execute": "8.4.1",
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
         "dataloader": "2.0.0",
-        "graphql-executor": "0.0.18",
+        "graphql-executor": "0.0.22",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -407,13 +407,13 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.4.tgz",
-      "integrity": "sha512-Q0/YtDq0APR6syRclsQMNguWKRlchd8nFTOpLhfc7Xeiy21VhEEi4Ik+quRySfb7ubDfJGhiUq4MQW43FhWJvg==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.7.tgz",
+      "integrity": "sha512-fwXLycYvabPhusGtYuFrOPbjeIvLWr6viGkQc9KmiBm2Z2kZrlNRNUlYkXXRzMoiqRkzqFJYhOgWDE7LsOnbjw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/import": "^6.6.6",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/import": "6.6.9",
+        "@graphql-tools/utils": "8.6.5",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -451,12 +451,12 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.6.tgz",
-      "integrity": "sha512-a0aVajxqu1MsL8EwavA44Osw20lBOIhq8IM2ZIHFPP62cPAcOB26P+Sq57DHMsSyX5YQ0ab9XPM2o4e1dQhs0w==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.9.tgz",
+      "integrity": "sha512-sKaLqvPmNLQlY4te+nnBhRrf5WBISoiyVkbriCLz0kHw805iHdJaU2KxUoHsRTR7WlYq0g9gzB0oVaRh99Q5aA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -477,12 +477,12 @@
       }
     },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.4.tgz",
-      "integrity": "sha512-1AROMFh8Lyorf2gTWXgVaUbU3ic84gzAgpRmJCsCla/Nnvn6JiCs4aWHsalk4ZWVXCaK04c8gk8Px1uNQUj02Q==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.7.tgz",
+      "integrity": "sha512-dm0LcfiWYin7cUR4RWC33C9bNppujvSU7hwTH+sHmSguNnat9Kn8dBntVSgrY3qCbKuGfz/PshQHIODXrRwAKg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -504,13 +504,13 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.2.tgz",
-      "integrity": "sha512-URPqVP77mYxdZxT895DzrWf2C23S3yC/oAmXD4D4YlxR5eVVH/fxu0aZR78WcEKF331fWSiFwWy9j7BZWvkj7g==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.6.tgz",
+      "integrity": "sha512-IocEP4METGdbDzV44VaeiXO387NOYSW4cTuBP8qybHZX0XlIp8bEv7c8GKS3m8DeRop/9SnOL7HyiAfNMA4Chg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/schema": "8.3.2",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -531,12 +531,12 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.3.tgz",
-      "integrity": "sha512-XCSmL6/Xg8259OTWNp69B57CPWiVL69kB7pposFrufG/zaAlI9BS68dgzrxmmSqZV5ZHU4r/6Tbf6fwnEJGiSw==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
+      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -556,13 +556,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.2.tgz",
-      "integrity": "sha512-77feSmIuHdoxMXRbRyxE8rEziKesd/AcqKV6fmxe7Zt+PgIQITxNDew2XJJg7qFTMNM43W77Ia6njUSBxNOkwg==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.6.tgz",
+      "integrity": "sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/merge": "^8.2.3",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/merge": "8.2.6",
+        "@graphql-tools/utils": "8.6.5",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -583,14 +583,14 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.2.tgz",
-      "integrity": "sha512-CmRKGg9iao8AW1p3BgZLPwzGZoVeIiIwUfCoaxgTTOqFfJceIaIee362mbJyQD1zD0R74yCnj4CQnLbs3bd30A==",
+      "version": "7.9.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.8.tgz",
+      "integrity": "sha512-nRMXwwoIDLt7ohBWvKKjEEH61YS1nnWs6BVgGStePfmRGrhxECpLWmfAmKLNXPqDJN7Nu6ykFJYjt65j5l6qsw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "^8.5.1",
-        "@graphql-tools/utils": "^8.6.2",
-        "@graphql-tools/wrap": "^8.4.4",
+        "@graphql-tools/delegate": "8.7.1",
+        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/wrap": "8.4.10",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -636,14 +636,14 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.4.tgz",
-      "integrity": "sha512-roBa4FC65QLlpFCtLtmip3SibGRoLnlLUXyQgOSzW5V+lcDpbGu2GIx9A0VerKC8Cf0iqWaYgI7mhGn+mharkg==",
+      "version": "8.4.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.10.tgz",
+      "integrity": "sha512-1/pcKRDTGIUspUl6uhlfQ0u1l4j15TVGkOkijI+gX25Q9sfAJclT0bovKBksP39G6v4hZnolpOU2txJ47MxxEg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "^8.5.1",
-        "@graphql-tools/schema": "^8.3.2",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/delegate": "8.7.1",
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -652,9 +652,9 @@
       }
     },
     "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-      "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.3.0"
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -1045,16 +1045,16 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.25.tgz",
-      "integrity": "sha512-KS6hm/VuRO+3jIrg4uidz3mQ8NWvCbiTTOg3yoH30zuGVUvjqZlnXw66h0kuzyfP21hDkrdIbufXCW6BAQdSNw==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.28.tgz",
+      "integrity": "sha512-/nLMyVE5IC9PQdBtmgjpGZfK0wo8UupomAPx+7HlbEgVDkZOa9xCiZP9goo5aLYofP0gHXgovjXdXrE2obANag==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
-        "undici": "^4.9.3",
+        "undici": "^5.0.0",
         "web-streams-polyfill": "^3.2.0"
       }
     },
@@ -1448,9 +1448,9 @@
       "dev": true
     },
     "node_modules/form-data-encoder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
-      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "dev": true
     },
     "node_modules/formdata-node": {
@@ -1610,9 +1610,9 @@
       }
     },
     "node_modules/graphql-executor": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.18.tgz",
-      "integrity": "sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.22.tgz",
+      "integrity": "sha512-WbKSnSHFn6REKKH4T6UAwDM3mLUnYMQlQLNG0Fw+Lkb3ilCnL3m5lkJ7411LAI9sF7BvPbthovVZhsEUh9Xfag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
@@ -1634,9 +1634,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.3.tgz",
-      "integrity": "sha512-ZolWOi6bzI35ovGROCZROB9nDbwZiJdIsaPdzW/jkICCGNb3qL/33IONY/yQiBa+Je2uA11HfY4Uxse4+/ePYA==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.4.tgz",
+      "integrity": "sha512-5r8tAzznI1zeh7k12+3z07KkgXPckQbnC9h4kJ2TBDWG2wb26TJTbVHQOiAncDBgPbtXtc1A2BlttiRuPH2t/w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1908,13 +1908,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -2468,9 +2468,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2482,9 +2482,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.1.tgz",
-      "integrity": "sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
       "dev": true,
       "engines": {
         "node": ">=12.18"
@@ -2777,9 +2777,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
-      "integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
       "dev": true
     },
     "@babel/template": {
@@ -2880,21 +2880,21 @@
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.2.tgz",
-      "integrity": "sha512-ICWqM+MvEkIPHm18Q0cmkvm134zeQMomBKmTRxyxMNhL/ouz6Nqld52/brSlaHnzA3fczupeRJzZ0YatruGBcQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.1.tgz",
+      "integrity": "sha512-63+lNWrwXmofjZVa7ML+n9CBviClF3K+RP3Xx3hxGQ8BrhvB1pWS1yzaUZqrkiiKdTu1v3mJGVfmooHwzlyPwQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -2916,24 +2916,24 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.3.tgz",
-      "integrity": "sha512-e65cEmAccodc3tlVskU0JgEbHgJUGB4sbd/dk2v15nOFzjj9izBTsTdvebI1Bm28Mip10vBJj9G0jJcTeOIyhg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.1.tgz",
+      "integrity": "sha512-e98/NRaOH5wQy624bRd5i5qUKz5tCs8u4xBmxW89d7t6V6CveXj7pvAgmnR9DbwOkO6IA3P799p/aa/YG/pWTA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "^8.3.2",
-        "@graphql-tools/schema": "^8.3.2",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/batch-execute": "8.4.1",
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
         "dataloader": "2.0.0",
-        "graphql-executor": "0.0.18",
+        "graphql-executor": "0.0.22",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -2942,22 +2942,22 @@
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.4.tgz",
-      "integrity": "sha512-Q0/YtDq0APR6syRclsQMNguWKRlchd8nFTOpLhfc7Xeiy21VhEEi4Ik+quRySfb7ubDfJGhiUq4MQW43FhWJvg==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.7.tgz",
+      "integrity": "sha512-fwXLycYvabPhusGtYuFrOPbjeIvLWr6viGkQc9KmiBm2Z2kZrlNRNUlYkXXRzMoiqRkzqFJYhOgWDE7LsOnbjw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "^6.6.6",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/import": "6.6.9",
+        "@graphql-tools/utils": "8.6.5",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -2979,20 +2979,20 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.6.tgz",
-      "integrity": "sha512-a0aVajxqu1MsL8EwavA44Osw20lBOIhq8IM2ZIHFPP62cPAcOB26P+Sq57DHMsSyX5YQ0ab9XPM2o4e1dQhs0w==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.9.tgz",
+      "integrity": "sha512-sKaLqvPmNLQlY4te+nnBhRrf5WBISoiyVkbriCLz0kHw805iHdJaU2KxUoHsRTR7WlYq0g9gzB0oVaRh99Q5aA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3001,21 +3001,21 @@
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.4.tgz",
-      "integrity": "sha512-1AROMFh8Lyorf2gTWXgVaUbU3ic84gzAgpRmJCsCla/Nnvn6JiCs4aWHsalk4ZWVXCaK04c8gk8Px1uNQUj02Q==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.7.tgz",
+      "integrity": "sha512-dm0LcfiWYin7cUR4RWC33C9bNppujvSU7hwTH+sHmSguNnat9Kn8dBntVSgrY3qCbKuGfz/PshQHIODXrRwAKg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3024,21 +3024,21 @@
       }
     },
     "@graphql-tools/load": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.2.tgz",
-      "integrity": "sha512-URPqVP77mYxdZxT895DzrWf2C23S3yC/oAmXD4D4YlxR5eVVH/fxu0aZR78WcEKF331fWSiFwWy9j7BZWvkj7g==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.6.tgz",
+      "integrity": "sha512-IocEP4METGdbDzV44VaeiXO387NOYSW4cTuBP8qybHZX0XlIp8bEv7c8GKS3m8DeRop/9SnOL7HyiAfNMA4Chg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "8.3.2",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3047,19 +3047,19 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.3.tgz",
-      "integrity": "sha512-XCSmL6/Xg8259OTWNp69B57CPWiVL69kB7pposFrufG/zaAlI9BS68dgzrxmmSqZV5ZHU4r/6Tbf6fwnEJGiSw==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
+      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/utils": "8.6.5",
         "tslib": "~2.3.0"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3068,21 +3068,21 @@
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.2.tgz",
-      "integrity": "sha512-77feSmIuHdoxMXRbRyxE8rEziKesd/AcqKV6fmxe7Zt+PgIQITxNDew2XJJg7qFTMNM43W77Ia6njUSBxNOkwg==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.6.tgz",
+      "integrity": "sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "^8.2.3",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/merge": "8.2.6",
+        "@graphql-tools/utils": "8.6.5",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3091,14 +3091,14 @@
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.2.tgz",
-      "integrity": "sha512-CmRKGg9iao8AW1p3BgZLPwzGZoVeIiIwUfCoaxgTTOqFfJceIaIee362mbJyQD1zD0R74yCnj4CQnLbs3bd30A==",
+      "version": "7.9.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.8.tgz",
+      "integrity": "sha512-nRMXwwoIDLt7ohBWvKKjEEH61YS1nnWs6BVgGStePfmRGrhxECpLWmfAmKLNXPqDJN7Nu6ykFJYjt65j5l6qsw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "^8.5.1",
-        "@graphql-tools/utils": "^8.6.2",
-        "@graphql-tools/wrap": "^8.4.4",
+        "@graphql-tools/delegate": "8.7.1",
+        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/wrap": "8.4.10",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
@@ -3117,9 +3117,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3137,22 +3137,22 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.4.tgz",
-      "integrity": "sha512-roBa4FC65QLlpFCtLtmip3SibGRoLnlLUXyQgOSzW5V+lcDpbGu2GIx9A0VerKC8Cf0iqWaYgI7mhGn+mharkg==",
+      "version": "8.4.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.10.tgz",
+      "integrity": "sha512-1/pcKRDTGIUspUl6uhlfQ0u1l4j15TVGkOkijI+gX25Q9sfAJclT0bovKBksP39G6v4hZnolpOU2txJ47MxxEg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "^8.5.1",
-        "@graphql-tools/schema": "^8.3.2",
-        "@graphql-tools/utils": "^8.6.2",
+        "@graphql-tools/delegate": "8.7.1",
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.2.tgz",
-          "integrity": "sha512-x1DG0cJgpJtImUlNE780B/dfp8pxvVxOD6UeykFH5rHes26S4kGokbgU8F1IgrJ1vAPm/OVBHtd2kicTsPfwdA==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
           "dev": true,
           "requires": {
             "tslib": "~2.3.0"
@@ -3217,9 +3217,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3449,16 +3449,16 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.25.tgz",
-      "integrity": "sha512-KS6hm/VuRO+3jIrg4uidz3mQ8NWvCbiTTOg3yoH30zuGVUvjqZlnXw66h0kuzyfP21hDkrdIbufXCW6BAQdSNw==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.28.tgz",
+      "integrity": "sha512-/nLMyVE5IC9PQdBtmgjpGZfK0wo8UupomAPx+7HlbEgVDkZOa9xCiZP9goo5aLYofP0gHXgovjXdXrE2obANag==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
-        "undici": "^4.9.3",
+        "undici": "^5.0.0",
         "web-streams-polyfill": "^3.2.0"
       }
     },
@@ -3760,9 +3760,9 @@
       "dev": true
     },
     "form-data-encoder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
-      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "dev": true
     },
     "formdata-node": {
@@ -3884,9 +3884,9 @@
       }
     },
     "graphql-executor": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.18.tgz",
-      "integrity": "sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.22.tgz",
+      "integrity": "sha512-WbKSnSHFn6REKKH4T6UAwDM3mLUnYMQlQLNG0Fw+Lkb3ilCnL3m5lkJ7411LAI9sF7BvPbthovVZhsEUh9Xfag==",
       "dev": true,
       "requires": {}
     },
@@ -3898,9 +3898,9 @@
       "requires": {}
     },
     "graphql-ws": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.3.tgz",
-      "integrity": "sha512-ZolWOi6bzI35ovGROCZROB9nDbwZiJdIsaPdzW/jkICCGNb3qL/33IONY/yQiBa+Je2uA11HfY4Uxse4+/ePYA==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.4.tgz",
+      "integrity": "sha512-5r8tAzznI1zeh7k12+3z07KkgXPckQbnC9h4kJ2TBDWG2wb26TJTbVHQOiAncDBgPbtXtc1A2BlttiRuPH2t/w==",
       "dev": true,
       "requires": {}
     },
@@ -4101,13 +4101,13 @@
       "requires": {}
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "minimatch": {
@@ -4468,16 +4468,16 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "peer": true
     },
     "undici": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.1.tgz",
-      "integrity": "sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
       "dev": true
     },
     "unixify": {

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.4.8 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.0 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.4.8' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.0-rc.0' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.4.8"
+PACKAGE_VERSION="v0.5.0-rc.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.4.8'
+$package_version = 'v0.5.0-rc.0'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.8",
+  "version": "0.5.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.4.8",
+      "version": "0.5.0-rc.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.4.8",
+  "version": "0.5.0-rc.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.5.0-rc.0] - 2022-04-05

> Important: X breaking changes below, indicated by **❗ BREAKING ❗**

## ❗ BREAKING ❗

- **`rover-fed2` has been deprecated - @EverlastingBugstopper, #1058**

  `rover fed2 supergraph compose` has been deprecated. You should instead set `federation_version: 2` in your `supergraph.yaml` to use Federation 2 with the `rover supergraph compose` command.

## 🚀 Features

- **`rover supergraph compose` optionally updates automatically - @EverlastingBugstopper, #1058 fixes #2046**

  When running `rover supergraph compose`, Rover will automatically download the correct version of composition to use. When you first install Rover, it will automatically download the latest composition function for Federation 1 and Federation 2. In your `supergraph.yaml` files, you can specify `federation_version: 1` or `federation_version: 2` to always get the latest updates. You can pass the `--skip-update` flag to skip checking for an update. You can also specify an exact version if you'd like to pin your composition function, like so: `federation_version: =2.0.0-preview.9`.

  Additionally, you can run `rover install --plugin supergraph@latest-2` or `rover install --plugin supergraph@v2.0.0-preview.9` to install a plugin ahead of time, which may be helpful in CI.

- **Adds `--insecure-unmask-key` to `rover config whoami` - @EverlastingBugstopper, #1043 fixes #1023**

  Previously, running `rover config whoami` would output your entire API key to the terminal. This is not the documented behavior, and it is insecure because someone could be sharing their screen while trying to debug and accidentally leak their API key.

  Now, `rover config whoami` will mask your API key when it prints to the terminal. You can override this behavior by passing the `--insecure-unmask-key` flag.

- **Retry on timeouts and connection errors - @ptondereau, #1014 fixes #790**

  Rover will now automatically retry HTTP requests that fail due to timeouts or initial connection errors.

## 🐛 Fixes

- **Fixed a dead link in ARCHITECTURE.md - @ptondereau, #1053**

## 🛠 Maintenance

- **Simplify `rover subgraph fetch` query - @EverlastingBugstopper, #1056 fixes #992**

  `rover subgraph fetch` now uses a much more efficient query that only requests a single subgraph at a time rather than all of them. Yay GraphQL!

## 📚 Documentation

- **Set up new docs infrastructure - @trevorblades, #1051, #1052**

  @trevorblades has done an awesome job setting up new docs for Apollo, including Rover! Check out the [shiny new repo](https://github.com/apollographql/docs).