### PR TITLE
chore: store answer to elv2 accept

### DIFF
--- a/crates/houston/src/config.rs
+++ b/crates/houston/src/config.rs
@@ -1,4 +1,5 @@
 use directories_next::ProjectDirs;
+use serde::{Deserialize, Serialize};
 
 use crate::HoustonProblem;
 
@@ -67,6 +68,36 @@ impl Config {
         fs::remove_dir_all(&self.home)
             .map_err(|_| HoustonProblem::NoConfigFound(self.home.to_string()))
     }
+
+    /// Writes elv2 = "accept" to self.home.join("elv2.toml")
+    pub fn accept_elv2_license(&self) -> Result<(), HoustonProblem> {
+        let toml_path = self.get_elv2_toml_path();
+        let elv2_toml = Elv2Toml { did_accept: true };
+        let contents = toml::to_string(&elv2_toml)?;
+        std::fs::write(&toml_path, &contents)?;
+        Ok(())
+    }
+
+    /// Retrieves the value of sefl.home.join("elv2.toml")
+    pub fn did_accept_elv2_license(&self) -> bool {
+        let toml_path = self.get_elv2_toml_path();
+        if let Ok(contents) = std::fs::read_to_string(&toml_path) {
+            if let Ok(elv2_toml) = toml::from_str::<Elv2Toml>(&contents) {
+                eprintln!("{}", &elv2_toml.did_accept);
+                return elv2_toml.did_accept;
+            }
+        }
+        false
+    }
+
+    fn get_elv2_toml_path(&self) -> Utf8PathBuf {
+        self.home.join("elv2_license.toml")
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Elv2Toml {
+    did_accept: bool,
 }
 
 #[cfg(test)]

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -3,7 +3,6 @@ const os = require("os");
 const cTable = require("console.table");
 const libc = require("detect-libc");
 const { join } = require("path");
-const { spawnSync } = require("child_process");
 
 const error = (msg) => {
   console.error(msg);
@@ -112,28 +111,19 @@ const run = () => {
 const install = () => {
   const binary = getBinary();
   binary.install();
-  let pluginInstallCommand = `${binary.binaryPath} install --plugin`;
-  let commands = [
-    `${pluginInstallCommand} supergraph@latest-0`,
-    `${pluginInstallCommand} supergraph@latest-2`,
-  ];
-  for (command of commands) {
-    try {
-      spawnSync(command, {
-        stdio: "inherit",
-        shell: true,
-      });
-    } catch (e) {
-      console.error(
-        `'${command.replace(
-          binary.binaryPath,
-          binary.name
-        )}' failed with message '${
-          e.message
-        }'. 'rover supergraph compose' might not work properly on your machine.`
-      );
-    }
-  }
+
+  // use setTimeout so the message prints after the install happens.
+  setTimeout(() => {
+    // these messages are duplicated in `src/command/install/mod.rs`
+    // for the curl installer.
+    console.log(
+      "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=1"
+    );
+    console.log(
+      "You can check out our documentation at https://go.apollo.dev/r/docs."
+    ),
+      400;
+  });
 };
 
 module.exports = {

--- a/installers/npm/install.js
+++ b/installers/npm/install.js
@@ -2,16 +2,3 @@
 
 const { install } = require("./binary");
 install();
-
-// use setTimeout so the message prints after the install happens.zzs
-setTimeout(() => {
-  // these messages are duplicated in `src/command/install/mod.rs`
-  // for the curl installer.
-  console.log(
-    "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=1"
-  );
-  console.log(
-    "You can check out our documentation at https://go.apollo.dev/r/docs."
-  ),
-    400;
-});


### PR DESCRIPTION
fixes #1072 by making users accept the ELv2 license exactly one time per machine. `APOLLO_ELV2_LICENSE=accept` should be used in CI.

---

this PR also makes it so that plugins are only installed on the first run to remove inconsistencies between npm and curl installers