### PR TITLE
fixup: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,60 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.5.0] - 2022-04-11
+
+> Important: X breaking changes below, indicated by **❗ BREAKING ❗**
+
+## ❗ BREAKING ❗
+
+- **`rover-fed2` has been deprecated - @EverlastingBugstopper, #1058**
+
+  `rover fed2 supergraph compose` has been deprecated. You should instead set `federation_version: 2` in your `supergraph.yaml` to use Federation 2 with the `rover supergraph compose` command.
+
+## 🚀 Features
+
+- **`rover supergraph compose` optionally updates automatically - @EverlastingBugstopper, #1058 fixes #2046**
+
+  When running `rover supergraph compose`, Rover will automatically download the correct version of composition to use. In your `supergraph.yaml` files, you can specify `federation_version: 1` or `federation_version: 2` to always get the latest updates. You can pass the `--skip-update` flag to skip checking for an update. You can also specify an exact version if you'd like to pin your federation version, like so: `federation_version: =2.0.0`.
+
+  Additionally, you can run `rover install --plugin supergraph@latest-2` or `rover install --plugin supergraph@v2.0.0` to install a plugin ahead of time, which may be helpful in CI. For Federation 2, you'll have to accept the ELv2 license one time per machine. You likely want to set `APOLLO_ELV2_LICENSE=accept` in CI if you are using Federation 2.
+
+- **Adds `--insecure-unmask-key` to `rover config whoami` - @EverlastingBugstopper, #1043 fixes #1023**
+
+  Previously, running `rover config whoami` would output your entire API key to the terminal. This is not the documented behavior, and it is insecure because someone could be sharing their screen while trying to debug and accidentally leak their API key.
+
+  Now, `rover config whoami` will mask your API key when it prints to the terminal. You can override this behavior by passing the `--insecure-unmask-key` flag.
+
+- **Retry on timeouts and connection errors - @ptondereau, #1014 fixes #790**
+
+  Rover will now automatically retry HTTP requests that fail due to timeouts or initial connection errors.
+
+- **Define an HTTP agent for non-studio requests - @ptondereau, #1075 fixes #961**
+
+  Rover now sends a User-Agent header along with all requests, not just requests to Apollo Studio.
+
+- **Adds support for HTTP(S) proxies in npm installer - @farawaysouthwest, #1067 fixes #899**
+
+  You can now install Rover from npm if you are behind a proxy.
+
+## 🐛 Fixes
+
+- **Fixed a dead link in ARCHITECTURE.md - @ptondereau, #1053**
+
+## 🛠 Maintenance
+
+- **Simplify `rover subgraph fetch` query - @EverlastingBugstopper, #1056 fixes #992**
+
+  `rover subgraph fetch` now uses a much more efficient query that only requests a single subgraph at a time rather than all of them. Yay GraphQL!
+
+- **Upgrades `apollo-encoder` - @bnjjj, #1017 fixes #1010**
+
+## 📚 Documentation
+
+- **Set up new docs infrastructure - @trevorblades, #1051, #1052**
+
+  @trevorblades has done an awesome job setting up new docs for Apollo, including Rover! Check out the [shiny new repo](https://github.com/apollographql/docs).
+
 # [0.5.0-rc.1] - 2022-04-05
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -1155,14 +1155,14 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.1",
 ]
 
 [[package]]
@@ -1961,6 +1961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.5.0-rc.1
+Rover 0.5.0
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -142,7 +142,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.0 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -160,7 +160,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.5.0-rc.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.0' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -321,27 +321,15 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.1.tgz",
-      "integrity": "sha512-63+lNWrwXmofjZVa7ML+n9CBviClF3K+RP3Xx3hxGQ8BrhvB1pWS1yzaUZqrkiiKdTu1v3mJGVfmooHwzlyPwQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.2.tgz",
+      "integrity": "sha512-5/el640oG/jfjQCjCRDdtIALyUib8YPONM2NSmckp2g1nOrPTAx/isz3Uptp9y5OI1UXXhONiKy5euTbgsGoXw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -364,14 +352,14 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.1.tgz",
-      "integrity": "sha512-e98/NRaOH5wQy624bRd5i5qUKz5tCs8u4xBmxW89d7t6V6CveXj7pvAgmnR9DbwOkO6IA3P799p/aa/YG/pWTA==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.2.tgz",
+      "integrity": "sha512-SSmx5N6Cq23KRT0YepdmcYugey7MDZSXxtJ8KHHdc5eW9IAHXZWsJWdVnI9woU9omsnE6svnxblZb1UUBl7AUg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/batch-execute": "8.4.1",
-        "@graphql-tools/schema": "8.3.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/batch-execute": "8.4.2",
+        "@graphql-tools/schema": "8.3.7",
+        "@graphql-tools/utils": "8.6.6",
         "dataloader": "2.0.0",
         "graphql-executor": "0.0.22",
         "tslib": "~2.3.0",
@@ -381,41 +369,17 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.7.tgz",
-      "integrity": "sha512-fwXLycYvabPhusGtYuFrOPbjeIvLWr6viGkQc9KmiBm2Z2kZrlNRNUlYkXXRzMoiqRkzqFJYhOgWDE7LsOnbjw==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.8.tgz",
+      "integrity": "sha512-SpQZQ0klbox/kxYCLFBTmhLuQFm7P6usWVIqwROK4JSomwCuccc2zDsr1H7ayDpanD3yfkzMsl6gPkOkAo52pA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/import": "6.6.9",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/import": "6.6.10",
+        "@graphql-tools/utils": "8.6.6",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -438,12 +402,12 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.6.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.9.tgz",
-      "integrity": "sha512-sKaLqvPmNLQlY4te+nnBhRrf5WBISoiyVkbriCLz0kHw805iHdJaU2KxUoHsRTR7WlYq0g9gzB0oVaRh99Q5aA==",
+      "version": "6.6.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.10.tgz",
+      "integrity": "sha512-yHdlEPTvIjrngtQFNgkMQJt/DjG3hQKvc6Mb8kaatFV4yERN5zx+0vpdrwxTwRNG1N7bI/YCkbrc7PXOb+g89Q==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -451,25 +415,13 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.7.tgz",
-      "integrity": "sha512-dm0LcfiWYin7cUR4RWC33C9bNppujvSU7hwTH+sHmSguNnat9Kn8dBntVSgrY3qCbKuGfz/PshQHIODXrRwAKg==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.8.tgz",
+      "integrity": "sha512-W3nVLAp8m787A17wja7ysayij7WMRu+lF8LeCWr9eoyiCuw65i63y0G4eqZ5+Q0+E2BYWlKJyk/Z0vsFVJGMUA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
@@ -478,26 +430,14 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/load": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.6.tgz",
-      "integrity": "sha512-IocEP4METGdbDzV44VaeiXO387NOYSW4cTuBP8qybHZX0XlIp8bEv7c8GKS3m8DeRop/9SnOL7HyiAfNMA4Chg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.7.tgz",
+      "integrity": "sha512-Z4oKf4MdBvl0EyubmvPL14ldhovKz8C61rQPHD8pjnC8Z0RbvW0a/sns/yuHuCVZoJMsSboU65DPzPTIoQUM4w==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/schema": "8.3.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/schema": "8.3.7",
+        "@graphql-tools/utils": "8.6.6",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       },
@@ -505,37 +445,13 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
-      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.7.tgz",
+      "integrity": "sha512-rKxjNogqu1UYAG/y5FOb6lJsmSQbWA+jq4inWjNEVX54VGGE7/WGnmPaqcsyomNOfS3vIRS6NnG+DxiQSqetjg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.5",
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
+        "@graphql-tools/utils": "8.6.6",
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
@@ -543,13 +459,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.6.tgz",
-      "integrity": "sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==",
+      "version": "8.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.7.tgz",
+      "integrity": "sha512-7byr9J6rfMPFPfiR4u65dy20xHATTvbgOY7KYd1sYPnMKKfRZe0tUgpnE+noXcfob7N8s366WaVh7bEoztQMwg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/merge": "8.2.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/merge": "8.2.7",
+        "@graphql-tools/utils": "8.6.6",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -557,27 +473,15 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.9.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.8.tgz",
-      "integrity": "sha512-nRMXwwoIDLt7ohBWvKKjEEH61YS1nnWs6BVgGStePfmRGrhxECpLWmfAmKLNXPqDJN7Nu6ykFJYjt65j5l6qsw==",
+      "version": "7.9.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.9.tgz",
+      "integrity": "sha512-qhjBJ3oCXZrzvJchVwtrahr48TXOHPYZ4YXklGrbJVoJs3LP0a7CYUwuXeiNuN+dpgaxkb175sIEN9m0FadGRw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "8.7.1",
-        "@graphql-tools/utils": "8.6.5",
-        "@graphql-tools/wrap": "8.4.10",
+        "@graphql-tools/delegate": "8.7.2",
+        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/wrap": "8.4.11",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
@@ -598,18 +502,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/utils": {
       "version": "8.6.6",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.6.tgz",
@@ -623,28 +515,16 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.4.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.10.tgz",
-      "integrity": "sha512-1/pcKRDTGIUspUl6uhlfQ0u1l4j15TVGkOkijI+gX25Q9sfAJclT0bovKBksP39G6v4hZnolpOU2txJ47MxxEg==",
+      "version": "8.4.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.11.tgz",
+      "integrity": "sha512-bif9yNZCoG1fFTGuIV4UblsJI95VSufl0RReXdr6f2yNbnqjSzgoDMB17WQlLrNOBrXa7r8N5aWBr5hBGhtGig==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "8.7.1",
-        "@graphql-tools/schema": "8.3.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/delegate": "8.7.2",
+        "@graphql-tools/schema": "8.3.7",
+        "@graphql-tools/utils": "8.6.6",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -1032,9 +912,9 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.28.tgz",
-      "integrity": "sha512-/nLMyVE5IC9PQdBtmgjpGZfK0wo8UupomAPx+7HlbEgVDkZOa9xCiZP9goo5aLYofP0gHXgovjXdXrE2obANag==",
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.33.tgz",
+      "integrity": "sha512-2IljikrWuhEroSlidX0i/TXjL01IIQUigWC/9tq7U3C/GoQQBqc02xNIVTqoZG6nPn/P9C9YMH78A4aTLUticQ==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -1621,9 +1501,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.4.tgz",
-      "integrity": "sha512-5r8tAzznI1zeh7k12+3z07KkgXPckQbnC9h4kJ2TBDWG2wb26TJTbVHQOiAncDBgPbtXtc1A2BlttiRuPH2t/w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.7.0.tgz",
+      "integrity": "sha512-8yYuvnyqIjlJ/WfebOyu2GSOQeFauRxnfuTveY9yvrDGs2g3kR9Nv4gu40AKvRHbXlSJwTbMJ6dVxAtEyKwVRA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -2514,9 +2394,9 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -2685,9 +2565,9 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -2857,26 +2737,15 @@
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.1.tgz",
-      "integrity": "sha512-63+lNWrwXmofjZVa7ML+n9CBviClF3K+RP3Xx3hxGQ8BrhvB1pWS1yzaUZqrkiiKdTu1v3mJGVfmooHwzlyPwQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.2.tgz",
+      "integrity": "sha512-5/el640oG/jfjQCjCRDdtIALyUib8YPONM2NSmckp2g1nOrPTAx/isz3Uptp9y5OI1UXXhONiKy5euTbgsGoXw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/code-file-loader": {
@@ -2893,53 +2762,31 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.1.tgz",
-      "integrity": "sha512-e98/NRaOH5wQy624bRd5i5qUKz5tCs8u4xBmxW89d7t6V6CveXj7pvAgmnR9DbwOkO6IA3P799p/aa/YG/pWTA==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.2.tgz",
+      "integrity": "sha512-SSmx5N6Cq23KRT0YepdmcYugey7MDZSXxtJ8KHHdc5eW9IAHXZWsJWdVnI9woU9omsnE6svnxblZb1UUBl7AUg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "8.4.1",
-        "@graphql-tools/schema": "8.3.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/batch-execute": "8.4.2",
+        "@graphql-tools/schema": "8.3.7",
+        "@graphql-tools/utils": "8.6.6",
         "dataloader": "2.0.0",
         "graphql-executor": "0.0.22",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.7.tgz",
-      "integrity": "sha512-fwXLycYvabPhusGtYuFrOPbjeIvLWr6viGkQc9KmiBm2Z2kZrlNRNUlYkXXRzMoiqRkzqFJYhOgWDE7LsOnbjw==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.8.tgz",
+      "integrity": "sha512-SpQZQ0klbox/kxYCLFBTmhLuQFm7P6usWVIqwROK4JSomwCuccc2zDsr1H7ayDpanD3yfkzMsl6gPkOkAo52pA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "6.6.9",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/import": "6.6.10",
+        "@graphql-tools/utils": "8.6.6",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
@@ -2956,126 +2803,71 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.6.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.9.tgz",
-      "integrity": "sha512-sKaLqvPmNLQlY4te+nnBhRrf5WBISoiyVkbriCLz0kHw805iHdJaU2KxUoHsRTR7WlYq0g9gzB0oVaRh99Q5aA==",
+      "version": "6.6.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.10.tgz",
+      "integrity": "sha512-yHdlEPTvIjrngtQFNgkMQJt/DjG3hQKvc6Mb8kaatFV4yERN5zx+0vpdrwxTwRNG1N7bI/YCkbrc7PXOb+g89Q==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.7.tgz",
-      "integrity": "sha512-dm0LcfiWYin7cUR4RWC33C9bNppujvSU7hwTH+sHmSguNnat9Kn8dBntVSgrY3qCbKuGfz/PshQHIODXrRwAKg==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.8.tgz",
+      "integrity": "sha512-W3nVLAp8m787A17wja7ysayij7WMRu+lF8LeCWr9eoyiCuw65i63y0G4eqZ5+Q0+E2BYWlKJyk/Z0vsFVJGMUA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/load": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.6.tgz",
-      "integrity": "sha512-IocEP4METGdbDzV44VaeiXO387NOYSW4cTuBP8qybHZX0XlIp8bEv7c8GKS3m8DeRop/9SnOL7HyiAfNMA4Chg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.7.tgz",
+      "integrity": "sha512-Z4oKf4MdBvl0EyubmvPL14ldhovKz8C61rQPHD8pjnC8Z0RbvW0a/sns/yuHuCVZoJMsSboU65DPzPTIoQUM4w==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "8.3.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/schema": "8.3.7",
+        "@graphql-tools/utils": "8.6.6",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
-      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.7.tgz",
+      "integrity": "sha512-rKxjNogqu1UYAG/y5FOb6lJsmSQbWA+jq4inWjNEVX54VGGE7/WGnmPaqcsyomNOfS3vIRS6NnG+DxiQSqetjg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/utils": "8.6.6",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.6.tgz",
-      "integrity": "sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==",
+      "version": "8.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.7.tgz",
+      "integrity": "sha512-7byr9J6rfMPFPfiR4u65dy20xHATTvbgOY7KYd1sYPnMKKfRZe0tUgpnE+noXcfob7N8s366WaVh7bEoztQMwg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "8.2.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/merge": "8.2.7",
+        "@graphql-tools/utils": "8.6.6",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.9.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.8.tgz",
-      "integrity": "sha512-nRMXwwoIDLt7ohBWvKKjEEH61YS1nnWs6BVgGStePfmRGrhxECpLWmfAmKLNXPqDJN7Nu6ykFJYjt65j5l6qsw==",
+      "version": "7.9.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.9.tgz",
+      "integrity": "sha512-qhjBJ3oCXZrzvJchVwtrahr48TXOHPYZ4YXklGrbJVoJs3LP0a7CYUwuXeiNuN+dpgaxkb175sIEN9m0FadGRw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "8.7.1",
-        "@graphql-tools/utils": "8.6.5",
-        "@graphql-tools/wrap": "8.4.10",
+        "@graphql-tools/delegate": "8.7.2",
+        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/wrap": "8.4.11",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
@@ -3091,17 +2883,6 @@
         "tslib": "^2.3.0",
         "value-or-promise": "^1.0.11",
         "ws": "^8.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/utils": {
@@ -3114,27 +2895,16 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.4.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.10.tgz",
-      "integrity": "sha512-1/pcKRDTGIUspUl6uhlfQ0u1l4j15TVGkOkijI+gX25Q9sfAJclT0bovKBksP39G6v4hZnolpOU2txJ47MxxEg==",
+      "version": "8.4.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.11.tgz",
+      "integrity": "sha512-bif9yNZCoG1fFTGuIV4UblsJI95VSufl0RReXdr6f2yNbnqjSzgoDMB17WQlLrNOBrXa7r8N5aWBr5hBGhtGig==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "8.7.1",
-        "@graphql-tools/schema": "8.3.6",
-        "@graphql-tools/utils": "8.6.5",
+        "@graphql-tools/delegate": "8.7.2",
+        "@graphql-tools/schema": "8.3.7",
+        "@graphql-tools/utils": "8.6.6",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
-          "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -3426,9 +3196,9 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.28.tgz",
-      "integrity": "sha512-/nLMyVE5IC9PQdBtmgjpGZfK0wo8UupomAPx+7HlbEgVDkZOa9xCiZP9goo5aLYofP0gHXgovjXdXrE2obANag==",
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.33.tgz",
+      "integrity": "sha512-2IljikrWuhEroSlidX0i/TXjL01IIQUigWC/9tq7U3C/GoQQBqc02xNIVTqoZG6nPn/P9C9YMH78A4aTLUticQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -3875,9 +3645,9 @@
       "requires": {}
     },
     "graphql-ws": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.4.tgz",
-      "integrity": "sha512-5r8tAzznI1zeh7k12+3z07KkgXPckQbnC9h4kJ2TBDWG2wb26TJTbVHQOiAncDBgPbtXtc1A2BlttiRuPH2t/w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.7.0.tgz",
+      "integrity": "sha512-8yYuvnyqIjlJ/WfebOyu2GSOQeFauRxnfuTveY9yvrDGs2g3kR9Nv4gu40AKvRHbXlSJwTbMJ6dVxAtEyKwVRA==",
       "dev": true,
       "requires": {}
     },
@@ -4488,9 +4258,9 @@
       "dev": true
     },
     "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "dev": true
     },
     "webidl-conversions": {

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.5.0-rc.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.0 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.5.0-rc.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.0' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.5.0-rc.1"
+PACKAGE_VERSION="v0.5.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.5.0-rc.1'
+$package_version = 'v0.5.0'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.5.0-rc.1",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
i did something wrong w/my last release pr and didn't notice until now. fixup #1078 

# [0.5.0] - 2022-04-11

> Important: X breaking changes below, indicated by **❗ BREAKING ❗**

## ❗ BREAKING ❗

- **`rover-fed2` has been deprecated - @EverlastingBugstopper, #1058**

  `rover fed2 supergraph compose` has been deprecated. You should instead set `federation_version: 2` in your `supergraph.yaml` to use Federation 2 with the `rover supergraph compose` command.

## 🚀 Features

- **`rover supergraph compose` optionally updates automatically - @EverlastingBugstopper, #1058 fixes #2046**

  When running `rover supergraph compose`, Rover will automatically download the correct version of composition to use. In your `supergraph.yaml` files, you can specify `federation_version: 1` or `federation_version: 2` to always get the latest updates. You can pass the `--skip-update` flag to skip checking for an update. You can also specify an exact version if you'd like to pin your federation version, like so: `federation_version: =2.0.0`.

  Additionally, you can run `rover install --plugin supergraph@latest-2` or `rover install --plugin supergraph@v2.0.0` to install a plugin ahead of time, which may be helpful in CI. For Federation 2, you'll have to accept the ELv2 license one time per machine. You likely want to set `APOLLO_ELV2_LICENSE=accept` in CI if you are using Federation 2.

- **Adds `--insecure-unmask-key` to `rover config whoami` - @EverlastingBugstopper, #1043 fixes #1023**

  Previously, running `rover config whoami` would output your entire API key to the terminal. This is not the documented behavior, and it is insecure because someone could be sharing their screen while trying to debug and accidentally leak their API key.

  Now, `rover config whoami` will mask your API key when it prints to the terminal. You can override this behavior by passing the `--insecure-unmask-key` flag.

- **Retry on timeouts and connection errors - @ptondereau, #1014 fixes #790**

  Rover will now automatically retry HTTP requests that fail due to timeouts or initial connection errors.

- **Define an HTTP agent for non-studio requests - @ptondereau, #1075 fixes #961**

  Rover now sends a User-Agent header along with all requests, not just requests to Apollo Studio.

- **Adds support for HTTP(S) proxies in npm installer - @farawaysouthwest, #1067 fixes #899**

  You can now install Rover from npm if you are behind a proxy.

## 🐛 Fixes

- **Fixed a dead link in ARCHITECTURE.md - @ptondereau, #1053**

## 🛠 Maintenance

- **Simplify `rover subgraph fetch` query - @EverlastingBugstopper, #1056 fixes #992**

  `rover subgraph fetch` now uses a much more efficient query that only requests a single subgraph at a time rather than all of them. Yay GraphQL!

- **Upgrades `apollo-encoder` - @bnjjj, #1017 fixes #1010**

## 📚 Documentation

- **Set up new docs infrastructure - @trevorblades, #1051, #1052**

  @trevorblades has done an awesome job setting up new docs for Apollo, including Rover! Check out the [shiny new repo](https://github.com/apollographql/docs).