### PR TITLE
feat: return hard error in CI for accepting elv2

### DIFF
--- a/installers/binstall/src/error.rs
+++ b/installers/binstall/src/error.rs
@@ -29,7 +29,11 @@ pub enum InstallerError {
     #[error(transparent)]
     PathNotUtf8(#[from] camino::FromPathBufError),
 
-    /// Attempted to install a plugin without first installing the main tool
-    #[error("You cannot install {} without first installing {}.", plugin, tool)]
-    PluginRequiresTool { plugin: String, tool: String },
+    /// Attempted to install a plugin that requires accepting ELv2
+    /// without passing a flag to accept the license
+    #[error(
+        "You cannot install this '{}' plugin without accepting the ELv2 license.",
+        plugin
+    )]
+    MustAcceptElv2 { plugin: String },
 }

--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -56,7 +56,7 @@ impl Installer {
         if requires_elv2_license && !accept_elv2_license {
             eprintln!("{} is licensed under the Elastic license, the full text can be found here: https://raw.githubusercontent.com/apollographql/rover/{}/plugins/{}/LICENSE", plugin_name, &version, plugin_name);
             eprintln!("By installing this plugin, you accept the terms and conditions outlined by this license.");
-            self.prompt_accept_elv2_license()?;
+            self.prompt_accept_elv2_license(plugin_name.to_string())?;
         }
         let bin_dir_path = self.get_bin_dir_path()?;
         if !bin_dir_path.exists() {
@@ -212,11 +212,13 @@ impl Installer {
         Ok(self.prompt_confirm()?)
     }
 
-    fn prompt_accept_elv2_license(&self) -> Result<bool, InstallerError> {
+    fn prompt_accept_elv2_license(&self, plugin_name: String) -> Result<bool, InstallerError> {
         // If we're not attached to a TTY then we can't get user input, so there's
         // nothing to do except inform the user about the `--elv2-license` flag.
         if !atty::is(Stream::Stdin) {
-            return Err(io::Error::from(io::ErrorKind::AlreadyExists).into());
+            return Err(InstallerError::MustAcceptElv2 {
+                plugin: plugin_name,
+            });
         }
 
         eprintln!("Do you accept the terms and conditions of the ELv2 license? [y/N]: ");


### PR DESCRIPTION
fixes #1081 in ci if you run `rover supergraph compose` for fed 2 you'll get this error instead of hanging forever:

```
error: You cannot install this 'supergraph' plugin without accepting the ELv2 license.
        Before running this command again, you need to either set `APOLLO_ELV2_LICENSE=accept` as an environment variable, or pass the `--elv2-license=accept` argument.
```

---

locally if you run the same thing without a tty attached (like with `nohup` you'll get this:

```
error: You cannot install this 'supergraph' plugin without accepting the ELv2 license.
        Before running this command again, you need to either set `APOLLO_ELV2_LICENSE=accept` as an environment variable, or pass the `--elv2-license=accept` argument. You will only need to do this once on this machine.
```

---

if you run locally _with_ TTY, the experience is the same

```
Do you accept the terms and conditions of the ELv2 license? [y/N]:
```