### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.5.1] - 2022-04-11
+
+## 🐛 Fixes
+
+- **Return a hard error in CI when the ELv2 license is not accepted instead of hanging for eternity - @EverlastingBugstopper, #1082 fixes #1081**
+
+  If you ran `rover supergraph compose` with `federation_version: 2` in CI - it would prompt you to accept the ELv2 license and hang waiting for the input for eternity. This is no longer the case and you will get a helpful error message detailing exactly what you need to do to never see the error again. For more details on the license, see our [FAQ](https://www.apollographql.com/docs/resources/elastic-license-v2-faq/).
+
+- **Removes extraneous debug statement - @EverlastingBugstopper, #1079**
+
+  In my rush this morning I missed the removal of an `eprintln` statement. It's gone now.
+
 # [0.5.0] - 2022-04-11
 
 > Important: X breaking changes below, indicated by **❗ BREAKING ❗**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
 
 [[package]]
 name = "httpdate"
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.5.0"
+version = "0.5.1"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 ## Command-line options
 
 ```console
-Rover 0.5.0
+Rover 0.5.1
 
 Rover - Your Graph Companion
 Read the getting started guide by running:
@@ -142,7 +142,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.5.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.1 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -160,7 +160,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.5.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.1' | iex
 ```
 
 #### npm installer

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.5.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.1 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.5.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.1' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.5.0"
+PACKAGE_VERSION="v0.5.1"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.5.0'
+$package_version = 'v0.5.1'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.5.1] - 2022-04-11

## 🐛 Fixes

- **Return a hard error in CI when the ELv2 license is not accepted instead of hanging for eternity - @EverlastingBugstopper, #1082 fixes #1081**

  If you ran `rover supergraph compose` with `federation_version: 2` in CI - it would prompt you to accept the ELv2 license and hang waiting for the input for eternity. This is no longer the case and you will get a helpful error message detailing exactly what you need to do to never see the error again. For more details on the license, see our [FAQ](https://www.apollographql.com/docs/resources/elastic-license-v2-faq/).

- **Removes extraneous debug statement - @EverlastingBugstopper, #1079**

  In my rush this morning I missed the removal of an `eprintln` statement. It's gone now.