### PR TITLE
chore: fixup rover-fed2

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -308,7 +308,8 @@ pub enum Command {
     /// Configuration profile commands
     Config(command::Config),
 
-    /// Federation 2 Alpha commands
+    /// (deprecated) Federation 2 Alpha commands
+    #[structopt(setting(structopt::clap::AppSettings::Hidden))]
     Fed2(command::Fed2),
 
     /// Supergraph schema commands

--- a/src/command/fed2/supergraph/compose.rs
+++ b/src/command/fed2/supergraph/compose.rs
@@ -23,7 +23,7 @@ impl Compose {
     pub fn run(&self, _client_config: StudioClientConfig) -> Result<RoverOutput> {
         let mut err = RoverError::new(anyhow!("This command has been deprecated."));
         err.set_suggestion(Suggestion::Adhoc(format!(
-            "Please set `federation_version = 2` in `{}` and run `rover supergraph compose`",
+            "Please set `federation_version: 2` in `{}` and run `rover supergraph compose`",
             &self.config_path
         )));
         Err(err)


### PR DESCRIPTION
fixes #1085 and makes the `fed2` subcommand hidden from rover's help page.