### PR TITLE
feat: adds federation version output to supergraph compose

### DIFF
--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -39,6 +39,7 @@ pub enum RoverOutput {
     CompositionResult {
         supergraph_sdl: String,
         hints: Vec<BuildHint>,
+        composition_version: Option<String>,
     },
     SubgraphList(SubgraphListResponse),
     CheckResponse(CheckResponse),
@@ -192,6 +193,7 @@ impl RoverOutput {
             RoverOutput::CompositionResult {
                 supergraph_sdl,
                 hints,
+                composition_version: _composition_version,
             } => {
                 let warn_prefix = Cyan.bold().paint("HINT:");
                 for hint in hints {
@@ -281,10 +283,21 @@ impl RoverOutput {
             RoverOutput::CompositionResult {
                 supergraph_sdl,
                 hints,
-            } => json!({
-              "core_schema": supergraph_sdl,
-              "hints": hints
-            }),
+                composition_version,
+            } => {
+                if let Some(composition_version) = composition_version {
+                    json!({
+                      "core_schema": supergraph_sdl,
+                      "hints": hints,
+                      "composition_version": composition_version
+                    })
+                } else {
+                    json!({
+                        "core_schema": supergraph_sdl,
+                        "hints": hints
+                    })
+                }
+            }
             RoverOutput::GraphPublishResponse {
                 graph_ref: _,
                 publish_response,

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -94,6 +94,14 @@ impl Compose {
         f.write_all(supergraph_config_yaml.as_bytes())?;
         f.sync_all()?;
         tracing::debug!("config file written to {}", &yaml_path);
+
+        let composition_version =
+            exe.as_str().split("supergraph-").collect::<Vec<&str>>()[1].to_string();
+        eprintln!(
+            "Composing supergraph with Federation {}.",
+            &composition_version
+        );
+
         let output = Command::new(&exe)
             .args(&["compose", &yaml_path.to_string()])
             .output()
@@ -106,6 +114,7 @@ impl Compose {
                 Ok(build_output) => Ok(RoverOutput::CompositionResult {
                     hints: build_output.hints,
                     supergraph_sdl: build_output.supergraph_sdl,
+                    composition_version: Some(composition_version),
                 }),
                 Err(build_errors) => Err(RoverError::from(RoverClientError::BuildErrors {
                     source: build_errors,


### PR DESCRIPTION
running `rover supergraph compose` prints out `Composing supergraph with Federation v2.0.1`, and also includes `composition_version` when running `rover supergraph compose` with the `--output json` argument