### PR TITLE
release: v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.5.2] - 2022-04-26
+
+## 🚀 Features
+
+- **Default `rover supergraph compose` to Federation 2 if a `@link` directive is found in a subgraph schema - @EverlastingBugstopper, #1097 fixes #1090**
+
+  When running `rover supergraph compose`, if `supergraph.yaml` refers to a subgraph that contains an `@link` directive and you haven't set the `federation_version` key, then Rover will use Federation 2 composition by default.
+
+- **Output Federation version information when running `rover supergraph compose` - @EverlastingBugstopper, #1102**
+
+  When running `rover supergraph compose`, Rover will print the Federation version number that it is using. You can access this version string programatically by running the command with the `--output json` argument and accessing the `federation_version` field.
+
+- **Accept `-` as valid `supergraph.yaml` to read config from stdin - @EverlastingBugstopper, #1092 fixes #525**
+
+  You can now run commands like `cat supergraph.yaml | rover supergraph compose --config -` much like you've always been able to do with the `--schema` argument in other Rover commands.
+
+## 🐛 Fixes
+
+- **Hides `rover-fed2` from `rover --help` - @EverlastingBugstopper, #1091 fixes #1085**
+
+## 🛠 Maintenance
+
+- **Address Rust 1.60.0 lints - @EverlastingBugstopper, #1098**
+
+- **Updates `binary-install` to v1.0.0 for the npm installer - @EverlastingBugstopper, #1099**
+
+## 📚 Documentation
+
+- **Fixes some broken Federation 2 links - @StephenBarlow, #1084**
+
+- **Documents dynamic composition versions - @EverlastingBugstopper, #1087**
+
 # [0.5.1] - 2022-04-11
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "apollo-encoder"
@@ -352,15 +352,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "ci_info"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b631946fd12bceaf43aa998a7902c5eeabff8f23cf294a186d5a23c4d79d1f0"
+checksum = "b764ddeb477baefbe1653d644585e522d35471030e4634b2cfff3ac2baef1274"
 dependencies = [
  "envmnt",
  "serde",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
  "bytes",
  "memchr",
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "envmnt"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f96dd862f12fac698dec3932dff0e6fb34bffeb5515ae5932d620cfe076571e"
+checksum = "9fbb2fcaad9e6c9e3388dfcc1b44ae5508ae864b7af36f163a8a7c1a48796eee"
 dependencies = [
  "fsio",
  "indexmap",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1177,7 +1177,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide 0.5.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "isahc"
@@ -1840,9 +1840,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libgit2-sys"
@@ -1954,16 +1954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd37b2e65fbd459544194d8f52ed84027e031684335a062c708774c09d172b0b"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -2081,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -2295,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -2625,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2870,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946fa04a8ac43ff78a1f4b811990afb9ddbdf5890b46d6dda0ba1998230138b7"
+checksum = "b827f2113224f3f19a665136f006709194bdfdcb1fdc1e4b2b5cbac8e0cced54"
 dependencies = [
  "rustversion",
  "serde",
@@ -3330,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3425,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
@@ -3438,7 +3428,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e793cd7300306ebefde30a6282a9016899b7bad63799511253d95518a62bcd"
 dependencies = [
- "combine 4.6.3",
+ "combine 4.6.4",
  "indexmap",
  "itertools",
 ]
@@ -3451,9 +3441,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
  "log",
@@ -3475,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3505,9 +3495,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -3554,9 +3544,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.5.1"
+version = "0.5.2"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.5.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.2 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -160,7 +160,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.5.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.2' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -320,26 +320,14 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-eslint/eslint-plugin/node_modules/@graphql-tools/utils": {
-      "version": "8.6.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
-      "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.2.tgz",
-      "integrity": "sha512-5/el640oG/jfjQCjCRDdtIALyUib8YPONM2NSmckp2g1nOrPTAx/isz3Uptp9y5OI1UXXhONiKy5euTbgsGoXw==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.6.tgz",
+      "integrity": "sha512-8O42fReZMssrA4HCkpK68RlRQz/QAvLfOkz+/6dDX2X7VgZtRx3VvFiJd2hFaGdNbLzklBWXF9E6hJdJGkEO5g==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.6.6",
-        "dataloader": "2.0.0",
+        "@graphql-tools/utils": "8.6.9",
+        "dataloader": "2.1.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -363,29 +351,17 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/utils": {
-      "version": "8.6.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
-      "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.2.tgz",
-      "integrity": "sha512-SSmx5N6Cq23KRT0YepdmcYugey7MDZSXxtJ8KHHdc5eW9IAHXZWsJWdVnI9woU9omsnE6svnxblZb1UUBl7AUg==",
+      "version": "8.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.7.tgz",
+      "integrity": "sha512-Yb9UHG+Upm0M+5FgtWipXM0/Q8Vuuh1Ieod7hFDmAwHGHbmwG0YpcS/NMdxrQAZYWnli9EdnSPgDAFnWLFN+ZQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/batch-execute": "8.4.2",
-        "@graphql-tools/schema": "8.3.7",
-        "@graphql-tools/utils": "8.6.6",
-        "dataloader": "2.0.0",
-        "graphql-executor": "0.0.22",
+        "@graphql-tools/batch-execute": "8.4.6",
+        "@graphql-tools/schema": "8.3.10",
+        "@graphql-tools/utils": "8.6.9",
+        "dataloader": "2.1.0",
+        "graphql-executor": "0.0.23",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -394,13 +370,13 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.8.tgz",
-      "integrity": "sha512-SpQZQ0klbox/kxYCLFBTmhLuQFm7P6usWVIqwROK4JSomwCuccc2zDsr1H7ayDpanD3yfkzMsl6gPkOkAo52pA==",
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.11.tgz",
+      "integrity": "sha512-3RMTfBN0VYSJH+5he9DxW8nGSn5p2+dNN2O2H88QSSwGorkONmKBdmf+9+JTzrEDvPObOzBjIuSD8wCnXlNaQA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/import": "6.6.10",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/import": "6.6.13",
+        "@graphql-tools/utils": "8.6.9",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
@@ -425,7 +401,105 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@graphql-tools/utils": {
+    "node_modules/@graphql-tools/import": {
+      "version": "6.6.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.13.tgz",
+      "integrity": "sha512-yqdCem+ZZFVAaIC2IxWyAXSEHLNPIuMzm4avTQe/LbYNRFRTpzyIYo3clc22ixeuh2LqSL3tLXKq2IsggCAeQw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "8.6.9",
+        "resolve-from": "5.0.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.11.tgz",
+      "integrity": "sha512-3in/1y+OVKP3eJ8aloxWD2HdZLcZChgHRk5j3ey3C+ANTwoedIgTWcwxro+iLH40IZ7a6z+I/Lb2dEc8xlgwug==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "8.6.9",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/load": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.10.tgz",
+      "integrity": "sha512-I9b9Md1DdB7Du//+x8CtBAKUW21jyuENCPssvlBjHZjvmx5cIGrTftqwGzuDBgR0Zm72tkmat/FTu6/SQPiyeQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "8.3.10",
+        "@graphql-tools/utils": "8.6.9",
+        "p-limit": "3.1.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge": {
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.10.tgz",
+      "integrity": "sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "8.6.9",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "8.3.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.10.tgz",
+      "integrity": "sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/merge": "8.2.10",
+        "@graphql-tools/utils": "8.6.9",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader": {
+      "version": "7.9.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.15.tgz",
+      "integrity": "sha512-WwYtsy4nEUYPOKgrCjhOdLNebnbLS4Rqv++TRlV3Pd4Zi+qVNsEQVwlfVEQZK4qelEhWNqessZILu/jx5B6Vng==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/delegate": "8.7.7",
+        "@graphql-tools/utils": "8.6.9",
+        "@graphql-tools/wrap": "8.4.16",
+        "@n1ru4l/graphql-live-query": "^0.9.0",
+        "@types/ws": "^8.0.0",
+        "cross-undici-fetch": "^0.3.0",
+        "dset": "^3.1.0",
+        "extract-files": "^11.0.0",
+        "graphql-ws": "^5.4.1",
+        "isomorphic-ws": "^4.0.1",
+        "meros": "^1.1.4",
+        "sync-fetch": "^0.3.1",
+        "tslib": "^2.3.0",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
       "version": "8.6.9",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
       "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
@@ -437,128 +511,15 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-tools/import": {
-      "version": "6.6.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.10.tgz",
-      "integrity": "sha512-yHdlEPTvIjrngtQFNgkMQJt/DjG3hQKvc6Mb8kaatFV4yERN5zx+0vpdrwxTwRNG1N7bI/YCkbrc7PXOb+g89Q==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "8.6.6",
-        "resolve-from": "5.0.0",
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.8.tgz",
-      "integrity": "sha512-W3nVLAp8m787A17wja7ysayij7WMRu+lF8LeCWr9eoyiCuw65i63y0G4eqZ5+Q0+E2BYWlKJyk/Z0vsFVJGMUA==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "8.6.6",
-        "globby": "^11.0.3",
-        "tslib": "~2.3.0",
-        "unixify": "^1.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/load": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.7.tgz",
-      "integrity": "sha512-Z4oKf4MdBvl0EyubmvPL14ldhovKz8C61rQPHD8pjnC8Z0RbvW0a/sns/yuHuCVZoJMsSboU65DPzPTIoQUM4w==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/schema": "8.3.7",
-        "@graphql-tools/utils": "8.6.6",
-        "p-limit": "3.1.0",
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/merge": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.7.tgz",
-      "integrity": "sha512-rKxjNogqu1UYAG/y5FOb6lJsmSQbWA+jq4inWjNEVX54VGGE7/WGnmPaqcsyomNOfS3vIRS6NnG+DxiQSqetjg==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "8.6.6",
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema": {
-      "version": "8.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.7.tgz",
-      "integrity": "sha512-7byr9J6rfMPFPfiR4u65dy20xHATTvbgOY7KYd1sYPnMKKfRZe0tUgpnE+noXcfob7N8s366WaVh7bEoztQMwg==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/merge": "8.2.7",
-        "@graphql-tools/utils": "8.6.6",
-        "tslib": "~2.3.0",
-        "value-or-promise": "1.0.11"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/url-loader": {
-      "version": "7.9.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.9.tgz",
-      "integrity": "sha512-qhjBJ3oCXZrzvJchVwtrahr48TXOHPYZ4YXklGrbJVoJs3LP0a7CYUwuXeiNuN+dpgaxkb175sIEN9m0FadGRw==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/delegate": "8.7.2",
-        "@graphql-tools/utils": "8.6.6",
-        "@graphql-tools/wrap": "8.4.11",
-        "@n1ru4l/graphql-live-query": "^0.9.0",
-        "@types/websocket": "^1.0.4",
-        "@types/ws": "^8.0.0",
-        "cross-undici-fetch": "^0.1.19",
-        "dset": "^3.1.0",
-        "extract-files": "^11.0.0",
-        "graphql-sse": "^1.0.1",
-        "graphql-ws": "^5.4.1",
-        "isomorphic-ws": "^4.0.1",
-        "meros": "^1.1.4",
-        "subscriptions-transport-ws": "^0.11.0",
-        "sync-fetch": "^0.3.1",
-        "tslib": "^2.3.0",
-        "value-or-promise": "^1.0.11",
-        "ws": "^8.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/utils": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.6.tgz",
-      "integrity": "sha512-wjY2ljKLCnnbRrDNPPgPNqCujou0LFSOWcxAjV6DYUlfFWTsAEvlYmsmY4T+K12wI/fnqoJ2bUwIlap1plFDMg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.4.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.11.tgz",
-      "integrity": "sha512-bif9yNZCoG1fFTGuIV4UblsJI95VSufl0RReXdr6f2yNbnqjSzgoDMB17WQlLrNOBrXa7r8N5aWBr5hBGhtGig==",
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.16.tgz",
+      "integrity": "sha512-b3yz7uN0en44sBEv/fAEQIqdiCEM/gQJSaLyA7Z2hWJwM0gQ5kiq0XMwKvyUAIY8NGig7IywC7bbup5Jc2F35Q==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "8.7.2",
-        "@graphql-tools/schema": "8.3.7",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/delegate": "8.7.7",
+        "@graphql-tools/schema": "8.3.10",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -637,9 +598,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "17.0.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.28.tgz",
+      "integrity": "sha512-UYmIeBnB0On70dN1iGCinsL1qH5JmIEJwa+3KX0Xw4HQJ8KA16ULlyTCNmnzfyzj/BlxZKmZLqp4TYdssnov1w==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -647,15 +608,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
-    },
-    "node_modules/@types/websocket": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
-      "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -679,9 +631,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -768,12 +720,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -948,9 +894,9 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.33.tgz",
-      "integrity": "sha512-2IljikrWuhEroSlidX0i/TXjL01IIQUigWC/9tq7U3C/GoQQBqc02xNIVTqoZG6nPn/P9C9YMH78A4aTLUticQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.3.0.tgz",
+      "integrity": "sha512-as3gHg3EJrc4QMS11/GdHtyY+m3LnIf8GrziHQRe/dGxSHqEP4RcONJ/3UVaPeA1j687aYvwzWMPWKgqsdXbtA==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -962,9 +908,9 @@
       }
     },
     "node_modules/dataloader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
-      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
       "dev": true
     },
     "node_modules/debug": {
@@ -1233,12 +1179,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
     },
     "node_modules/extract-files": {
       "version": "11.0.0",
@@ -1513,9 +1453,9 @@
       }
     },
     "node_modules/graphql-executor": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.22.tgz",
-      "integrity": "sha512-WbKSnSHFn6REKKH4T6UAwDM3mLUnYMQlQLNG0Fw+Lkb3ilCnL3m5lkJ7411LAI9sF7BvPbthovVZhsEUh9Xfag==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.23.tgz",
+      "integrity": "sha512-3Ivlyfjaw3BWmGtUSnMpP/a4dcXCp0mJtj0PiPG14OKUizaMKlSEX+LX2Qed0LrxwniIwvU6B4w/koVjEPyWJg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
@@ -1524,22 +1464,10 @@
         "graphql": "^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/graphql-sse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.1.0.tgz",
-      "integrity": "sha512-xE8AGPJa5X+g7iFmRQw/8H+7lXIDJvSkW6lou/XSSq17opPQl+dbKOMiqraHMx52VrDgS061ZVx90OSuqS6ykA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.11 <=16"
-      }
-    },
     "node_modules/graphql-ws": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.7.0.tgz",
-      "integrity": "sha512-8yYuvnyqIjlJ/WfebOyu2GSOQeFauRxnfuTveY9yvrDGs2g3kR9Nv4gu40AKvRHbXlSJwTbMJ6dVxAtEyKwVRA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.8.1.tgz",
+      "integrity": "sha512-UVf/fxlHultC1+12tX9ShTIipqQFNZ96g7N51RFQlk7MFPsDUUMCR3QXVEzHEd5xlTp16rs5vCyfBljvcPN3fA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1686,12 +1614,6 @@
       "peerDependencies": {
         "ws": "*"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2209,44 +2131,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
-      "dev": true,
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2257,15 +2141,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sync-fetch": {
@@ -2770,27 +2645,16 @@
         "graphql-config": "^4.3.0",
         "graphql-depth-limit": "^1.1.0",
         "lodash.lowercase": "^4.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.9",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
-          "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.2.tgz",
-      "integrity": "sha512-5/el640oG/jfjQCjCRDdtIALyUib8YPONM2NSmckp2g1nOrPTAx/isz3Uptp9y5OI1UXXhONiKy5euTbgsGoXw==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.4.6.tgz",
+      "integrity": "sha512-8O42fReZMssrA4HCkpK68RlRQz/QAvLfOkz+/6dDX2X7VgZtRx3VvFiJd2hFaGdNbLzklBWXF9E6hJdJGkEO5g==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.6",
-        "dataloader": "2.0.0",
+        "@graphql-tools/utils": "8.6.9",
+        "dataloader": "2.1.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       }
@@ -2806,42 +2670,31 @@
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.9",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
-          "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.2.tgz",
-      "integrity": "sha512-SSmx5N6Cq23KRT0YepdmcYugey7MDZSXxtJ8KHHdc5eW9IAHXZWsJWdVnI9woU9omsnE6svnxblZb1UUBl7AUg==",
+      "version": "8.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.7.7.tgz",
+      "integrity": "sha512-Yb9UHG+Upm0M+5FgtWipXM0/Q8Vuuh1Ieod7hFDmAwHGHbmwG0YpcS/NMdxrQAZYWnli9EdnSPgDAFnWLFN+ZQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "8.4.2",
-        "@graphql-tools/schema": "8.3.7",
-        "@graphql-tools/utils": "8.6.6",
-        "dataloader": "2.0.0",
-        "graphql-executor": "0.0.22",
+        "@graphql-tools/batch-execute": "8.4.6",
+        "@graphql-tools/schema": "8.3.10",
+        "@graphql-tools/utils": "8.6.9",
+        "dataloader": "2.1.0",
+        "graphql-executor": "0.0.23",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.8.tgz",
-      "integrity": "sha512-SpQZQ0klbox/kxYCLFBTmhLuQFm7P6usWVIqwROK4JSomwCuccc2zDsr1H7ayDpanD3yfkzMsl6gPkOkAo52pA==",
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.11.tgz",
+      "integrity": "sha512-3RMTfBN0VYSJH+5he9DxW8nGSn5p2+dNN2O2H88QSSwGorkONmKBdmf+9+JTzrEDvPObOzBjIuSD8wCnXlNaQA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "6.6.10",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/import": "6.6.13",
+        "@graphql-tools/utils": "8.6.9",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
@@ -2858,96 +2711,82 @@
         "@babel/types": "^7.16.8",
         "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.6.9",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
-          "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/import": {
-      "version": "6.6.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.10.tgz",
-      "integrity": "sha512-yHdlEPTvIjrngtQFNgkMQJt/DjG3hQKvc6Mb8kaatFV4yERN5zx+0vpdrwxTwRNG1N7bI/YCkbrc7PXOb+g89Q==",
+      "version": "6.6.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.13.tgz",
+      "integrity": "sha512-yqdCem+ZZFVAaIC2IxWyAXSEHLNPIuMzm4avTQe/LbYNRFRTpzyIYo3clc22ixeuh2LqSL3tLXKq2IsggCAeQw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/utils": "8.6.9",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.8.tgz",
-      "integrity": "sha512-W3nVLAp8m787A17wja7ysayij7WMRu+lF8LeCWr9eoyiCuw65i63y0G4eqZ5+Q0+E2BYWlKJyk/Z0vsFVJGMUA==",
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.3.11.tgz",
+      "integrity": "sha512-3in/1y+OVKP3eJ8aloxWD2HdZLcZChgHRk5j3ey3C+ANTwoedIgTWcwxro+iLH40IZ7a6z+I/Lb2dEc8xlgwug==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/utils": "8.6.9",
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/load": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.7.tgz",
-      "integrity": "sha512-Z4oKf4MdBvl0EyubmvPL14ldhovKz8C61rQPHD8pjnC8Z0RbvW0a/sns/yuHuCVZoJMsSboU65DPzPTIoQUM4w==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.10.tgz",
+      "integrity": "sha512-I9b9Md1DdB7Du//+x8CtBAKUW21jyuENCPssvlBjHZjvmx5cIGrTftqwGzuDBgR0Zm72tkmat/FTu6/SQPiyeQ==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "8.3.7",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/schema": "8.3.10",
+        "@graphql-tools/utils": "8.6.9",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.7.tgz",
-      "integrity": "sha512-rKxjNogqu1UYAG/y5FOb6lJsmSQbWA+jq4inWjNEVX54VGGE7/WGnmPaqcsyomNOfS3vIRS6NnG+DxiQSqetjg==",
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.10.tgz",
+      "integrity": "sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.7.tgz",
-      "integrity": "sha512-7byr9J6rfMPFPfiR4u65dy20xHATTvbgOY7KYd1sYPnMKKfRZe0tUgpnE+noXcfob7N8s366WaVh7bEoztQMwg==",
+      "version": "8.3.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.10.tgz",
+      "integrity": "sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "8.2.7",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/merge": "8.2.10",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.9.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.9.tgz",
-      "integrity": "sha512-qhjBJ3oCXZrzvJchVwtrahr48TXOHPYZ4YXklGrbJVoJs3LP0a7CYUwuXeiNuN+dpgaxkb175sIEN9m0FadGRw==",
+      "version": "7.9.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.9.15.tgz",
+      "integrity": "sha512-WwYtsy4nEUYPOKgrCjhOdLNebnbLS4Rqv++TRlV3Pd4Zi+qVNsEQVwlfVEQZK4qelEhWNqessZILu/jx5B6Vng==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "8.7.2",
-        "@graphql-tools/utils": "8.6.6",
-        "@graphql-tools/wrap": "8.4.11",
+        "@graphql-tools/delegate": "8.7.7",
+        "@graphql-tools/utils": "8.6.9",
+        "@graphql-tools/wrap": "8.4.16",
         "@n1ru4l/graphql-live-query": "^0.9.0",
-        "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
-        "cross-undici-fetch": "^0.1.19",
+        "cross-undici-fetch": "^0.3.0",
         "dset": "^3.1.0",
         "extract-files": "^11.0.0",
-        "graphql-sse": "^1.0.1",
         "graphql-ws": "^5.4.1",
         "isomorphic-ws": "^4.0.1",
         "meros": "^1.1.4",
-        "subscriptions-transport-ws": "^0.11.0",
         "sync-fetch": "^0.3.1",
         "tslib": "^2.3.0",
         "value-or-promise": "^1.0.11",
@@ -2955,23 +2794,23 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.6.tgz",
-      "integrity": "sha512-wjY2ljKLCnnbRrDNPPgPNqCujou0LFSOWcxAjV6DYUlfFWTsAEvlYmsmY4T+K12wI/fnqoJ2bUwIlap1plFDMg==",
+      "version": "8.6.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
+      "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
       "dev": true,
       "requires": {
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.4.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.11.tgz",
-      "integrity": "sha512-bif9yNZCoG1fFTGuIV4UblsJI95VSufl0RReXdr6f2yNbnqjSzgoDMB17WQlLrNOBrXa7r8N5aWBr5hBGhtGig==",
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.4.16.tgz",
+      "integrity": "sha512-b3yz7uN0en44sBEv/fAEQIqdiCEM/gQJSaLyA7Z2hWJwM0gQ5kiq0XMwKvyUAIY8NGig7IywC7bbup5Jc2F35Q==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "8.7.2",
-        "@graphql-tools/schema": "8.3.7",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/delegate": "8.7.7",
+        "@graphql-tools/schema": "8.3.10",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       }
@@ -3033,9 +2872,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "17.0.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.28.tgz",
+      "integrity": "sha512-UYmIeBnB0On70dN1iGCinsL1qH5JmIEJwa+3KX0Xw4HQJ8KA16ULlyTCNmnzfyzj/BlxZKmZLqp4TYdssnov1w==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3043,15 +2882,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
-    },
-    "@types/websocket": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
-      "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -3072,9 +2902,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -3133,12 +2963,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
@@ -3265,9 +3089,9 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.33.tgz",
-      "integrity": "sha512-2IljikrWuhEroSlidX0i/TXjL01IIQUigWC/9tq7U3C/GoQQBqc02xNIVTqoZG6nPn/P9C9YMH78A4aTLUticQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.3.0.tgz",
+      "integrity": "sha512-as3gHg3EJrc4QMS11/GdHtyY+m3LnIf8GrziHQRe/dGxSHqEP4RcONJ/3UVaPeA1j687aYvwzWMPWKgqsdXbtA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -3279,9 +3103,9 @@
       }
     },
     "dataloader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
-      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
       "dev": true
     },
     "debug": {
@@ -3476,12 +3300,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
     },
     "extract-files": {
@@ -3700,23 +3518,16 @@
       }
     },
     "graphql-executor": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.22.tgz",
-      "integrity": "sha512-WbKSnSHFn6REKKH4T6UAwDM3mLUnYMQlQLNG0Fw+Lkb3ilCnL3m5lkJ7411LAI9sF7BvPbthovVZhsEUh9Xfag==",
-      "dev": true,
-      "requires": {}
-    },
-    "graphql-sse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/graphql-sse/-/graphql-sse-1.1.0.tgz",
-      "integrity": "sha512-xE8AGPJa5X+g7iFmRQw/8H+7lXIDJvSkW6lou/XSSq17opPQl+dbKOMiqraHMx52VrDgS061ZVx90OSuqS6ykA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/graphql-executor/-/graphql-executor-0.0.23.tgz",
+      "integrity": "sha512-3Ivlyfjaw3BWmGtUSnMpP/a4dcXCp0mJtj0PiPG14OKUizaMKlSEX+LX2Qed0LrxwniIwvU6B4w/koVjEPyWJg==",
       "dev": true,
       "requires": {}
     },
     "graphql-ws": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.7.0.tgz",
-      "integrity": "sha512-8yYuvnyqIjlJ/WfebOyu2GSOQeFauRxnfuTveY9yvrDGs2g3kR9Nv4gu40AKvRHbXlSJwTbMJ6dVxAtEyKwVRA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.8.1.tgz",
+      "integrity": "sha512-UVf/fxlHultC1+12tX9ShTIipqQFNZ96g7N51RFQlk7MFPsDUUMCR3QXVEzHEd5xlTp16rs5vCyfBljvcPN3fA==",
       "dev": true,
       "requires": {}
     },
@@ -3817,12 +3628,6 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "dev": true,
       "requires": {}
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4174,28 +3979,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "dev": true,
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4204,12 +3987,6 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
     },
     "sync-fetch": {
       "version": "0.3.1",

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.5.1 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.5.2 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.5.1' | iex
+iwr 'https://rover.apollo.dev/win/v0.5.2' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.5.1"
+PACKAGE_VERSION="v0.5.2"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.5.1'
+$package_version = 'v0.5.2'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -32,9 +32,12 @@
       }
     },
     "node_modules/axios-proxy-builder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/axios-proxy-builder/-/axios-proxy-builder-0.1.1.tgz",
-      "integrity": "sha512-WzrnBYjFeMpGz3XReCXenl2uSiVYmDnH1Aq+jRT2toWFMacqn0itOu2ZHNhsIX2tpGe+AMx5DQ5iIgEcZRT/sA=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/axios-proxy-builder/-/axios-proxy-builder-0.1.2.tgz",
+      "integrity": "sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -295,6 +298,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -325,9 +336,12 @@
       }
     },
     "axios-proxy-builder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/axios-proxy-builder/-/axios-proxy-builder-0.1.1.tgz",
-      "integrity": "sha512-WzrnBYjFeMpGz3XReCXenl2uSiVYmDnH1Aq+jRT2toWFMacqn0itOu2ZHNhsIX2tpGe+AMx5DQ5iIgEcZRT/sA=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/axios-proxy-builder/-/axios-proxy-builder-0.1.2.tgz",
+      "integrity": "sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==",
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -513,6 +527,11 @@
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       }
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# [0.5.2] - 2022-04-26

## 🚀 Features

- **Default `rover supergraph compose` to Federation 2 if a `@link` directive is found in a subgraph schema - @EverlastingBugstopper, #1097 fixes #1090**

  When running `rover supergraph compose`, if `supergraph.yaml` refers to a subgraph that contains an `@link` directive and you haven't set the `federation_version` key, then Rover will use Federation 2 composition by default.

- **Output Federation version information when running `rover supergraph compose` - @EverlastingBugstopper, #1102**

  When running `rover supergraph compose`, Rover will print the Federation version number that it is using. You can access this version string programatically by running the command with the `--output json` argument and accessing the `federation_version` field.

- **Accept `-` as valid `supergraph.yaml` to read config from stdin - @EverlastingBugstopper, #1092 fixes #525**

  You can now run commands like `cat supergraph.yaml | rover supergraph compose --config -` much like you've always been able to do with the `--schema` argument in other Rover commands.

## 🐛 Fixes

- **Hides `rover-fed2` from `rover --help` - @EverlastingBugstopper, #1091 fixes #1085**

## 🛠 Maintenance

- **Address Rust 1.60.0 lints - @EverlastingBugstopper, #1098**

- **Updates `binary-install` to v1.0.0 for the npm installer - @EverlastingBugstopper, #1099**

## 📚 Documentation

- **Fixes some broken Federation 2 links - @StephenBarlow, #1084**

- **Documents dynamic composition versions - @EverlastingBugstopper, #1087**