### PR TITLE
chore: fixup npm installer

### DIFF
--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -2,7 +2,6 @@ const { Binary } = require("binary-install");
 const os = require("os");
 const cTable = require("console.table");
 const libc = require("detect-libc");
-const { join } = require("path");
 const { configureProxy } = require("axios-proxy-builder");
 
 const error = (msg) => {
@@ -116,7 +115,13 @@ const install = () => {
   );
 };
 
+const run = () => {
+  const binary = getBinary();
+  binary.run();
+};
+
 module.exports = {
   install,
+  run,
   getBinary,
 };

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -3,6 +3,9 @@
   "version": "0.5.2",
   "description": "The new Apollo CLI",
   "main": "index.js",
+  "bin": {
+    "rover": "run.js"
+  },
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE .",
     "postinstall": "node ./install.js",

--- a/installers/npm/run.js
+++ b/installers/npm/run.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const { run } = require("./binary");
+run();


### PR DESCRIPTION
i erroneously thought that I could remove the `run.js` and `binary` portion of rover's `package.json` but unfortunately this broke installs. adding it back.