### PR TITLE
feat: adds `cargo xtask docs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # .env to store APOLLO_KEY for VS Code
 .env
+
+# Local dev-docs folder
+/dev-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,11 @@ To run the tests that are run in CI:
 cargo xtask test
 ```
 
+To spin up a local development server for Rover's docset:
+```bash
+cargo xtask docs
+```
+
 [Apollo GraphQL]: https://www.apollographql.com
 [Rust]: https://www.rust-lang.org/
 [`cargo`]: https://doc.rust-lang.org/cargo/index.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3899,6 +3899,7 @@ dependencies = [
  "semver",
  "serde_json",
  "serde_json_traversal",
+ "serde_yaml",
  "structopt",
  "tar",
  "tempfile",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 semver = "1"
 serde_json = "1"
 serde_json_traversal = "0.2"
+serde_yaml = "0.8"
 structopt = { version = "0.3", default-features = false }
 tar = "0.4"
 tempfile = "3.3"

--- a/xtask/src/commands/docs.rs
+++ b/xtask/src/commands/docs.rs
@@ -1,0 +1,44 @@
+use std::{collections::BTreeMap, fs};
+
+use anyhow::Result;
+use structopt::StructOpt;
+
+use crate::tools::{GitRunner, NpmRunner};
+
+use camino::Utf8PathBuf;
+
+#[derive(Debug, StructOpt)]
+pub struct Docs {
+    #[structopt(long, short, default_value = "./dev-docs")]
+    path: Utf8PathBuf,
+
+    // The monodocs branch to check out
+    #[structopt(long, short, default_value = "main")]
+    pub(crate) branch: String,
+
+    // The monodocs org to clone
+    #[structopt(long, short, default_value = "apollographql")]
+    pub(crate) org: String,
+}
+
+impl Docs {
+    pub fn run(&self, verbose: bool) -> Result<()> {
+        let git_runner = GitRunner::new(verbose, &self.path)?;
+        let docs = git_runner.clone_docs(&self.org, &self.branch)?;
+        let local_sources_yaml_path = docs.join("sources").join("local.yml");
+        let local_sources_yaml = fs::read_to_string(&local_sources_yaml_path)?;
+        let mut local_sources: BTreeMap<String, Utf8PathBuf> =
+            serde_yaml::from_str(&local_sources_yaml)?;
+        local_sources.insert(
+            "rover".to_string(),
+            crate::utils::PKG_PROJECT_ROOT.join("docs").join("source"),
+        );
+        fs::write(
+            &local_sources_yaml_path,
+            serde_yaml::to_string(&local_sources)?,
+        )?;
+        let npm_runner = NpmRunner::new(true)?;
+        npm_runner.dev_docs(&self.path)?;
+        Ok(())
+    }
+}

--- a/xtask/src/commands/integration_test.rs
+++ b/xtask/src/commands/integration_test.rs
@@ -24,7 +24,7 @@ impl IntegrationTest {
     pub fn run(&self, verbose: bool) -> Result<()> {
         let release = false;
         let cargo_runner = CargoRunner::new(verbose)?;
-        let git_runner = GitRunner::new(verbose)?;
+        let git_runner = GitRunner::tmp(verbose)?;
 
         if let Target::GnuLinux = self.target {
             let binary_paths = cargo_runner.build(&self.target, release, None)?;

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod dist;
+pub(crate) mod docs;
 pub(crate) mod integration_test;
 pub(crate) mod lint;
 pub(crate) mod package;
@@ -8,6 +9,7 @@ pub(crate) mod unit_test;
 pub(crate) mod version;
 
 pub(crate) use dist::Dist;
+pub(crate) use docs::Docs;
 pub(crate) use integration_test::IntegrationTest;
 pub(crate) use lint::Lint;
 pub(crate) use package::Package;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -29,6 +29,9 @@ struct Xtask {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
+    /// Spin up a local development server for editing documentation
+    Docs(commands::Docs),
+
     /// Build Rover's binaries for distribution
     Dist(commands::Dist),
 
@@ -54,6 +57,7 @@ pub enum Command {
 impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
+            Command::Docs(command) => command.run(self.verbose),
             Command::Dist(command) => command.run(self.verbose),
             Command::Lint(command) => command.run(self.verbose),
             Command::UnitTest(command) => command.run(self.verbose),

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -33,7 +33,7 @@ impl CargoRunner {
         version: Option<&RoverVersion>,
     ) -> Result<HashMap<String, Utf8PathBuf>> {
         if let Some(version) = version {
-            let git_runner = GitRunner::new(self.runner.verbose)?;
+            let git_runner = GitRunner::tmp(self.runner.verbose)?;
             let repo_path = git_runner.checkout_rover_version(version.to_string().as_str())?;
             let versioned_schema_url = format!(
                     "https://github.com/apollographql/rover/releases/download/{0}/rover-{0}-schema.graphql",

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fs};
 
 use crate::tools::Runner;
 
@@ -7,15 +7,35 @@ use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 
 pub(crate) struct GitRunner {
-    temp_dir_path: Utf8PathBuf,
     runner: Runner,
 
     // we store _temp_dir here since its Drop implementation deletes the directory
-    _temp_dir: TempDir,
+    repo: RepoLocation,
+}
+
+enum RepoLocation {
+    Local(LocalRepo),
+    Tmp(TmpRepo),
+}
+
+struct LocalRepo {
+    path: Utf8PathBuf,
+}
+
+struct TmpRepo {
+    path: Utf8PathBuf,
+    _handle: TempDir,
 }
 
 impl GitRunner {
-    pub(crate) fn new(verbose: bool) -> Result<Self> {
+    pub(crate) fn new(verbose: bool, path: &Utf8PathBuf) -> Result<Self> {
+        let runner = Runner::new("git", verbose)?;
+        Ok(GitRunner {
+            runner,
+            repo: RepoLocation::Local(LocalRepo { path: path.clone() }),
+        })
+    }
+    pub(crate) fn tmp(verbose: bool) -> Result<Self> {
         let runner = Runner::new("git", verbose)?;
         let temp_dir = TempDir::new().with_context(|| "Could not create temp directory")?;
         let temp_dir_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())
@@ -23,31 +43,57 @@ impl GitRunner {
 
         Ok(GitRunner {
             runner,
-            temp_dir_path,
-            _temp_dir: temp_dir,
+            repo: RepoLocation::Tmp(TmpRepo {
+                path: temp_dir_path,
+                _handle: temp_dir,
+            }),
         })
     }
 
-    pub(crate) fn clone_supergraph_demo(&self, org: &str, branch: &str) -> Result<Utf8PathBuf> {
-        let repo_name = "supergraph-demo";
-        let repo_url = format!("https://github.com/{}/{}", org, repo_name);
+    fn get_path(&self) -> Result<Utf8PathBuf> {
+        let path = match &self.repo {
+            RepoLocation::Local(local) => local.path.clone(),
+            RepoLocation::Tmp(tmp) => tmp.path.clone(),
+        };
+
+        if fs::metadata(&path).is_err() {
+            fs::create_dir_all(&path)?;
+        }
+        Ok(path)
+    }
+
+    fn clone(&self, org: &str, name: &str, branch: &str) -> Result<Utf8PathBuf> {
+        let url = format!("https://github.com/{}/{}", org, name);
+        let path = self.get_path()?;
+        if let RepoLocation::Local(local) = &self.repo {
+            if fs::metadata(&local.path.join(".git")).is_ok() {
+                self.runner
+                    .exec(&["reset", "--hard", "HEAD"], &path, None)?;
+                self.runner.exec(&["checkout", branch], &path, None)?;
+                self.runner.exec(&["pull"], &path, None)?;
+                return Ok(local.path.clone());
+            }
+        }
+
         self.runner.exec(
-            &["clone", &repo_url, "--branch", branch],
-            &self.temp_dir_path,
+            &["clone", &url, "--branch", branch, &path.to_string()],
+            &crate::utils::PKG_PROJECT_ROOT,
             None,
         )?;
 
-        let repo_path = self.temp_dir_path.join(repo_name);
-        Ok(repo_path)
+        Ok(path)
+    }
+
+    pub(crate) fn clone_supergraph_demo(&self, org: &str, branch: &str) -> Result<Utf8PathBuf> {
+        self.clone(org, "supergraph-demo", branch)
+    }
+
+    pub(crate) fn clone_docs(&self, org: &str, branch: &str) -> Result<Utf8PathBuf> {
+        self.clone(org, "docs", branch)
     }
 
     pub(crate) fn checkout_rover_version(&self, rover_version: &str) -> Result<Utf8PathBuf> {
-        let repo_name = "rover";
-        let repo_url = format!("https://github.com/apollographql/{}", repo_name);
-        self.runner
-            .exec(&["clone", &repo_url], &self.temp_dir_path, None)?;
-
-        let repo_path = self.temp_dir_path.join(repo_name);
+        let repo_path = self.clone("apollographql", "rover", "main")?;
 
         self.runner.exec(
             &["checkout", &format!("tags/{}", rover_version)],

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -64,6 +64,16 @@ impl NpmRunner {
         Ok(())
     }
 
+    pub(crate) fn dev_docs(&self, dir: &Utf8PathBuf) -> Result<()> {
+        self.require_volta()?;
+        if fs::metadata(dir.join("node_modules")).is_err() {
+            self.npm_exec(&["i"], dir)?;
+        }
+        crate::info!("serving './docs' at http://localhost:8000/rover");
+        self.npm_exec(&["run", "start:local"], dir)?;
+        Ok(())
+    }
+
     pub(crate) fn update_linter(&self) -> Result<()> {
         self.npm_exec(&["update"], &self.rover_client_lint_directory)?;
         Ok(())


### PR DESCRIPTION
you can now run `cargo xtask docs` to spin up a local netlify server with your local docset. it does so by cloning `https://github.com/apollographql/docs` to `./dev-docs` (which is in `.gitignore`), and modifying `./sources/local.yml` to point the `rover` local source to `./docs/source`. It then runs `npm i` if `node_modules` does not exist, and `npm run start:local`. You can then navigate to `http://localhost:8000/rover` in your browser and changes you make to `./docs/source/**.md` files will be updated automatically on save.