### PR TITLE
chore: DRY up reused CLI options

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,18 +191,12 @@ All commands under the `graph` namespace accept a required, positional argument 
 To add these to our new `graph hello` command, we can copy and paste the field from any other `graph` command like so:
 
 ```rust
+use crate::options::GraphOpts;
+
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Hello {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to publish to.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF"))]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
-
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    opts: GraphOpts
 }
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,12 +191,15 @@ All commands under the `graph` namespace accept a required, positional argument 
 To add these to our new `graph hello` command, we can copy and paste the field from any other `graph` command like so:
 
 ```rust
-use crate::options::GraphOpts;
+use crate::options::{ProfileOpt, GraphRefOpt};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Hello {
     #[structopt(flatten)]
-    opts: GraphOpts
+    graph: GraphRefOpt,
+
+    #[structop(flatten)]
+    profile: ProfileOpt,
 }
 ```
 
@@ -222,7 +225,7 @@ To access functionality from `rover-client` in our `rover graph hello` command, 
 
 You can do this by changing the `Command::Hello(command) => command.run(),` line to `Command::Hello(command) => command.run(client_config),`.
 
-Then you'll need to change `Hello::run` to accept a `client_config: StudioClientConfig` parameter in `src/command/graph/hello.rs`, and add `use crate::utils::client::StudioClientConfig` and `use rover_client::shared::GraphRef` import statements. Then, at the top of the run function, you can create a `StudioClient` by adding `let client = client_config.get_authenticated_client(&self.profile_name)?;`. You can see examples of this in the other commands.
+Then you'll need to change `Hello::run` to accept a `client_config: StudioClientConfig` parameter in `src/command/graph/hello.rs`, and add `use crate::utils::client::StudioClientConfig` and `use rover_client::shared::GraphRef` import statements. Then, at the top of the run function, you can create a `StudioClient` by adding `let client = client_config.get_authenticated_client(&self.profile.name)?;`. You can see examples of this in the other commands.
 
 ##### Auto-generated help command
 
@@ -351,16 +354,16 @@ It should look something like this (you should make sure you are following the s
 
 ```rust
 pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-    let client = client_config.get_client(&self.profile_name)?;
-    let graph_ref = self.graph.to_string();
+    let client = client_config.get_client(&self.profile.name)?;
+    let graph_ref = self.graph.graph_ref.to_string();
     eprintln!(
         "Checking deletion of graph {} using credentials from the {} profile.",
         Cyan.normal().paint(&graph_ref),
-        Yellow.normal().paint(&self.profile_name)
+        Yellow.normal().paint(&self.profile.name)
     );
     let deleted_at = hello::run(
         hello::graph_hello::Variables {
-            graph_id: self.graph.name.clone(),
+            graph_id: self.graph.graph_ref.clone(),
         },
         &client,
     )?;

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -6,7 +6,7 @@ use crate::shared::GraphRef;
 use crate::RoverClientError;
 
 use prettytable::format::consts::FORMAT_BOX_CHARS;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use prettytable::{cell, row, Table};
 use serde_json::{json, Value};
@@ -162,7 +162,7 @@ pub struct CheckConfig {
     pub validation_period: Option<ValidationPeriod>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct ValidationPeriod {
     pub from: Period,
     pub to: Period,
@@ -187,7 +187,7 @@ impl FromStr for ValidationPeriod {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Period {
     Now,
     Past(i64),

--- a/crates/rover-client/src/shared/graph_ref.rs
+++ b/crates/rover-client/src/shared/graph_ref.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 use crate::RoverClientError;
 
 use regex::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct GraphRef {
     pub name: String,
     pub variant: String,

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -6,7 +6,7 @@ use config::Profile;
 use houston as config;
 
 use crate::command::RoverOutput;
-use crate::{anyhow, Result};
+use crate::{anyhow, options::ProfileOpt, Result};
 
 #[derive(Debug, Serialize, StructOpt)]
 /// Authenticate a configuration profile with an API key
@@ -20,16 +20,15 @@ use crate::{anyhow, Result};
 ///
 /// Run `rover docs open api-keys` for more details on Apollo's API keys.
 pub struct Auth {
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 }
 
 impl Auth {
     pub fn run(&self, config: config::Config) -> Result<RoverOutput> {
         let api_key = api_key_prompt()?;
-        Profile::set_api_key(&self.profile_name, &config, &api_key)?;
-        Profile::get_credential(&self.profile_name, &config).map(|_| {
+        Profile::set_api_key(&self.profile.profile_name, &config, &api_key)?;
+        Profile::get_credential(&self.profile.profile_name, &config).map(|_| {
             eprintln!("Successfully saved API key.");
         })?;
         Ok(RoverOutput::EmptySuccess)

--- a/src/command/fed2/supergraph/compose.rs
+++ b/src/command/fed2/supergraph/compose.rs
@@ -1,9 +1,12 @@
-use crate::utils::{
-    client::StudioClientConfig,
-    parsers::{parse_file_descriptor, FileDescriptorType},
-};
 use crate::Suggestion;
 use crate::{anyhow, command::RoverOutput, error::RoverError, Result};
+use crate::{
+    options::ProfileOpt,
+    utils::{
+        client::StudioClientConfig,
+        parsers::{parse_file_descriptor, FileDescriptorType},
+    },
+};
 
 use serde::Serialize;
 use structopt::StructOpt;
@@ -15,10 +18,9 @@ pub struct Compose {
     #[serde(skip_serializing)]
     supergraph_yaml: FileDescriptorType,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    _profile_name: String,
+    #[structopt(flatten)]
+    #[allow(unused)]
+    profile: ProfileOpt,
 }
 
 impl Compose {

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -2,9 +2,10 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::graph::check::{self, GraphCheckInput};
-use rover_client::shared::{CheckConfig, GitContext, GraphRef, ValidationPeriod};
+use rover_client::shared::{CheckConfig, GitContext, ValidationPeriod};
 
 use crate::command::RoverOutput;
+use crate::options::GraphRefOpt;
 use crate::utils::client::StudioClientConfig;
 use crate::utils::parsers::{
     parse_file_descriptor, parse_query_count_threshold, parse_query_percentage_threshold,
@@ -14,11 +15,8 @@ use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Check {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to validate.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
     /// Name of configuration profile to use
     #[structopt(long = "profile", default_value = "default")]
@@ -59,12 +57,12 @@ impl Check {
 
         eprintln!(
             "Checking the proposed schema against metrics from {}",
-            &self.graph
+            &self.graph.graph_ref
         );
 
         let res = check::run(
             GraphCheckInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
                 proposed_schema,
                 git_context,
                 config: CheckConfig {

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -2,12 +2,11 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::graph::check::{self, GraphCheckInput};
-use rover_client::shared::{CheckConfig, GitContext, ValidationPeriod};
+use rover_client::shared::{CheckConfig, GitContext};
 
 use crate::command::RoverOutput;
-use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt};
+use crate::options::{CheckConfigOpts, GraphRefOpt, ProfileOpt, SchemaOpt};
 use crate::utils::client::StudioClientConfig;
-use crate::utils::parsers::{parse_query_count_threshold, parse_query_percentage_threshold};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -22,20 +21,8 @@ pub struct Check {
     #[serde(skip_serializing)]
     schema: SchemaOpt,
 
-    /// The minimum number of times a query or mutation must have been executed
-    /// in order to be considered in the check operation
-    #[structopt(long, parse(try_from_str = parse_query_count_threshold))]
-    query_count_threshold: Option<i64>,
-
-    /// Minimum percentage of times a query or mutation must have been executed
-    /// in the time window, relative to total request count, for it to be
-    /// considered in the check. Valid numbers are in the range 0 <= x <= 100
-    #[structopt(long, parse(try_from_str = parse_query_percentage_threshold))]
-    query_percentage_threshold: Option<f64>,
-
-    /// Size of the time window with which to validate schema against (i.e "24h" or "1w 2d 5h")
-    #[structopt(long)]
-    validation_period: Option<ValidationPeriod>,
+    #[structopt(flatten)]
+    config: CheckConfigOpts,
 }
 
 impl Check {
@@ -60,9 +47,9 @@ impl Check {
                 proposed_schema,
                 git_context,
                 config: CheckConfig {
-                    query_count_threshold: self.query_count_threshold,
-                    query_count_threshold_percentage: self.query_percentage_threshold,
-                    validation_period: self.validation_period.clone(),
+                    query_count_threshold: self.config.query_count_threshold,
+                    query_count_threshold_percentage: self.config.query_percentage_threshold,
+                    validation_period: self.config.validation_period.clone(),
                 },
             },
             &client,

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -5,12 +5,9 @@ use rover_client::operations::graph::check::{self, GraphCheckInput};
 use rover_client::shared::{CheckConfig, GitContext, ValidationPeriod};
 
 use crate::command::RoverOutput;
-use crate::options::GraphRefOpt;
+use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt};
 use crate::utils::client::StudioClientConfig;
-use crate::utils::parsers::{
-    parse_file_descriptor, parse_query_count_threshold, parse_query_percentage_threshold,
-    FileDescriptorType,
-};
+use crate::utils::parsers::{parse_query_count_threshold, parse_query_percentage_threshold};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -18,15 +15,12 @@ pub struct Check {
     #[structopt(flatten)]
     graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 
-    /// The schema file to check. You can pass `-` to use stdin instead of a file.
-    #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
+    #[structopt(flatten)]
     #[serde(skip_serializing)]
-    schema: FileDescriptorType,
+    schema: SchemaOpt,
 
     /// The minimum number of times a query or mutation must have been executed
     /// in order to be considered in the check operation
@@ -50,7 +44,7 @@ impl Check {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
         let proposed_schema = self
             .schema
             .read_file_descriptor("SDL", &mut std::io::stdin())?;

--- a/src/command/graph/fetch.rs
+++ b/src/command/graph/fetch.rs
@@ -3,39 +3,34 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::graph::fetch::{self, GraphFetchInput};
-use rover_client::shared::GraphRef;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to fetch from.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 }
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = self.graph.to_string();
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
+        let graph_ref = self.graph.graph_ref.to_string();
         eprintln!(
             "Fetching SDL from {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
-            Yellow.normal().paint(&self.profile_name)
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         let fetch_response = fetch::run(
             GraphFetchInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
             },
             &client,
         )?;

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -3,30 +3,26 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::graph::publish::{self, GraphPublishInput};
-use rover_client::shared::{GitContext, GraphRef};
+use rover_client::shared::GitContext;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::utils::parsers::{parse_file_descriptor, FileDescriptorType};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Publish {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to publish to.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
+
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 
     /// The schema file to publish. You can pass `-` to use stdin instead of a file.
     #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
     #[serde(skip_serializing)]
     schema: FileDescriptorType,
-
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
 }
 
 impl Publish {
@@ -35,12 +31,12 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = self.graph.to_string();
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
+        let graph_ref = self.graph.graph_ref.to_string();
         eprintln!(
             "Publishing SDL to {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
-            Yellow.normal().paint(&self.profile_name)
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         let proposed_schema = self
@@ -51,7 +47,7 @@ impl Publish {
 
         let publish_response = publish::run(
             GraphPublishInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
                 proposed_schema,
                 git_context,
             },
@@ -59,7 +55,7 @@ impl Publish {
         )?;
 
         Ok(RoverOutput::GraphPublishResponse {
-            graph_ref: self.graph.clone(),
+            graph_ref: self.graph.graph_ref.clone(),
             publish_response,
         })
     }

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -6,9 +6,8 @@ use rover_client::operations::graph::publish::{self, GraphPublishInput};
 use rover_client::shared::GitContext;
 
 use crate::command::RoverOutput;
-use crate::options::{GraphRefOpt, ProfileOpt};
+use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt};
 use crate::utils::client::StudioClientConfig;
-use crate::utils::parsers::{parse_file_descriptor, FileDescriptorType};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -19,10 +18,9 @@ pub struct Publish {
     #[structopt(flatten)]
     profile: ProfileOpt,
 
-    /// The schema file to publish. You can pass `-` to use stdin instead of a file.
-    #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
+    #[structopt(flatten)]
     #[serde(skip_serializing)]
-    schema: FileDescriptorType,
+    schema: SchemaOpt,
 }
 
 impl Publish {

--- a/src/command/readme/fetch.rs
+++ b/src/command/readme/fetch.rs
@@ -2,45 +2,41 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::Result;
+
 use rover_client::operations::readme::fetch::{self, ReadmeFetchInput};
-use rover_client::shared::GraphRef;
 
 use ansi_term::Colour::{Cyan, Yellow};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to publish to.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 }
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = self.graph.to_string();
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
+        let graph_ref = self.graph.graph_ref.to_string();
 
         eprintln!(
             "Fetching README for {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
-            Yellow.normal().paint(&self.profile_name)
+            Yellow.normal().paint(&self.profile.profile_name)
         );
         let readme = fetch::run(
             ReadmeFetchInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
             },
             &client,
         )?;
         Ok(RoverOutput::ReadmeFetchResponse {
-            graph_ref: self.graph.clone(),
+            graph_ref: self.graph.graph_ref.clone(),
             content: readme.content,
             last_updated_time: readme.last_updated_time,
         })

--- a/src/command/readme/publish.rs
+++ b/src/command/readme/publish.rs
@@ -2,41 +2,37 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::utils::parsers::{parse_file_descriptor, FileDescriptorType};
 use crate::Result;
+
 use rover_client::operations::readme::publish::{self, ReadmePublishInput};
-use rover_client::shared::GraphRef;
 
 use ansi_term::Colour::{Cyan, Yellow};
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Publish {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to publish to.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
+
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 
     /// The file upload as the README. You can pass `-` to use stdin instead of a file.
     #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
     #[serde(skip_serializing)]
     file: FileDescriptorType,
-
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
 }
 
 impl Publish {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = self.graph.to_string();
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
+        let graph_ref = self.graph.graph_ref.to_string();
         eprintln!(
             "Publishing README for {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
-            Yellow.normal().paint(&self.profile_name)
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         let new_readme = self
@@ -46,14 +42,14 @@ impl Publish {
 
         let publish_response = publish::run(
             ReadmePublishInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
                 readme: new_readme,
             },
             &client,
         )?;
 
         Ok(RoverOutput::ReadmePublishResponse {
-            graph_ref: self.graph.clone(),
+            graph_ref: self.graph.graph_ref.clone(),
             new_content: publish_response.new_content,
             last_updated_time: publish_response.last_updated_time,
         })

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -5,12 +5,9 @@ use rover_client::operations::subgraph::check::{self, SubgraphCheckInput};
 use rover_client::shared::{CheckConfig, GitContext, ValidationPeriod};
 
 use crate::command::RoverOutput;
-use crate::options::{GraphRefOpt, ProfileOpt, SubgraphOpt};
+use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt, SubgraphOpt};
 use crate::utils::client::StudioClientConfig;
-use crate::utils::parsers::{
-    parse_file_descriptor, parse_query_count_threshold, parse_query_percentage_threshold,
-    FileDescriptorType,
-};
+use crate::utils::parsers::{parse_query_count_threshold, parse_query_percentage_threshold};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -24,10 +21,9 @@ pub struct Check {
     #[structopt(flatten)]
     profile: ProfileOpt,
 
-    /// The schema file to check. You can pass `-` to use stdin instead of a file.
-    #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
+    #[structopt(flatten)]
     #[serde(skip_serializing)]
-    schema: FileDescriptorType,
+    schema: SchemaOpt,
 
     /// The minimum number of times a query or mutation must have been executed
     /// in order to be considered in the check operation

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -2,12 +2,11 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::subgraph::check::{self, SubgraphCheckInput};
-use rover_client::shared::{CheckConfig, GitContext, ValidationPeriod};
+use rover_client::shared::{CheckConfig, GitContext};
 
 use crate::command::RoverOutput;
-use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt, SubgraphOpt};
+use crate::options::{CheckConfigOpts, GraphRefOpt, ProfileOpt, SchemaOpt, SubgraphOpt};
 use crate::utils::client::StudioClientConfig;
-use crate::utils::parsers::{parse_query_count_threshold, parse_query_percentage_threshold};
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
@@ -25,20 +24,8 @@ pub struct Check {
     #[serde(skip_serializing)]
     schema: SchemaOpt,
 
-    /// The minimum number of times a query or mutation must have been executed
-    /// in order to be considered in the check operation
-    #[structopt(long, parse(try_from_str = parse_query_count_threshold))]
-    query_count_threshold: Option<i64>,
-
-    /// Minimum percentage of times a query or mutation must have been executed
-    /// in the time window, relative to total request count, for it to be
-    /// considered in the check. Valid numbers are in the range 0 <= x <= 100
-    #[structopt(long, parse(try_from_str = parse_query_percentage_threshold))]
-    query_percentage_threshold: Option<f64>,
-
-    /// Size of the time window with which to validate schema against (i.e "24h" or "1w 2d 5h")
-    #[structopt(long)]
-    validation_period: Option<ValidationPeriod>,
+    #[structopt(flatten)]
+    config: CheckConfigOpts,
 }
 
 impl Check {
@@ -65,9 +52,9 @@ impl Check {
                 subgraph: self.subgraph.subgraph_name.clone(),
                 git_context,
                 config: CheckConfig {
-                    query_count_threshold: self.query_count_threshold,
-                    query_count_threshold_percentage: self.query_percentage_threshold,
-                    validation_period: self.validation_period.clone(),
+                    query_count_threshold: self.config.query_count_threshold,
+                    query_count_threshold_percentage: self.config.query_percentage_threshold,
+                    validation_period: self.config.validation_period.clone(),
                 },
             },
             &client,

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -3,29 +3,22 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt, SubgraphOpt};
 use crate::utils::{self, client::StudioClientConfig};
 use crate::Result;
 
 use rover_client::operations::subgraph::delete::{self, SubgraphDeleteInput};
-use rover_client::shared::GraphRef;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Delete {
-    /// <NAME>@<VARIANT> of federated graph in Apollo Studio to delete subgraph from.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    subgraph: SubgraphOpt,
 
-    /// Name of subgraph in federated graph to delete
-    #[structopt(long = "name")]
-    #[serde(skip_serializing)]
-    subgraph: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 
     /// Skips the step where the command asks for user confirmation before
     /// deleting the subgraph. Also skips preview of build errors that
@@ -36,12 +29,12 @@ pub struct Delete {
 
 impl Delete {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
         eprintln!(
             "Checking for build errors resulting from deleting subgraph {} from {} using credentials from the {} profile.",
-            Cyan.normal().paint(&self.subgraph),
-            Cyan.normal().paint(self.graph.to_string()),
-            Yellow.normal().paint(&self.profile_name)
+            Cyan.normal().paint(&self.subgraph.subgraph_name),
+            Cyan.normal().paint(self.graph.graph_ref.to_string()),
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         // this is probably the normal path -- preview a subgraph delete
@@ -51,16 +44,16 @@ impl Delete {
             // run delete with dryRun, so we can preview build errors
             let delete_dry_run_response = delete::run(
                 SubgraphDeleteInput {
-                    graph_ref: self.graph.clone(),
-                    subgraph: self.subgraph.clone(),
+                    graph_ref: self.graph.graph_ref.clone(),
+                    subgraph: self.subgraph.subgraph_name.clone(),
                     dry_run,
                 },
                 &client,
             )?;
 
             RoverOutput::SubgraphDeleteResponse {
-                graph_ref: self.graph.clone(),
-                subgraph: self.subgraph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
+                subgraph: self.subgraph.subgraph_name.clone(),
                 dry_run,
                 delete_response: delete_dry_run_response,
             }
@@ -77,16 +70,16 @@ impl Delete {
 
         let delete_response = delete::run(
             SubgraphDeleteInput {
-                graph_ref: self.graph.clone(),
-                subgraph: self.subgraph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
+                subgraph: self.subgraph.subgraph_name.clone(),
                 dry_run,
             },
             &client,
         )?;
 
         Ok(RoverOutput::SubgraphDeleteResponse {
-            graph_ref: self.graph.clone(),
-            subgraph: self.subgraph.clone(),
+            graph_ref: self.graph.graph_ref.clone(),
+            subgraph: self.subgraph.subgraph_name.clone(),
             dry_run,
             delete_response,
         })

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -3,46 +3,39 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::subgraph::fetch::{self, SubgraphFetchInput};
-use rover_client::shared::GraphRef;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt, SubgraphOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to fetch from.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    subgraph: SubgraphOpt,
 
-    /// Name of subgraph in federated graph to update
-    #[structopt(long = "name")]
-    #[serde(skip_serializing)]
-    subgraph: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 }
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = self.graph.to_string();
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
+        let graph_ref = self.graph.graph_ref.to_string();
         eprintln!(
             "Fetching SDL from {} (subgraph: {}) using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
-            Cyan.normal().paint(&self.subgraph),
-            Yellow.normal().paint(&self.profile_name)
+            Cyan.normal().paint(&self.subgraph.subgraph_name),
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         let fetch_response = fetch::run(
             SubgraphFetchInput {
-                graph_ref: self.graph.clone(),
-                subgraph_name: self.subgraph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
+                subgraph_name: self.subgraph.subgraph_name.clone(),
             },
             &client,
         )?;

--- a/src/command/subgraph/list.rs
+++ b/src/command/subgraph/list.rs
@@ -3,39 +3,34 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use rover_client::operations::subgraph::list::{self, SubgraphListInput};
-use rover_client::shared::GraphRef;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::Result;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct List {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to list subgraphs from.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 }
 
 impl List {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
 
         eprintln!(
             "Listing subgraphs for {} using credentials from the {} profile.",
-            Cyan.normal().paint(self.graph.to_string()),
-            Cyan.normal().paint(&self.profile_name)
+            Cyan.normal().paint(self.graph.graph_ref.to_string()),
+            Cyan.normal().paint(&self.profile.profile_name)
         );
 
         let list_details = list::run(
             SubgraphListInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
             },
             &client,
         )?;

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverOutput;
+use crate::options::{GraphRefOpt, ProfileOpt, SubgraphOpt};
 use crate::utils::{
     client::StudioClientConfig,
     parsers::{parse_file_descriptor, FileDescriptorType},
@@ -10,30 +11,23 @@ use crate::utils::{
 use crate::Result;
 
 use rover_client::operations::subgraph::publish::{self, SubgraphPublishInput};
-use rover_client::shared::{GitContext, GraphRef};
+use rover_client::shared::GitContext;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Publish {
-    /// <NAME>@<VARIANT> of federated graph in Apollo Studio to publish to.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
+
+    #[structopt(flatten)]
+    subgraph: SubgraphOpt,
+
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 
     /// The schema file to publish. You can pass `-` to use stdin instead of a file.
     #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
     #[serde(skip_serializing)]
     schema: FileDescriptorType,
-
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
-
-    /// Name of subgraph in federated graph to update
-    #[structopt(long = "name")]
-    #[serde(skip_serializing)]
-    subgraph: String,
 
     /// Indicate whether to convert a non-federated graph into a subgraph
     #[structopt(short, long)]
@@ -53,12 +47,12 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
         eprintln!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
-            Cyan.normal().paint(&self.graph.to_string()),
-            Cyan.normal().paint(&self.subgraph),
-            Yellow.normal().paint(&self.profile_name)
+            Cyan.normal().paint(&self.graph.graph_ref.to_string()),
+            Cyan.normal().paint(&self.subgraph.subgraph_name),
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         let schema = self
@@ -69,8 +63,8 @@ impl Publish {
 
         let publish_response = publish::run(
             SubgraphPublishInput {
-                graph_ref: self.graph.clone(),
-                subgraph: self.subgraph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
+                subgraph: self.subgraph.subgraph_name.clone(),
                 url: self.routing_url.clone(),
                 schema,
                 git_context,
@@ -80,8 +74,8 @@ impl Publish {
         )?;
 
         Ok(RoverOutput::SubgraphPublishResponse {
-            graph_ref: self.graph.clone(),
-            subgraph: self.subgraph.clone(),
+            graph_ref: self.graph.graph_ref.clone(),
+            subgraph: self.subgraph.subgraph_name.clone(),
             publish_response,
         })
     }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -3,11 +3,8 @@ use serde::Serialize;
 use structopt::StructOpt;
 
 use crate::command::RoverOutput;
-use crate::options::{GraphRefOpt, ProfileOpt, SubgraphOpt};
-use crate::utils::{
-    client::StudioClientConfig,
-    parsers::{parse_file_descriptor, FileDescriptorType},
-};
+use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt, SubgraphOpt};
+use crate::utils::client::StudioClientConfig;
 use crate::Result;
 
 use rover_client::operations::subgraph::publish::{self, SubgraphPublishInput};
@@ -24,10 +21,9 @@ pub struct Publish {
     #[structopt(flatten)]
     profile: ProfileOpt,
 
-    /// The schema file to publish. You can pass `-` to use stdin instead of a file.
-    #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
+    #[structopt(flatten)]
     #[serde(skip_serializing)]
-    schema: FileDescriptorType,
+    schema: SchemaOpt,
 
     /// Indicate whether to convert a non-federated graph into a subgraph
     #[structopt(short, long)]

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -10,6 +10,7 @@ use crate::{
         RoverOutput,
     },
     error::{RoverError, Suggestion},
+    options::ProfileOpt,
     Context, Result,
 };
 
@@ -30,10 +31,8 @@ pub struct Compose {
     #[serde(skip_serializing)]
     supergraph_yaml: FileDescriptorType,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 
     /// Accept the elv2 license if you are using federation 2. Note that you only need to do this once per machine.
     #[structopt(long = "elv2-license", parse(from_str = license_accept), case_insensitive = true, env = "APOLLO_ELV2_LICENSE")]
@@ -53,7 +52,7 @@ impl Compose {
         let mut supergraph_config = resolve_supergraph_yaml(
             &self.supergraph_yaml,
             client_config.clone(),
-            &self.profile_name,
+            &self.profile.profile_name,
         )?;
         // first, grab the _actual_ federation version from the config we just resolved
         // (this will always be `Some` as long as we have created with `resolve_supergraph_yaml` so it is safe to unwrap)

--- a/src/command/supergraph/compose/no_compose.rs
+++ b/src/command/supergraph/compose/no_compose.rs
@@ -2,6 +2,7 @@ use camino::Utf8PathBuf;
 use serde::Serialize;
 use structopt::StructOpt;
 
+use crate::options::ProfileOpt;
 use crate::utils::client::StudioClientConfig;
 use crate::{
     anyhow,
@@ -18,11 +19,9 @@ pub struct Compose {
     #[allow(unused)]
     config_path: Option<Utf8PathBuf>,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
+    #[structopt(flatten)]
     #[allow(unused)]
-    profile_name: String,
+    profile: ProfileOpt,
 }
 
 impl Compose {

--- a/src/command/supergraph/fetch.rs
+++ b/src/command/supergraph/fetch.rs
@@ -1,8 +1,11 @@
 use crate::utils::client::StudioClientConfig;
-use crate::{command::RoverOutput, Result};
+use crate::{
+    command::RoverOutput,
+    options::{GraphRefOpt, ProfileOpt},
+    Result,
+};
 
 use rover_client::operations::supergraph::fetch::{self, SupergraphFetchInput};
-use rover_client::shared::GraphRef;
 
 use ansi_term::Colour::{Cyan, Yellow};
 use serde::Serialize;
@@ -10,31 +13,26 @@ use structopt::StructOpt;
 
 #[derive(Debug, Serialize, StructOpt)]
 pub struct Fetch {
-    /// <NAME>@<VARIANT> of graph in Apollo Studio to fetch from.
-    /// @<VARIANT> may be left off, defaulting to @current
-    #[structopt(name = "GRAPH_REF")]
-    #[serde(skip_serializing)]
-    graph: GraphRef,
+    #[structopt(flatten)]
+    graph: GraphRefOpt,
 
-    /// Name of configuration profile to use
-    #[structopt(long = "profile", default_value = "default")]
-    #[serde(skip_serializing)]
-    profile_name: String,
+    #[structopt(flatten)]
+    profile: ProfileOpt,
 }
 
 impl Fetch {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
-        let client = client_config.get_authenticated_client(&self.profile_name)?;
-        let graph_ref = self.graph.to_string();
+        let client = client_config.get_authenticated_client(&self.profile.profile_name)?;
+        let graph_ref = self.graph.graph_ref.to_string();
         eprintln!(
             "Fetching supergraph SDL from {} using credentials from the {} profile.",
             Cyan.normal().paint(&graph_ref),
-            Yellow.normal().paint(&self.profile_name)
+            Yellow.normal().paint(&self.profile.profile_name)
         );
 
         let fetch_response = fetch::run(
             SupergraphFetchInput {
-                graph_ref: self.graph.clone(),
+                graph_ref: self.graph.graph_ref.clone(),
             },
             &client,
         )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod command;
 mod error;
+mod options;
 pub mod utils;
 
 pub use error::{anyhow, Context, Result, Suggestion};

--- a/src/options/check.rs
+++ b/src/options/check.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+use rover_client::shared::ValidationPeriod;
+
+use crate::{error::RoverError, Result};
+
+#[derive(Debug, Serialize, Deserialize, StructOpt)]
+pub struct CheckConfigOpts {
+    /// The minimum number of times a query or mutation must have been executed
+    /// in order to be considered in the check operation
+    #[structopt(long, parse(try_from_str = parse_query_count_threshold))]
+    pub query_count_threshold: Option<i64>,
+
+    /// Minimum percentage of times a query or mutation must have been executed
+    /// in the time window, relative to total request count, for it to be
+    /// considered in the check. Valid numbers are in the range 0 <= x <= 100
+    #[structopt(long, parse(try_from_str = parse_query_percentage_threshold))]
+    pub query_percentage_threshold: Option<f64>,
+
+    /// Size of the time window with which to validate schema against (i.e "24h" or "1w 2d 5h")
+    #[structopt(long)]
+    pub validation_period: Option<ValidationPeriod>,
+}
+
+fn parse_query_count_threshold(threshold: &str) -> Result<i64> {
+    let threshold = threshold.parse::<i64>()?;
+    if threshold < 1 {
+        Err(RoverError::parse_error(
+            "The number of queries must be a positive integer.",
+        ))
+    } else {
+        Ok(threshold)
+    }
+}
+
+fn parse_query_percentage_threshold(threshold: &str) -> Result<f64> {
+    let threshold = threshold.parse::<i64>()?;
+    if !(0..=100).contains(&threshold) {
+        Err(RoverError::parse_error(
+            "Valid numbers are in the range 0 <= x <= 100",
+        ))
+    } else {
+        Ok((threshold / 100) as f64)
+    }
+}

--- a/src/options/graph.rs
+++ b/src/options/graph.rs
@@ -1,0 +1,12 @@
+use rover_client::shared::GraphRef;
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+#[derive(Debug, Serialize, Deserialize, StructOpt)]
+pub struct GraphRefOpt {
+    /// <NAME>@<VARIANT> of graph in Apollo Studio to fetch from.
+    /// @<VARIANT> may be left off, defaulting to @current
+    #[structopt(name = "GRAPH_REF")]
+    #[serde(skip_serializing)]
+    pub graph_ref: GraphRef,
+}

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -1,7 +1,9 @@
 mod graph;
 mod profile;
+mod schema;
 mod subgraph;
 
 pub(crate) use graph::GraphRefOpt;
 pub(crate) use profile::ProfileOpt;
+pub(crate) use schema::SchemaOpt;
 pub(crate) use subgraph::SubgraphOpt;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -1,8 +1,10 @@
+mod check;
 mod graph;
 mod profile;
 mod schema;
 mod subgraph;
 
+pub(crate) use check::CheckConfigOpts;
 pub(crate) use graph::GraphRefOpt;
 pub(crate) use profile::ProfileOpt;
 pub(crate) use schema::SchemaOpt;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -1,0 +1,7 @@
+mod graph;
+mod profile;
+mod subgraph;
+
+pub(crate) use graph::GraphRefOpt;
+pub(crate) use profile::ProfileOpt;
+pub(crate) use subgraph::SubgraphOpt;

--- a/src/options/profile.rs
+++ b/src/options/profile.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+#[derive(Debug, Serialize, Deserialize, StructOpt)]
+pub struct ProfileOpt {
+    /// Name of configuration profile to use
+    #[structopt(long = "profile", default_value = "default")]
+    #[serde(skip_serializing)]
+    pub profile_name: String,
+}

--- a/src/options/schema.rs
+++ b/src/options/schema.rs
@@ -1,0 +1,25 @@
+use structopt::StructOpt;
+
+use crate::{
+    utils::parsers::{parse_file_descriptor, FileDescriptorType},
+    Result,
+};
+
+use std::io::Read;
+
+#[derive(Debug, StructOpt)]
+pub struct SchemaOpt {
+    /// The schema file to check. You can pass `-` to use stdin instead of a file.
+    #[structopt(long, short = "s", parse(try_from_str = parse_file_descriptor))]
+    schema: FileDescriptorType,
+}
+
+impl SchemaOpt {
+    pub(crate) fn read_file_descriptor(
+        &self,
+        file_description: &str,
+        stdin: &mut impl Read,
+    ) -> Result<String> {
+        self.schema.read_file_descriptor(file_description, stdin)
+    }
+}

--- a/src/options/subgraph.rs
+++ b/src/options/subgraph.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+#[derive(Debug, Serialize, Deserialize, StructOpt)]
+pub struct SubgraphOpt {
+    /// Name of the subgraph to validate
+    #[structopt(long = "name")]
+    #[serde(skip_serializing)]
+    pub subgraph_name: String,
+}

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -85,28 +85,6 @@ pub fn parse_file_descriptor(input: &str) -> Result<FileDescriptorType> {
     }
 }
 
-pub fn parse_query_count_threshold(threshold: &str) -> Result<i64> {
-    let threshold = threshold.parse::<i64>()?;
-    if threshold < 1 {
-        Err(RoverError::parse_error(
-            "The number of queries must be a positive integer.",
-        ))
-    } else {
-        Ok(threshold)
-    }
-}
-
-pub fn parse_query_percentage_threshold(threshold: &str) -> Result<f64> {
-    let threshold = threshold.parse::<i64>()?;
-    if !(0..=100).contains(&threshold) {
-        Err(RoverError::parse_error(
-            "Valid numbers are in the range 0 <= x <= 100",
-        ))
-    } else {
-        Ok((threshold / 100) as f64)
-    }
-}
-
 /// Parses a key:value pair from a string and returns a tuple of key:value.
 /// If a full key:value can't be parsed, it will error.
 pub fn parse_header(header: &str) -> Result<(String, String)> {


### PR DESCRIPTION
i just learned about the magical properties of `#[structopt(flatten)]` and now we don't have to copy and paste the same arguments everywhere, we can define them once and reuse them!