### PR TITLE
Upgrade graphql_client to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,28 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,19 +1380,19 @@ dependencies = [
 
 [[package]]
 name = "graphql-parser"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
- "failure",
+ "thiserror",
 ]
 
 [[package]]
 name = "graphql_client"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b58571cfc3cc42c3e8ff44fc6cfbb6c0dea17ed22d20f9d8f1efc4e8209a3f"
+checksum = "7fc16d75d169fddb720d8f1c7aed6413e329e1584079b9734ff07266a193f5bc"
 dependencies = [
  "graphql_query_derive",
  "serde",
@@ -1423,13 +1401,13 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bf9cd823359d74ad3d3ecf1afd4a975f4ff2f891cdf9a66744606daf52de8c"
+checksum = "f290ecfa3bea3e8a157899dc8a1d96ee7dd6405c18c8ddd213fc58939d18a0e9"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
- "heck 0.3.3",
+ "heck 0.4.0",
  "lazy_static",
  "proc-macro2",
  "quote",
@@ -1440,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56b093bfda71de1da99758b036f4cc811fd2511c8a76f75680e9ffbd2bb4251"
+checksum = "a755cc59cda2641ea3037b4f9f7ef40471c329f55c1fa2db6fa0bb7ae6c1f7ce"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",
@@ -3056,18 +3034,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]

--- a/crates/launchpad/Cargo.toml
+++ b/crates/launchpad/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 apollo-encoder = "0.3.1"
 backoff = "0.4"
-graphql_client = "0.10"
+graphql_client = "0.11.0"
 humantime = "2.1.0"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = [

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -24,7 +24,7 @@ git-url-parse = "0.4.0"
 git2 = { version = "0.14", default-features = false, features = [
     "vendored-openssl",
 ] }
-graphql_client = "0.10"
+graphql_client = "0.11.0"
 humantime = "2.1.0"
 launchpad = { path = "../launchpad", version = "0.1.0" }
 hyper = "0.14"

--- a/crates/rover-client/src/operations/graph/check/types.rs
+++ b/crates/rover-client/src/operations/graph/check/types.rs
@@ -32,15 +32,15 @@ impl From<CheckConfig> for MutationConfig {
             None => (None, None),
         };
         Self {
-            queryCountThreshold: input.query_count_threshold,
-            queryCountThresholdPercentage: input.query_count_threshold_percentage,
+            query_count_threshold: input.query_count_threshold,
+            query_count_threshold_percentage: input.query_count_threshold_percentage,
             from,
             to,
             // we don't support configuring these, but we can't leave them out
-            excludedClients: None,
-            excludedOperationNames: None,
-            ignoredOperations: None,
-            includedVariants: None,
+            excluded_clients: None,
+            excluded_operation_names: None,
+            ignored_operations: None,
+            included_variants: None,
         }
     }
 }
@@ -97,7 +97,7 @@ impl From<GitContext> for MutationGitContextInput {
             branch: git_context.branch,
             commit: git_context.commit,
             committer: git_context.author,
-            remoteUrl: git_context.remote_url,
+            remote_url: git_context.remote_url,
             message: None,
         }
     }

--- a/crates/rover-client/src/operations/graph/publish/types.rs
+++ b/crates/rover-client/src/operations/graph/publish/types.rs
@@ -31,7 +31,7 @@ impl From<GitContext> for GraphPublishContextInput {
             branch: git_context.branch,
             commit: git_context.commit,
             committer: git_context.author,
-            remoteUrl: git_context.remote_url,
+            remote_url: git_context.remote_url,
             message: None,
         }
     }

--- a/crates/rover-client/src/operations/subgraph/check/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check/types.rs
@@ -28,7 +28,7 @@ impl From<GitContext> for MutationGitContextInput {
             branch: git_context.branch,
             commit: git_context.commit,
             committer: git_context.author,
-            remoteUrl: git_context.remote_url,
+            remote_url: git_context.remote_url,
             message: None,
         }
     }
@@ -69,15 +69,15 @@ impl From<CheckConfig> for MutationConfig {
             None => (None, None),
         };
         Self {
-            queryCountThreshold: input.query_count_threshold,
-            queryCountThresholdPercentage: input.query_count_threshold_percentage,
+            query_count_threshold: input.query_count_threshold,
+            query_count_threshold_percentage: input.query_count_threshold_percentage,
             from,
             to,
             // we don't support configuring these, but we can't leave them out
-            excludedClients: None,
-            excludedOperationNames: None,
-            ignoredOperations: None,
-            includedVariants: None,
+            excluded_clients: None,
+            excluded_operation_names: None,
+            ignored_operations: None,
+            included_variants: None,
         }
     }
 }

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -63,7 +63,7 @@ impl From<GitContext> for GitContextInput {
             branch: git_context.branch,
             commit: git_context.commit,
             committer: git_context.author,
-            remoteUrl: git_context.remote_url,
+            remote_url: git_context.remote_url,
             message: None,
         }
     }


### PR DESCRIPTION
This removes the deprecated `failure` crate from the dependency graph.

This should fix automated reports about https://github.com/advisories/GHSA-jq66-xh47-j9f3 even though I wouldn’t expect any "real world" code to be affected since you’d have to go out of your way to override `__private_get_type_id__`.