### PR TITLE
chore: improves schema downloading and debugging

### DIFF
--- a/crates/launchpad/src/blocking/client.rs
+++ b/crates/launchpad/src/blocking/client.rs
@@ -108,7 +108,14 @@ impl GraphQLClient {
                                 || response_status.is_client_error()
                                 || response_status.is_redirection()
                             {
-                                Err(BackoffError::transient(status_error))
+                                if matches!(response_status, StatusCode::BAD_REQUEST) {
+                                    if let Ok(text) = success.text() {
+                                        tracing::debug!("{}", text);
+                                    }
+                                    Err(BackoffError::Permanent(status_error))
+                                } else {
+                                    Err(BackoffError::transient(status_error))
+                                }
                             } else {
                                 Err(BackoffError::Permanent(status_error))
                             }

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -14,8 +14,6 @@ use uuid::Uuid;
 ///
 /// Note: eprintln! statements only show up with `cargo build -vv`
 fn main() -> Result<()> {
-    // Rerun the build if this script updates last_run.uuid (which it does every time).
-    eprintln!("cargo:rerun-if-changed=.schema/last_run.uuid");
     fs::create_dir_all(".schema")?;
     write(".schema/last_run.uuid", Uuid::new_v4())
         .expect("Failed to write UUID to .schema/last_run.uuid");
@@ -87,8 +85,10 @@ const QUERY: &str = r#"query FetchSchema($fetchDocument: Boolean!) {
 }"#;
 
 fn query(fetch_document: bool) -> Result<(String, Option<String>)> {
-    let graphql_endpoint = option_env!("APOLLO_GRAPHQL_SCHEMA_URL")
-        .unwrap_or_else(|| "https://api.apollographql.com/api/graphql");
+    let graphql_endpoint = option_env!("APOLLO_GRAPHQL_SCHEMA_URL").unwrap_or_else(|| {
+        option_env!("APOLLO_REGISTRY_URL")
+            .unwrap_or_else(|| "https://api.apollographql.com/api/graphql")
+    });
     let client = Client::new();
     let schema_query = serde_json::json!({
         "variables": {"fetchDocument": fetch_document},


### PR DESCRIPTION
this pr:

-makes `400 Bad Request` errors "permanent" (meaning they will not be retried)
- makes the `.schema` directory _actually_ regenerate if it is deleted (by removing the check on last_run.uuid)
- respects `APOLLO_REGISTRY_URL` when fetching the schema
- adds debug information to bad request errors