### PR TITLE
correct help msg for `rover subgraph introspect`

### DIFF
--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -32,7 +32,7 @@ pub enum Command {
     /// Fetch a subgraph schema from the Apollo graph registry
     Fetch(fetch::Fetch),
 
-    /// Introspect a subgraph from the Apollo registry
+    /// Introspect a running subgraph endpoint to retrieve its schema definition (SDL)
     Introspect(introspect::Introspect),
 
     /// List all subgraphs for a federated graph


### PR DESCRIPTION
The `rover subgraph introspect` command actually fetches the federated SDL
from a running subgraph directly NOT from the Apollo Registry as the previous
message suggested.