### PR TITLE
feat: improves info for filesystem read/write

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,7 +113,7 @@ A minimal command in Rover would be laid out exactly like this:
 
 ```rust
 use serde::{Deserialize, Serialize};
-use clap::Parser
+use saucer::Parser
 use crate::output::RoverOutput;
 
 #[derive(Debug, Serialize, Parser)]
@@ -130,7 +130,7 @@ For our `graph hello` command, we'll add a new `hello.rs` file under `src/comman
 
 ```rust
 use serde::Serialize;
-use clap::Parser;
+use saucer::{clap, Parser};
 
 use crate::command::RoverOutput;
 use crate::Result;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,11 +388,11 @@ version = "0.1.0"
 dependencies = [
  "assert_fs",
  "atty",
- "camino",
  "cc",
  "directories-next",
  "flate2",
  "reqwest",
+ "saucer",
  "serial_test",
  "tar",
  "tempdir",
@@ -1496,8 +1496,8 @@ name = "houston"
 version = "0.0.0"
 dependencies = [
  "assert_fs",
- "camino",
  "directories-next",
+ "saucer",
  "serde",
  "thiserror",
  "toml",
@@ -2431,6 +2431,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,8 +2576,8 @@ name = "robot-panic"
 version = "1.0.3"
 dependencies = [
  "backtrace",
- "camino",
  "os_type",
+ "saucer",
  "serde",
  "termcolor",
  "toml",
@@ -2566,7 +2590,6 @@ name = "rover"
 version = "0.7.0"
 dependencies = [
  "ansi_term",
- "anyhow",
  "apollo-federation-types",
  "apollo-parser",
  "assert-json-diff",
@@ -2576,9 +2599,7 @@ dependencies = [
  "billboard",
  "binstall",
  "calm_io",
- "camino",
  "chrono",
- "clap",
  "console 0.15.0",
  "crossterm",
  "heck",
@@ -2591,6 +2612,7 @@ dependencies = [
  "reqwest",
  "robot-panic",
  "rover-client",
+ "saucer",
  "semver",
  "serde",
  "serde_json",
@@ -2612,10 +2634,8 @@ dependencies = [
 name = "rover-client"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "apollo-federation-types",
  "backoff",
- "camino",
  "chrono",
  "git-url-parse",
  "git2",
@@ -2631,6 +2651,7 @@ dependencies = [
  "prettytable-rs",
  "regex",
  "reqwest",
+ "saucer",
  "semver",
  "serde",
  "serde_json",
@@ -2695,6 +2716,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saucer"
+version = "0.1.0"
+source = "git+https://github.com/EverlastingBugstopper/awc.git?branch=main#048ce288ecad49c9d8c33100c3729d23351bd2ab"
+dependencies = [
+ "anyhow",
+ "camino",
+ "clap",
+ "log",
+ "rayon",
 ]
 
 [[package]]
@@ -2963,10 +2996,10 @@ name = "sputnik"
 version = "0.0.0"
 dependencies = [
  "assert_fs",
- "camino",
  "ci_info",
  "git2",
  "reqwest",
+ "saucer",
  "semver",
  "serde",
  "serde_json",
@@ -3755,16 +3788,14 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
- "anyhow",
  "assert_fs",
  "base64",
- "camino",
  "cargo_metadata",
- "clap",
  "flate2",
  "lazy_static",
  "regex",
  "reqwest",
+ "saucer",
  "semver",
  "serde_json",
  "serde_json_traversal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,15 +57,16 @@ rover-client = { path = "./crates/rover-client" }
 sputnik = { path = "./crates/sputnik" }
 timber = { path = "./crates/timber" }
 
+# git dependencies
+billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../awc/saucer" }
+
 # crates.io dependencies
 ansi_term = "0.12"
-anyhow = "1"
 atty = "0.2"
-billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
 calm_io = "0.1"
-camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
-clap = { version = "3", features = ["env", "derive"] }
 console = "0.15"
 crossterm = "0.23"
 heck = "0.4"

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-camino = "1"
 directories-next = "2.0"
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../../../awc/saucer" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 toml = "0.5"

--- a/crates/houston/src/config.rs
+++ b/crates/houston/src/config.rs
@@ -3,9 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::HoustonProblem;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use saucer::{Fs, Utf8Path, Utf8PathBuf};
 use std::convert::TryFrom;
-use std::fs;
 
 /// Config allows end users to override default settings
 /// usually determined by Houston. They are intended to
@@ -52,7 +51,7 @@ impl Config {
         }?;
 
         if !home.exists() {
-            fs::create_dir_all(&home)
+            Fs::create_dir_all(&home, "")
                 .map_err(|_| HoustonProblem::CouldNotCreateConfigHome(home.to_string()))?;
         }
 
@@ -65,7 +64,7 @@ impl Config {
     /// Removes all configuration files from filesystem
     pub fn clear(&self) -> Result<(), HoustonProblem> {
         tracing::debug!(home_dir = ?self.home);
-        fs::remove_dir_all(&self.home)
+        Fs::remove_dir_all(&self.home, "")
             .map_err(|_| HoustonProblem::NoConfigFound(self.home.to_string()))
     }
 
@@ -74,14 +73,14 @@ impl Config {
         let toml_path = self.get_elv2_toml_path();
         let elv2_toml = Elv2Toml { did_accept: true };
         let contents = toml::to_string(&elv2_toml)?;
-        std::fs::write(&toml_path, &contents)?;
+        Fs::write_file(&toml_path, &contents, "")?;
         Ok(())
     }
 
-    /// Retrieves the value of sefl.home.join("elv2.toml")
+    /// Retrieves the value of self.home.join("elv2.toml")
     pub fn did_accept_elv2_license(&self) -> bool {
         let toml_path = self.get_elv2_toml_path();
-        if let Ok(contents) = std::fs::read_to_string(&toml_path) {
+        if let Ok(contents) = Fs::read_file(&toml_path, "") {
             if let Ok(elv2_toml) = toml::from_str::<Elv2Toml>(&contents) {
                 return elv2_toml.did_accept;
             }
@@ -103,7 +102,7 @@ struct Elv2Toml {
 mod tests {
     use super::Config;
     use assert_fs::TempDir;
-    use camino::Utf8PathBuf;
+    use saucer::Utf8PathBuf;
     use std::convert::TryFrom;
     #[test]
     fn it_can_clear_global_config() {

--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -35,7 +35,7 @@ pub enum HoustonProblem {
 
     /// PathNotUtf8 occurs when Houston encounters a file path that is not valid UTF-8
     #[error(transparent)]
-    PathNotUtf8(#[from] camino::FromPathBufError),
+    PathNotUtf8(#[from] saucer::FromPathBufError),
 
     /// TomlSerialization occurs when a profile's configuration can't be serialized to a String.
     #[error(transparent)]
@@ -48,4 +48,8 @@ pub enum HoustonProblem {
     /// io::Error occurs when any given std::io::Error arises.
     #[error(transparent)]
     IoError(#[from] io::Error),
+
+    /// saucer::Error comes from saucer::Error
+    #[error(transparent)]
+    SaucerError(#[from] saucer::Error),
 }

--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -1,8 +1,8 @@
 use crate::{profile::Profile, Config, HoustonProblem};
 use serde::{Deserialize, Serialize};
 
-use camino::Utf8PathBuf as PathBuf;
-use std::{fmt, fs};
+use saucer::{Fs, Utf8PathBuf};
+use std::fmt;
 
 /// Holds sensitive information regarding authentication.
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,7 +11,7 @@ pub struct Sensitive {
 }
 
 impl Sensitive {
-    fn path(profile_name: &str, config: &Config) -> PathBuf {
+    fn path(profile_name: &str, config: &Config) -> Utf8PathBuf {
         Profile::dir(profile_name, config).join(".sensitive")
     }
 
@@ -21,10 +21,10 @@ impl Sensitive {
         let data = toml::to_string(self)?;
 
         if let Some(dirs) = &path.parent() {
-            fs::create_dir_all(&dirs)?;
+            Fs::create_dir_all(&dirs, "")?;
         }
 
-        fs::write(&path, &data)?;
+        Fs::write_file(&path, &data, "")?;
         tracing::debug!(path = ?path, data_len = ?data.len());
         Ok(())
     }
@@ -32,7 +32,7 @@ impl Sensitive {
     /// Opens and deserializes `$APOLLO_CONFIG_HOME/<profile_name>/.sensitive`.
     pub fn load(profile_name: &str, config: &Config) -> Result<Sensitive, HoustonProblem> {
         let path = Sensitive::path(profile_name, config);
-        let data = fs::read_to_string(&path)?;
+        let data = Fs::read_file(&path, "")?;
         tracing::debug!(path = ?path, data_len = ?data.len());
         Ok(toml::from_str(&data)?)
     }

--- a/crates/houston/tests/auth.rs
+++ b/crates/houston/tests/auth.rs
@@ -2,7 +2,7 @@ use config::Config;
 use houston as config;
 
 use assert_fs::TempDir;
-use camino::Utf8Path;
+use saucer::Utf8Path;
 
 #[test]
 fn it_can_set_and_get_an_api_key_via_creds_file() {

--- a/crates/houston/tests/profile.rs
+++ b/crates/houston/tests/profile.rs
@@ -1,7 +1,7 @@
 use assert_fs::TempDir;
-use camino::Utf8Path;
 use config::Config;
 use houston as config;
+use saucer::Utf8Path;
 
 #[test]
 fn it_lists_many_profiles() {

--- a/crates/robot-panic/Cargo.toml
+++ b/crates/robot-panic/Cargo.toml
@@ -7,8 +7,9 @@ publish = false
 
 [dependencies]
 backtrace = "0.3"
-camino = "1"
 os_type = "2.4"
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../../../awc/saucer" }
 serde = "1.0"
 termcolor = "1.1"
 toml = "0.5"

--- a/crates/robot-panic/src/report.rs
+++ b/crates/robot-panic/src/report.rs
@@ -5,13 +5,13 @@
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
+use std::env;
 use std::error::Error;
 use std::fmt::Write as FmtWrite;
 use std::mem;
-use std::{env, fs::File, io::Write};
 
 use backtrace::Backtrace;
-use camino::Utf8PathBuf;
+use saucer::{Fs, Utf8PathBuf};
 use serde::Serialize;
 use url::Url;
 use uuid::Uuid;
@@ -139,9 +139,7 @@ impl Report {
         let file_name = format!("report-{}.toml", &uuid);
         let base_file_path = Utf8PathBuf::try_from(tmp_dir)?;
         let file_path = base_file_path.join(file_name);
-        let mut file = File::create(&file_path)?;
-        let toml = self.serialize().unwrap();
-        file.write_all(toml.as_bytes())?;
+        Fs::write_file(&file_path, self.serialize().unwrap(), "")?;
         Ok(file_path)
     }
 

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -45,14 +45,14 @@ thiserror = "1"
 tracing = "0.1"
 
 [build-dependencies]
-anyhow = "1"
-camino = "1"
 online = { version = "3.0.1", default-features = false, features = ["sync"] }
 reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "blocking",
     "native-tls-vendored",
 ] }
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../../../awc/saucer" }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-camino = "1"
 ci_info = { version = "0.14", features = ["serde-1"] }
 git2 = "0.14"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "socks"] }
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../../../awc/saucer" }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -15,7 +15,7 @@ pub enum SputnikError {
 
     /// PathNotUtf8 occurs when Sputink encounters a file path that is not valid UTF-8
     #[error(transparent)]
-    PathNotUtf8(#[from] camino::FromPathBufError),
+    PathNotUtf8(#[from] saucer::FromPathBufError),
 
     /// HttpError occurs when an error occurs while reporting anonymous usage data.
     #[error("Could not report anonymous usage data.")]
@@ -37,4 +37,8 @@ pub enum SputnikError {
     /// CommandParseError occurs when serializing a command fails.
     #[error("Could not parse command line arguments")]
     CommandParseError,
+
+    /// SaucerError comes from the saucer crate
+    #[error(transparent)]
+    SaucerError(#[from] saucer::Error),
 }

--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -1,10 +1,9 @@
-use camino::{Utf8Path, Utf8PathBuf};
 use reqwest::blocking::Client;
+use saucer::{Utf8Path, Utf8PathBuf};
 use url::Url;
 use uuid::Uuid;
 
-use std::fs::{self, File};
-use std::io::Write;
+use saucer::Fs;
 
 use crate::{Command, SputnikError};
 
@@ -52,7 +51,7 @@ pub trait Report {
 
 fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
     if Utf8Path::exists(path) {
-        if let Ok(contents) = fs::read_to_string(path) {
+        if let Ok(contents) = Fs::read_file(path, "") {
             if let Ok(machine_uuid) = Uuid::parse_str(&contents) {
                 return Ok(machine_uuid);
             }
@@ -64,8 +63,7 @@ fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
 
 fn write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
     let machine_id = Uuid::new_v4();
-    let mut file = File::create(path)?;
-    file.write_all(machine_id.to_string().as_bytes())?;
+    Fs::write_file(path, machine_id, "")?;
     Ok(machine_id)
 }
 
@@ -74,7 +72,7 @@ mod tests {
     use super::{get_or_write_machine_id, write_machine_id};
 
     use assert_fs::prelude::*;
-    use camino::Utf8PathBuf;
+    use saucer::Utf8PathBuf;
     use std::convert::TryFrom;
 
     /// if a machine ID hasn't been written already, one will be created

--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -51,7 +51,7 @@ pub trait Report {
 
 fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
     if let Ok(contents) = Fs::read_file(path, "") {
-        if let Ok(machine_uuid) = Uuid::parse_str(&contents.trim()) {
+        if let Ok(machine_uuid) = Uuid::parse_str(contents.trim()) {
             return Ok(machine_uuid);
         }
     }
@@ -60,7 +60,8 @@ fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
 
 fn write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
     let machine_id = Uuid::new_v4();
-    Fs::write_file(path, machine_id.to_string(), "")?;
+    let machine_str = machine_id.to_string();
+    Fs::write_file(path, &machine_str, "")?;
     Ok(machine_id)
 }
 

--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -1,5 +1,5 @@
 use reqwest::blocking::Client;
-use saucer::{Utf8Path, Utf8PathBuf};
+use saucer::Utf8PathBuf;
 use url::Url;
 use uuid::Uuid;
 
@@ -50,20 +50,17 @@ pub trait Report {
 }
 
 fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
-    if Utf8Path::exists(path) {
-        if let Ok(contents) = Fs::read_file(path, "") {
-            if let Ok(machine_uuid) = Uuid::parse_str(&contents) {
-                return Ok(machine_uuid);
-            }
+    if let Ok(contents) = Fs::read_file(path, "") {
+        if let Ok(machine_uuid) = Uuid::parse_str(&contents.trim()) {
+            return Ok(machine_uuid);
         }
     }
-
     write_machine_id(path)
 }
 
 fn write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {
     let machine_id = Uuid::new_v4();
-    Fs::write_file(path, machine_id, "")?;
+    Fs::write_file(path, machine_id.to_string(), "")?;
     Ok(machine_id)
 }
 

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -1,8 +1,8 @@
-use camino::Utf8PathBuf;
 use ci_info::types::Vendor as CiVendor;
 use git2::Repository;
 use reqwest::blocking::Client;
 use reqwest::Url;
+use saucer::Utf8PathBuf;
 use semver::Version;
 use serde::Serialize;
 use sha2::{Digest, Sha256};

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 atty = "0.2"
-camino = "1"
 directories-next = "2.0"
 flate2 = "1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "native-tls", "socks"] }
@@ -16,6 +15,8 @@ thiserror = "1.0"
 tar = "0.4"
 tempdir = "0.3"
 tracing = "0.1"
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../../../awc/saucer"}
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cc = "1.0"

--- a/installers/binstall/src/error.rs
+++ b/installers/binstall/src/error.rs
@@ -27,7 +27,7 @@ pub enum InstallerError {
 
     /// A specified path was not valid UTF-8
     #[error(transparent)]
-    PathNotUtf8(#[from] camino::FromPathBufError),
+    PathNotUtf8(#[from] saucer::FromPathBufError),
 
     /// Attempted to install a plugin that requires accepting ELv2
     /// without passing a flag to accept the license
@@ -36,4 +36,10 @@ pub enum InstallerError {
         plugin
     )]
     MustAcceptElv2 { plugin: String },
+
+    #[error("This binary has already been placed in the installation destination.")]
+    AlreadyInstalled,
+
+    #[error(transparent)]
+    SaucerError(#[from] saucer::Error),
 }

--- a/installers/binstall/src/lib.rs
+++ b/installers/binstall/src/lib.rs
@@ -18,8 +18,8 @@
 //! it's pretty simple! We're largely just moving over our currently running
 //! executable to a different path.
 
-use camino::Utf8PathBuf;
 use directories_next::BaseDirs;
+use saucer::Utf8PathBuf;
 
 use std::convert::TryFrom;
 
@@ -61,7 +61,7 @@ mod tests {
     use assert_fs::TempDir;
 
     #[cfg(not(windows))]
-    use camino::Utf8PathBuf;
+    use saucer::Utf8PathBuf;
 
     #[cfg(not(windows))]
     #[test]

--- a/installers/binstall/src/system/unix.rs
+++ b/installers/binstall/src/system/unix.rs
@@ -1,4 +1,4 @@
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::fs;

--- a/src/bin/rover.rs
+++ b/src/bin/rover.rs
@@ -1,4 +1,3 @@
-use clap::Parser;
 use robot_panic::setup_panic;
 use rover::cli::Rover;
 
@@ -11,6 +10,5 @@ fn main() -> std::io::Result<()> {
         homepage: rover::PKG_HOMEPAGE.into(),
         repository: rover::PKG_REPOSITORY.into()
     });
-    let app = Rover::from_args();
-    app.run()
+    Rover::run_from_args()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use calm_io::stdoutln;
-use camino::Utf8PathBuf;
-use clap::{AppSettings, Parser};
 use lazycell::{AtomicLazyCell, LazyCell};
 use reqwest::blocking::Client;
+use saucer::Utf8PathBuf;
+use saucer::{clap, AppSettings, Parser};
 use serde::Serialize;
 
 use crate::command::output::JsonOutput;
@@ -104,6 +104,10 @@ pub struct Rover {
 }
 
 impl Rover {
+    pub fn run_from_args() -> io::Result<()> {
+        Rover::from_args().run()
+    }
+
     pub fn run(&self) -> io::Result<()> {
         timber::init(self.log_level);
         tracing::trace!(command_structure = ?self);
@@ -340,7 +344,7 @@ pub enum OutputType {
 }
 
 impl FromStr for OutputType {
-    type Err = anyhow::Error;
+    type Err = saucer::Error;
 
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         match input {

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::Cyan;
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use config::Profile;
@@ -45,7 +45,6 @@ fn api_key_prompt() -> Result<String> {
 
     eprintln!("Copy the key and paste it into the prompt below.");
     term.write_str("> ")?;
-
     let api_key = term.read_secure_line()?;
     if is_valid(&api_key) {
         Ok(api_key)
@@ -61,7 +60,7 @@ fn is_valid(api_key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use assert_fs::TempDir;
-    use camino::Utf8Path;
+    use saucer::Utf8Path;
     use serial_test::serial;
 
     use houston::{Config, Profile};

--- a/src/command/config/clear.rs
+++ b/src/command/config/clear.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/config/delete.rs
+++ b/src/command/config/delete.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use houston as config;

--- a/src/command/config/list.rs
+++ b/src/command/config/list.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::Result;

--- a/src/command/config/mod.rs
+++ b/src/command/config/mod.rs
@@ -4,7 +4,7 @@ mod delete;
 mod list;
 mod whoami;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -1,6 +1,6 @@
 use ansi_term::Colour::Green;
-use clap::Parser;
 use rover_client::operations::config::who_am_i::{self, Actor, ConfigWhoAmIInput};
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use houston::{mask_key, CredentialOrigin};

--- a/src/command/docs/list.rs
+++ b/src/command/docs/list.rs
@@ -2,7 +2,7 @@ use crate::{command::RoverOutput, Result};
 
 use super::shortlinks;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/command/docs/mod.rs
+++ b/src/command/docs/mod.rs
@@ -2,7 +2,7 @@ mod list;
 mod open;
 pub mod shortlinks;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::{command::RoverOutput, Result};

--- a/src/command/docs/open.rs
+++ b/src/command/docs/open.rs
@@ -3,7 +3,7 @@ use crate::{anyhow, command::RoverOutput, Result};
 use super::shortlinks;
 
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use std::process::Command;

--- a/src/command/explain.rs
+++ b/src/command/explain.rs
@@ -1,7 +1,7 @@
 use crate::command::RoverOutput;
 use crate::error::metadata::code::Code;
 use crate::Result;
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/command/fed2/mod.rs
+++ b/src/command/fed2/mod.rs
@@ -1,6 +1,6 @@
 mod supergraph;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/fed2/supergraph/compose.rs
+++ b/src/command/fed2/supergraph/compose.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/command/fed2/supergraph/mod.rs
+++ b/src/command/fed2/supergraph/mod.rs
@@ -1,7 +1,7 @@
 mod compose;
 // mod fetch;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::graph::check::{self, GraphCheckInput};

--- a/src/command/graph/delete.rs
+++ b/src/command/graph/delete.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::graph::delete::{self, GraphDeleteInput};

--- a/src/command/graph/fetch.rs
+++ b/src/command/graph/fetch.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::graph::fetch::{self, GraphFetchInput};

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -1,6 +1,6 @@
 use crate::Result;
-use clap::Parser;
 use reqwest::blocking::Client;
+use saucer::{clap, Parser};
 use serde::Serialize;
 use std::collections::HashMap;
 use url::Url;

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -4,7 +4,7 @@ mod fetch;
 mod introspect;
 mod publish;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::graph::publish::{self, GraphPublishInput};

--- a/src/command/info.rs
+++ b/src/command/info.rs
@@ -3,7 +3,7 @@ use crate::Result;
 use crate::PKG_VERSION;
 
 use calm_io::stderrln;
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 use std::env;
 

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -55,7 +55,7 @@ impl Plugin {
 }
 
 impl FromStr for Plugin {
-    type Err = anyhow::Error;
+    type Err = saucer::Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let lowercase = s.to_lowercase();

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -24,7 +24,7 @@ use serde_json::{json, Value};
 use termimad::MadSkin;
 
 /// RoverOutput defines all of the different types of data that are printed
-/// to `stdout`. Every one of Rover's commands should return `anyhow::Result<RoverOutput>`
+/// to `stdout`. Every one of Rover's commands should return `saucer::Result<RoverOutput>`
 /// If the command needs to output some type of data, it should be structured
 /// in this enum, and its print logic should be handled in `RoverOutput::print`
 ///

--- a/src/command/readme/fetch.rs
+++ b/src/command/readme/fetch.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/readme/mod.rs
+++ b/src/command/readme/mod.rs
@@ -1,7 +1,7 @@
 mod fetch;
 mod publish;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/readme/publish.rs
+++ b/src/command/readme/publish.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::subgraph::check::{self, SubgraphCheckInput};

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::subgraph::fetch::{self, SubgraphFetchInput};

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
 use reqwest::blocking::Client;
+use saucer::{clap, Parser};
 use serde::Serialize;
 use std::collections::HashMap;
 use url::Url;

--- a/src/command/subgraph/list.rs
+++ b/src/command/subgraph/list.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::Cyan;
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use rover_client::operations::subgraph::list::{self, SubgraphListInput};

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -5,7 +5,7 @@ mod introspect;
 mod list;
 mod publish;
 
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -1,5 +1,5 @@
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -17,8 +17,8 @@ use crate::{
 use apollo_federation_types::{build::BuildResult, config::FederationVersion};
 use rover_client::RoverClientError;
 
-use camino::Utf8PathBuf;
-use clap::Parser;
+use saucer::Utf8PathBuf;
+use saucer::{clap, Parser};
 use serde::Serialize;
 use tempdir::TempDir;
 
@@ -97,7 +97,7 @@ impl Compose {
         let federation_version =
             exe.as_str().split("supergraph-").collect::<Vec<&str>>()[1].to_string();
         eprintln!(
-            "Composing supergraph with Federation {}.",
+            "composing supergraph with Federation {}.",
             &federation_version
         );
 

--- a/src/command/supergraph/compose/no_compose.rs
+++ b/src/command/supergraph/compose/no_compose.rs
@@ -1,5 +1,5 @@
-use camino::Utf8PathBuf;
-use clap::Parser;
+use saucer::Utf8PathBuf;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::options::ProfileOpt;

--- a/src/command/supergraph/fetch.rs
+++ b/src/command/supergraph/fetch.rs
@@ -8,7 +8,7 @@ use crate::{
 use rover_client::operations::supergraph::fetch::{self, SupergraphFetchInput};
 
 use ansi_term::Colour::{Cyan, Yellow};
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -6,8 +6,8 @@ mod resolve_config;
 #[cfg(feature = "composition-js")]
 pub(crate) use resolve_config::resolve_supergraph_yaml;
 
-use camino::Utf8PathBuf;
-use clap::Parser;
+use saucer::Utf8PathBuf;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -3,8 +3,9 @@ use apollo_federation_types::{
     config::{FederationVersion, SchemaSource, SupergraphConfig},
 };
 use apollo_parser::{ast, Parser};
+use saucer::Fs;
 
-use std::{collections::HashMap, fs, str::FromStr};
+use std::{collections::HashMap, str::FromStr};
 
 use rover_client::blocking::GraphQLClient;
 use rover_client::operations::subgraph::fetch::{self, SubgraphFetchInput};
@@ -47,9 +48,8 @@ pub(crate) fn resolve_supergraph_yaml(
                     FileDescriptorType::Stdin => file.clone(),
                 };
 
-                let schema = fs::read_to_string(&relative_schema_path).map_err(|e| {
-                    let err = anyhow!("Could not read \"{}\": {}", &relative_schema_path, e);
-                    let mut err = RoverError::new(err);
+                let schema = Fs::read_file(&relative_schema_path, "").map_err(|e| {
+                    let mut err = RoverError::new(e);
                     err.set_suggestion(Suggestion::ValidComposeFile);
                     err
                 })?;

--- a/src/command/update/check.rs
+++ b/src/command/update/check.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
 use reqwest::blocking::Client;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/command/update/mod.rs
+++ b/src/command/update/mod.rs
@@ -1,7 +1,7 @@
 mod check;
 
-use clap::Parser;
 use reqwest::blocking::Client;
+use saucer::{clap, Parser};
 use serde::Serialize;
 
 use crate::command::RoverOutput;

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -32,11 +32,11 @@ pub struct Metadata {
     pub(crate) json_version: JsonVersion,
 }
 
-/// `Metadata` structs can be created from an `anyhow::Error`
+/// `Metadata` structs can be created from an `saucer::Error`
 /// This works by downcasting the errors to their underlying types
 /// and creating `Suggestion`s and `Code`s where applicable
-impl From<&mut anyhow::Error> for Metadata {
-    fn from(error: &mut anyhow::Error) -> Self {
+impl From<&mut saucer::Error> for Metadata {
+    fn from(error: &mut saucer::Error) -> Self {
         let mut skip_printing_cause = false;
         if let Some(rover_client_error) = error.downcast_ref::<RoverClientError>() {
             let (suggestion, code) = match rover_client_error {
@@ -190,6 +190,7 @@ impl From<&mut anyhow::Error> for Metadata {
                     (Some(Suggestion::SubmitIssue), Some(Code::E025))
                 }
                 HoustonProblem::IoError(_) => (Some(Suggestion::SubmitIssue), Some(Code::E026)),
+                HoustonProblem::SaucerError(_) => (None, None),
             };
             return Metadata {
                 json_version: JsonVersion::default(),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod metadata;
 
-pub use anyhow::{anyhow, Context};
 pub(crate) use metadata::Metadata;
+pub use saucer::{anyhow, Context};
 
 pub type Result<T> = std::result::Result<T, RoverError>;
 
@@ -29,13 +29,13 @@ use apollo_federation_types::build::BuildErrors;
 #[derive(Serialize, Debug)]
 pub struct RoverError {
     #[serde(flatten, serialize_with = "serialize_anyhow")]
-    error: anyhow::Error,
+    error: saucer::Error,
 
     #[serde(flatten)]
     metadata: Metadata,
 }
 
-fn serialize_anyhow<S>(error: &anyhow::Error, serializer: S) -> std::result::Result<S::Ok, S::Error>
+fn serialize_anyhow<S>(error: &saucer::Error, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -62,7 +62,7 @@ where
 impl RoverError {
     pub fn new<E>(error: E) -> Self
     where
-        E: Into<anyhow::Error>,
+        E: Into<saucer::Error>,
     {
         let mut error = error.into();
         let metadata = Metadata::from(error.borrow_mut());
@@ -133,7 +133,7 @@ impl Display for RoverError {
     }
 }
 
-impl<E: Into<anyhow::Error>> From<E> for RoverError {
+impl<E: Into<saucer::Error>> From<E> for RoverError {
     fn from(error: E) -> Self {
         Self::new(error)
     }

--- a/src/options/check.rs
+++ b/src/options/check.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::{Deserialize, Serialize};
 
 use rover_client::shared::ValidationPeriod;

--- a/src/options/graph.rs
+++ b/src/options/graph.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
 use rover_client::shared::GraphRef;
+use saucer::{clap, Parser};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Parser)]

--- a/src/options/profile.rs
+++ b/src/options/profile.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Parser)]

--- a/src/options/schema.rs
+++ b/src/options/schema.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 
 use crate::{
     utils::parsers::{parse_file_descriptor, FileDescriptorType},

--- a/src/options/subgraph.rs
+++ b/src/options/subgraph.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use saucer::{clap, Parser};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Parser)]

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -1,4 +1,4 @@
-use camino::{Utf8Path, Utf8PathBuf};
+use saucer::{Utf8Path, Utf8PathBuf};
 
 use crate::{anyhow, error::RoverError, Context, Result, Suggestion};
 
@@ -106,7 +106,7 @@ pub fn parse_header(header: &str) -> std::result::Result<(String, String), io::E
 mod tests {
     use super::{parse_file_descriptor, FileDescriptorType};
     use assert_fs::prelude::*;
-    use camino::Utf8PathBuf;
+    use saucer::Utf8PathBuf;
     use std::convert::TryFrom;
 
     #[test]

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -1,4 +1,4 @@
-use saucer::{Utf8Path, Utf8PathBuf};
+use saucer::{Fs, Utf8Path, Utf8PathBuf};
 
 use crate::{anyhow, error::RoverError, Context, Result, Suggestion};
 
@@ -29,7 +29,7 @@ impl FileDescriptorType {
             }
             Self::File(file_path) => {
                 if Utf8Path::exists(file_path) {
-                    let contents = std::fs::read_to_string(file_path).with_context(|| {
+                    let contents = Fs::read_file(file_path, "").with_context(|| {
                         format!("Could not read {} from {}", file_description, file_path)
                     })?;
                     Ok(contents)

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -1,5 +1,5 @@
-use camino::Utf8PathBuf;
 use reqwest::blocking::Client;
+use saucer::Utf8PathBuf;
 use url::Url;
 
 use crate::utils::env::RoverEnvKey;
@@ -130,7 +130,7 @@ mod tests {
 
     use sputnik::Command;
 
-    use clap::Parser;
+    use saucer::Parser;
     use serde_json::json;
 
     use std::collections::HashMap;

--- a/tests/config/profile.rs
+++ b/tests/config/profile.rs
@@ -1,7 +1,7 @@
 use assert_cmd::Command;
 use assert_fs::TempDir;
-use camino::Utf8PathBuf;
 use predicates::prelude::*;
+use saucer::Utf8PathBuf;
 
 use houston::{Config, Profile};
 use rover::utils::env::RoverEnvKey;

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::process::Command;
 
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
 use serde_json::Value;
 
 // The behavior of these tests _must_ remain unchanged

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,15 +9,14 @@ publish = false
 [dependencies]
 ansi_term = "0.12"
 assert_fs = "1"
-anyhow = "1"
 base64 = "0.13"
-camino = "1"
 cargo_metadata = "0.14"
-clap = { version = "3", default-features = false, features = ["std", "env", "derive"] }
 flate2 = "1"
 lazy_static = "1.4"
 regex = "1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "native-tls"]}
+saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
+# saucer = { path = "../../awc/saucer" }
 semver = "1"
 serde_json = "1"
 serde_json_traversal = "0.2"

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result};
-use clap::Parser;
+use saucer::{clap, Parser};
+use saucer::{Context, Result};
 
 use crate::commands::version::RoverVersion;
 use crate::target::{Target, POSSIBLE_TARGETS};

--- a/xtask/src/commands/docs.rs
+++ b/xtask/src/commands/docs.rs
@@ -1,11 +1,12 @@
-use std::{collections::BTreeMap, fs};
+use std::collections::BTreeMap;
 
-use anyhow::Result;
-use clap::Parser;
+use saucer::Fs;
+use saucer::Result;
+use saucer::{clap, Parser};
 
 use crate::tools::{GitRunner, NpmRunner};
 
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct Docs {
@@ -26,16 +27,17 @@ impl Docs {
         let git_runner = GitRunner::new(verbose, &self.path)?;
         let docs = git_runner.clone_docs(&self.org, &self.branch)?;
         let local_sources_yaml_path = docs.join("sources").join("local.yml");
-        let local_sources_yaml = fs::read_to_string(&local_sources_yaml_path)?;
+        let local_sources_yaml = Fs::read_file(&local_sources_yaml_path, "")?;
         let mut local_sources: BTreeMap<String, Utf8PathBuf> =
             serde_yaml::from_str(&local_sources_yaml)?;
         local_sources.insert(
             "rover".to_string(),
             crate::utils::PKG_PROJECT_ROOT.join("docs").join("source"),
         );
-        fs::write(
+        Fs::write_file(
             &local_sources_yaml_path,
             serde_yaml::to_string(&local_sources)?,
+            "",
         )?;
         let npm_runner = NpmRunner::new(true)?;
         npm_runner.dev_docs(&self.path)?;

--- a/xtask/src/commands/integration_test.rs
+++ b/xtask/src/commands/integration_test.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Result};
-use clap::Parser;
+use saucer::{anyhow, Result};
+use saucer::{clap, Parser};
 
 use crate::target::{Target, TARGET_GNU_LINUX};
 use crate::tools::{CargoRunner, GitRunner, MakeRunner};

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
-use clap::Parser;
+use saucer::Result;
+use saucer::{clap, Parser};
 
 use crate::tools::{CargoRunner, NpmRunner};
 

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, ensure, Context, Result};
-use clap::Parser;
+use saucer::{bail, ensure, Context, Result};
+use saucer::{clap, Parser};
 use serde_json_traversal::serde_json_traversal;
 use std::io::Write as _;
 use std::path::Path;

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(target_os = "macos")]
 mod macos;
 
-use anyhow::{bail, ensure, Context, Result};
-use camino::Utf8PathBuf;
-use clap::Parser;
+use saucer::Utf8PathBuf;
+use saucer::{bail, ensure, Context, Result};
+use saucer::{clap, Parser};
 use std::path::Path;
 
 use crate::target::{Target, POSSIBLE_TARGETS};

--- a/xtask/src/commands/prep/docs.rs
+++ b/xtask/src/commands/prep/docs.rs
@@ -1,7 +1,8 @@
-use anyhow::{anyhow, Context, Result};
-use camino::Utf8PathBuf;
+use saucer::Fs;
+use saucer::Utf8PathBuf;
+use saucer::{anyhow, Context, Result};
 
-use std::{convert::TryFrom, fs};
+use std::convert::TryFrom;
 
 use crate::utils::PKG_PROJECT_ROOT;
 
@@ -31,7 +32,7 @@ impl DocsRunner {
             .join("codes");
 
         // sort code files alphabetically
-        let raw_code_files = fs::read_dir(&codes_dir)?;
+        let raw_code_files = Fs::get_dir_entries(&codes_dir, "")?;
 
         let mut code_files = Vec::new();
         for raw_code_file in raw_code_files {
@@ -42,7 +43,7 @@ impl DocsRunner {
                 code_files.push(raw_code_file);
             }
         }
-        code_files.sort_by_key(|f| f.path());
+        code_files.sort_by_key(|f| f.path().to_string());
 
         let mut all_descriptions = String::new();
 
@@ -52,7 +53,7 @@ impl DocsRunner {
         for code in code_files {
             let path = Utf8PathBuf::try_from(code.path())?;
 
-            let contents = fs::read_to_string(&path)?;
+            let contents = Fs::read_file(&path, "")?;
             let code_name = path
                 .file_name()
                 .ok_or_else(|| anyhow!("Path {} doesn't have a file name", &path))?
@@ -72,7 +73,7 @@ impl DocsRunner {
         let source_path = self.project_root.join("CONTRIBUTING.md");
         let destination_path = self.docs_root.join("source").join("contributing.md");
 
-        let source_content_with_header = fs::read_to_string(&source_path)
+        let source_content_with_header = Fs::read_file(&source_path, "")
             .with_context(|| format!("Could not read contents of {} to a String", &source_path))?;
         // Don't include the first header and the empty newline after it.
         let source_content = source_content_with_header
@@ -89,7 +90,7 @@ impl DocsRunner {
     ) -> Result<()> {
         // build up a new docs page with existing content line-by-line
         // and then concat the replacement content
-        let destination_content = fs::read_to_string(&destination_path).with_context(|| {
+        let destination_content = Fs::read_file(&destination_path, "").with_context(|| {
             format!(
                 "Could not read contents of {} to a String",
                 &destination_path
@@ -105,7 +106,7 @@ impl DocsRunner {
         }
         new_content.push_str(source_content);
 
-        fs::write(&destination_path, new_content)?;
+        Fs::write_file(&destination_path, new_content, "")?;
         Ok(())
     }
 }

--- a/xtask/src/commands/prep/installers.rs
+++ b/xtask/src/commands/prep/installers.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
 use regex::bytes::Regex;
+use saucer::{anyhow, Context, Result};
+use saucer::{Utf8Path, Utf8PathBuf};
 
 use std::{fs, str};
 

--- a/xtask/src/commands/prep/mod.rs
+++ b/xtask/src/commands/prep/mod.rs
@@ -1,8 +1,8 @@
 mod docs;
 mod installers;
 
-use anyhow::{Context, Result};
-use clap::Parser;
+use saucer::{clap, Parser};
+use saucer::{Context, Result};
 
 use crate::commands::prep::docs::DocsRunner;
 use crate::tools::{CargoRunner, NpmRunner};

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
-use clap::Parser;
+use saucer::Result;
+use saucer::{clap, Parser};
 
 use crate::commands::{IntegrationTest, UnitTest};
 use crate::target::{Target, POSSIBLE_TARGETS};

--- a/xtask/src/commands/unit_test.rs
+++ b/xtask/src/commands/unit_test.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
-use camino::Utf8PathBuf;
-use clap::Parser;
+use saucer::Result;
+use saucer::Utf8PathBuf;
+use saucer::{clap, Parser};
 
 use crate::target::{Target, POSSIBLE_TARGETS};
 use crate::tools::{CargoRunner, Runner};

--- a/xtask/src/commands/version.rs
+++ b/xtask/src/commands/version.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use saucer::anyhow;
 use semver::Version;
 
 use crate::Result;
@@ -11,7 +11,7 @@ pub(crate) struct RoverVersion {
 }
 
 impl FromStr for RoverVersion {
-    type Err = anyhow::Error;
+    type Err = saucer::Error;
 
     fn from_str(proposed_version: &str) -> Result<Self, Self::Err> {
         if proposed_version.is_empty() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,8 +5,7 @@ pub(crate) mod tools;
 pub(crate) mod utils;
 
 use ansi_term::Colour::Green;
-use anyhow::Result;
-use clap::Parser;
+use saucer::{clap, Parser, Result};
 
 fn main() -> Result<()> {
     let app = Xtask::from_args();

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -1,5 +1,5 @@
-use anyhow::anyhow;
-use camino::Utf8Path;
+use saucer::anyhow;
+use saucer::Utf8Path;
 
 use std::{collections::HashMap, fmt, str::FromStr};
 
@@ -107,7 +107,7 @@ impl Default for Target {
 }
 
 impl FromStr for Target {
-    type Err = anyhow::Error;
+    type Err = saucer::Error;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match input {

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -1,5 +1,5 @@
-use anyhow::anyhow;
-use camino::Utf8PathBuf;
+use saucer::anyhow;
+use saucer::Utf8PathBuf;
 
 use crate::commands::version::RoverVersion;
 use crate::target::Target;

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -2,9 +2,9 @@ use std::{convert::TryFrom, fs};
 
 use crate::tools::Runner;
 
-use anyhow::{Context, Result};
 use assert_fs::TempDir;
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
+use saucer::{Context, Result};
 
 pub(crate) struct GitRunner {
     runner: Runner,

--- a/xtask/src/tools/make.rs
+++ b/xtask/src/tools/make.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use crate::tools::Runner;
 use crate::utils::CommandOutput;
 
-use anyhow::{anyhow, Context, Result};
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
+use saucer::{anyhow, Context, Result};
 
 pub(crate) struct MakeRunner {
     runner: Runner,

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Context, Result};
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
+use saucer::{anyhow, Context, Result};
 use which::which;
 
 use std::{convert::TryFrom, fs, str};

--- a/xtask/src/tools/runner.rs
+++ b/xtask/src/tools/runner.rs
@@ -1,7 +1,7 @@
 use crate::utils::CommandOutput;
 
-use anyhow::{anyhow, Context, Result};
-use camino::Utf8PathBuf;
+use saucer::Utf8PathBuf;
+use saucer::{anyhow, Context, Result};
 use which::which;
 
 use std::collections::HashMap;

--- a/xtask/src/tools/strip.rs
+++ b/xtask/src/tools/strip.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
-use camino::Utf8PathBuf;
+use saucer::Result;
+use saucer::Utf8PathBuf;
 
 use crate::tools::Runner;
 use crate::utils::PKG_PROJECT_ROOT;

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Context, Result};
-use camino::Utf8PathBuf;
 use cargo_metadata::{Metadata, MetadataCommand};
 use lazy_static::lazy_static;
+use saucer::Utf8PathBuf;
+use saucer::{anyhow, Context, Result};
 
 use std::{collections::HashMap, convert::TryFrom, env, process::Output, str};
 


### PR DESCRIPTION
starts using the `saucer` crate for file system read/writes. will provide better errors than the ones provided by `std::fs` like `permission denied os error (2)` by at least providing context about which file we were trying to read/write to. also every read/write/other fs will now be included in the `--log info` output.