### PR TITLE
Install rover before run if missing

### DIFF
--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -103,8 +103,6 @@ const getBinary = () => {
 const install = () => {
   const binary = getBinary();
   const proxy = configureProxy(binary.url);
-  binary.install(proxy);
-
   // these messages are duplicated in `src/command/install/mod.rs`
   // for the curl installer.
   console.log(
@@ -113,6 +111,8 @@ const install = () => {
   console.log(
     "You can check out our documentation at https://go.apollo.dev/r/docs."
   );
+
+  return binary.install(proxy);
 };
 
 const run = () => {

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "axios-proxy-builder": "^0.1.1",
-        "binary-install": "^1.0.1",
+        "binary-install": "^1.0.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.0"
       },
@@ -48,9 +48,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-install": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.1.tgz",
-      "integrity": "sha512-5/rP8iHlYWwV7OKX1PaYasm2vi5iq4SLM+fT9UVjbbfiwR4cw+WANFTapOcVMznOMa3s6tYFiq84tbijopravg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.2.tgz",
+      "integrity": "sha512-9d8YIog5ImlBlgq8JktCC9aZMO5KgmrtKibsPlmgXhHV19dgs24hRd2MbUdeSrjewH7H89FV7mz9MFq+iUYr9w==",
       "dependencies": {
         "axios": "^0.26.1",
         "rimraf": "^3.0.2",
@@ -352,9 +352,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "binary-install": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.1.tgz",
-      "integrity": "sha512-5/rP8iHlYWwV7OKX1PaYasm2vi5iq4SLM+fT9UVjbbfiwR4cw+WANFTapOcVMznOMa3s6tYFiq84tbijopravg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.2.tgz",
+      "integrity": "sha512-9d8YIog5ImlBlgq8JktCC9aZMO5KgmrtKibsPlmgXhHV19dgs24hRd2MbUdeSrjewH7H89FV7mz9MFq+iUYr9w==",
       "requires": {
         "axios": "^0.26.1",
         "rimraf": "^3.0.2",

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
     "axios-proxy-builder": "^0.1.1",
-    "binary-install": "^1.0.1",
+    "binary-install": "^1.0.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.0"
   },

--- a/installers/npm/run.js
+++ b/installers/npm/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-const { run } = require("./binary");
-run();
+const { run, install: maybeInstall } = require("./binary");
+maybeInstall().then(run);


### PR DESCRIPTION
Currently, rover installs its binary into `binary-install/node_modules/.bin`.
Changes to project dependencies followed by a `yarn` run wipe this file out
(I suppose) with its caching mechanism. The `postinstall` script isn't rerun
when this happens, so the binary is left missing.

This updates the node bin to first check if the binary exists before running,
triggering an install if necessary. I'm not convinced this is a great
solution, but this is at least a significant improvement in UX for now.

Fixes #1178

TODO:
- [ ] Dependent on changes in https://github.com/EverlastingBugstopper/binary-install/pull/20

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
