### PR TITLE
chore: address clippy v1.62.1 lints

### DIFF
--- a/crates/robot-panic/src/lib.rs
+++ b/crates/robot-panic/src/lib.rs
@@ -222,8 +222,6 @@ pub fn print_msg(crash_report: &Report, meta: &Metadata) -> IoResult<()> {
 
 /// Utility function which will handle dumping information to disk
 pub fn get_report(meta: &Metadata, panic_info: &PanicInfo) -> Report {
-    let mut expl = String::new();
-
     let message = match (
         panic_info.payload().downcast_ref::<&str>(),
         panic_info.payload().downcast_ref::<String>(),
@@ -238,14 +236,16 @@ pub fn get_report(meta: &Metadata, panic_info: &PanicInfo) -> Report {
         None => "Unknown".into(),
     };
 
-    match panic_info.location() {
-        Some(location) => expl.push_str(&format!(
-            "Panic occurred in file '{}' at line {}\n",
-            location.file(),
-            location.line()
-        )),
-        None => expl.push_str("Panic location unknown.\n"),
-    }
+    let expl = match panic_info.location() {
+        Some(location) => {
+            format!(
+                "Panic occurred in file '{}' at line {}\n",
+                location.file(),
+                location.line()
+            )
+        }
+        None => "Panic location unknown.\n".to_string(),
+    };
 
     Report::new(&meta.name, &meta.version, Method::Panic, expl, cause)
 }

--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -14,7 +14,8 @@ use uuid::Uuid;
 /// Note: eprintln! statements only show up with `cargo build -vv`
 fn main() -> Result<()> {
     Fs::create_dir_all(".schema", "")?;
-    Fs::write_file(".schema/last_run.uuid", Uuid::new_v4(), "")?;
+    let last_run_uuid = Uuid::new_v4().to_string();
+    Fs::write_file(".schema/last_run.uuid", &last_run_uuid, "")?;
 
     let hash_path = Utf8PathBuf::from(".schema/hash.id");
 

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -93,7 +93,8 @@ impl CheckResponse {
         }
 
         if let Some(url) = &self.target_url {
-            msg.push_str(&format!("View full details at {}", url));
+            msg.push_str("View full details at ");
+            msg.push_str(url);
         }
 
         msg

--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -12,6 +12,8 @@ use crate::utils::client::StudioClientConfig;
 use crate::utils::env::RoverEnvKey;
 use crate::Result;
 
+use std::fmt::Write as _;
+
 use houston as config;
 
 #[derive(Debug, Serialize, Parser)]
@@ -44,25 +46,28 @@ impl WhoAmI {
         match identity.key_actor_type {
             Actor::GRAPH => {
                 if let Some(graph_title) = identity.graph_title {
-                    message.push_str(&format!(
-                        "{}: {}\n",
+                    let _ = writeln!(
+                        message,
+                        "{}: {}",
                         Green.normal().paint("Graph Title"),
                         &graph_title
-                    ));
+                    );
                 }
-                message.push_str(&format!(
-                    "{}: {}\n",
+                let _ = writeln!(
+                    message,
+                    "{}: {}",
                     Green.normal().paint("Unique Graph ID"),
                     identity.id
-                ));
+                );
                 Ok(())
             }
             Actor::USER => {
-                message.push_str(&format!(
-                    "{}: {}\n",
+                let _ = writeln!(
+                    message,
+                    "{}: {}",
                     Green.normal().paint("User ID"),
                     identity.id
-                ));
+                );
                 Ok(())
             }
             _ => Err(anyhow!(
@@ -75,7 +80,7 @@ impl WhoAmI {
             CredentialOrigin::EnvVar => format!("${}", &RoverEnvKey::Key),
         };
 
-        message.push_str(&format!("{}: {}", Green.normal().paint("Origin"), &origin));
+        let _ = write!(message, "{}: {}", Green.normal().paint("Origin"), &origin);
 
         let credential =
             config::Profile::get_credential(&self.profile.profile_name, &client_config.config)?;
@@ -86,11 +91,12 @@ impl WhoAmI {
             mask_key(&credential.api_key)
         };
 
-        message.push_str(&format!(
+        let _ = write!(
+            message,
             "\n{}: {}",
             Green.normal().paint("API Key"),
             &maybe_masked_key
-        ));
+        );
 
         eprintln!("{}", message);
 

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Write as _};
 
 use ansi_term::Colour::{Cyan, Yellow};
 use rover_client::shared::GraphRef;
@@ -110,7 +110,7 @@ impl Display for Suggestion {
                                 if i == num_valid_variants - 1 {
                                     valid_variants_msg.push_str("and ");
                                 }
-                                valid_variants_msg.push_str(&format!("{}", Cyan.normal().paint(variant)));
+                                let _ = write!(valid_variants_msg, "{}", Cyan.normal().paint(variant));
                                 if i < num_valid_variants - 1 {
                                     valid_variants_msg.push_str(", ");
                                 }


### PR DESCRIPTION
mostly changes from `push_str(&format` to `write!` and also a critical fix for rover-client/build.rs