### PR TITLE
fix(ci): checkout code before installing deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,10 +203,10 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
+      - checkout
       - install_system_deps:
           platform: << parameters.platform >>
           rust_channel: stable
-      - checkout
       - attach_workspace:
           at: artifacts
       - gh/setup


### PR DESCRIPTION
release builds are currently failing due to a configuration change introduced in #1188. this PR moves the checkout step ahead of the install dependencies step to circumvent this failure.