### PR TITLE
print to stderr instead of stdout

### DIFF
--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -105,10 +105,10 @@ const install = () => {
   const proxy = configureProxy(binary.url);
   // these messages are duplicated in `src/command/install/mod.rs`
   // for the curl installer.
-  console.log(
+  console.error(
     "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=1"
   );
-  console.log(
+  console.error(
     "You can check out our documentation at https://go.apollo.dev/r/docs."
   );
 

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -100,19 +100,21 @@ const getBinary = () => {
   return binary;
 };
 
-const install = () => {
+const install = (suppressLogs = false) => {
   const binary = getBinary();
   const proxy = configureProxy(binary.url);
   // these messages are duplicated in `src/command/install/mod.rs`
   // for the curl installer.
-  console.error(
-    "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=1"
-  );
-  console.error(
-    "You can check out our documentation at https://go.apollo.dev/r/docs."
-  );
+  if (!suppressLogs) {
+    console.error(
+      "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=1"
+    );
+    console.error(
+      "You can check out our documentation at https://go.apollo.dev/r/docs."
+    );
+  }
 
-  return binary.install(proxy);
+  return binary.install(proxy, suppressLogs);
 };
 
 const run = () => {

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "axios-proxy-builder": "^0.1.1",
-        "binary-install": "^1.0.2",
+        "binary-install": "^1.0.6",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.0"
       },
@@ -48,9 +48,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-install": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.2.tgz",
-      "integrity": "sha512-9d8YIog5ImlBlgq8JktCC9aZMO5KgmrtKibsPlmgXhHV19dgs24hRd2MbUdeSrjewH7H89FV7mz9MFq+iUYr9w==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.6.tgz",
+      "integrity": "sha512-h3K4jaC4jEauK3csXI9GxGBJldkpuJlHCIBv8i+XBNhPuxnlERnD1PWVczQYDqvhJfv0IHUbB3lhDrZUMHvSgw==",
       "dependencies": {
         "axios": "^0.26.1",
         "rimraf": "^3.0.2",
@@ -352,9 +352,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "binary-install": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.2.tgz",
-      "integrity": "sha512-9d8YIog5ImlBlgq8JktCC9aZMO5KgmrtKibsPlmgXhHV19dgs24hRd2MbUdeSrjewH7H89FV7mz9MFq+iUYr9w==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.6.tgz",
+      "integrity": "sha512-h3K4jaC4jEauK3csXI9GxGBJldkpuJlHCIBv8i+XBNhPuxnlERnD1PWVczQYDqvhJfv0IHUbB3lhDrZUMHvSgw==",
       "requires": {
         "axios": "^0.26.1",
         "rimraf": "^3.0.2",

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
     "axios-proxy-builder": "^0.1.1",
-    "binary-install": "^1.0.3",
+    "binary-install": "^1.0.6",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.0"
   },

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
-    "axios-proxy-builder": "0.1.1",
+    "axios-proxy-builder": "^0.1.1",
     "binary-install": "^1.0.3",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.0"

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -37,8 +37,8 @@
   },
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
-    "axios-proxy-builder": "^0.1.1",
-    "binary-install": "^1.0.2",
+    "axios-proxy-builder": "0.1.1",
+    "binary-install": "^1.0.3",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.0"
   },

--- a/installers/npm/run.js
+++ b/installers/npm/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 const { run, install: maybeInstall } = require("./binary");
-maybeInstall().then(run);
+maybeInstall(true).then(run);


### PR DESCRIPTION
This PR fixes #1197 and #1198, I didn't mean to merge #1199. 

This fix is needed because now on every npm invocation we also run a "maybe install" because sometimes tools like yarn delete the binary that we download.