### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.8.1] - 2022-07-28
+
+## 🐛 Fixes
+
+- **Fixes superfluous output in npm installer - @EverlastingBugstopper, #1200 fixes #1197 and #1198**
+
+  In 0.8.0, we released a fix for our npm installer that makes it compatible with yarn workspaces by reinstalling Rover if it doesn't exist. Unfortunately, that means that steps that rely on printing to stdout contained information about the installs in those invocations. This has been fixed.
+
+## 📚 Documentation
+
+- **Adds documentation for the async checks feature introduced in 0.8.1 - @EverlastingBugstopper, #1193**
+
 # [0.8.0] - 2022-07-27
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ansi_term",
  "apollo-federation-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.8.0"
+version = "0.8.1"
 default-run = "rover"
 
 publish = false

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -322,12 +322,12 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.0.tgz",
-      "integrity": "sha512-S9/76X4uYIbVlJyRzXhCBbTJvVD0VvaWNqGiKgkITxlq4aBsTOHVuE84OSi3E1QKP3PTiJYrgMIn220iFOkyQw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.1.tgz",
+      "integrity": "sha512-hRVDduX0UDEneVyEWtc2nu5H2PxpfSfM/riUlgZvo/a/nG475uyehxR5cFGvTEPEQUKY3vGIlqvtRigzqTfCew==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "dataloader": "2.1.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
@@ -337,13 +337,13 @@
       }
     },
     "node_modules/@graphql-tools/code-file-loader": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.0.tgz",
-      "integrity": "sha512-mzevVv5JYyyRIbE6R0mxIniCAZWUGdoNYX97HdVgqChLOl2XRf9I8MarVPewHLmjLTZuWrdQx4ta4sPTLk4tUQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.1.tgz",
+      "integrity": "sha512-nyr0zln7fi4E8lK98THdb8k3gPsSCiyXRFTTNhPRUCPeOD2RCpUZCClM5AB0xv8HjILAipdaxjhb2elPvnY5dw==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "7.3.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/graphql-tag-pluck": "7.3.1",
+        "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -353,14 +353,14 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.8.0.tgz",
-      "integrity": "sha512-dbhfOI8rQXPcowXrbwHLOBY9oGi7qxtlrXF4RuRXmjqGTs2AgogdOE3Ep1+6wFD7qYTuFmHXZ8Cl0PmhoZUgrg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.8.1.tgz",
+      "integrity": "sha512-NDcg3GEQmdEHlnF7QS8b4lM1PSF+DKeFcIlLEfZFBvVq84791UtJcDj8734sIHLukmyuAxXMfA1qLd2l4lZqzA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/batch-execute": "8.5.0",
-        "@graphql-tools/schema": "8.5.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/batch-execute": "8.5.1",
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "8.9.0",
         "dataloader": "2.1.0",
         "tslib": "~2.4.0",
         "value-or-promise": "1.0.11"
@@ -370,13 +370,13 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.4.0.tgz",
-      "integrity": "sha512-r1lslE5GlWO/nbDX82enHjvva7qQiZEIPm+LC9JSgKaYuVoYHuIuIAVYkpBHeaRK1Kbh/86pEhL7PuBZ/cIWSA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.0.tgz",
+      "integrity": "sha512-X3wcC+ZljbXTwdTTSp3oUHJd66mFLDKI750uhB0HidBxE6+wyw7fhmJVJiYROXPswaGliuabpo0JEyLj7hhWKA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/import": "6.7.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/import": "6.7.1",
+        "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -386,15 +386,15 @@
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.0.tgz",
-      "integrity": "sha512-GxtgGTSOiQuFc/yNWXsPJ5QEgGlH+4qBf1paqUJtjFpm89dZA+VkdjoIDiFg8fyXGivjZ37+XAUbuu6UlsT+6Q==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.1.tgz",
+      "integrity": "sha512-+Aayl4y42ASrxDvu613lp3NiK1JRggy/m9wlo93dJp/9L5vKPYlrtFvuQ1tpPEEuSBboYNa/erOsELrRwzzakA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.8",
         "@babel/traverse": "^7.16.8",
         "@babel/types": "^7.16.8",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -402,12 +402,12 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.0.tgz",
-      "integrity": "sha512-u9JL4fClKKyBTQpgb4QFacYUwgBCs4lW1NaHX0hD2zBdahIYidokBY0QkOqOCEAnWeFqpEmAjB62ulLiAJWc2g==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.1.tgz",
+      "integrity": "sha512-StLosFVhdw+eZkL+v9dBabszxCAZtEYW4Oy1+750fDkH39GrmzOB8mWiYna7rm9+GMisC9atJtXuAfMF02Aoag==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
       },
@@ -416,12 +416,12 @@
       }
     },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.0.tgz",
-      "integrity": "sha512-6oR7Ulc5iZc5SM3g1Yj91DqSu3TNbfGK/0baE8KyUlvq6KiIuWFWDy13RGnNesftt4RSWvZqGzu/kzXcBHtt+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.1.tgz",
+      "integrity": "sha512-+QaeRyJcvUXUNEoIaecYrABunqk8/opFbpdHPAijJyVHvlsYfqXR12/501g+/QZzGHKYnyi+Q3lsZbBboj5LBg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -431,13 +431,13 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.7.0.tgz",
-      "integrity": "sha512-6KX7Z8BtlFScDr0pIac92QZWlPGbHcpNMesX/6Y3Vsp3FeFnAYfzZldXZQcJoW7Yl+gHdFwYVq683wSH64kNrw==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.7.1.tgz",
+      "integrity": "sha512-rJ2WUV41wwAkMnBgtcBym3TKVbPgz7z9tBCjOmbNVLy5bB9StVPdo2Uci0D5xYSgLV9XIt+zdyAnYGptioJeWg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/schema": "8.5.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "8.9.0",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       },
@@ -446,12 +446,12 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.0.tgz",
-      "integrity": "sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
+      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -459,13 +459,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.0.tgz",
-      "integrity": "sha512-VeFtKjM3SA9/hCJJfr95aEdC3G0xIKM9z0Qdz4i+eC1g2fdZYnfWFt2ucW4IME+2TDd0enHlKzaV0qk2SLVUww==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
+      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/merge": "8.3.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/merge": "8.3.1",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
       },
@@ -474,14 +474,14 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.13.0.tgz",
-      "integrity": "sha512-hM3yIDij0EqrHrLKNRpFRhQD0tmzt7E5OevOL9O3CLKCcv2Ho4wXQD7gscwVJJdg2Qyr22Pqr/IdtR8QiMScRA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.13.1.tgz",
+      "integrity": "sha512-98B+HHbp/nhpnzRDS2BZGMAqJLD6aWTyjXyKastcPozdNm3AwAlZmdLt+2ypFeuqbsqUSNaGW5gWyPCQ4PC4MA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "8.8.0",
-        "@graphql-tools/utils": "8.8.0",
-        "@graphql-tools/wrap": "8.5.0",
+        "@graphql-tools/delegate": "8.8.1",
+        "@graphql-tools/utils": "8.9.0",
+        "@graphql-tools/wrap": "8.5.1",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.0.2",
@@ -500,9 +500,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -512,14 +512,14 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.5.0.tgz",
-      "integrity": "sha512-I+x9dBNzC135WWPi04ejqurR/zDmhfeGbCftCaYKF4CvgWd+ZaJx4Uc74n1SBegQtrj+KDrOS4HgKwf9vAVR7A==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.5.1.tgz",
+      "integrity": "sha512-KpVVfha2wLSpE08YLX0jeo5nXPfDLASlxOqMlvfa/B4X8SOVmuLyN1L5YZ132tPLDF93uflwlHFnUO5ahpRNlA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "8.8.0",
-        "@graphql-tools/schema": "8.5.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/delegate": "8.8.1",
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
       },
@@ -670,9 +670,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -2745,136 +2745,136 @@
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.0.tgz",
-      "integrity": "sha512-S9/76X4uYIbVlJyRzXhCBbTJvVD0VvaWNqGiKgkITxlq4aBsTOHVuE84OSi3E1QKP3PTiJYrgMIn220iFOkyQw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.1.tgz",
+      "integrity": "sha512-hRVDduX0UDEneVyEWtc2nu5H2PxpfSfM/riUlgZvo/a/nG475uyehxR5cFGvTEPEQUKY3vGIlqvtRigzqTfCew==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "dataloader": "2.1.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
       }
     },
     "@graphql-tools/code-file-loader": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.0.tgz",
-      "integrity": "sha512-mzevVv5JYyyRIbE6R0mxIniCAZWUGdoNYX97HdVgqChLOl2XRf9I8MarVPewHLmjLTZuWrdQx4ta4sPTLk4tUQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.1.tgz",
+      "integrity": "sha512-nyr0zln7fi4E8lK98THdb8k3gPsSCiyXRFTTNhPRUCPeOD2RCpUZCClM5AB0xv8HjILAipdaxjhb2elPvnY5dw==",
       "dev": true,
       "requires": {
-        "@graphql-tools/graphql-tag-pluck": "7.3.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/graphql-tag-pluck": "7.3.1",
+        "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.8.0.tgz",
-      "integrity": "sha512-dbhfOI8rQXPcowXrbwHLOBY9oGi7qxtlrXF4RuRXmjqGTs2AgogdOE3Ep1+6wFD7qYTuFmHXZ8Cl0PmhoZUgrg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.8.1.tgz",
+      "integrity": "sha512-NDcg3GEQmdEHlnF7QS8b4lM1PSF+DKeFcIlLEfZFBvVq84791UtJcDj8734sIHLukmyuAxXMfA1qLd2l4lZqzA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "8.5.0",
-        "@graphql-tools/schema": "8.5.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/batch-execute": "8.5.1",
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "8.9.0",
         "dataloader": "2.1.0",
         "tslib": "~2.4.0",
         "value-or-promise": "1.0.11"
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.4.0.tgz",
-      "integrity": "sha512-r1lslE5GlWO/nbDX82enHjvva7qQiZEIPm+LC9JSgKaYuVoYHuIuIAVYkpBHeaRK1Kbh/86pEhL7PuBZ/cIWSA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.0.tgz",
+      "integrity": "sha512-X3wcC+ZljbXTwdTTSp3oUHJd66mFLDKI750uhB0HidBxE6+wyw7fhmJVJiYROXPswaGliuabpo0JEyLj7hhWKA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/import": "6.7.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/import": "6.7.1",
+        "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.0.tgz",
-      "integrity": "sha512-GxtgGTSOiQuFc/yNWXsPJ5QEgGlH+4qBf1paqUJtjFpm89dZA+VkdjoIDiFg8fyXGivjZ37+XAUbuu6UlsT+6Q==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.1.tgz",
+      "integrity": "sha512-+Aayl4y42ASrxDvu613lp3NiK1JRggy/m9wlo93dJp/9L5vKPYlrtFvuQ1tpPEEuSBboYNa/erOsELrRwzzakA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.8",
         "@babel/traverse": "^7.16.8",
         "@babel/types": "^7.16.8",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/import": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.0.tgz",
-      "integrity": "sha512-u9JL4fClKKyBTQpgb4QFacYUwgBCs4lW1NaHX0hD2zBdahIYidokBY0QkOqOCEAnWeFqpEmAjB62ulLiAJWc2g==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.1.tgz",
+      "integrity": "sha512-StLosFVhdw+eZkL+v9dBabszxCAZtEYW4Oy1+750fDkH39GrmzOB8mWiYna7rm9+GMisC9atJtXuAfMF02Aoag==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.0.tgz",
-      "integrity": "sha512-6oR7Ulc5iZc5SM3g1Yj91DqSu3TNbfGK/0baE8KyUlvq6KiIuWFWDy13RGnNesftt4RSWvZqGzu/kzXcBHtt+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.1.tgz",
+      "integrity": "sha512-+QaeRyJcvUXUNEoIaecYrABunqk8/opFbpdHPAijJyVHvlsYfqXR12/501g+/QZzGHKYnyi+Q3lsZbBboj5LBg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
       }
     },
     "@graphql-tools/load": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.7.0.tgz",
-      "integrity": "sha512-6KX7Z8BtlFScDr0pIac92QZWlPGbHcpNMesX/6Y3Vsp3FeFnAYfzZldXZQcJoW7Yl+gHdFwYVq683wSH64kNrw==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.7.1.tgz",
+      "integrity": "sha512-rJ2WUV41wwAkMnBgtcBym3TKVbPgz7z9tBCjOmbNVLy5bB9StVPdo2Uci0D5xYSgLV9XIt+zdyAnYGptioJeWg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/schema": "8.5.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "8.9.0",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.0.tgz",
-      "integrity": "sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
+      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.0.tgz",
-      "integrity": "sha512-VeFtKjM3SA9/hCJJfr95aEdC3G0xIKM9z0Qdz4i+eC1g2fdZYnfWFt2ucW4IME+2TDd0enHlKzaV0qk2SLVUww==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
+      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
       "dev": true,
       "requires": {
-        "@graphql-tools/merge": "8.3.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/merge": "8.3.1",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.13.0.tgz",
-      "integrity": "sha512-hM3yIDij0EqrHrLKNRpFRhQD0tmzt7E5OevOL9O3CLKCcv2Ho4wXQD7gscwVJJdg2Qyr22Pqr/IdtR8QiMScRA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.13.1.tgz",
+      "integrity": "sha512-98B+HHbp/nhpnzRDS2BZGMAqJLD6aWTyjXyKastcPozdNm3AwAlZmdLt+2ypFeuqbsqUSNaGW5gWyPCQ4PC4MA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "8.8.0",
-        "@graphql-tools/utils": "8.8.0",
-        "@graphql-tools/wrap": "8.5.0",
+        "@graphql-tools/delegate": "8.8.1",
+        "@graphql-tools/utils": "8.9.0",
+        "@graphql-tools/wrap": "8.5.1",
         "@n1ru4l/graphql-live-query": "^0.9.0",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.0.2",
@@ -2890,23 +2890,23 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/wrap": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.5.0.tgz",
-      "integrity": "sha512-I+x9dBNzC135WWPi04ejqurR/zDmhfeGbCftCaYKF4CvgWd+ZaJx4Uc74n1SBegQtrj+KDrOS4HgKwf9vAVR7A==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.5.1.tgz",
+      "integrity": "sha512-KpVVfha2wLSpE08YLX0jeo5nXPfDLASlxOqMlvfa/B4X8SOVmuLyN1L5YZ132tPLDF93uflwlHFnUO5ahpRNlA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "8.8.0",
-        "@graphql-tools/schema": "8.5.0",
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/delegate": "8.8.1",
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "8.9.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
       }
@@ -3031,9 +3031,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==",
       "dev": true
     },
     "@types/parse-json": {

--- a/docs/source/ci-cd.md
+++ b/docs/source/ci-cd.md
@@ -45,7 +45,7 @@ jobs:
           name: Install
           command: |
             # download and install Rover
-            curl -sSL https://rover.apollo.dev/nix/v0.8.0 | sh
+            curl -sSL https://rover.apollo.dev/nix/v0.8.1 | sh
 
             # This allows the PATH changes to persist to the next `run` step
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.8.0 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.8.1 | sh
 
           # Add Rover to the $GITHUB_PATH so it can be used in another step
           # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
@@ -206,10 +206,10 @@ Normally when installing, Rover adds the path of its executable to your `$PATH`.
 
 To avoid this issue, do one of the following:
 - Use the script, but reference `rover` by its full path (`$HOME/.rover/bin/rover`)
-- Download the latest release via cURL and extract the binary like so (this downloads Rover `0.8.0` for Linux x86 architectures):
+- Download the latest release via cURL and extract the binary like so (this downloads Rover `0.8.1` for Linux x86 architectures):
 
     ```
-    curl -L https://github.com/apollographql/rover/releases/download/v0.8.0/rover-v0.8.0-x86_64-unknown-linux-gnu.tar.gz | tar --strip-components=1 -zxv
+    curl -L https://github.com/apollographql/rover/releases/download/v0.8.1/rover-v0.8.1-x86_64-unknown-linux-gnu.tar.gz | tar --strip-components=1 -zxv
     ```
 
 #### Permission issues

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.8.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.8.1 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.8.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.8.1' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.8.0"
+PACKAGE_VERSION="v0.8.1"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.8.0'
+$package_version = 'v0.8.1'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## 🐛 Fixes

- **Fixes superfluous output in npm installer - @EverlastingBugstopper, #1200 fixes #1197 and #1198**

  In 0.8.0, we released a fix for our npm installer that makes it compatible with yarn workspaces by reinstalling Rover if it doesn't exist. Unfortunately, that means that steps that rely on printing to stdout contained information about the installs in those invocations. This has been fixed.

## 📚 Documentation

- **Adds documentation for the async checks feature introduced in 0.8.1 - @EverlastingBugstopper, #1193**