### PR TITLE
use more specific URL for obtaining "Personal API Key"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🛠 Maintenance
 
+- **Link directly to API Keys page in Studio - @abernix, #1202**
+
+  The `rover config auth` command will now provide a link that takes you directly to the "API Keys" page where you can create a Personal API Key, rather than a page that requires you to click through to another page.
+
 ## 📚 Documentation -->
 
 # [0.8.1] - 2022-07-28

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -2,7 +2,7 @@
 // docs: https://www.apollographql.com/docs/devtools/editor-plugins/
 // install: https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo
 // to configure, you need a `.env` file in this directory containing an `APOLLO_KEY=your_api_key`
-// that can be created at https://studio-staging.apollographql.com/user-settings
+// that can be created at https://studio.apollographql.com/user-settings/api-keys
 
 module.exports = {
   client: {

--- a/docs/source/commands/config.mdx
+++ b/docs/source/commands/config.mdx
@@ -43,7 +43,7 @@ You create a new configuration profile with the `config auth` command:
 ```
 rover config auth
 
-Go to https://studio.apollographql.com/user-settings and create a new Personal API Key.
+Go to https://studio.apollographql.com/user-settings/api-keys and create a new Personal API Key.
 Copy the key and paste it into the prompt below.
 >
 ```

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -40,7 +40,7 @@ fn api_key_prompt() -> Result<String> {
     eprintln!(
         "Go to {} and create a new Personal API Key.",
         Cyan.normal()
-            .paint("https://studio.apollographql.com/user-settings")
+            .paint("https://studio.apollographql.com/user-settings/api-keys")
     );
 
     eprintln!("Copy the key and paste it into the prompt below.");


### PR DESCRIPTION
Opening for the basis of suggestion, but happy to have this closed, too.

This changes the user instructions during authentication (e.g., `rover config auth`) setup to link to the "API keys" page directly, rather than the parent page which first requires you to click onto the API keys.

I believe this might be a new page and thus this is an incremental improvement, but it may have been intentional to link to the previous page?  Not sure!