### PR TITLE
feat: adds --watch to introspect commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "crossterm",
  "heck",
  "houston",
+ "launchpad",
  "lazycell",
  "opener",
  "os_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ apollo-parser = "0.2"
 # workspace dependencies
 binstall = { path = "./installers/binstall" }
 houston = { path = "./crates/houston" }
+launchpad = { path = "./crates/launchpad" }
 robot-panic = { path = "./crates/robot-panic" }
 rover-client = { path = "./crates/rover-client" }
 sputnik = { path = "./crates/sputnik" }

--- a/crates/launchpad/src/error.rs
+++ b/crates/launchpad/src/error.rs
@@ -9,6 +9,7 @@ pub enum RoverClientError {
         /// The encountered GraphQL error.
         msg: String,
     },
+
     /// Failed to parse Introspection Response coming from server.
     #[error("{msg}")]
     IntrospectionError {
@@ -27,89 +28,27 @@ pub enum RoverClientError {
     /// Invalid JSON in response body.
     #[error("Could not parse JSON")]
     InvalidJson(#[from] serde_json::Error),
-    /*
-    /// Encountered an error handling the received response.
-    #[error("{msg}")]
-    AdhocError {
-        /// The error message.
-        msg: String,
-    },*/
+
     /// Encountered a 400-599 error from an endpoint.
     #[error("Unable to get a response from an endpoint. Client returned an error.\n\n{msg}")]
     ClientError {
         /// Error message from client.
         msg: String,
     },
-    /*
-        /// The user provided an invalid subgraph name.
-        #[error("Could not find subgraph \"{invalid_subgraph}\".")]
-        NoSubgraphInGraph {
-            /// The invalid subgraph name
-            invalid_subgraph: String,
 
-            /// A list of valid subgraph names
-            // this is not used in the error message, but can be accessed
-            // by application-level error handlers
-            valid_subgraphs: Vec<String>,
-        },
-    */
     /// Encountered an error sending the request.
     #[error(transparent)]
     SendRequest(#[from] reqwest::Error),
 
-    /// This error occurs when the Studio API returns no implementing services for a graph
-    /// This response shouldn't be possible!
-    #[error("The response from Apollo Studio was malformed. Response body contains `null` value for \"{null_field}\"")]
+    /// This error occurs when the GraphQL API returns null for a non-nullable field
+    #[error(
+        "The response  was malformed. Response body contains `null` value for \"{null_field}\""
+    )]
     MalformedResponse { null_field: String },
-    /*
-        /// The API returned an invalid ChangeSeverity value
-        #[error("Invalid ChangeSeverity.")]
-        InvalidSeverity,
 
-        /// The user supplied an invalid validation period
-        #[error("You can only specify a duration as granular as seconds.")]
-        ValidationPeriodTooGranular,
-
-        /// The user supplied an invalid validation period duration
-        #[error(transparent)]
-        InvalidValidationPeriodDuration(#[from] humantime::DurationError),
-
-        /// This error occurs when a user has a malformed Graph Ref
-        #[error("Graph IDs must be in the format <NAME> or <NAME>@<VARIANT>, where <NAME> can only contain letters, numbers, or the characters `-` or `_`, and must be 64 characters or less. <VARIANT> must be 64 characters or less.")]
-        InvalidGraphRef,
-    */
     /// This error occurs when a user has a malformed API key
     #[error(
         "The API key you provided is malformed. An API key must have three parts separated by a colon."
     )]
     MalformedKey,
-    /*
-    /// The registry could not find this key
-    #[error("The registry did not recognize the provided API key")]
-    InvalidKey,
-
-    /// Could not parse the latest version
-    #[error("Could not parse the latest release version")]
-    UnparseableReleaseVersion { source: semver::Error },
-
-    /// Encountered an error while processing the request for the latest version
-    #[error("There's something wrong with the latest GitHub release URL")]
-    BadReleaseUrl,
-
-    #[error("This endpoint doesn't support subgraph introspection via the Query._service field")]
-    SubgraphIntrospectionNotAvailable,*/
 }
-
-/*
-fn operation_check_error_msg(check_response: &CheckResponse) -> String {
-    let failure_count = check_response.get_failure_count();
-    let plural = match failure_count {
-        1 => "",
-        _ => "s",
-    };
-    format!(
-        "This operation check has encountered {} schema change{} that would break operations from existing client traffic.",
-        failure_count, plural
-    )
-}
-*/

--- a/crates/launchpad/src/introspect/runner.rs
+++ b/crates/launchpad/src/introspect/runner.rs
@@ -25,6 +25,7 @@ pub(crate) struct GraphIntrospectQuery;
 pub fn run(
     input: GraphIntrospectInput,
     client: &GraphQLClient,
+    should_retry: bool,
 ) -> Result<GraphIntrospectResponse, RoverClientError> {
     let variables = input.clone().into();
     let mut header_map = HeaderMap::new();
@@ -34,7 +35,12 @@ pub fn run(
             HeaderValue::from_str(&header_value)?,
         );
     }
-    let response_data = client.post::<GraphIntrospectQuery>(variables, &mut header_map)?;
+    let response_data = if should_retry {
+        client.post::<GraphIntrospectQuery>(variables, &mut header_map)
+    } else {
+        client.post_no_retry::<GraphIntrospectQuery>(variables, &mut header_map)
+    }?;
+
     build_response(response_data)
 }
 

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -38,12 +38,25 @@ impl StudioClient {
     /// Client method for making a GraphQL request to Apollo Studio.
     ///
     /// Takes one argument, `variables`. Returns a Response or a RoverClientError.
+    /// Automatically retries requests.
     pub fn post<Q: GraphQLQuery>(
         &self,
         variables: Q::Variables,
     ) -> Result<Q::ResponseData, RoverClientError> {
         let mut header_map = self.build_studio_headers()?;
         Ok(self.client.post::<Q>(variables, &mut header_map)?)
+    }
+
+    /// Client method for making a GraphQL request to Apollo Studio.
+    ///
+    /// Takes one argument, `variables`. Returns a Response or a RoverClientError.
+    /// Does not automatically retry requests.
+    pub fn post_no_retry<Q: GraphQLQuery>(
+        &self,
+        variables: Q::Variables,
+    ) -> Result<Q::ResponseData, RoverClientError> {
+        let mut header_map = self.build_studio_headers()?;
+        Ok(self.client.post_no_retry::<Q>(variables, &mut header_map)?)
     }
 
     /// Function for building a [HeaderMap] for making http requests. Use for making

--- a/crates/rover-client/src/operations/graph/introspect.rs
+++ b/crates/rover-client/src/operations/graph/introspect.rs
@@ -8,5 +8,5 @@ pub fn run(
     client: &GraphQLClient,
     should_retry: bool,
 ) -> Result<GraphIntrospectResponse, RoverClientError> {
-    launchpad_run(input, client, should_retry).map_err(|e| RoverClientError::from(e))
+    launchpad_run(input, client, should_retry).map_err(RoverClientError::from)
 }

--- a/crates/rover-client/src/operations/graph/introspect.rs
+++ b/crates/rover-client/src/operations/graph/introspect.rs
@@ -1,0 +1,12 @@
+use crate::{blocking::GraphQLClient, RoverClientError};
+use launchpad::introspect::run as launchpad_run;
+pub use launchpad::introspect::{GraphIntrospectInput, GraphIntrospectResponse, Schema};
+
+/// Runs the introspection query
+pub fn run(
+    input: GraphIntrospectInput,
+    client: &GraphQLClient,
+    should_retry: bool,
+) -> Result<GraphIntrospectResponse, RoverClientError> {
+    launchpad_run(input, client, should_retry).map_err(|e| RoverClientError::from(e))
+}

--- a/crates/rover-client/src/operations/graph/mod.rs
+++ b/crates/rover-client/src/operations/graph/mod.rs
@@ -11,7 +11,7 @@ pub mod check_workflow;
 pub mod check;
 
 /// "graph introspect" command execution
-pub use launchpad::introspect;
+pub mod introspect;
 
 /// "graph delete" command execution
 pub mod delete;

--- a/crates/rover-client/src/operations/subgraph/introspect/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/introspect/runner.rs
@@ -19,6 +19,7 @@ pub(crate) struct SubgraphIntrospectQuery;
 pub fn run(
     input: SubgraphIntrospectInput,
     client: &GraphQLClient,
+    should_retry: bool,
 ) -> Result<SubgraphIntrospectResponse, RoverClientError> {
     let mut header_map = HeaderMap::new();
     for (header_key, header_value) in input.clone().headers {
@@ -27,7 +28,11 @@ pub fn run(
             HeaderValue::from_str(&header_value)?,
         );
     }
-    let response_data = client.post::<SubgraphIntrospectQuery>(input.into(), &mut header_map);
+    let response_data = if should_retry {
+        client.post::<SubgraphIntrospectQuery>(input.into(), &mut header_map)
+    } else {
+        client.post_no_retry::<SubgraphIntrospectQuery>(input.into(), &mut header_map)
+    };
 
     match response_data {
         Ok(data) => build_response(data),

--- a/docs/source/commands/graphs.mdx
+++ b/docs/source/commands/graphs.mdx
@@ -39,7 +39,7 @@ rover graph introspect http://example.com/graphql
 
 The server must be reachable by Rover and it must have introspection enabled.
 
-#### Using the `--watch` flag
+#### Watching for schema changes
 
 You can pass `--watch` to `rover graph introspect` and Rover will introspect your GraphQL endpoint every second. Rover will only print an updated introspection response (or error message) to your terminal if the output of the query differs from the output of the previous query. 
 

--- a/docs/source/commands/graphs.mdx
+++ b/docs/source/commands/graphs.mdx
@@ -41,7 +41,7 @@ The server must be reachable by Rover and it must have introspection enabled.
 
 #### Watching for schema changes
 
-You can pass `--watch` to `rover graph introspect` and Rover will introspect your GraphQL endpoint every second. Rover will only print an updated introspection response (or error message) to your terminal if the output of the query differs from the output of the previous query. 
+If you pass `--watch` to `rover graph introspect`, Rover introspects your GraphQL endpoint every second. Whenever the returned schema differs from the _previously_ returned schema, Rover outputs the updated schema.  
 
 #### Including headers
 

--- a/docs/source/commands/graphs.mdx
+++ b/docs/source/commands/graphs.mdx
@@ -39,6 +39,10 @@ rover graph introspect http://example.com/graphql
 
 The server must be reachable by Rover and it must have introspection enabled.
 
+#### Using the `--watch` flag
+
+You can pass `--watch` to `rover graph introspect` and Rover will introspect your GraphQL endpoint every second. Rover will only print an updated introspection response (or error message) to your terminal if the output of the query differs from the output of the previous query. 
+
 #### Including headers
 
 If the endpoint you're trying to reach requires HTTP headers, you can use the `--header` (`-H`) flag to pass `key:value` pairs of headers. If you have multiple headers to pass, use the header multiple times. If the header includes any spaces, the pair must be quoted.

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -54,7 +54,7 @@ The subgraph must be reachable by Rover. The subgraph does _not_ need to have in
 
 #### Watching for schema changes
 
-You can pass `--watch` to `rover subgraph introspect` and Rover will introspect your subgraph every second. Rover will only print an updated introspection response (or error message) to your terminal if the output of the query differs from the output of the previous query. 
+If you pass `--watch` to `rover subgraph introspect`, Rover introspects your subgraph every second. Whenever the returned schema differs from the _previously_ returned schema, Rover outputs the updated schema.  
 
 #### Including headers
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -52,7 +52,7 @@ The subgraph must be reachable by Rover. The subgraph does _not_ need to have in
 
 > Unlike a standard introspection query, the result of `rover subgraph introspect` _does_ include certain directives (specifically, directives related to federation like `@key`). This is possible because the command uses a separate introspection mechanism provided by the [Apollo Federation specification](/federation/federation-spec/#fetch-service-capabilities).
 
-#### Using the `--watch` flag
+#### Watching for schema changes
 
 You can pass `--watch` to `rover subgraph introspect` and Rover will introspect your subgraph every second. Rover will only print an updated introspection response (or error message) to your terminal if the output of the query differs from the output of the previous query. 
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -52,6 +52,10 @@ The subgraph must be reachable by Rover. The subgraph does _not_ need to have in
 
 > Unlike a standard introspection query, the result of `rover subgraph introspect` _does_ include certain directives (specifically, directives related to federation like `@key`). This is possible because the command uses a separate introspection mechanism provided by the [Apollo Federation specification](/federation/federation-spec/#fetch-service-capabilities).
 
+#### Using the `--watch` flag
+
+You can pass `--watch` to `rover subgraph introspect` and Rover will introspect your subgraph every second. Rover will only print an updated introspection response (or error message) to your terminal if the output of the query differs from the output of the previous query. 
+
 #### Including headers
 
 If the endpoint you're trying to reach requires HTTP headers, you can use the `--header` (`-H`) flag to pass `key:value` pairs of headers. If you have multiple headers to pass, provide the flag multiple times. If a header includes any spaces, the pair must be quoted.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-use calm_io::stdoutln;
 use lazycell::{AtomicLazyCell, LazyCell};
 use reqwest::blocking::Client;
 use saucer::Utf8PathBuf;
@@ -148,13 +147,13 @@ impl Rover {
             Ok(output) => {
                 match self.output_type {
                     OutputType::Plain => output.print()?,
-                    OutputType::Json => stdoutln!("{}", JsonOutput::from(output))?,
+                    OutputType::Json => JsonOutput::from(output).print()?,
                 }
                 process::exit(0);
             }
             Err(error) => {
                 match self.output_type {
-                    OutputType::Json => stdoutln!("{}", JsonOutput::from(error))?,
+                    OutputType::Json => JsonOutput::from(error).print()?,
                     OutputType::Plain => {
                         tracing::debug!(?error);
                         error.print()?;
@@ -190,12 +189,14 @@ impl Rover {
                 self.get_client_config()?,
                 self.get_git_context()?,
                 self.get_checks_timeout_seconds()?,
+                self.get_json(),
             ),
             Command::Readme(command) => command.run(self.get_client_config()?),
             Command::Subgraph(command) => command.run(
                 self.get_client_config()?,
                 self.get_git_context()?,
                 self.get_checks_timeout_seconds()?,
+                self.get_json(),
             ),
             Command::Update(command) => {
                 command.run(self.get_rover_config()?, self.get_reqwest_client())
@@ -206,6 +207,10 @@ impl Rover {
             Command::Info(command) => command.run(),
             Command::Explain(command) => command.run(),
         }
+    }
+
+    pub(crate) fn get_json(&self) -> bool {
+        matches!(self.output_type, OutputType::Json)
     }
 
     pub(crate) fn get_rover_config(&self) -> Result<Config> {

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use rover_client::{
     blocking::GraphQLClient,
     operations::graph::introspect::{self, GraphIntrospectInput, GraphIntrospectResponse},
-    RoverClientError,
 };
 
 use crate::command::RoverOutput;

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -1,51 +1,94 @@
-use crate::Result;
+use crate::{command::output::JsonOutput, options::IntrospectOpts, Result};
 use reqwest::blocking::Client;
 use saucer::{clap, Parser};
 use serde::Serialize;
 use std::collections::HashMap;
-use url::Url;
 
 use rover_client::{
     blocking::GraphQLClient,
-    operations::graph::introspect::{self, GraphIntrospectInput},
+    operations::graph::introspect::{self, GraphIntrospectInput, GraphIntrospectResponse},
+    RoverClientError,
 };
 
 use crate::command::RoverOutput;
-use crate::utils::parsers::parse_header;
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Introspect {
-    /// The endpoint of the graph to introspect
-    #[serde(skip_serializing)]
-    pub endpoint: Url,
-
-    /// headers to pass to the endpoint. Values must be key:value pairs.
-    /// If a value has a space in it, use quotes around the pair,
-    /// ex. -H "Auth:some key"
-
-    // The `name` here is for the help text and error messages, to print like
-    // --header <key:value> rather than the plural field name --header <headers>
-    #[clap(name="key:value", multiple=true, long="header", short='H', parse(try_from_str = parse_header))]
-    #[serde(skip_serializing)]
-    pub headers: Option<Vec<(String, String)>>,
+    #[clap(flatten)]
+    opts: IntrospectOpts,
 }
 
 impl Introspect {
-    pub fn run(&self, client: Client) -> Result<RoverOutput> {
-        let client = GraphQLClient::new(&self.endpoint.to_string(), client)?;
+    pub fn run(&self, client: Client, json: bool) -> Result<RoverOutput> {
+        if self.opts.watch {
+            self.exec_and_watch(&client, json)?;
+            Ok(RoverOutput::EmptySuccess)
+        } else {
+            let response = self.exec(&client, true)?;
+            Ok(RoverOutput::Introspection(response.schema_sdl))
+        }
+    }
+
+    pub fn exec(&self, client: &Client, should_retry: bool) -> Result<GraphIntrospectResponse> {
+        let client = GraphQLClient::new(&self.opts.endpoint.to_string(), client.clone())?;
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();
-        if let Some(arg_headers) = &self.headers {
+        if let Some(arg_headers) = &self.opts.headers {
             for (header_key, header_value) in arg_headers {
                 headers.insert(header_key.to_string(), header_value.to_string());
             }
         };
 
-        let introspection_response = introspect::run(GraphIntrospectInput { headers }, &client)?;
+        Ok(introspect::run(
+            GraphIntrospectInput { headers },
+            &client,
+            should_retry,
+        )?)
+    }
 
-        Ok(RoverOutput::Introspection(
-            introspection_response.schema_sdl,
-        ))
+    pub fn exec_and_watch(&self, client: &Client, json: bool) -> Result<RoverOutput> {
+        let mut last_result = None;
+        loop {
+            match self.exec(client, false) {
+                Ok(response) => {
+                    let sdl = response.schema_sdl.to_string();
+                    let mut was_updated = true;
+                    if let Some(last) = last_result {
+                        if last == response.schema_sdl {
+                            was_updated = false
+                        }
+                    }
+
+                    if was_updated {
+                        let output = RoverOutput::Introspection(sdl.to_string());
+                        if json {
+                            let _ = JsonOutput::from(output).print();
+                        } else {
+                            let _ = output.print();
+                        }
+                    }
+                    last_result = Some(sdl);
+                }
+                Err(error) => {
+                    let mut was_updated = true;
+                    let e = error.to_string();
+                    if let Some(last) = last_result {
+                        if last == e {
+                            was_updated = false;
+                        }
+                    }
+                    if was_updated {
+                        if json {
+                            let _ = JsonOutput::from(error).print();
+                        } else {
+                            let _ = error.print();
+                        }
+                    }
+                    last_result = Some(e);
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_secs(1))
+        }
     }
 }

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -44,6 +44,7 @@ impl Graph {
         client_config: StudioClientConfig,
         git_context: GitContext,
         checks_timeout_seconds: u64,
+        json: bool,
     ) -> Result<RoverOutput> {
         match &self.command {
             Command::Check(command) => {
@@ -52,7 +53,7 @@ impl Graph {
             Command::Delete(command) => command.run(client_config),
             Command::Fetch(command) => command.run(client_config),
             Command::Publish(command) => command.run(client_config, git_context),
-            Command::Introspect(command) => command.run(client_config.get_reqwest_client()),
+            Command::Introspect(command) => command.run(client_config.get_reqwest_client(), json),
         }
     }
 }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -469,6 +469,10 @@ impl JsonOutput {
             error,
         }
     }
+
+    pub(crate) fn print(&self) -> io::Result<()> {
+        stdoutln!("{}", self)
+    }
 }
 
 impl fmt::Display for JsonOutput {

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -2,48 +2,94 @@ use reqwest::blocking::Client;
 use saucer::{clap, Parser};
 use serde::Serialize;
 use std::collections::HashMap;
-use url::Url;
+
+use crate::{command::output::JsonOutput, options::IntrospectOpts};
 
 use rover_client::{
     blocking::GraphQLClient,
-    operations::subgraph::introspect::{self, SubgraphIntrospectInput},
+    operations::subgraph::introspect::{self, SubgraphIntrospectInput, SubgraphIntrospectResponse},
 };
 
 use crate::command::RoverOutput;
-use crate::utils::parsers::parse_header;
 use crate::Result;
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Introspect {
-    /// The endpoint of the subgraph to introspect
-    #[serde(skip_serializing)]
-    pub endpoint: Url,
-
-    /// headers to pass to the endpoint. Values must be key:value pairs.
-    /// If a value has a space in it, use quotes around the pair,
-    /// ex. -H "Auth:some key"
-
-    // The `name` here is for the help text and error messages, to print like
-    // --header <key:value> rather than the plural field name --header <headers>
-    #[clap(name="key:value", multiple=true, long="header", short='H', parse(try_from_str = parse_header))]
-    #[serde(skip_serializing)]
-    pub headers: Option<Vec<(String, String)>>,
+    #[clap(flatten)]
+    opts: IntrospectOpts,
 }
 
 impl Introspect {
-    pub fn run(&self, client: Client) -> Result<RoverOutput> {
-        let client = GraphQLClient::new(&self.endpoint.to_string(), client)?;
+    pub fn run(&self, client: Client, json: bool) -> Result<RoverOutput> {
+        if self.opts.watch {
+            self.exec_and_watch(&client, json)?;
+            Ok(RoverOutput::EmptySuccess)
+        } else {
+            let response = self.exec(&client, true)?;
+            Ok(RoverOutput::Introspection(response.result))
+        }
+    }
+
+    pub fn exec(&self, client: &Client, should_retry: bool) -> Result<SubgraphIntrospectResponse> {
+        let client = GraphQLClient::new(&self.opts.endpoint.to_string(), client.clone())?;
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();
-        if let Some(arg_headers) = &self.headers {
+        if let Some(arg_headers) = &self.opts.headers {
             for (header_key, header_value) in arg_headers {
                 headers.insert(header_key.to_string(), header_value.to_string());
             }
         };
 
-        let introspection_response = introspect::run(SubgraphIntrospectInput { headers }, &client)?;
+        Ok(introspect::run(
+            SubgraphIntrospectInput { headers },
+            &client,
+            should_retry,
+        )?)
+    }
 
-        Ok(RoverOutput::Introspection(introspection_response.result))
+    pub fn exec_and_watch(&self, client: &Client, json: bool) -> Result<RoverOutput> {
+        let mut last_result = None;
+        loop {
+            match self.exec(client, false) {
+                Ok(response) => {
+                    let sdl = response.result.to_string();
+                    let mut was_updated = true;
+                    if let Some(last) = last_result {
+                        if last == response.result {
+                            was_updated = false
+                        }
+                    }
+
+                    if was_updated {
+                        let output = RoverOutput::Introspection(sdl.to_string());
+                        if json {
+                            let _ = JsonOutput::from(output).print();
+                        } else {
+                            let _ = output.print();
+                        }
+                    }
+                    last_result = Some(sdl);
+                }
+                Err(error) => {
+                    let mut was_updated = true;
+                    let e = error.to_string();
+                    if let Some(last) = last_result {
+                        if last == e {
+                            was_updated = false;
+                        }
+                    }
+                    if was_updated {
+                        if json {
+                            let _ = JsonOutput::from(error).print();
+                        } else {
+                            let _ = error.print();
+                        }
+                    }
+                    last_result = Some(e);
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_secs(1))
+        }
     }
 }

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -48,10 +48,11 @@ impl Subgraph {
         client_config: StudioClientConfig,
         git_context: GitContext,
         checks_timeout_seconds: u64,
+        json: bool,
     ) -> Result<RoverOutput> {
         match &self.command {
             Command::Publish(command) => command.run(client_config, git_context),
-            Command::Introspect(command) => command.run(client_config.get_reqwest_client()),
+            Command::Introspect(command) => command.run(client_config.get_reqwest_client(), json),
             Command::Delete(command) => command.run(client_config),
             Command::Fetch(command) => command.run(client_config),
             Command::Check(command) => {

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -72,6 +72,7 @@ pub(crate) fn resolve_supergraph_yaml(
                         headers: HashMap::new(),
                     },
                     &client,
+                    false,
                 )?;
                 let schema = introspection_response.result;
 

--- a/src/options/introspect.rs
+++ b/src/options/introspect.rs
@@ -1,0 +1,26 @@
+use reqwest::Url;
+use saucer::{clap, Parser};
+use serde::{Deserialize, Serialize};
+
+use crate::utils::parsers::parse_header;
+
+#[derive(Debug, Serialize, Deserialize, Parser)]
+pub struct IntrospectOpts {
+    /// The endpoint of the subgraph to introspect
+    #[serde(skip_serializing)]
+    pub endpoint: Url,
+
+    /// headers to pass to the endpoint. Values must be key:value pairs.
+    /// If a value has a space in it, use quotes around the pair,
+    /// ex. -H "Auth:some key"
+
+    // The `name` here is for the help text and error messages, to print like
+    // --header <key:value> rather than the plural field name --header <headers>
+    #[clap(name="key:value", multiple=true, long="header", short='H', parse(try_from_str = parse_header))]
+    #[serde(skip_serializing)]
+    pub headers: Option<Vec<(String, String)>>,
+
+    /// poll the endpoint, printing the introspection result if/when its contents change
+    #[clap(long)]
+    pub watch: bool,
+}

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -1,11 +1,13 @@
 mod check;
 mod graph;
+mod introspect;
 mod profile;
 mod schema;
 mod subgraph;
 
 pub(crate) use check::CheckConfigOpts;
 pub(crate) use graph::GraphRefOpt;
+pub(crate) use introspect::IntrospectOpts;
 pub(crate) use profile::ProfileOpt;
 pub(crate) use schema::SchemaOpt;
 pub(crate) use subgraph::SubgraphOpt;


### PR DESCRIPTION
this PR adds `--watch` to both `rover graph introspect` and `rover subgraph introspect`. if you run these commands with the `--watch` flag, Rover will poll the endpoint you provided every second. It will compare the results of the query to the results the server responded with a second ago, and if the output is different, Rover will print that output to the terminal. If nothing has changed, Rover does not print new output.

The following is example output of `rover graph introspect --watch` on an Apollo Server endpoint. I started the command before starting the graph, got an error, spun up the graph, got a successful introspection response, changed something in the server, killed it, got another connection error, spun up the graph again, and got a new updated introspection response.

```console
$ rover graph introspect http://localhost:4001 --watch
error[E028]: error sending request for url (http://localhost:4001/): error trying to connect: tcp connect error: Connection refused (os error 111)
        Make sure the endpoint is accepting connections and is spelled correctly
Introspection Response: 

scalar _FieldSet
scalar _Any
type Query {
  "A simple type for getting started!"
  hello: String
  _service: _Service!
}
type _Service {
  sdl: String
}
directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
directive @extends on OBJECT | INTERFACE
directive @external(reason: String) on OBJECT | FIELD_DEFINITION
directive @tag(name: String!) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
"Exposes a URL that specifies the behavior of this scalar."
directive @specifiedBy(
    "The URL that specifies the behavior of this scalar."
    url: String!
  ) on SCALAR

error[E028]: error sending request for url (http://localhost:4001/): error trying to connect: tcp connect error: Connection refused (os error 111)
        Make sure the endpoint is accepting connections and is spelled correctly
Introspection Response: 

scalar _FieldSet
scalar _Any
type Query {
  "A simple type for getting started!"
  goodbye: String
  _service: _Service!
}
type _Service {
  sdl: String
}
directive @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
directive @extends on OBJECT | INTERFACE
directive @external(reason: String) on OBJECT | FIELD_DEFINITION
directive @tag(name: String!) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
"Exposes a URL that specifies the behavior of this scalar."
directive @specifiedBy(
    "The URL that specifies the behavior of this scalar."
    url: String!
  ) on SCALAR
```

this also works with `--output json` and `jq`:

```console
$ rover graph introspect http://localhost:4001 --watch --output json | jq
{
  "data": {
    "success": false
  },
  "error": {
    "code": "E028",
    "message": "error sending request for url (http://localhost:4001/): error trying to connect: tcp connect error: Connection refused (os error 111)"
  },
  "json_version": "1"
}
{
  "data": {
    "introspection_response": "scalar _FieldSet\nscalar _Any\ntype Query {\n  \"A simple type for getting started!\"\n  hello: String\n  _service: _Service!\n}\ntype _Service {\n  sdl: String\n}\ndirective @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE\ndirective @requires(fields: _FieldSet!) on FIELD_DEFINITION\ndirective @provides(fields: _FieldSet!) on FIELD_DEFINITION\ndirective @extends on OBJECT | INTERFACE\ndirective @external(reason: String) on OBJECT | FIELD_DEFINITION\ndirective @tag(name: String!) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION\n\"Exposes a URL that specifies the behavior of this scalar.\"\ndirective @specifiedBy(\n    \"The URL that specifies the behavior of this scalar.\"\n    url: String!\n  ) on SCALAR\n",
    "success": true
  },
  "error": null,
  "json_version": "1"
}
{
  "data": {
    "success": false
  },
  "error": {
    "code": "E028",
    "message": "error sending request for url (http://localhost:4001/): error trying to connect: tcp connect error: Connection refused (os error 111)"
  },
  "json_version": "1"
}
{
  "data": {
    "introspection_response": "scalar _FieldSet\nscalar _Any\ntype Query {\n  \"A simple type for getting started!\"\n  goodbye: String\n  _service: _Service!\n}\ntype _Service {\n  sdl: String\n}\ndirective @key(fields: _FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE\ndirective @requires(fields: _FieldSet!) on FIELD_DEFINITION\ndirective @provides(fields: _FieldSet!) on FIELD_DEFINITION\ndirective @extends on OBJECT | INTERFACE\ndirective @external(reason: String) on OBJECT | FIELD_DEFINITION\ndirective @tag(name: String!) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION\n\"Exposes a URL that specifies the behavior of this scalar.\"\ndirective @specifiedBy(\n    \"The URL that specifies the behavior of this scalar.\"\n    url: String!\n  ) on SCALAR\n",
    "success": true
  },
  "error": null,
  "json_version": "1"
}
```