### PR TITLE
feat: Add markdown output for Check command

### DIFF
--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -68,8 +68,8 @@ impl CheckResponse {
     }
 
     pub fn get_table(&self, markdown: Option<MarkdownOutputMode>) -> String {
-        if markdown.is_some() {
-            return match markdown.unwrap() {
+        if let Some(markdown) = markdown {
+            return match markdown {
                 MarkdownOutputMode::Failed => self.get_markdown(true),
                 MarkdownOutputMode::Success => self.get_markdown(false),
             };

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -115,6 +115,40 @@ impl CheckResponse {
     pub fn get_json(&self) -> Value {
         json!(self)
     }
+
+    pub fn get_markdown(&self) -> String {
+        let mut markdown = String::new();
+
+        markdown.push_str("### Check success");
+        markdown.push('\n');
+
+        markdown.push_str("#### Change details");
+        markdown.push('\n');
+
+        if self.changes.is_empty() {
+            markdown.push_str("No changes");
+            return markdown;
+        }
+
+        markdown.push_str("| Severity | Code | Description |");
+        markdown.push('\n');
+        markdown.push_str("| -------- | ---- | ----------- |");
+        markdown.push('\n');
+
+        for check in &self.changes {
+            markdown.push_str(
+                format!("|{}|{}|{}|", check.severity, check.code, check.description).as_str(),
+            );
+            markdown.push('\n');
+        }
+
+        if let Some(url) = &self.target_url {
+            markdown.push('\n');
+            markdown.push_str(format!("[View full details]({})", url).as_str());
+        }
+
+        markdown
+    }
 }
 
 /// ChangeSeverity indicates whether a proposed change

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -6,7 +6,7 @@ mod graph_ref;
 
 pub use async_check_response::CheckRequestSuccessResult;
 pub use check_response::{
-    ChangeSeverity, CheckConfig, CheckResponse, SchemaChange, ValidationPeriod,
+    ChangeSeverity, CheckConfig, CheckResponse, MarkdownOutputMode, SchemaChange, ValidationPeriod,
 };
 pub use fetch_response::{FetchResponse, Sdl, SdlType};
 pub use git_context::GitContext;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ pub struct Rover {
     log_level: Option<Level>,
 
     /// Specify Rover's output type
-    #[clap(long = "output", default_value = "plain", possible_values = &["json", "plain"], case_insensitive = true, global = true)]
+    #[clap(long = "output", default_value = "plain", possible_values = &["json", "plain", "markdown"], case_insensitive = true, global = true)]
     output_type: OutputType,
 
     /// Accept invalid certificates when performing HTTPS requests.
@@ -148,13 +148,14 @@ impl Rover {
                 match self.output_type {
                     OutputType::Plain => output.print()?,
                     OutputType::Json => JsonOutput::from(output).print()?,
+                    OutputType::Markdown => output.print_markdown()?,
                 }
                 process::exit(0);
             }
             Err(error) => {
                 match self.output_type {
                     OutputType::Json => JsonOutput::from(error).print()?,
-                    OutputType::Plain => {
+                    OutputType::Plain | OutputType::Markdown => {
                         tracing::debug!(?error);
                         error.print()?;
                     }
@@ -359,6 +360,7 @@ pub enum Command {
 pub enum OutputType {
     Plain,
     Json,
+    Markdown,
 }
 
 impl FromStr for OutputType {
@@ -368,6 +370,7 @@ impl FromStr for OutputType {
         match input {
             "plain" => Ok(Self::Plain),
             "json" => Ok(Self::Json),
+            "markdown" => Ok(Self::Markdown),
             _ => Err(anyhow!("Invalid output type.")),
         }
     }

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -16,7 +16,7 @@ use rover_client::shared::GitContext;
 #[derive(Debug, Serialize, Parser)]
 pub struct Graph {
     #[clap(subcommand)]
-    command: Command,
+    pub command: Command,
 }
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod docs;
 mod explain;
 mod fed2;
-mod graph;
+pub(crate) mod graph;
 mod info;
 mod install;
 mod readme;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -6,7 +6,7 @@ mod graph;
 mod info;
 mod install;
 mod readme;
-mod subgraph;
+pub(crate) mod subgraph;
 mod supergraph;
 mod update;
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -18,7 +18,7 @@ use rover_client::operations::subgraph::delete::SubgraphDeleteResponse;
 use rover_client::operations::subgraph::list::SubgraphListResponse;
 use rover_client::operations::subgraph::publish::SubgraphPublishResponse;
 use rover_client::shared::{
-    CheckRequestSuccessResult, CheckResponse, FetchResponse, GraphRef, SdlType,
+    CheckRequestSuccessResult, CheckResponse, FetchResponse, GraphRef, MarkdownOutputMode, SdlType,
 };
 use rover_client::RoverClientError;
 use serde::Serialize;
@@ -251,7 +251,7 @@ impl RoverOutput {
             }
             RoverOutput::CheckResponse(check_response) => {
                 print_descriptor("Check Result")?;
-                print_content(check_response.get_table())?;
+                print_content(check_response.get_table(None))?;
             }
             RoverOutput::AsyncCheckResponse(check_response) => {
                 print_descriptor("Check Started")?;
@@ -424,7 +424,10 @@ impl RoverOutput {
     pub(crate) fn print_markdown(&self) -> io::Result<()> {
         match self {
             RoverOutput::CheckResponse(check_response) => {
-                stdoutln!("{}", check_response.get_markdown())
+                stdoutln!(
+                    "{}",
+                    check_response.get_table(Some(MarkdownOutputMode::Success))
+                )
             }
             _ => stderrln!("Only check command is supported for markdown output"),
         }
@@ -1274,7 +1277,7 @@ mod tests {
 [View full details](https://studio.apollographql.com/graph/my-graph/composition/big-hash?variant=current)";
             assert_eq!(
                 expected_markdown.to_string(),
-                mock_check_response.get_markdown()
+                mock_check_response.get_table(Some(MarkdownOutputMode::Success))
             );
         } else {
             panic!("The shape of this response should return a CheckResponse")

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -17,7 +17,7 @@ use rover_client::shared::GitContext;
 #[derive(Debug, Serialize, Parser)]
 pub struct Subgraph {
     #[clap(subcommand)]
-    command: Command,
+    pub command: Command,
 }
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod metadata;
 
 pub(crate) use metadata::Metadata;
+use rover_client::shared::MarkdownOutputMode;
 pub use saucer::{anyhow, Context};
 
 pub type Result<T> = std::result::Result<T, RoverError>;
@@ -78,13 +79,18 @@ impl RoverError {
         &self.metadata.suggestion
     }
 
-    pub fn print(&self) -> io::Result<()> {
+    pub fn print(&self, as_markdown: bool) -> io::Result<()> {
         if let Some(RoverClientError::OperationCheckFailure {
             graph_ref: _,
             check_response,
         }) = self.error.downcast_ref::<RoverClientError>()
         {
-            stdoutln!("{}", check_response.get_table())?;
+            let markdown_output_mode = match as_markdown {
+                true => Some(MarkdownOutputMode::Failed),
+                false => None,
+            };
+
+            stdoutln!("{}", check_response.get_table(markdown_output_mode))?;
         }
 
         stderr!("{}", self)?;

--- a/src/options/introspect.rs
+++ b/src/options/introspect.rs
@@ -67,7 +67,7 @@ impl IntrospectOpts {
                         if json {
                             let _ = JsonOutput::from(error).print();
                         } else {
-                            let _ = error.print();
+                            let _ = error.print(false);
                         }
                     }
                     last_result = Some(e);


### PR DESCRIPTION
Following idea of https://github.com/apollographql/rover/issues/843
I could add more data from the `CheckResponse` but I've just followed the bash script in the issue.
I don't know how to handle check error state at this level for a `Check` command.