### PR TITLE
docs: updates help text and refactors subgraph name prompt

### DIFF
--- a/examples/dev/hello/hello.js
+++ b/examples/dev/hello/hello.js
@@ -1,5 +1,5 @@
 const { ApolloServer, gql } = require('apollo-server');
-const { buildSubgraphSchema} = require("@apollo/subgraph")
+const { buildSubgraphSchema } = require("@apollo/subgraph")
 
 // The GraphQL schema
 const typeDefs = gql`
@@ -13,14 +13,15 @@ const typeDefs = gql`
 const resolvers = {
   Query: {
     hello: () => 'world',
+    goodbye: () => 'everybody'
   },
 };
 
 const server = new ApolloServer({
- schema: buildSubgraphSchema({
-   typeDefs,
-   resolvers,
- })
+  schema: buildSubgraphSchema({
+    typeDefs,
+    resolvers,
+  })
 });
 
 server.listen({ port: 4001 }).then(({ url }) => {

--- a/examples/dev/hello/package-lock.json
+++ b/examples/dev/hello/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "apollo-subgraph",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@apollo/subgraph": "^2.0.5",
         "apollo-server": "^3.10.0",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,9 +326,13 @@ pub enum Command {
 
     /// Run your supergraph locally with a router and one or more subgraphs.
     ///
-    /// Run `rover dev` in multiple subgraph project directories,
-    /// and Rover will compose them together and start a dev instance of the Apollo Router. You can work with any GraphQL API
-    /// that you have an SDL file for, or has introspection enabled.
+    /// The first `rover dev` process you run starts a dev instance of the Apollo Router and connects it to the running subgraph you specify.
+    /// You can then run additional instances of `rover dev` to add more subgraphs to your local supergraph (the same router instance is used).
+    /// As you add subgraphs, `rover dev` automatically composes all subgraph schemas into a new supergraph schema for the router.
+    ///
+    /// The router instance is tied to the *first* `rover dev` process. If you terminate that process, the router terminates.
+    /// If you terminate a `rover dev` process *besides* the first process (thereby removing a subgraph), 
+    /// a new supergraph schema is composed from the remaining subgraphs.
     ///
     /// ⚠️ Do not run this command in production! ⚠️ It is intended for local development.
     Dev(command::Dev),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -331,7 +331,7 @@ pub enum Command {
     /// As you add subgraphs, `rover dev` automatically composes all subgraph schemas into a new supergraph schema for the router.
     ///
     /// The router instance is tied to the *first* `rover dev` process. If you terminate that process, the router terminates.
-    /// If you terminate a `rover dev` process *besides* the first process (thereby removing a subgraph), 
+    /// If you terminate a `rover dev` process *besides* the first process (thereby removing a subgraph),
     /// a new supergraph schema is composed from the remaining subgraphs.
     ///
     /// ⚠️ Do not run this command in production! ⚠️ It is intended for local development.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -324,7 +324,7 @@ pub enum Command {
     /// Configuration profile commands
     Config(command::Config),
 
-    /// Initialize a local supergraph development server.
+    /// Run your supergraph locally with a router and one or more subgraphs.
     ///
     /// Run `rover dev` in multiple subgraph project directories,
     /// and Rover will compose them together and start a dev instance of the Apollo Router. You can work with any GraphQL API

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -330,7 +330,7 @@ pub enum Command {
     /// and Rover will compose them together and start a dev instance of the Apollo Router. You can work with any GraphQL API
     /// that you have an SDL file for, or has introspection enabled.
     ///
-    /// You should not run this command in production.
+    /// ⚠️ Do not run this command in production! ⚠️ It is intended for local development.
     Dev(command::Dev),
 
     /// (deprecated) Federation 2 Alpha commands

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -324,7 +324,13 @@ pub enum Command {
     /// Configuration profile commands
     Config(command::Config),
 
-    /// Develop a GraphQL API
+    /// Initialize a local supergraph development server.
+    ///
+    /// Run `rover dev` in multiple subgraph project directories,
+    /// and Rover will compose them together and start a dev instance of the Apollo Router. You can work with any GraphQL API
+    /// that you have an SDL file for, or has introspection enabled.
+    ///
+    /// You should not run this command in production.
     Dev(command::Dev),
 
     /// (deprecated) Federation 2 Alpha commands

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -1,4 +1,3 @@
-use dialoguer::Input;
 use interprocess::local_socket::LocalSocketStream;
 use saucer::Utf8PathBuf;
 use tempdir::TempDir;
@@ -7,7 +6,7 @@ use super::command::CommandRunner;
 use super::compose::ComposeRunner;
 use super::router::RouterRunner;
 use super::socket::{MessageReceiver, MessageSender};
-use super::{Dev, DevOpts};
+use super::Dev;
 use crate::command::RoverOutput;
 use crate::error::RoverError;
 use crate::utils::client::StudioClientConfig;
@@ -19,25 +18,6 @@ pub fn log_err_and_continue(err: RoverError) {
     let _ = err.print();
 }
 
-impl DevOpts {
-    pub fn get_name(&self) -> Result<String> {
-        if let Some(name) = self.name.as_ref().map(|s| s.to_string()) {
-            Ok(name)
-        } else {
-            let dirname = std::env::current_dir()
-                .ok()
-                .and_then(|x| x.file_name().map(|x| x.to_string_lossy().to_string()));
-            let mut input = Input::new();
-            input.with_prompt("what is the name of this subgraph?");
-            if let Some(dirname) = dirname {
-                input.default(dirname);
-            }
-            let name: String = input.interact_text()?;
-            Ok(name)
-        }
-    }
-}
-
 impl Dev {
     pub fn run(
         &self,
@@ -47,7 +27,7 @@ impl Dev {
         // TODO: update the `4000` once you can change the port
         // if rover dev is extending a supergraph, it should be the graph ref instead
         let socket_addr = "/tmp/supergraph-4000.sock";
-        let name = self.opts.get_name()?;
+        let name = self.opts.subgraph_opt.prompt_for_name()?;
         let command_runner = Arc::new(Mutex::new(CommandRunner::new(socket_addr)));
 
         // read the subgraphs that are already running as a part of this `rover dev` instance

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -28,7 +28,7 @@ mod do_dev;
 #[cfg(not(feature = "composition-js"))]
 mod no_dev;
 
-use crate::options::PluginOpts;
+use crate::options::{OptionalSubgraphOpt, PluginOpts};
 use reqwest::Url;
 use saucer::{clap, Parser, Utf8PathBuf};
 use serde::Serialize;
@@ -47,27 +47,37 @@ pub struct DevOpts {
     #[clap(flatten)]
     pub schema_opts: SchemaOpts,
 
-    #[clap(long)]
-    pub name: Option<String>,
+    #[clap(flatten)]
+    pub subgraph_opt: OptionalSubgraphOpt,
 }
 
 #[derive(Debug, Parser, Serialize)]
 pub struct SchemaOpts {
-    /// Url of a running subgraph that a graph router can send operations to
-    /// (often a localhost endpoint).
-    #[clap(long)]
+    /// Url of a running subgraph that a graph router can send operations to, (i.e., http://localhost:4001).
+    ///
+    /// If you pass a `--command` argument and no `--url` argument,
+    /// `rover dev` will attempt to detect the endpoint by doing a scan of your ports. If you find
+    /// this takes too long or is unable to detect your GraphQL server, pass the `--url` argument
+    /// to skip the auto-detection step.
+    #[clap(long = "url", short = 'u')]
     #[serde(skip_serializing)]
-    pub url: Option<Url>,
+    pub subgraph_url: Option<Url>,
 
-    /// Command to run a subgraph that a graph router can send operations to
-    #[clap(long)]
+    /// Command to run a subgraph that a graph router can send operations to, (i.e., 'npm run start', 'cargo run', 'go run server.go').
+    ///
+    /// This argument is provided as a convenience to you, you do not have to pass this argument to run `rover dev`,
+    /// you can instead start your server independently in another terminal before running `rover dev`.
+    #[clap(long = "command")]
     #[serde(skip_serializing)]
-    pub command: Option<String>,
+    pub subgraph_command: Option<String>,
 
-    /// Path to an SDL file for a running subgraph that a graph router can send operations to
-    #[clap(long, short = 's')]
+    /// Path to an SDL file for a running subgraph that a graph router can send operations to.
+    ///
+    /// If this argument is passed, `rover dev` will not introspect your endpoint every second to retrieve your schema.
+    /// Instead, it will instead watch your file system for changes to the schema, only recomposing when necessary.
+    #[clap(long = "schema", short = 's')]
     #[serde(skip_serializing)]
-    pub schema: Option<Utf8PathBuf>,
+    pub subgraph_schema_path: Option<Utf8PathBuf>,
     // TODO: this is semi-blocked because the router doesn't provide this as a CLI flag
     // /// The port to run the local supergraph on. Each port gets its own namespace,
     // /// meaning if you run multiple `rover dev` instances with the same `--port`,

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -63,7 +63,9 @@ pub struct SchemaOpts {
     #[serde(skip_serializing)]
     pub subgraph_url: Option<Url>,
 
-    /// Command to run a subgraph that a graph router can send operations to, (i.e., 'npm run start', 'cargo run', 'go run server.go').
+    /// If provided, `rover dev` runs this command to start up your locally running subgraph before adding it to your supergraph.
+    ///
+    /// Common examples: 'npm run start', 'cargo run', 'go run server.go'
     ///
     /// Provide this option only if you want `rover dev` to be responsible for starting up your subgraph.
     /// If you prefer to handle starting your subgraph in a separate terminal before running `rover dev`, omit this option.

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -73,8 +73,8 @@ pub struct SchemaOpts {
 
     /// The path to a GraphQL schema file that `rover dev` will use as this subgraph's schema.
     ///
-    /// If this argument is passed, `rover dev` will not introspect your endpoint every second to retrieve your schema.
-    /// Instead, it will instead watch your file system for changes to the schema, only recomposing when necessary.
+    /// If this argument is passed, `rover dev` does not periodically introspect the running subgraph to obtain its schema.
+    /// Instead, it watches the file at the provided path and recomposes the supergraph schema whenever changes occur.
     #[clap(long = "schema", short = 's')]
     #[serde(skip_serializing)]
     pub subgraph_schema_path: Option<Utf8PathBuf>,

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -53,7 +53,7 @@ pub struct DevOpts {
 
 #[derive(Debug, Parser, Serialize)]
 pub struct SchemaOpts {
-    /// Url of a running subgraph that a graph router can send operations to, (i.e., http://localhost:4001).
+    /// The URL that the `rover dev` router should use to communicate with this running subgraph (e.g., http://localhost:4001).
     ///
     /// If you pass a `--command` argument and no `--url` argument,
     /// `rover dev` will attempt to detect the endpoint by doing a scan of your ports. If you find

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -71,7 +71,7 @@ pub struct SchemaOpts {
     #[serde(skip_serializing)]
     pub subgraph_command: Option<String>,
 
-    /// Path to an SDL file for a running subgraph that a graph router can send operations to.
+    /// The path to a GraphQL schema file that `rover dev` will use as this subgraph's schema.
     ///
     /// If this argument is passed, `rover dev` will not introspect your endpoint every second to retrieve your schema.
     /// Instead, it will instead watch your file system for changes to the schema, only recomposing when necessary.

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -55,7 +55,7 @@ pub struct DevOpts {
 pub struct SchemaOpts {
     /// The URL that the `rover dev` router should use to communicate with this running subgraph (e.g., http://localhost:4001).
     ///
-    /// If you don't provide this option, `rover dev` attempts to detect your subgraph's endpoint by scanning your ports. 
+    /// If you don't provide this option, `rover dev` attempts to detect your subgraph's endpoint by scanning your ports.
     /// To speed up startup and avoid a failed detection, we recommend always passing the `--url` option.
     ///
     /// If you don't provide this option *or* `--command`, `rover dev` prompts you for the command to start up your subgraph.

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -55,10 +55,10 @@ pub struct DevOpts {
 pub struct SchemaOpts {
     /// The URL that the `rover dev` router should use to communicate with this running subgraph (e.g., http://localhost:4001).
     ///
-    /// If you pass a `--command` argument and no `--url` argument,
-    /// `rover dev` will attempt to detect the endpoint by doing a scan of your ports. If you find
-    /// this takes too long or is unable to detect your GraphQL server, pass the `--url` argument
-    /// to skip the auto-detection step.
+    /// If you don't provide this option, `rover dev` attempts to detect your subgraph's endpoint by scanning your ports. 
+    /// To speed up startup and avoid a failed detection, we recommend always passing the `--url` option.
+    ///
+    /// If you don't provide this option *or* `--command`, `rover dev` prompts you for the command to start up your subgraph.
     #[clap(long = "url", short = 'u')]
     #[serde(skip_serializing)]
     pub subgraph_url: Option<Url>,

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -65,8 +65,8 @@ pub struct SchemaOpts {
 
     /// Command to run a subgraph that a graph router can send operations to, (i.e., 'npm run start', 'cargo run', 'go run server.go').
     ///
-    /// This argument is provided as a convenience to you, you do not have to pass this argument to run `rover dev`,
-    /// you can instead start your server independently in another terminal before running `rover dev`.
+    /// Provide this option only if you want `rover dev` to be responsible for starting up your subgraph.
+    /// If you prefer to handle starting your subgraph in a separate terminal before running `rover dev`, omit this option.
     #[clap(long = "command")]
     #[serde(skip_serializing)]
     pub subgraph_command: Option<String>,

--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -34,7 +34,7 @@ impl SchemaOpts {
                     "subgraph with name '{}' is already running in this `rover dev` session",
                     &name
                 )));
-            } else if let Some(user_input_url) = self.url.as_ref() {
+            } else if let Some(user_input_url) = self.subgraph_url.as_ref() {
                 let normalized_user_urls = normalize_loopback_urls(user_input_url);
                 let normalized_session_urls = normalize_loopback_urls(&session_subgraph_url);
                 for normalized_user_url in &normalized_user_urls {
@@ -50,7 +50,7 @@ impl SchemaOpts {
             }
         }
 
-        let url = match (self.command.as_ref(), self.url.as_ref()) {
+        let url = match (self.subgraph_command.as_ref(), self.subgraph_url.as_ref()) {
             // they provided a command and a url
             (Some(command), Some(url)) => {
                 command_runner.spawn(&name, command)?;
@@ -116,7 +116,7 @@ impl SchemaOpts {
             }
         };
 
-        let schema = if let Some(schema) = &self.schema {
+        let schema = if let Some(schema) = &self.subgraph_schema_path {
             Fs::assert_path_exists(schema, "")?;
             Some(schema.clone())
         } else {

--- a/src/options/subgraph.rs
+++ b/src/options/subgraph.rs
@@ -1,9 +1,15 @@
-use saucer::{clap, Parser};
+use dialoguer::Input;
+use saucer::{
+    clap::{self, ErrorKind as ClapErrorKind},
+    CommandFactory, Parser,
+};
 use serde::{Deserialize, Serialize};
+
+use crate::{cli::Rover, Result};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct SubgraphOpt {
-    /// Name of the subgraph to validate
+    /// The name of the subgraph
     #[clap(long = "name")]
     #[serde(skip_serializing)]
     pub subgraph_name: String,
@@ -11,8 +17,37 @@ pub struct SubgraphOpt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct OptionalSubgraphOpt {
-    /// Name of the subgraph to validate
+    /// The name of the subgraph
     #[clap(long = "name")]
     #[serde(skip_serializing)]
     pub subgraph_name: Option<String>,
+}
+
+impl OptionalSubgraphOpt {
+    pub fn prompt_for_name(&self) -> Result<String> {
+        if let Some(name) = &self.subgraph_name {
+            Ok(name.to_string())
+        } else if atty::is(atty::Stream::Stderr) {
+            let mut input = Input::new();
+            input.with_prompt("what is the name of this subgraph?");
+            if let Some(dirname) = Self::maybe_name_from_dir() {
+                input.default(dirname);
+            }
+            let name: String = input.interact_text()?;
+            Ok(name)
+        } else {
+            let mut cmd = Rover::command();
+            cmd.error(
+                ClapErrorKind::MissingRequiredArgument,
+                "--name <SUBGRAPH_NAME> is required when not attached to a TTY",
+            )
+            .exit();
+        }
+    }
+
+    fn maybe_name_from_dir() -> Option<String> {
+        std::env::current_dir()
+            .ok()
+            .and_then(|x| x.file_name().map(|x| x.to_string_lossy().to_lowercase()))
+    }
 }

--- a/src/options/subgraph.rs
+++ b/src/options/subgraph.rs
@@ -17,7 +17,7 @@ pub struct SubgraphOpt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct OptionalSubgraphOpt {
-    /// The name of the subgraph
+    /// The name of the subgraph. This must be unique to each `rover dev` session.
     #[clap(long = "name")]
     #[serde(skip_serializing)]
     pub subgraph_name: Option<String>,


### PR DESCRIPTION
fixes #1232

i've pasted the help text below excluding global arguments that already exist in Rover

help text before:

```console
$ cargo rover dev --help
rover-dev 
Develop a GraphQL API

USAGE:
    rover dev [OPTIONS]

OPTIONS:
        --command <COMMAND>
            Command to run a subgraph that a graph router can send operations to

        --name <NAME>
            
    -s, --schema <SCHEMA>
            Path to an SDL file for a running subgraph that a graph router can send operations to

        --url <URL>
            Url of a running subgraph that a graph router can send operations to (often a localhost
            endpoint)
```

help text after:

```console
$ cargo rover dev --help
rover-dev 
Run your supergraph locally with a router and one or more subgraphs.

The first `rover dev` process you run starts a dev instance of the Apollo Router and connects it to
the running subgraph you specify. You can then run additional instances of `rover dev` to add more
subgraphs to your local supergraph (the same router instance is used). As you add subgraphs, `rover
dev` automatically composes all subgraph schemas into a new supergraph schema for the router.

The router instance is tied to the *first* `rover dev` process. If you terminate that process, the
router terminates. If you terminate a `rover dev` process *besides* the first process (thereby
removing a subgraph), a new supergraph schema is composed from the remaining subgraphs.

⚠️ Do not run this command in production! ⚠️ It is intended for local development.

USAGE:
    rover dev [OPTIONS]

OPTIONS:
        --command <SUBGRAPH_COMMAND>
            If provided, `rover dev` runs this command to start up your locally running subgraph
            before adding it to your supergraph.
            
            Common examples: 'npm run start', 'cargo run', 'go run server.go'
            
            Provide this option only if you want `rover dev` to be responsible for starting up your
            subgraph. If you prefer to handle starting your subgraph in a separate terminal before
            running `rover dev`, omit this option.

    -s, --schema <SUBGRAPH_SCHEMA_PATH>
            The path to a GraphQL schema file that `rover dev` will use as this subgraph's schema.
            
            If this argument is passed, `rover dev` does not periodically introspect the running
            subgraph to obtain its schema. Instead, it watches the file at the provided path and
            recomposes the supergraph schema whenever changes occur.

    -u, --url <SUBGRAPH_URL>
            The URL that the `rover dev` router should use to communicate with this running subgraph
            (e.g., http://localhost:4001).
            
            If you don't provide this option, `rover dev` attempts to detect your subgraph's
            endpoint by scanning your ports. To speed up startup and avoid a failed detection, we
            recommend always passing the `--url` option.
            
            If you don't provide this option *or* `--command`, `rover dev` prompts you for the
            command to start up your subgraph.
```

