### PR TITLE
fix(1244): trim double quotes in multilingual descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "apollo-encoder"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cde958e05663a85c6e22a18f4e758fda923526908e3e5b8ba89a00828eb8c71"
+checksum = "344a1afec31ce0273dc2061105b04e5c4ab620fe0748a76244338aa893db42f3"
 
 [[package]]
 name = "apollo-federation-types"

--- a/crates/launchpad/Cargo.toml
+++ b/crates/launchpad/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-apollo-encoder = "0.3.1"
+apollo-encoder = "0.3.2"
 backoff = "0.4"
 graphql_client = "0.11.0"
 humantime = "2.1.0"

--- a/crates/launchpad/src/introspect/fixtures/interfaces.json
+++ b/crates/launchpad/src/introspect/fixtures/interfaces.json
@@ -1417,6 +1417,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "favouriteBook",
+                            "description": "Улюблена книга, прочитана цього рока \"\" | 今年読んだお気に入りの本",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Book",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "similarBooks",
                             "description": "A simple list of similar books",
                             "args": [],

--- a/crates/launchpad/src/introspect/schema.rs
+++ b/crates/launchpad/src/introspect/schema.rs
@@ -1425,153 +1425,157 @@ mod tests {
         assert_eq!(
             schema.encode(),
             indoc! { r#"
-        type Query {
-          "Fetch a simple list of products with an offset"
-          topProducts(first: Int = 5): [Product] @deprecated(reason: "Use `products` instead")
-          "Fetch a paginated list of products based on a filter type."
-          products(first: Int = 5, after: Int = 0, type: ProductType): ProductConnection
-          """
-          The currently authenticated user root. All nodes off of this
-          root will be authenticated as the current user
-          """
-          me: User
-        }
-        "A review is any feedback about products across the graph"
-        type Review {
-          id: ID!
-          "The plain text version of the review"
-          body: String
-          "The user who authored the review"
-          author: User
-          "The product which this review is about"
-          product: Product
-        }
-        "The base User in Acephei"
-        type User {
-          "A globally unique id for the user"
-          id: ID!
-          "The users full name as provided"
-          name: String
-          "The account username of the user"
-          username: String
-          "A list of all reviews by the user"
-          reviews: [Review]
-        }
-        "A connection wrapper for lists of reviews"
-        type ReviewConnection {
-          "Helpful metadata about the connection"
-          pageInfo: PageInfo
-          "List of reviews returned by the search"
-          edges: [ReviewEdge]
-        }
-        """
-        The PageInfo type provides pagination helpers for determining
-        if more data can be fetched from the list
-        """
-        type PageInfo {
-          "More items exist in the list"
-          hasNextPage: Boolean
-          "Items earlier in the list exist"
-          hasPreviousPage: Boolean
-        }
-        "A connection edge for the Review type"
-        type ReviewEdge {
-          review: Review
-        }
-        "A connection wrapper for lists of products"
-        type ProductConnection {
-          "Helpful metadata about the connection"
-          pageInfo: PageInfo
-          "List of products returned by the search"
-          edges: [ProductEdge]
-        }
-        "A connection edge for the Product type"
-        type ProductEdge {
-          product: Product
-        }
-        "The basic book in the graph"
-        type Book implements Product {
-          "All books can be found by an isbn"
-          isbn: String!
-          "The title of the book"
-          title: String
-          "The year the book was published"
-          year: Int
-          "A simple list of similar books"
-          similarBooks: [Book]
-          reviews: [Review]
-          reviewList(first: Int = 5, after: Int = 0): ReviewConnection
-          """
-          relatedReviews for a book use the knowledge of `similarBooks` from the books
-          service to return related reviews that may be of interest to the user
-          """
-          relatedReviews(first: Int = 5, after: Int = 0): ReviewConnection
-          "Since books are now products, we can also use their upc as a primary id"
-          upc: String!
-          "The name of a book is the book's title + year published"
-          name(delimeter: String = " "): String
-          price: Int
-          weight: Int
-        }
-        "Information about the brand Amazon"
-        type Amazon {
-          "The url of a referrer for a product"
-          referrer: String
-        }
-        "Information about the brand Ikea"
-        type Ikea {
-          "Which asile to find an item"
-          asile: Int
-        }
-        """
-        The Furniture type represents all products which are items
-        of furniture.
-        """
-        type Furniture implements Product {
-          "The modern primary identifier for furniture"
-          upc: String!
-          "The SKU field is how furniture was previously stored, and still exists in some legacy systems"
-          sku: String!
-          name: String
-          price: Int
-          "The brand of furniture"
-          brand: Brand
-          weight: Int
-          reviews: [Review]
-          reviewList(first: Int = 5, after: Int = 0): ReviewConnection
-        }
-        "The Product type represents all products within the system"
-        interface Product {
-          "The primary identifier of products in the graph"
-          upc: String!
-          "The display name of the product"
-          name: String
-          "A simple integer price of the product in US dollars"
-          price: Int
-          "How much the product weighs in kg"
-          weight: Int @deprecated(reason: "Not all product's have a weight")
-          "A simple list of all reviews for a product"
-          reviews: [Review] @deprecated(reason: """The `reviews` field on product is deprecated to roll over the return
-        type from a simple list to a paginated list. The easiest way to fix your
-        operations is to alias the new field `reviewList` to `review`.
-        Once all clients have updated, we will roll over this field and deprecate
-        `reviewList` in favor of the field name `reviews` again""")
-          """
-          A paginated list of reviews. This field naming is temporary while all clients
-          migrate off of the un-paginated version of this field call reviews. To ease this migration,
-          alias your usage of `reviewList` to `reviews` so that after the roll over is finished, you
-          can remove the alias and use the final field name.
-          """
-          reviewList(first: Int = 5, after: Int = 0): ReviewConnection
-        }
-        "A union of all brands represented within the store"
-        union Brand = Ikea | Amazon
-        "An enum of product types"
-        enum ProductType {
-          LATEST
-          TRENDING
-        }
-    "#}
+             type Query {
+               "Fetch a simple list of products with an offset"
+               topProducts(first: Int = 5): [Product] @deprecated(reason: "Use `products` instead")
+               "Fetch a paginated list of products based on a filter type."
+               products(first: Int = 5, after: Int = 0, type: ProductType): ProductConnection
+               """
+               The currently authenticated user root. All nodes off of this
+               root will be authenticated as the current user
+               """
+               me: User
+             }
+             "A review is any feedback about products across the graph"
+             type Review {
+               id: ID!
+               "The plain text version of the review"
+               body: String
+               "The user who authored the review"
+               author: User
+               "The product which this review is about"
+               product: Product
+             }
+             "The base User in Acephei"
+             type User {
+               "A globally unique id for the user"
+               id: ID!
+               "The users full name as provided"
+               name: String
+               "The account username of the user"
+               username: String
+               "A list of all reviews by the user"
+               reviews: [Review]
+             }
+             "A connection wrapper for lists of reviews"
+             type ReviewConnection {
+               "Helpful metadata about the connection"
+               pageInfo: PageInfo
+               "List of reviews returned by the search"
+               edges: [ReviewEdge]
+             }
+             """
+             The PageInfo type provides pagination helpers for determining
+             if more data can be fetched from the list
+             """
+             type PageInfo {
+               "More items exist in the list"
+               hasNextPage: Boolean
+               "Items earlier in the list exist"
+               hasPreviousPage: Boolean
+             }
+             "A connection edge for the Review type"
+             type ReviewEdge {
+               review: Review
+             }
+             "A connection wrapper for lists of products"
+             type ProductConnection {
+               "Helpful metadata about the connection"
+               pageInfo: PageInfo
+               "List of products returned by the search"
+               edges: [ProductEdge]
+             }
+             "A connection edge for the Product type"
+             type ProductEdge {
+               product: Product
+             }
+             "The basic book in the graph"
+             type Book implements Product {
+               "All books can be found by an isbn"
+               isbn: String!
+               "The title of the book"
+               title: String
+               "The year the book was published"
+               year: Int
+               """
+               Улюблена книга, прочитана цього рока "" | 今年読んだお気に入りの本
+               """
+               favouriteBook: Book
+               "A simple list of similar books"
+               similarBooks: [Book]
+               reviews: [Review]
+               reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+               """
+               relatedReviews for a book use the knowledge of `similarBooks` from the books
+               service to return related reviews that may be of interest to the user
+               """
+               relatedReviews(first: Int = 5, after: Int = 0): ReviewConnection
+               "Since books are now products, we can also use their upc as a primary id"
+               upc: String!
+               "The name of a book is the book's title + year published"
+               name(delimeter: String = " "): String
+               price: Int
+               weight: Int
+             }
+             "Information about the brand Amazon"
+             type Amazon {
+               "The url of a referrer for a product"
+               referrer: String
+             }
+             "Information about the brand Ikea"
+             type Ikea {
+               "Which asile to find an item"
+               asile: Int
+             }
+             """
+             The Furniture type represents all products which are items
+             of furniture.
+             """
+             type Furniture implements Product {
+               "The modern primary identifier for furniture"
+               upc: String!
+               "The SKU field is how furniture was previously stored, and still exists in some legacy systems"
+               sku: String!
+               name: String
+               price: Int
+               "The brand of furniture"
+               brand: Brand
+               weight: Int
+               reviews: [Review]
+               reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+             }
+             "The Product type represents all products within the system"
+             interface Product {
+               "The primary identifier of products in the graph"
+               upc: String!
+               "The display name of the product"
+               name: String
+               "A simple integer price of the product in US dollars"
+               price: Int
+               "How much the product weighs in kg"
+               weight: Int @deprecated(reason: "Not all product's have a weight")
+               "A simple list of all reviews for a product"
+               reviews: [Review] @deprecated(reason: """The `reviews` field on product is deprecated to roll over the return
+             type from a simple list to a paginated list. The easiest way to fix your
+             operations is to alias the new field `reviewList` to `review`.
+             Once all clients have updated, we will roll over this field and deprecate
+             `reviewList` in favor of the field name `reviews` again""")
+               """
+               A paginated list of reviews. This field naming is temporary while all clients
+               migrate off of the un-paginated version of this field call reviews. To ease this migration,
+               alias your usage of `reviewList` to `reviews` so that after the roll over is finished, you
+               can remove the alias and use the final field name.
+               """
+               reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+             }
+             "A union of all brands represented within the store"
+             union Brand = Ikea | Amazon
+             "An enum of product types"
+             enum ProductType {
+               LATEST
+               TRENDING
+             }
+         "#}
         )
     }
 }


### PR DESCRIPTION
updates to apollo-encoder@0.3.2

fixes #1244, fixes #1114