### PR TITLE
fix: fixes up socket message passing

### DIFF
--- a/src/command/dev/introspect.rs
+++ b/src/command/dev/introspect.rs
@@ -88,7 +88,7 @@ pub struct SubgraphIntrospectRunner {
 
 impl SubgraphIntrospectRunner {
     pub fn run(&self) -> Result<String> {
-        tracing::info!(
+        tracing::debug!(
             "running `rover subgraph introspect --endpoint {}`",
             &self.endpoint
         );
@@ -111,7 +111,7 @@ pub struct GraphIntrospectRunner {
 
 impl GraphIntrospectRunner {
     pub fn run(&self) -> Result<String> {
-        tracing::info!(
+        tracing::debug!(
             "running `rover graph introspect --endpoint {}`",
             &self.endpoint
         );

--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -20,6 +20,7 @@ impl SchemaOpts {
         name: SubgraphName,
         client: Client,
         session_subgraphs: Vec<SubgraphKey>,
+        is_main_session: bool,
     ) -> Result<SubgraphSchemaWatcher> {
         let mut preexisting_socket_addrs = Vec::new();
         for (session_subgraph_name, session_subgraph_url) in session_subgraphs {
@@ -102,9 +103,14 @@ impl SchemaOpts {
         };
 
         if let Some(schema) = schema {
-            SubgraphSchemaWatcher::new_from_file_path(socket_addr, (name, url), schema)
+            SubgraphSchemaWatcher::new_from_file_path(
+                socket_addr,
+                (name, url),
+                schema,
+                is_main_session,
+            )
         } else {
-            SubgraphSchemaWatcher::new_from_url(socket_addr, (name, url), client)
+            SubgraphSchemaWatcher::new_from_url(socket_addr, (name, url), client, is_main_session)
         }
     }
 }

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -24,6 +24,7 @@ impl SubgraphSchemaWatcher {
         socket_addr: &str,
         subgraph_key: SubgraphKey,
         path: P,
+        is_main_session: bool,
     ) -> Result<Self>
     where
         P: AsRef<Utf8Path>,
@@ -31,7 +32,7 @@ impl SubgraphSchemaWatcher {
         Ok(Self {
             schema_watcher_kind: SubgraphSchemaWatcherKind::File(path.as_ref().to_path_buf()),
             subgraph_key,
-            message_sender: MessageSender::new(socket_addr),
+            message_sender: MessageSender::new(socket_addr, is_main_session),
         })
     }
 
@@ -39,22 +40,29 @@ impl SubgraphSchemaWatcher {
         socket_addr: &str,
         subgraph_key: SubgraphKey,
         client: Client,
+        is_main_session: bool,
     ) -> Result<Self> {
         let (_, url) = subgraph_key.clone();
         let introspect_runner =
             IntrospectRunnerKind::Unknown(UnknownIntrospectRunner::new(url, client));
-        Self::new_from_introspect_runner(socket_addr, subgraph_key, introspect_runner)
+        Self::new_from_introspect_runner(
+            socket_addr,
+            subgraph_key,
+            introspect_runner,
+            is_main_session,
+        )
     }
 
     pub fn new_from_introspect_runner(
         socket_addr: &str,
         subgraph_key: SubgraphKey,
         introspect_runner: IntrospectRunnerKind,
+        is_main_session: bool,
     ) -> Result<Self> {
         Ok(Self {
             schema_watcher_kind: SubgraphSchemaWatcherKind::Introspect(introspect_runner),
             subgraph_key,
-            message_sender: MessageSender::new(socket_addr),
+            message_sender: MessageSender::new(socket_addr, is_main_session),
         })
     }
 


### PR DESCRIPTION
fixes #1255 deadlock for interprocess communication.

deadlocks were occurring because sometimes we would attempt to connect to a socket and then we would immediately drop it without writing anything to it. we sometimes want to do this in order to check if we are the main `rover dev` session or not, but the problem is that every incoming connection blocks waiting for a message to come in. we now send the unit type message for those "empty" connections in order to unblock the stream reader and allow them to process another incoming connection.