### PR TITLE
fix: kill all sessions when main session shuts down

### DIFF
--- a/examples/supergraph-demo/package.json
+++ b/examples/supergraph-demo/package.json
@@ -7,11 +7,14 @@
   "author": "Apollo Developers <opensource@apollographql.com>",
   "license": "MIT",
   "scripts": {
-    "start": "concurrently \"npm run dev:products\" \"npm run dev:pandas\" \"npm run dev:users\"",
-    "dev": "npm run start",
-    "dev:products": "cd products && npm i && npm run dev",
-    "dev:pandas": "cd pandas && npm i && npm run dev",
-    "dev:users": "cd users && npm i && npm run dev"
+    "start": "concurrently \"npm run start:products\" \"npm run start:pandas\" \"npm run start:users\"",
+    "dev": "concurrently \"npm run dev:products\" \"npm run dev:pandas\" \"npm run dev:users\"",
+    "start:products": "cd products && npm run start",
+    "start:pandas": "cd pandas && npm run start",
+    "start:users": "cd users && npm run start",
+    "dev:products": "cd products && npm run dev",
+    "dev:pandas": "cd pandas && npm run dev",
+    "dev:users": "cd users && npm run dev"
   },
   "devDependencies": {
     "concurrently": "^7.3.0"

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -141,6 +141,15 @@ impl Dev {
         // and after we bind to the socket in main `rover dev` sessions
         ready_receiver.recv().unwrap();
 
+        if !is_main_session {
+            rayon::spawn(move || {
+                if let Err(e) = MessageSender::new(socket_addr, is_main_session).health_check() {
+                    log_err_and_continue(e);
+                    std::process::exit(1);
+                }
+            })
+        }
+
         // watch the subgraph for changes on the main thread
         subgraph_refresher.watch_subgraph()?;
         Ok(RoverOutput::EmptySuccess)


### PR DESCRIPTION
fixes #1228 by adding a health check loop that attempts to connect to the socket once every second and do a write/read to see if the main `rover dev` session is still alive. if it's not it will return an error and shutdown.

main `rover dev` session looks like this when you send `ctrl+c`:

```console
$ rover dev --name products --url http://localhost:4002
...
...
...
2022-08-26T20:33:16.666394Z  INFO apollo_router::state_machine: transitioned to running
^C
shutting down main `rover dev` session
```

in child `rover dev` session, they will also shut down with this error message:

```console
$ rover dev --name pandas --url http://localhost:4003
watching 'pandas' subgraph for changes...
notifying main `rover dev` session about new subgraph 'pandas'
watching ./pandas.graphql for changes
error: the main `rover dev` session has been killed, shutting down
```