### PR TITLE
fix: detect improper VS code pastes on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ansi_term",
  "apollo-federation-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.8.1"
+version = "0.8.2"
 default-run = "rover"
 
 publish = false

--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -33,6 +33,10 @@ pub enum HoustonProblem {
     #[error("No non-sensitive configuration found for profile \"{0}\".")]
     NoNonSensitiveConfigFound(String),
 
+    /// CorruptedProfile occurs on Windows when `rover config auth` was run with older versions of Rover.
+    #[error("The API key associated with profile \"{0}\" is corrupt.")]
+    CorruptedProfile(String),
+
     /// PathNotUtf8 occurs when Houston encounters a file path that is not valid UTF-8
     #[error(transparent)]
     PathNotUtf8(#[from] saucer::FromPathBufError),

--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -34,7 +34,13 @@ impl Sensitive {
         let path = Sensitive::path(profile_name, config);
         let data = Fs::read_file(&path, "")?;
         tracing::debug!(path = ?path, data_len = ?data.len());
-        Ok(toml::from_str(&data)?)
+        let sensitive: Self = toml::from_str(&data)?;
+        // old versions of rover used to create every single profile with this
+        if sensitive.api_key.as_bytes() == &[22] {
+            Err(HoustonProblem::CorruptedProfile(profile_name.to_string()))
+        } else {
+            Ok(sensitive)
+        }
     }
 }
 

--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -35,7 +35,8 @@ impl Sensitive {
         let data = Fs::read_file(&path, "")?;
         tracing::debug!(path = ?path, data_len = ?data.len());
         let sensitive: Self = toml::from_str(&data)?;
-        // old versions of rover used to create every single profile with this on windows
+        // old versions of rover used to allow profiles to be created
+        // with these contents in certain PowerShell environments
         if sensitive.api_key.as_bytes() == [22] {
             Err(HoustonProblem::CorruptedProfile(profile_name.to_string()))
         } else {

--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -35,8 +35,8 @@ impl Sensitive {
         let data = Fs::read_file(&path, "")?;
         tracing::debug!(path = ?path, data_len = ?data.len());
         let sensitive: Self = toml::from_str(&data)?;
-        // old versions of rover used to create every single profile with this
-        if sensitive.api_key.as_bytes() == &[22] {
+        // old versions of rover used to create every single profile with this on windows
+        if sensitive.api_key.as_bytes() == [22] {
             Err(HoustonProblem::CorruptedProfile(profile_name.to_string()))
         } else {
             Ok(sensitive)

--- a/installers/binstall/src/system/windows.rs
+++ b/installers/binstall/src/system/windows.rs
@@ -84,7 +84,7 @@ fn add_to_path(old_path: &str, path_str: &str) -> Option<String> {
     } else {
         let mut new_path = path_str.to_string();
         new_path.push(';');
-        new_path.push_str(&old_path);
+        new_path.push_str(old_path);
         Some(new_path)
     }
 }

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -53,7 +53,7 @@ fn api_key_prompt() -> Result<String> {
 fn validate(api_key: String) -> Result<String> {
     if api_key.is_empty() {
         Err(anyhow!("Received an empty API Key. Please try again.").into())
-    } else if api_key.as_bytes() == &[22] {
+    } else if api_key.as_bytes() == [22] {
         let mut err = RoverError::new(anyhow!("Your API key was not pasted successfully."));
         err.set_suggestion(Suggestion::Adhoc("Re-run this command, and when you are prompted to enter your API key, right click on the terminal and press paste instead of pressing Ctrl+V.".to_string()));
         Err(err)

--- a/src/command/config/auth.rs
+++ b/src/command/config/auth.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 use config::Profile;
 use houston as config;
 
-use crate::{anyhow, options::ProfileOpt, Result, command::RoverOutput, Suggestion, error::RoverError};
+use crate::{
+    anyhow, command::RoverOutput, error::RoverError, options::ProfileOpt, Result, Suggestion,
+};
 
 #[derive(Debug, Serialize, Parser)]
 /// Authenticate a configuration profile with an API key

--- a/src/error/metadata/code.rs
+++ b/src/error/metadata/code.rs
@@ -40,6 +40,7 @@ pub enum Code {
     E032,
     E033,
     E034,
+    E035,
 }
 
 impl Display for Code {
@@ -87,6 +88,7 @@ impl Code {
             (Code::E032, include_str!("./codes/E032.md").to_string()),
             (Code::E033, include_str!("./codes/E033.md").to_string()),
             (Code::E034, include_str!("./codes/E034.md").to_string()),
+            (Code::E035, include_str!("./codes/E035.md").to_string()),
         ];
         contents.into_iter().collect()
     }

--- a/src/error/metadata/codes/E035.md
+++ b/src/error/metadata/codes/E035.md
@@ -1,0 +1,3 @@
+This error occurs on Windows when a configuration profile has a corrupted API key. Versions of Rover before v0.8.2 used to create corrupted API keys with the `rover config auth` command.
+
+You will need to recreate the configuration profile in order to proceed. See Rover's [configuring docs](https://go.apollo.dev/r/configuring) for more info.

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -198,9 +198,10 @@ impl From<&mut saucer::Error> for Metadata {
                 HoustonProblem::NoNonSensitiveConfigFound(_) => {
                     (Some(Suggestion::SubmitIssue), Some(Code::E022))
                 }
-                HoustonProblem::CorruptedProfile(profile_name) => {
-                    (Some(Suggestion::RecreateConfig(profile_name.to_string())), Some(Code::E035))
-                }
+                HoustonProblem::CorruptedProfile(profile_name) => (
+                    Some(Suggestion::RecreateConfig(profile_name.to_string())),
+                    Some(Code::E035),
+                ),
                 HoustonProblem::PathNotUtf8(_) => (Some(Suggestion::SubmitIssue), Some(Code::E023)),
                 HoustonProblem::TomlDeserialization(_) => {
                     (Some(Suggestion::SubmitIssue), Some(Code::E024))

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -198,6 +198,9 @@ impl From<&mut saucer::Error> for Metadata {
                 HoustonProblem::NoNonSensitiveConfigFound(_) => {
                     (Some(Suggestion::SubmitIssue), Some(Code::E022))
                 }
+                HoustonProblem::CorruptedProfile(profile_name) => {
+                    (Some(Suggestion::RecreateConfig(profile_name.to_string())), Some(Code::E035))
+                }
                 HoustonProblem::PathNotUtf8(_) => (Some(Suggestion::SubmitIssue), Some(Code::E023)),
                 HoustonProblem::TomlDeserialization(_) => {
                     (Some(Suggestion::SubmitIssue), Some(Code::E024))

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -15,6 +15,7 @@ pub enum Suggestion {
     SetConfigHome,
     MigrateConfigHomeOrCreateConfig,
     CreateConfig,
+    RecreateConfig(String),
     ListProfiles,
     UseFederatedGraph,
     RunComposition,
@@ -74,6 +75,12 @@ impl Display for Suggestion {
                     "Try setting up a configuration profile by running {}",
                     Yellow.normal().paint("`rover config auth`")
                 )
+            }
+            Suggestion::RecreateConfig(profile_name) => {
+                format!("Recreate this configuration profile by running {}.", Yellow.normal().paint(format!("`rover config auth{}`", match profile_name.as_str() {
+                    "default" => "".to_string(),
+                    profile_name => format!(" --profile {}", profile_name)
+                })))
             }
             Suggestion::ListProfiles => {
                 format!(


### PR DESCRIPTION
fixes #1026.

if you run `rover config auth` from VS Code's default PowerShell config on Windows, the API key file will always be saved with these contents:

```toml
api_key = "\u0016"
```

This is clearly incorrect! This PR adds new error messages for users who created their API keys in this way that look like this:

```console
$ rover config whoami
error[E035]: The API key associated with profile "default" is corrupt.
        Recreate this configuration profile by running `rover config auth`.
```

and if new users try to press "ctrl+v" in their integrated VS Code terminal, we will detect that case and error, instructing them on what to do instead.

```console
$ rover config auth
Go to https://studio.apollographql.com/user-settings/api-keys and create a new Personal API Key.
Copy the key and paste it into the prompt below.
>
error: Your API key was not pasted successfully.
        Re-run this command, and when you are prompted to enter your API key, right click on the terminal and press paste instead of pressing Ctrl+V.
```