### PR TITLE
enable exposing the query plan within `rover dev`

### DIFF
--- a/src/command/dev/router.rs
+++ b/src/command/dev/router.rs
@@ -76,6 +76,7 @@ impl RouterRunner {
         plugins:
             experimental.include_subgraph_errors:
               all: true
+            experimental.expose_query_plan: true
         "#;
         Ok(Fs::write_file(&self.router_config_path, contents, "")
             .context("could not create router config")?)


### PR DESCRIPTION
fixes #1272

Implements the experimental expose query plan feature in `rover dev` until
we enable Apollo Router to negotiate this itself via an env variable.

Past Work: https://github.com/apollographql/router/issues/1075
Future Work: https://github.com/apollographql/router/issues/1474