### PR TITLE
feat: allow configurable router downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "344a1afec31ce0273dc2061105b04e5c4ab620fe0748a76244338aa893db42f3"
 [[package]]
 name = "apollo-federation-types"
 version = "0.6.1"
-source = "git+https://github.com/apollographql/federation-rs?branch=avery/add-deserialize#1bbe7138f830dc1b0ee85f43bbad678c4c0941e1"
+source = "git+https://github.com/apollographql/federation-rs?rev=4c28792e68b099d4f1fcdb06fbb421b973bfb434#4c28792e68b099d4f1fcdb06fbb421b973bfb434"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ composition-js = []
 # https://github.com/apollographql/federation-rs dependencies
 # apollo-federation-types = "0.5"
 # apollo-federation-types = { path = "../federation-rs/apollo-federation-types" }
-apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", branch = "avery/add-deserialize" }
+apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "4c28792e68b099d4f1fcdb06fbb421b973bfb434" }
 
 # https://github.com/apollographql/apollo-rs dependencies
 apollo-parser = "0.2"

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -15,7 +15,7 @@ houston = { path = "../houston" }
 # https://github.com/apollographql/federation-rs dependencies
 # apollo-federation-types = "0.5"
 # apollo-federation-types = { path = "../../../federation-rs/apollo-federation-types" }
-apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", branch = "avery/add-deserialize" }
+apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "4c28792e68b099d4f1fcdb06fbb421b973bfb434" }
 
 # crates.io deps
 backoff = "0.4"

--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -92,8 +92,6 @@ impl Installer {
                 .to_str()
                 .map_err(|e| InstallerError::IoError(io::Error::new(io::ErrorKind::Other, e)))?
                 .to_string())
-        } else if plugin_tarball_url.contains("router") {
-            Ok("v0.12.0".to_string())
         } else {
             Err(InstallerError::IoError(io::Error::new(
                 io::ErrorKind::Other,

--- a/src/command/dev/router.rs
+++ b/src/command/dev/router.rs
@@ -1,4 +1,6 @@
+use apollo_federation_types::config::RouterVersion;
 use saucer::{anyhow, Context, Fs, Utf8PathBuf};
+use semver::Version;
 
 use std::collections::HashSet;
 use std::net::ToSocketAddrs;
@@ -42,7 +44,7 @@ impl RouterRunner {
     }
 
     pub fn get_command_to_spawn(&self) -> Result<String> {
-        let plugin = Plugin::Router;
+        let plugin = Plugin::Router(RouterVersion::Exact(Version::parse("1.0.0-alpha.0")?));
         let install_command = Install {
             force: false,
             plugin: Some(plugin),

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -1,84 +1,60 @@
 use std::str::FromStr;
 
-use apollo_federation_types::config::FederationVersion;
+use apollo_federation_types::config::{FederationVersion, PluginVersion, RouterVersion};
 use serde::{Deserialize, Serialize};
 
-use crate::{anyhow, Context, Result};
+use crate::{anyhow, error::RoverError, Context, Result};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) enum Plugin {
     Supergraph(FederationVersion),
-    Router,
+    Router(RouterVersion),
 }
 
 impl Plugin {
     pub fn get_name(&self) -> String {
         match self {
             Self::Supergraph(_) => "supergraph".to_string(),
-            Self::Router => "router".to_string(),
-        }
-    }
-
-    pub fn get_major_version(&self) -> u64 {
-        match self {
-            Self::Supergraph(v) => v.get_major_version(),
-            // TODO: replace this with real versioning
-            Self::Router => 0,
+            Self::Router(_) => "router".to_string(),
         }
     }
 
     pub fn requires_elv2_license(&self) -> bool {
         match self {
             Self::Supergraph(v) => v.get_major_version() == 2,
-            Self::Router => true,
+            Self::Router(_) => true,
         }
     }
 
-    pub fn get_tarball_url(&self) -> Result<String> {
+    pub fn get_tarball_version(&self) -> String {
         match self {
-            Self::Supergraph(v) => {
-                let target_arch = if cfg!(target_os = "windows") {
-                    Ok("x86_64-pc-windows-msvc")
-                } else if cfg!(target_os = "macos") {
-                    Ok("x86_64-apple-darwin")
-                } else if cfg!(target_os = "linux") && !cfg!(target_env = "musl") {
-                    Ok("x86_64-unknown-linux-gnu")
-                } else {
-                    Err(anyhow!(
-                        "Your current architecture does not support installation of this plugin."
-                    ))
-                }?;
-                Ok(format!(
-                    "https://rover.apollo.dev/tar/{name}/{target_arch}/{version}",
-                    name = self.get_name(),
-                    target_arch = target_arch,
-                    version = v.get_tarball_version()
-                ))
-            }
-            Self::Router => {
-                let target_arch = if !cfg!(target_arch = "x86_64") && !cfg!(target_os = "macos") {
-                    Err(anyhow!(
-                        "Your current architecture does not support installation of this plugin."
-                    ))
-                } else if cfg!(target_os = "windows") {
-                    Ok("x86_64-windows")
-                } else if cfg!(target_os = "macos") {
-                    Ok("x86_64-macos")
-                } else if cfg!(target_os = "linux") && !cfg!(target_env = "musl") {
-                    Ok("x86_64-linux")
-                } else {
-                    Err(anyhow!(
-                        "Your current architecture does not support installation of this plugin."
-                    ))
-                }?;
-                Ok(format!(
-                    // TODO: replace this with real versions, probably sourced from orbiter
-                    "https://github.com/apollographql/{name}/releases/download/v0.12.0/{name}-0.12.0-{target_arch}.tar.gz",
-                    name = self.get_name(),
-                    target_arch = target_arch,
-                ))
-            }
+            Self::Supergraph(v) => v.get_tarball_version(),
+            Self::Router(v) => v.get_tarball_version(),
         }
+    }
+
+    pub fn get_target_arch(&self) -> Result<String> {
+        if cfg!(target_os = "windows") {
+            Ok("x86_64-pc-windows-msvc")
+        } else if cfg!(target_os = "macos") {
+            Ok("x86_64-apple-darwin")
+        } else if cfg!(target_os = "linux") && !cfg!(target_env = "musl") {
+            Ok("x86_64-unknown-linux-gnu")
+        } else {
+            Err(RoverError::new(anyhow!(
+                "Your current architecture does not support installation of this plugin."
+            )))
+        }
+        .map(|s| s.to_string())
+    }
+
+    pub fn get_tarball_url(&self) -> Result<String> {
+        Ok(format!(
+            "https://rover.apollo.dev/tar/{name}/{target_arch}/{version}",
+            name = self.get_name(),
+            target_arch = self.get_target_arch()?,
+            version = self.get_tarball_version()
+        ))
     }
 }
 
@@ -92,16 +68,19 @@ impl FromStr for Plugin {
             let plugin_name = splits[0].clone();
             let plugin_version = splits[1].clone();
             if plugin_name == "supergraph" {
-                let federation_version = FederationVersion::from_str(&plugin_version).with_context(||
-                    format!("Invalid version '{}' for 'supergraph' plugin. Must be 'latest-0', 'latest-2', or an exact version preceeded with an '='.", &plugin_version))?;
+                let federation_version = FederationVersion::from_str(&plugin_version)
+                    .with_context(|| {
+                        format!(
+                            "Invalid version '{}' for 'supergraph' plugin. Must be 'latest-0', 'latest-2', or an exact version preceeded with an '='.",
+                            &plugin_version
+                        )
+                    })?;
                 Ok(Plugin::Supergraph(federation_version))
             } else if plugin_name == "router" {
-                // TODO: real versioning
-                eprintln!(
-                    "warn: router version {} has been ignored, using 0.12.0 instead",
-                    &plugin_version
-                );
-                Ok(Plugin::Router)
+                let router_version = RouterVersion::from_str(&plugin_version).with_context({
+                    || format!("Invalid version '{}' for 'router' plugin. Must be an exact version (>= 1.0.0 & < 2.0.0) preceeded with a 'v'.", &plugin_version)
+                })?;
+                Ok(Plugin::Router(router_version))
             } else {
                 // TODO: this should probably use ArgEnum instead
                 Err(anyhow!(

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 
 use apollo_federation_types::config::SupergraphConfig;
-use apollo_federation_types::{build::BuildResult, config::FederationVersion};
+use apollo_federation_types::{
+    build::BuildResult,
+    config::{FederationVersion, PluginVersion},
+};
 use rover_client::RoverClientError;
 
 use saucer::Utf8PathBuf;


### PR DESCRIPTION
fixes #1273 This PR updates `rover install --plugin router@` to download packages from orbiter rather than through GitHub releases directly. We still hard code the router version, but only in one place rather than many, and we leave the door open for downloading routers more automatically (like we do for `supergraph` plugins) once the dev interface has stabilized.