### PR TITLE
normalize git remote urls for anonymized telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -1850,7 +1849,6 @@ checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1864,20 +1862,6 @@ checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3000,8 +2984,8 @@ version = "0.0.0"
 dependencies = [
  "assert_fs",
  "ci_info",
- "git2",
  "reqwest",
+ "rover-client",
  "saucer",
  "semver",
  "serde",

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 ci_info = { version = "0.14", features = ["serde-1"] }
-git2 = "0.14"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "socks"] }
+rover-client = { path = "../rover-client" }
 saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", branch = "main" }
 # saucer = { path = "../../../awc/saucer" }
 semver = { version = "1", features = ["serde"] }


### PR DESCRIPTION
this PR adds normalization logic to the remote URLs reported to apollo's telemetry service. CI providers like GitLab include username and passwords in their remote URLs, which makes their hashes non-unique. we now use the same normalization techniques used to provide `GitContext` to the Apollo Studio GraphQL API which should give us stronger insights into the number of unique projects using rover.