### PR TITLE
chore: updates rover dev versioning strategy

### DIFF
--- a/src/command/dev/command.rs
+++ b/src/command/dev/command.rs
@@ -24,7 +24,7 @@ impl BackgroundTask {
         }
 
         let mut command = Command::new(bin);
-        command.args(args);
+        command.args(args).env("APOLLO_ROVER", "true");
 
         if cfg!(windows) {
             command.stdout(Stdio::null()).stderr(Stdio::null());

--- a/src/command/dev/compose.rs
+++ b/src/command/dev/compose.rs
@@ -17,6 +17,7 @@ pub struct ComposeRunner {
     client_config: StudioClientConfig,
     write_path: Utf8PathBuf,
     composition_state: Option<Result<CompositionOutput>>,
+    plugin_exe: Option<Utf8PathBuf>,
 }
 
 impl ComposeRunner {
@@ -32,6 +33,24 @@ impl ComposeRunner {
             client_config,
             write_path,
             composition_state: None,
+            plugin_exe: None,
+        }
+    }
+
+    pub fn maybe_install_supergraph(
+        &mut self,
+        supergraph_config: &SupergraphConfig,
+    ) -> Result<Utf8PathBuf> {
+        if let Some(plugin_exe) = &self.plugin_exe {
+            Ok(plugin_exe.clone())
+        } else {
+            let plugin_exe = self.compose.maybe_install_supergraph(
+                self.override_install_path.clone(),
+                self.client_config.clone(),
+                supergraph_config,
+            )?;
+            self.plugin_exe = Some(plugin_exe.clone());
+            Ok(plugin_exe)
         }
     }
 

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -97,7 +97,7 @@ impl Dev {
 
             // create a [`RouterRunner`] that we will spawn once we get our first subgraph
             // (which should come from this process but on another thread)
-            let mut router_runner = RouterRunner::new(
+            let router_runner = RouterRunner::new(
                 supergraph_schema_path,
                 temp_path.join("config.yaml"),
                 self.opts.plugin_opts.clone(),
@@ -106,12 +106,14 @@ impl Dev {
                 client_config,
             );
 
-            // attempt to install the router plugin before waiting for incoming messages
-            router_runner.maybe_install_router()?;
-
             // create a [`MessageReceiver`] that will keep track of the existing subgraphs
             let mut message_receiver =
                 MessageReceiver::new(&socket_addr, compose_runner, router_runner)?;
+
+            // attempt to install the router and supergraph plugins
+            //  before waiting for incoming messages
+
+            message_receiver.install_plugins()?;
 
             let kill_sender = MessageSender::new_subgraph(&socket_addr);
 

--- a/src/command/dev/leader.rs
+++ b/src/command/dev/leader.rs
@@ -48,6 +48,13 @@ impl MessageReceiver {
         }
     }
 
+    pub fn install_plugins(&mut self) -> Result<()> {
+        self.router_runner.maybe_install_router()?;
+        self.compose_runner
+            .maybe_install_supergraph(&self.supergraph_config())?;
+        Ok(())
+    }
+
     pub fn supergraph_config(&self) -> SupergraphConfig {
         let mut supergraph_config: SupergraphConfig = self
             .subgraphs

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -77,3 +77,12 @@ impl SupergraphOpts {
         Ok(SocketAddr::from_str(&format!("127.0.0.1:{}", &self.port))?)
     }
 }
+
+// TODO: make this configurable once the router is stable enough
+// and there is a way to determine the correct composition version
+// to use with a router version
+pub(crate) const DEV_ROUTER_VERSION: &str = "1.0.0-alpha.2"; // "1.0.0-alpha.3";
+
+// this number should be mapped to the federation version used by the router
+// https://www.apollographql.com/docs/router/federation-version-support/#support-table
+pub(crate) const DEV_COMPOSITION_VERSION: &str = "2.1.1"; // "2.1.2-alpha.0";

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -81,8 +81,8 @@ impl SupergraphOpts {
 // TODO: make this configurable once the router is stable enough
 // and there is a way to determine the correct composition version
 // to use with a router version
-pub(crate) const DEV_ROUTER_VERSION: &str = "1.0.0-alpha.2"; // "1.0.0-alpha.3";
+pub(crate) const DEV_ROUTER_VERSION: &str = "1.0.0-alpha.3";
 
 // this number should be mapped to the federation version used by the router
 // https://www.apollographql.com/docs/router/federation-version-support/#support-table
-pub(crate) const DEV_COMPOSITION_VERSION: &str = "2.1.1"; // "2.1.2-alpha.0";
+pub(crate) const DEV_COMPOSITION_VERSION: &str = "2.1.2-alpha.0";


### PR DESCRIPTION
fixes #1214, fixes #1278, and fixed an issue where `rover dev` would crash if the router and/or composer plugin installation took longer than 5 seconds.