### PR TITLE
chore: Refactor some `rover new` code

### DIFF
--- a/src/command/new/mod.rs
+++ b/src/command/new/mod.rs
@@ -1,17 +1,17 @@
-use crate::utils::client::StudioClientConfig;
+use std::convert::TryFrom;
+use std::fs::read_dir;
+use std::io::Write;
+
 use ansi_term::Colour::Cyan;
 use ansi_term::Style;
 use console::Term;
 use dialoguer::Select;
-use saucer::Utf8PathBuf;
 use saucer::{clap, Parser};
+use saucer::{Utf8PathBuf, ValueEnum};
 use serde::Serialize;
-use std::convert::TryFrom;
-use std::fs::read_dir;
-use std::io::Write;
-use std::str::FromStr;
 
 use crate::options::{GithubTemplate, ProjectLanguage, ProjectType, TemplateOpt};
+use crate::utils::client::StudioClientConfig;
 use crate::{anyhow, command::RoverOutput, error::RoverError, Result};
 
 #[derive(Debug, Clone, Serialize, Parser)]
@@ -28,57 +28,47 @@ pub struct New {
 impl New {
     pub fn run(&self, client_config: StudioClientConfig) -> Result<RoverOutput> {
         // read_dir will always have the root element, or a count of 1
-        //match this error for directory not created yet, create if it doesn't exist
-        if read_dir(&self.path).unwrap().count() > 1 {
-            return Err(RoverError::new(anyhow!(
-        "You can only create projects in a blank folder. This is to prevent from accidentally overwriting any work."
-      )));
+        match read_dir(&self.path) {
+            Ok(dir) => {
+                if dir.count() > 1 {
+                    return Err(
+                        RoverError::new(anyhow!(
+                            "You can only create projects in a blank folder. This is to prevent from accidentally overwriting any work."
+                        ))
+                    );
+                }
+            }
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    std::fs::create_dir_all(&self.path)?;
+                } else {
+                    return Err(RoverError::new(anyhow!(e)));
+                }
+            }
         }
 
-        let templates = self.get_templates()?;
-        let template_to_clone: Option<GithubTemplate> = if self.options.template.is_some() {
-            let template_id = self.options.template.clone().unwrap();
-            let index = templates.iter().position(|t| t.id == template_id).unwrap();
-
-            Some(templates[index].clone())
+        let template_to_clone: GithubTemplate = if let Some(template_id) = &self.options.template {
+            Self::get_template_by_id(template_id)?
         } else {
-            let project_type = ProjectType::from_str(
-                self.options
-                    .project_type
-                    .clone()
-                    .unwrap_or_else(|| self.prompt_project_type().unwrap().to_string())
-                    .as_str(),
-            )
-            .unwrap();
+            let project_type = self
+                .options
+                .project_type
+                .map(Ok)
+                .unwrap_or_else(|| self.prompt_project_type())?;
 
-            let selected_language = ProjectLanguage::from_str(
-                self.options
-                    .language
-                    .clone()
-                    .unwrap_or_else(|| self.prompt_language().unwrap().to_string())
-                    .as_str(),
-            )
-            .unwrap();
+            let project_language = self
+                .options
+                .language
+                .map(Ok)
+                .unwrap_or_else(|| self.prompt_language())?;
 
-            let available_templates: Vec<GithubTemplate> = templates
-                .into_iter()
-                .filter(|template| {
-                    project_type.eq(&template.project_type)
-                        && template.language == selected_language
-                })
-                .collect();
+            let templates = self.get_templates(project_type, project_language);
 
-            Some(self.template_prompt(&available_templates)?)
+            self.template_prompt(&templates)?
         };
 
-        if template_to_clone.is_none() {
-            return Err(RoverError::new(anyhow!(
-                "An invalid template id was provided"
-            )));
-        }
-
-        self.extract_github_tarball(
-            template_to_clone.unwrap(),
+        Self::extract_github_tarball(
+            template_to_clone,
             &self.path,
             &client_config.get_reqwest_client()?,
         )?;
@@ -93,40 +83,30 @@ impl New {
     }
 
     pub fn prompt_language(&self) -> Result<ProjectLanguage> {
-        let items = vec![
-            ProjectLanguage::Java,
-            ProjectLanguage::Javascript,
-            ProjectLanguage::Python,
-            ProjectLanguage::Rust,
-            ProjectLanguage::Typescript,
-        ];
+        let languages = <ProjectLanguage as ValueEnum>::value_variants();
         let selection = Select::new()
             .with_prompt("What language are you planning on using for the project?")
-            .items(&items)
+            .items(languages)
             .default(0)
             .interact_on_opt(&Term::stderr())?;
 
         match selection {
-            Some(index) => Ok(items[index].clone()),
+            Some(index) => Ok(languages[index]),
             None => Err(RoverError::new(anyhow!("No language selected"))),
         }
     }
 
     pub fn prompt_project_type(&self) -> Result<ProjectType> {
-        let items = vec![ProjectType::Subgraph, ProjectType::Client];
+        let types = <ProjectType as ValueEnum>::value_variants();
         let selection = Select::new()
             .with_prompt("What GraphQL project are you planning on building?")
-            .items(&items)
+            .items(types)
             .default(0)
             .interact_on_opt(&Term::stderr())?;
 
         match selection {
-            Some(index) => match index {
-                0 => Ok(ProjectType::Subgraph),
-                1 => Ok(ProjectType::Client),
-                _ => Err(RoverError::new(anyhow!("No project type selected"))),
-            },
-            None => Ok(ProjectType::All),
+            Some(index) => Ok(types[index]),
+            None => Err(RoverError::new(anyhow!("No project type selected"))),
         }
     }
 
@@ -143,12 +123,11 @@ impl New {
         }
     }
     pub fn extract_github_tarball(
-        &self,
         template: GithubTemplate,
         template_path: &str,
         client: &reqwest::blocking::Client,
     ) -> Result<()> {
-        let download_dir = tempdir::TempDir::new(&template.id)?;
+        let download_dir = tempdir::TempDir::new(template.id)?;
         let download_dir_path = Utf8PathBuf::try_from(download_dir.into_path())?;
         let tarball_path = download_dir_path.join(format!("{}.tar.gz", template.id));
         let tarball_url = format!("{}/archive/refs/heads/main.tar.gz", template.git_url);
@@ -185,103 +164,56 @@ impl New {
 
         Ok(())
     }
-    pub fn get_templates(&self) -> Result<Vec<GithubTemplate>> {
-        let project_type = match self
-            .options
-            .project_type
-            .clone()
-            .unwrap_or_default()
-            .as_str()
-        {
-            "1" => ProjectType::Client,
-            "2" => ProjectType::Subgraph,
-            _ => ProjectType::All,
-        };
 
-        let has_language = self.options.language.is_some();
-        // TODO: To be moved to Orbit until "features" is designed out
-        let templates = vec![GithubTemplate {
-            id: String::from("subgraph-template-javascript-apollo-server-boilerplate"),
-            git_url: String::from(
-              "https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate",
-            ),
-            display: String::from("Boilerplate using Apollo Server"),
+    pub fn get_templates(
+        &self,
+        project_type: ProjectType,
+        project_language: ProjectLanguage,
+    ) -> Vec<GithubTemplate> {
+        Self::TEMPLATES
+            .into_iter()
+            .filter(|template| template.project_type == project_type)
+            .filter(|template| project_language == template.language)
+            .collect()
+    }
+
+    pub fn get_template_by_id(id: &str) -> Result<GithubTemplate> {
+        Self::TEMPLATES
+            .into_iter()
+            .find(|template| template.id == id)
+            .ok_or_else(|| RoverError::new(anyhow!("No template found with id {}", id)))
+    }
+
+    // TODO: To be moved to an API (e.g., Orbiter)
+    const TEMPLATES: [GithubTemplate; 3] = [
+        GithubTemplate {
+            id: "subgraph-template-javascript-apollo-server-boilerplate",
+            git_url: "https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate",
+            display: "Boilerplate using Apollo Server",
             language: ProjectLanguage::Javascript,
             project_type: ProjectType::Subgraph,
-          },GithubTemplate {
-            id: String::from("subgraph-template-javascript-apollo-server-mocked"),
-            git_url: String::from(""),
-            display: String::from(
-                "Simple mocked SDL-based schema using Apollo Server Boilerplate template",
-            ),
-            language: ProjectLanguage::Javascript,
-            project_type: ProjectType::Subgraph,
-        },GithubTemplate {
-            id: String::from("subgraph-template-java-springboot-boilerplate"),
-            git_url: String::from(""),
-            display: String::from("(TBD) Springboot using federation-jvm"),
-            language: ProjectLanguage::Java,
-            project_type: ProjectType::Subgraph,
-        },GithubTemplate {
-            id: String::from("subgraph-template-strawberry-fastapi"),
-            git_url: String::from(
-                "https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi",
-            ),
-            display: String::from("Boilerplate using Strawberry with FastAPI"),
+        },
+        GithubTemplate {
+            id: "subgraph-template-strawberry-fastapi",
+            git_url: "https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi",
+            display: "Boilerplate using Strawberry with FastAPI",
             language: ProjectLanguage::Python,
             project_type: ProjectType::Subgraph,
-        },GithubTemplate {
-            id: String::from("subgraph-template-python-ariadne-boilerplate"),
-            git_url: String::from(""),
-            display: String::from("(TBD) Boilerplate using Ariadne"),
-            language: ProjectLanguage::Python,
-            project_type: ProjectType::Subgraph,
-        },GithubTemplate {
-            id: String::from("subgraph-template-rust-async-graphql-boilerplate"),
-            git_url: String::from(
-                "https://github.com/apollographql/subgraph-template-rust-async-graphql-boilerplate",
-            ),
-            display: String::from("Boilerplate using async-graphql"),
+        },
+        // GithubTemplate {
+        //     id: "subgraph-template-python-ariadne-boilerplate",
+        //     git_url: "",
+        //     display: "(TBD) Boilerplate using Ariadne",
+        //     language: ProjectLanguage::Python,
+        //     project_type: ProjectType::Subgraph,
+        // },
+        GithubTemplate {
+            id: "subgraph-template-rust-async-graphql-boilerplate",
+            git_url:
+            "https://github.com/apollographql/subgraph-template-rust-async-graphql-boilerplate",
+            display: "Boilerplate using async-graphql",
             language: ProjectLanguage::Rust,
             project_type: ProjectType::Subgraph,
-        },GithubTemplate {
-            id: String::from("subgraph-template-typescript-apollo-server-boilerplate"),
-            git_url: String::from(""),
-            display: String::from("Boilerplate using Apollo Server"),
-            language: ProjectLanguage::Typescript,
-            project_type: ProjectType::Subgraph,
-        },GithubTemplate {
-            id: String::from("apollo-client-javascript"),
-            git_url: String::from(""),
-            display: String::from("Javascript: Apollo Client"),
-            language: ProjectLanguage::Javascript,
-            project_type: ProjectType::Client,
-        },GithubTemplate {
-            id: String::from("apollo-client-typescript"),
-            git_url: String::from(""),
-            display: String::from("Typescript: Apollo Client"),
-            language: ProjectLanguage::Javascript,
-            project_type: ProjectType::Client,
-        }];
-
-        let temp_iter = templates.into_iter();
-        if project_type != ProjectType::All && has_language {
-            Ok(temp_iter
-                .filter(|template| {
-                    project_type.eq(&template.project_type)
-                        && template.language == self.options.language.clone().unwrap()
-                })
-                .collect())
-        } else if project_type != ProjectType::All {
-            Ok(temp_iter
-                .filter(|template| project_type.eq(&template.project_type))
-                .collect())
-        } else if has_language {
-            Ok(temp_iter
-                .filter(|template| template.language == self.options.language.clone().unwrap())
-                .collect())
-        } else {
-            Ok(temp_iter.collect())
         }
-    }
+    ];
 }

--- a/src/options/template.rs
+++ b/src/options/template.rs
@@ -1,32 +1,31 @@
-use crate::anyhow;
 use saucer::{clap, Parser};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::str::FromStr;
+use std::fmt::Display;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct TemplateOpt {
-    /// The GitHub id for the templates repository
+    /// The ID for the official template to use
     #[clap(short = 't', long = "template")]
     #[serde(skip_serializing)]
     pub template: Option<String>,
 
     /// Filter templates by the available language
-    #[clap(long = "language")]
+    #[clap(long = "language", value_enum)]
     #[serde(skip_serializing)]
-    pub language: Option<String>,
+    pub language: Option<ProjectLanguage>,
 
     /// Type of template project: client or subgraph
-    #[clap(long = "project-type")]
+    #[clap(long = "project-type", value_enum)]
     #[serde(skip_serializing)]
-    pub project_type: Option<String>,
+    pub project_type: Option<ProjectType>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Parser)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GithubTemplate {
-    pub id: String,
-    pub git_url: String,
-    pub display: String,
+    pub id: &'static str,
+    pub git_url: &'static str,
+    pub display: &'static str,
     pub language: ProjectLanguage,
     pub project_type: ProjectType,
 }
@@ -42,55 +41,22 @@ impl fmt::Display for GithubTemplate {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Parser)]
+#[derive(Clone, Copy, Deserialize, Debug, Eq, PartialEq, Serialize, clap::ValueEnum)]
 pub enum ProjectType {
-    All,
     Subgraph,
     Client,
 }
 
-impl PartialEq<String> for ProjectType {
-    fn eq(&self, other: &String) -> bool {
-        match &self {
-            ProjectType::All => other.to_lowercase() == "all",
-            ProjectType::Subgraph => other.to_lowercase() == "subgraph",
-            ProjectType::Client => other.to_lowercase() == "client",
-        }
-    }
-}
-impl PartialEq for ProjectType {
-    fn eq(&self, other: &ProjectType) -> bool {
-        match &self {
-            ProjectType::All => other.eq(&String::from("all")),
-            ProjectType::Subgraph => other.eq(&String::from("subgraph")),
-            ProjectType::Client => other.eq(&String::from("client")),
-        }
-    }
-}
-impl fmt::Display for ProjectType {
+impl Display for ProjectType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ProjectType::All => write!(f, "all"),
             ProjectType::Subgraph => write!(f, "subgraph"),
             ProjectType::Client => write!(f, "client"),
         }
     }
 }
 
-impl FromStr for ProjectType {
-    type Err = saucer::Error;
-
-    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
-        match input.to_lowercase().as_str() {
-            "all" => Ok(ProjectType::All),
-            "subgraph" => Ok(ProjectType::Subgraph),
-            "client" => Ok(ProjectType::Client),
-            _ => Err(anyhow!("Invalid Project Type")),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Parser)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, clap::ValueEnum)]
 pub enum ProjectLanguage {
     Java,
     Javascript,
@@ -99,29 +65,7 @@ pub enum ProjectLanguage {
     Typescript,
 }
 
-impl PartialEq<String> for ProjectLanguage {
-    fn eq(&self, other: &String) -> bool {
-        match &self {
-            ProjectLanguage::Java => other.to_lowercase() == "java",
-            ProjectLanguage::Javascript => other.to_lowercase() == "javascript",
-            ProjectLanguage::Python => other.to_lowercase() == "python",
-            ProjectLanguage::Rust => other.to_lowercase() == "rust",
-            ProjectLanguage::Typescript => other.to_lowercase() == "typescript",
-        }
-    }
-}
-impl PartialEq for ProjectLanguage {
-    fn eq(&self, other: &ProjectLanguage) -> bool {
-        match &self {
-            ProjectLanguage::Java => other.eq(&String::from("java")),
-            ProjectLanguage::Javascript => other.eq(&String::from("javascript")),
-            ProjectLanguage::Python => other.eq(&String::from("python")),
-            ProjectLanguage::Rust => other.eq(&String::from("rust")),
-            ProjectLanguage::Typescript => other.eq(&String::from("typescript")),
-        }
-    }
-}
-impl fmt::Display for ProjectLanguage {
+impl Display for ProjectLanguage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ProjectLanguage::Java => write!(f, "java"),
@@ -129,21 +73,6 @@ impl fmt::Display for ProjectLanguage {
             ProjectLanguage::Python => write!(f, "python"),
             ProjectLanguage::Rust => write!(f, "rust"),
             ProjectLanguage::Typescript => write!(f, "typescript"),
-        }
-    }
-}
-
-impl FromStr for ProjectLanguage {
-    type Err = saucer::Error;
-
-    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
-        match input.to_lowercase().as_str() {
-            "java" => Ok(ProjectLanguage::Java),
-            "javascript" => Ok(ProjectLanguage::Javascript),
-            "python" => Ok(ProjectLanguage::Python),
-            "rust" => Ok(ProjectLanguage::Rust),
-            "typescript" => Ok(ProjectLanguage::Typescript),
-            _ => Err(anyhow!("Invalid Project Type")),
         }
     }
 }


### PR DESCRIPTION
I think the changes look like more than they are, basically:

1. Remove some potential panics 
2. Integrate enums a bit better (e.g., so the option show up in `--help`)