### PR TITLE
fix: harden router spawner/killer

### DIFF
--- a/crates/rover-client/src/operations/subgraph/delete/types.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/types.rs
@@ -21,7 +21,7 @@ pub struct SubgraphDeleteInput {
 /// `updated_gateway` is true when composition succeeds and the gateway config
 /// is updated for the gateway to consume. `composition_errors` is just a list
 /// of strings for when there are build errors as a result of the delete.
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Eq, PartialEq)]
 pub struct SubgraphDeleteResponse {
     pub supergraph_was_updated: bool,
 

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -24,7 +24,7 @@ pub struct SubgraphPublishInput {
     pub convert_to_federated_graph: bool,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Eq, PartialEq)]
 pub struct SubgraphPublishResponse {
     pub api_schema_hash: Option<String>,
 

--- a/src/command/dev/compose.rs
+++ b/src/command/dev/compose.rs
@@ -111,7 +111,7 @@ impl ComposeRunner {
     }
 
     fn update_supergraph_schema(&self, sdl: &str) -> Result<()> {
-        eprintln!("composition succeeded, updating the supergraph schema.");
+        eprintln!("composition succeeded, reloading the router...");
         let context = format!("could not write SDL to {}", &self.write_path);
         match std::fs::File::create(&self.write_path) {
             Ok(mut opened_file) => {

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -1,19 +1,18 @@
-use interprocess::local_socket::{LocalSocketStream, NameTypeSupport};
+use interprocess::local_socket::NameTypeSupport;
 use saucer::{Context, Utf8PathBuf};
 use tempdir::TempDir;
 
 use super::compose::ComposeRunner;
-use super::follower::MessageSender;
-use super::leader::MessageReceiver;
+use super::follower::FollowerMessenger;
+use super::leader::LeaderMessenger;
 use super::router::RouterRunner;
 use super::Dev;
-use crate::command::dev::protocol::socket_write;
+
 use crate::command::RoverOutput;
 use crate::error::RoverError;
 use crate::utils::client::StudioClientConfig;
 use crate::Result;
 
-use std::io::BufReader;
 use std::{sync::mpsc::sync_channel, time::Duration};
 
 pub fn log_err_and_continue(err: RoverError) -> RoverError {
@@ -41,7 +40,7 @@ impl Dev {
         };
 
         // read the subgraphs that are already running as a part of this `rover dev` instance
-        let session_subgraphs = MessageSender::new_subgraph(&socket_addr).session_subgraphs();
+        let session_subgraphs = FollowerMessenger::new_subgraph(&socket_addr).session_subgraphs();
 
         // get a [`SubgraphRefresher`] that takes care of getting the schema for a single subgraph
         // either by polling the introspection endpoint or by watching the file system
@@ -64,11 +63,8 @@ impl Dev {
 
         let (ready_sender, ready_receiver) = sync_channel(1);
 
-        if let Ok(stream) = LocalSocketStream::connect(&*socket_addr) {
-            // write to the socket so we don't make the other session deadlock waiting on a message
-            let mut stream = BufReader::new(stream);
-            let _ = socket_write(&(), &mut stream);
-            let kill_sender = MessageSender::new_subgraph(&socket_addr);
+        if !is_main_session {
+            let kill_sender = FollowerMessenger::new_subgraph(&socket_addr);
             let kill_name = subgraph_refresher.get_name();
             ctrlc::set_handler(move || {
                 eprintln!("\nshutting down subgraph '{}'", &kill_name);
@@ -78,7 +74,7 @@ impl Dev {
                 std::process::exit(1)
             })
             .context("could not set ctrl-c handler")?;
-            ready_sender.send(()).unwrap();
+            ready_sender.send("follower").unwrap();
         } else {
             // if we can't connect to the socket, we should start it and listen for incoming
             // subgraph events
@@ -103,23 +99,27 @@ impl Dev {
                 self.opts.plugin_opts.clone(),
                 self.opts.supergraph_opts,
                 override_install_path,
-                client_config,
+                client_config.clone(),
             );
 
             // create a [`MessageReceiver`] that will keep track of the existing subgraphs
             let mut message_receiver =
-                MessageReceiver::new(&socket_addr, compose_runner, router_runner)?;
+                LeaderMessenger::new(&socket_addr, compose_runner, router_runner)?;
 
             // attempt to install the router and supergraph plugins
             //  before waiting for incoming messages
 
             message_receiver.install_plugins()?;
 
-            let kill_sender = MessageSender::new_subgraph(&socket_addr);
-
+            let kill_sender = FollowerMessenger::new_subgraph(&socket_addr);
+            let kill_client = client_config.get_reqwest_client()?;
+            let kill_port = self.opts.supergraph_opts.port;
+            let kill_socket_addr = socket_addr.clone();
             ctrlc::set_handler(move || {
                 eprintln!("\nshutting down main `rover dev` session");
                 let _ = kill_sender.kill_router().map_err(log_err_and_continue);
+                let _ = RouterRunner::wait_for_stop(kill_client.clone(), &kill_port);
+                let _ = std::fs::remove_file(&kill_socket_addr);
                 std::process::exit(1)
             })
             .context("could not set ctrl-c handler")?;
@@ -127,7 +127,6 @@ impl Dev {
             rayon::spawn(move || {
                 // watch for subgraph updates coming in on the socket
                 // and send compose messages over the compose channel
-
                 let _ = message_receiver
                     .receive_messages(ready_sender)
                     .map_err(log_err_and_continue);
@@ -139,12 +138,11 @@ impl Dev {
         // this happens immediately in child `rover dev` sessions
         // and after we bind to the socket in main `rover dev` sessions
         ready_receiver.recv().unwrap();
-
         tracing::info!("starting to watch for incoming changes");
 
         if !is_main_session {
             rayon::spawn(move || {
-                let sender = MessageSender::new_subgraph(&socket_addr);
+                let sender = FollowerMessenger::new_subgraph(&socket_addr);
                 if let Err(e) = sender.health_check() {
                     log_err_and_continue(e);
                     std::process::exit(1);

--- a/src/command/dev/leader.rs
+++ b/src/command/dev/leader.rs
@@ -225,7 +225,6 @@ impl LeaderMessenger {
                                 .map_err(log_err_and_continue);
                         }
                         FollowerMessageKind::GetSubgraphs => {
-                            tracing::info!("leader sending message");
                             let _ = Self::socket_write(
                                 LeaderMessageKind::CurrentSubgraphs(self.get_subgraphs()),
                                 &mut stream,
@@ -234,13 +233,11 @@ impl LeaderMessenger {
                         }
                         FollowerMessageKind::KillRouter => {
                             let _ = self.router_runner.kill().map_err(log_err_and_continue);
-                            tracing::info!("leader sending message");
                             let _ =
                                 Self::socket_write(LeaderMessageKind::MessageReceived, &mut stream)
                                     .map_err(log_err_and_continue);
                         }
                         FollowerMessageKind::HealthCheck => {
-                            tracing::info!("leader sending message");
                             let _ =
                                 Self::socket_write(LeaderMessageKind::MessageReceived, &mut stream)
                                     .map_err(log_err_and_continue);

--- a/src/command/dev/leader.rs
+++ b/src/command/dev/leader.rs
@@ -1,7 +1,7 @@
 use crate::{
     command::dev::{
-        compose::ComposeRunner, do_dev::log_err_and_continue, router::RouterRunner,
-        DEV_COMPOSITION_VERSION,
+        compose::ComposeRunner, do_dev::log_err_and_continue, follower::FollowerMessageKind,
+        router::RouterRunner, DEV_COMPOSITION_VERSION,
     },
     error::RoverError,
     Result,
@@ -18,14 +18,14 @@ use std::{collections::HashMap, fmt::Debug, io::BufReader, sync::mpsc::SyncSende
 use crate::command::dev::protocol::*;
 
 #[derive(Debug)]
-pub struct MessageReceiver {
+pub struct LeaderMessenger {
     subgraphs: HashMap<SubgraphKey, SubgraphSdl>,
     socket_addr: String,
     compose_runner: ComposeRunner,
     router_runner: RouterRunner,
 }
 
-impl MessageReceiver {
+impl LeaderMessenger {
     pub fn new(
         socket_addr: &str,
         compose_runner: ComposeRunner,
@@ -34,6 +34,7 @@ impl MessageReceiver {
         if let Ok(stream) = LocalSocketStream::connect(socket_addr) {
             // write to the socket so we don't make the other session deadlock waiting on a message
             let mut stream = BufReader::new(stream);
+            tracing::info!("leader sending message");
             let _ = socket_write(&(), &mut stream);
             Err(RoverError::new(anyhow!(
                 "there is already a main `rover dev` session"
@@ -46,6 +47,20 @@ impl MessageReceiver {
                 router_runner,
             })
         }
+    }
+
+    fn socket_read(
+        &self,
+        stream: &mut BufReader<LocalSocketStream>,
+    ) -> Result<Option<FollowerMessageKind>> {
+        tracing::info!("leader reading message");
+        let incoming = socket_read::<FollowerMessageKind>(stream);
+        if let Ok(Some(message)) = &incoming {
+            tracing::info!("leader received message {:?}", message);
+        } else {
+            tracing::info!("leader did not receive a message");
+        }
+        incoming
     }
 
     pub fn install_plugins(&mut self) -> Result<()> {
@@ -71,6 +86,7 @@ impl MessageReceiver {
     }
 
     pub fn compose(&mut self, stream: &mut BufReader<LocalSocketStream>) {
+        tracing::info!("main `rover dev` session is starting the composer");
         let composition_result = self
             .compose_runner
             .run(&mut self.supergraph_config())
@@ -85,6 +101,7 @@ impl MessageReceiver {
                 let _ = self.router_runner.kill().map_err(log_err_and_continue);
                 e
             });
+        tracing::info!("leader sending message");
         let _ = socket_write(&composition_result, stream).map_err(log_err_and_continue);
     }
 
@@ -136,7 +153,7 @@ impl MessageReceiver {
         subgraph_name: &SubgraphName,
         stream: &mut BufReader<LocalSocketStream>,
     ) -> Result<()> {
-        eprintln!("removing subgraph'{}'", &subgraph_name);
+        eprintln!("removing subgraph '{}'", &subgraph_name);
         let mut found = None;
         for (name, url) in self.subgraphs.keys() {
             if name == subgraph_name {
@@ -156,14 +173,14 @@ impl MessageReceiver {
         }
     }
 
-    pub fn receive_messages(&mut self, ready_sender: SyncSender<()>) -> Result<()> {
+    pub fn receive_messages(&mut self, ready_sender: SyncSender<&str>) -> Result<()> {
         let listener = LocalSocketListener::bind(&*self.socket_addr).with_context(|| {
             format!(
                 "could not start local socket server at {}",
                 &self.socket_addr
             )
         })?;
-        ready_sender.send(()).unwrap();
+        ready_sender.send("leader").unwrap();
         tracing::info!(
             "connected to socket {}, waiting for messages",
             &self.socket_addr
@@ -173,35 +190,36 @@ impl MessageReceiver {
             .filter_map(handle_socket_error)
             .for_each(|stream| {
                 let mut stream = BufReader::new(stream);
-                tracing::info!("received incoming socket connection");
-                let incoming = socket_read::<MessageKind>(&mut stream);
-                tracing::debug!(?incoming);
-                match incoming {
+                let follower_message = self.socket_read(&mut stream);
+                match follower_message {
                     Ok(Some(message)) => match message {
-                        MessageKind::AddSubgraph { subgraph_entry } => {
+                        FollowerMessageKind::AddSubgraph { subgraph_entry } => {
                             let _ = self
                                 .add_subgraph(&subgraph_entry, &mut stream)
                                 .map_err(log_err_and_continue);
                         }
-                        MessageKind::UpdateSubgraph { subgraph_entry } => {
+                        FollowerMessageKind::UpdateSubgraph { subgraph_entry } => {
                             let _ = self
                                 .update_subgraph(&subgraph_entry, &mut stream)
                                 .map_err(log_err_and_continue);
                         }
-                        MessageKind::RemoveSubgraph { subgraph_name } => {
+                        FollowerMessageKind::RemoveSubgraph { subgraph_name } => {
                             let _ = self
                                 .remove_subgraph(&subgraph_name, &mut stream)
                                 .map_err(log_err_and_continue);
                         }
-                        MessageKind::GetSubgraphs => {
+                        FollowerMessageKind::GetSubgraphs => {
+                            tracing::info!("leader sending message");
                             let _ = socket_write(&self.get_subgraphs(), &mut stream)
                                 .map_err(log_err_and_continue);
                         }
-                        MessageKind::KillRouter => {
+                        FollowerMessageKind::KillRouter => {
                             let _ = self.router_runner.kill().map_err(log_err_and_continue);
+                            tracing::info!("leader sending message");
                             let _ = socket_write(&(), &mut stream).map_err(log_err_and_continue);
                         }
-                        MessageKind::HealthCheck => {
+                        FollowerMessageKind::HealthCheck => {
+                            tracing::info!("leader sending message");
                             let _ = socket_write(&(), &mut stream).map_err(log_err_and_continue);
                         }
                     },

--- a/src/command/dev/protocol.rs
+++ b/src/command/dev/protocol.rs
@@ -3,7 +3,7 @@ use apollo_federation_types::build::SubgraphDefinition;
 use interprocess::local_socket::LocalSocketStream;
 use reqwest::Url;
 use saucer::{anyhow, Context, Error};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fmt::Debug,
     io::{self, BufRead, BufReader, Write},

--- a/src/command/dev/protocol.rs
+++ b/src/command/dev/protocol.rs
@@ -10,17 +10,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[non_exhaustive]
-pub enum MessageKind {
-    AddSubgraph { subgraph_entry: SubgraphEntry },
-    UpdateSubgraph { subgraph_entry: SubgraphEntry },
-    RemoveSubgraph { subgraph_name: SubgraphName },
-    KillRouter,
-    GetSubgraphs,
-    HealthCheck,
-}
-
 pub type SubgraphName = String;
 pub type SubgraphUrl = Url;
 pub type SubgraphSdl = String;
@@ -72,7 +61,7 @@ pub(crate) fn socket_read<B>(stream: &mut BufReader<LocalSocketStream>) -> Resul
 where
     B: Serialize + DeserializeOwned + Debug,
 {
-    tracing::info!("\n----    RECEIVE     ----\n");
+    tracing::debug!("\n----    RECEIVE     ----\n");
     let mut incoming_message = String::new();
 
     let now = Instant::now();
@@ -97,7 +86,7 @@ where
                                     &incoming_message
                                 )
                             })?;
-                        tracing::info!("\n{:?}\n", &incoming_message);
+                        tracing::debug!("\n{:?}\n", &incoming_message);
                         Some(incoming_message)
                     },
                 )
@@ -112,7 +101,7 @@ where
         std::thread::sleep(Duration::from_millis(500));
     }?;
 
-    tracing::info!("\n====   END RECEIVE    ====\n");
+    tracing::debug!("\n====   END RECEIVE    ====\n");
     Ok(result)
 }
 
@@ -120,8 +109,8 @@ pub(crate) fn socket_write<A>(message: &A, stream: &mut BufReader<LocalSocketStr
 where
     A: Serialize + DeserializeOwned + Debug,
 {
-    tracing::info!("\n----      SEND      ----\n");
-    tracing::info!("\n{:?}\n", &message);
+    tracing::debug!("\n----      SEND      ----\n");
+    tracing::debug!("\n{:?}\n", &message);
     let outgoing_json = serde_json::to_string(message)
         .with_context(|| format!("could not convert outgoing message {:?} to json", &message))?;
     let outgoing_string = format!("{}\n", &outgoing_json);
@@ -129,6 +118,6 @@ where
         .get_mut()
         .write_all(outgoing_string.as_bytes())
         .context("could not write outgoing message to socket")?;
-    tracing::info!("\n====    END SEND     ====\n");
+    tracing::debug!("\n====    END SEND     ====\n");
     Ok(())
 }

--- a/src/command/dev/router.rs
+++ b/src/command/dev/router.rs
@@ -152,6 +152,7 @@ impl RouterRunner {
         }
 
         if !ready {
+            tracing::info!("router stopped successfully");
             Ok(())
         } else {
             Err(RoverError::new(anyhow!("the router was unable to stop",)))

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -2,7 +2,7 @@ use std::{sync::mpsc::channel, time::Duration};
 
 use crate::{
     command::dev::{
-        follower::MessageSender,
+        follower::FollowerMessenger,
         introspect::{IntrospectRunnerKind, UnknownIntrospectRunner},
         protocol::SubgraphKey,
     },
@@ -17,7 +17,7 @@ use saucer::{anyhow, Fs, Utf8Path, Utf8PathBuf};
 pub struct SubgraphSchemaWatcher {
     schema_watcher_kind: SubgraphSchemaWatcherKind,
     subgraph_key: SubgraphKey,
-    message_sender: MessageSender,
+    message_sender: FollowerMessenger,
 }
 
 impl SubgraphSchemaWatcher {
@@ -33,7 +33,7 @@ impl SubgraphSchemaWatcher {
         Ok(Self {
             schema_watcher_kind: SubgraphSchemaWatcherKind::File(path.as_ref().to_path_buf()),
             subgraph_key,
-            message_sender: MessageSender::new(socket_addr, is_main_session),
+            message_sender: FollowerMessenger::new(socket_addr, is_main_session),
         })
     }
 
@@ -63,7 +63,7 @@ impl SubgraphSchemaWatcher {
         Ok(Self {
             schema_watcher_kind: SubgraphSchemaWatcherKind::Introspect(introspect_runner),
             subgraph_key,
-            message_sender: MessageSender::new(socket_addr, is_main_session),
+            message_sender: FollowerMessenger::new(socket_addr, is_main_session),
         })
     }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -33,7 +33,7 @@ use termimad::MadSkin;
 /// Not all commands will output machine readable information, and those should
 /// return `Ok(RoverOutput::EmptySuccess)`. If a new command is added and it needs to
 /// return something that is not described well in this enum, it should be added.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum RoverOutput {
     DocsList(BTreeMap<&'static str, &'static str>),
     FetchResponse(FetchResponse),

--- a/src/command/supergraph/compose/mod.rs
+++ b/src/command/supergraph/compose/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use do_compose::Compose;
 
 use apollo_federation_types::build::BuildHint;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CompositionOutput {
     pub supergraph_sdl: String,
     pub hints: Vec<BuildHint>,


### PR DESCRIPTION
This PR fixes #1294 and #1295.

there were some issues on MacOS related to leader/follower socket addresses that are fixed now, and we also hardened the router killer by waiting for the health check to start failing before shutting down the `rover dev` process