### PR TITLE
feat: require `rover dev` sessions to be the same version

### DIFF
--- a/src/command/dev/command.rs
+++ b/src/command/dev/command.rs
@@ -53,7 +53,6 @@ impl BackgroundTask {
 
 impl Drop for BackgroundTask {
     fn drop(&mut self) {
-        tracing::info!("background task with pgid {} was dropped", &self.child.id());
         self.kill()
     }
 }

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -29,17 +29,17 @@ impl Dev {
         self.opts
             .plugin_opts
             .prompt_for_license_accept(&client_config)?;
-        let socket_addr = self.opts.supergraph_opts.ipc_socket_addr();
+        let ipc_socket_addr = self.opts.supergraph_opts.ipc_socket_addr();
 
         // read the subgraphs that are already running as a part of this `rover dev` instance
-        let session_subgraph_finder = FollowerMessenger::new_subgraph(&socket_addr);
+        let session_subgraph_finder = FollowerMessenger::new_subgraph(&ipc_socket_addr);
         session_subgraph_finder.version_check()?;
         let session_subgraphs = session_subgraph_finder.session_subgraphs()?;
 
         // get a [`SubgraphRefresher`] that takes care of getting the schema for a single subgraph
         // either by polling the introspection endpoint or by watching the file system
         let mut subgraph_refresher = self.opts.subgraph_opts.get_subgraph_watcher(
-            &socket_addr,
+            &ipc_socket_addr,
             client_config
                 .get_builder()
                 .with_timeout(Duration::from_secs(2))
@@ -62,7 +62,7 @@ impl Dev {
                 "connecting to existing `rover dev` session running on `--port {}`",
                 &self.opts.supergraph_opts.port
             );
-            let kill_sender = FollowerMessenger::new_subgraph(&socket_addr);
+            let kill_sender = FollowerMessenger::new_subgraph(&ipc_socket_addr);
             let kill_name = subgraph_refresher.get_name();
             ctrlc::set_handler(move || {
                 eprintln!("\nshutting down subgraph '{}'", &kill_name);
@@ -80,7 +80,7 @@ impl Dev {
             //
             // remove the socket file before starting in case it was here from last time
             // if we can't connect to it, it's safe to remove
-            let _ = std::fs::remove_file(&socket_addr);
+            let _ = std::fs::remove_file(&ipc_socket_addr);
 
             if TcpListener::bind(self.opts.supergraph_opts.router_socket_addr()?).is_err() {
                 let mut err = RoverError::new(anyhow!(
@@ -110,27 +110,22 @@ impl Dev {
                 self.opts.plugin_opts.clone(),
                 self.opts.supergraph_opts,
                 override_install_path,
-                client_config.clone(),
+                client_config,
             );
 
             // create a [`MessageReceiver`] that will keep track of the existing subgraphs
             let mut message_receiver =
-                LeaderMessenger::new(&socket_addr, compose_runner, router_runner)?;
+                LeaderMessenger::new(&ipc_socket_addr, compose_runner, router_runner)?;
 
             // attempt to install the router and supergraph plugins
             // before waiting for incoming messages
 
             message_receiver.install_plugins()?;
 
-            let kill_sender = FollowerMessenger::new_subgraph(&socket_addr);
-            let kill_socket_addr = socket_addr.clone();
-            ctrlc::set_handler(move || {
-                eprintln!("\nshutting down main `rover dev` session");
-                let _ = kill_sender.kill_router().map_err(log_err_and_continue);
-                let _ = std::fs::remove_file(&kill_socket_addr);
-                std::process::exit(1)
-            })
-            .context("could not set ctrl-c handler")?;
+            let kill_messenger = FollowerMessenger::new_subgraph(&ipc_socket_addr);
+            let kill_socket_addr = ipc_socket_addr.clone();
+            ctrlc::set_handler(move || Self::shutdown(&kill_socket_addr, &kill_messenger))
+                .context("could not set ctrl-c handler")?;
 
             rayon::spawn(move || {
                 // watch for subgraph updates coming in on the socket
@@ -149,7 +144,7 @@ impl Dev {
 
         if !is_main_session {
             rayon::spawn(move || {
-                let sender = FollowerMessenger::new_subgraph(&socket_addr);
+                let sender = FollowerMessenger::new_subgraph(&ipc_socket_addr);
                 if let Err(e) = sender.health_check() {
                     log_err_and_continue(e);
                     std::process::exit(1);
@@ -160,5 +155,12 @@ impl Dev {
         // watch the subgraph for changes on the main thread
         subgraph_refresher.watch_subgraph()?;
         Ok(RoverOutput::EmptySuccess)
+    }
+
+    fn shutdown(ipc_socket_addr: &str, follower_messenger: &FollowerMessenger) {
+        eprintln!("\nshutting down main `rover dev` session");
+        let _ = follower_messenger.kill_router();
+        let _ = std::fs::remove_file(ipc_socket_addr);
+        std::process::exit(1)
     }
 }

--- a/src/command/dev/follower.rs
+++ b/src/command/dev/follower.rs
@@ -1,5 +1,5 @@
-use crate::command::dev::do_dev::log_err_and_continue;
 use crate::{error::RoverError, Result};
+use crate::{Suggestion, PKG_VERSION};
 use apollo_federation_types::build::SubgraphDefinition;
 use interprocess::local_socket::LocalSocketStream;
 use saucer::{anyhow, Context};
@@ -23,6 +23,104 @@ pub enum FollowerMessageKind {
     KillRouter,
     GetSubgraphs,
     HealthCheck,
+    GetVersion,
+}
+
+impl FollowerMessageKind {
+    pub fn add_subgraph(subgraph: &SubgraphDefinition) -> Result<Self> {
+        Ok(Self::AddSubgraph {
+            subgraph_entry: entry_from_definition(subgraph)?,
+        })
+    }
+
+    pub fn update_subgraph(subgraph: &SubgraphDefinition) -> Result<Self> {
+        Ok(Self::UpdateSubgraph {
+            subgraph_entry: entry_from_definition(subgraph)?,
+        })
+    }
+
+    pub fn remove_subgraph(subgraph_name: &SubgraphName) -> Self {
+        Self::RemoveSubgraph {
+            subgraph_name: subgraph_name.to_string(),
+        }
+    }
+
+    pub fn kill_router() -> Self {
+        Self::KillRouter
+    }
+
+    pub fn get_subgraphs() -> Self {
+        Self::GetSubgraphs
+    }
+
+    pub fn get_version() -> Self {
+        Self::GetVersion
+    }
+
+    pub fn health_check() -> Self {
+        Self::HealthCheck
+    }
+
+    pub fn print(&self, is_main_session: bool) {
+        if is_main_session {
+            tracing::debug!("sending message to self: {:?}", &self);
+        } else {
+            tracing::debug!("sending message to main `rover dev` session: {:?}", &self);
+        }
+        match &self {
+            Self::AddSubgraph { subgraph_entry } => {
+                if is_main_session {
+                    eprintln!(
+                        "starting main `rover dev` session with subgraph '{}'",
+                        &subgraph_entry.0 .0
+                    );
+                } else {
+                    eprintln!(
+                        "notifying main `rover dev` session about new subgraph '{}'",
+                        &subgraph_entry.0 .0
+                    );
+                }
+            }
+            Self::UpdateSubgraph { subgraph_entry } => {
+                if is_main_session {
+                    eprintln!(
+                        "updating the schema for subgraph '{}' in this `rover dev` session",
+                        &subgraph_entry.0 .0
+                    );
+                } else {
+                    eprintln!(
+                        "notifying main `rover dev` session about updated subgraph '{}'",
+                        &subgraph_entry.0 .0
+                    );
+                }
+            }
+            Self::RemoveSubgraph { subgraph_name } => {
+                if is_main_session {
+                    eprintln!(
+                        "removing subgraph '{}' from this `rover dev` session",
+                        &subgraph_name
+                    );
+                } else {
+                    eprintln!(
+                        "notifying main `rover dev` session about removed subgraph '{}'",
+                        &subgraph_name
+                    );
+                }
+            }
+            Self::KillRouter => {
+                tracing::debug!("shutting down the router for this `rover dev` session");
+            }
+            Self::HealthCheck => {
+                tracing::debug!("sending health check ping to the main `rover dev` session");
+            }
+            Self::GetVersion => {
+                tracing::debug!("requesting the version of the main `rover dev` session");
+            }
+            Self::GetSubgraphs => {
+                tracing::debug!("asking main `rover dev` session about existing subgraphs");
+            }
+        }
+    }
 }
 
 impl FollowerMessenger {
@@ -37,134 +135,117 @@ impl FollowerMessenger {
         Self::new(ipc_socket_addr, false)
     }
 
-    fn should_message(&self) -> bool {
-        !self.is_main_session
-    }
-
-    pub fn add_subgraph(&self, subgraph: &SubgraphDefinition) -> Result<()> {
-        if self.should_message() {
-            eprintln!(
-                "notifying main `rover dev` session about new subgraph '{}'",
-                &subgraph.name
-            );
-        }
-        let leader_message = self.socket_message(&FollowerMessageKind::AddSubgraph {
-            subgraph_entry: entry_from_definition(subgraph)?,
-        })?;
-
-        self.handle_leader_message(&leader_message);
-
+    pub fn kill_router(&self) -> Result<()> {
+        self.socket_message(&FollowerMessageKind::kill_router())?;
         Ok(())
-    }
-
-    pub fn update_subgraph(&self, subgraph: &SubgraphDefinition) -> Result<()> {
-        if self.should_message() {
-            eprintln!(
-                "notifying main `rover dev` session about updated subgraph '{}'",
-                &subgraph.name
-            );
-        }
-        let leader_message = self.socket_message(&FollowerMessageKind::UpdateSubgraph {
-            subgraph_entry: entry_from_definition(subgraph)?,
-        })?;
-
-        self.handle_leader_message(&leader_message);
-
-        Ok(())
-    }
-
-    pub fn remove_subgraph(&self, subgraph_name: &SubgraphName) -> Result<()> {
-        if self.should_message() {
-            eprintln!(
-                "notifying main `rover dev` session about removed subgraph '{}'",
-                &subgraph_name
-            );
-        }
-
-        let leader_message = self.socket_message(&FollowerMessageKind::RemoveSubgraph {
-            subgraph_name: subgraph_name.to_string(),
-        })?;
-
-        self.handle_leader_message(&leader_message);
-
-        Ok(())
-    }
-
-    fn handle_leader_message(&self, leader_message: &LeaderMessageKind) {
-        if self.should_message() {
-            match leader_message {
-                LeaderMessageKind::ErrorNotification { error } => {
-                    eprintln!("{}", error);
-                }
-                LeaderMessageKind::CompositionSuccess { subgraph_name } => {
-                    eprintln!(
-                        "successfully re-composed after removing the '{}' subgraph.",
-                        &subgraph_name
-                    );
-                }
-                LeaderMessageKind::CurrentSubgraphs { subgraphs } => {
-                    tracing::info!(
-                        "the main `rover dev` session currently has {} subgraphs",
-                        subgraphs.len()
-                    );
-                }
-                LeaderMessageKind::MessageReceived => {}
-            }
-        }
-    }
-
-    pub fn kill_router(&self) -> Result<LeaderMessageKind> {
-        self.socket_message(&FollowerMessageKind::KillRouter)
-    }
-
-    pub fn session_subgraphs(&self) -> Option<Vec<SubgraphKey>> {
-        if let Ok(leader_message) = self.socket_message(&FollowerMessageKind::GetSubgraphs) {
-            if let LeaderMessageKind::CurrentSubgraphs { subgraphs } = leader_message.clone() {
-                self.handle_leader_message(&leader_message);
-                Some(subgraphs)
-            } else {
-                unreachable!()
-            }
-        } else {
-            tracing::info!("initializing the main `rover dev` session",);
-            None
-        }
     }
 
     pub fn health_check(&self) -> Result<()> {
         loop {
-            if let Err(e) = self.socket_message(&FollowerMessageKind::HealthCheck) {
+            if let Err(e) = self.socket_message(&FollowerMessageKind::health_check()) {
                 break Err(e);
             }
             std::thread::sleep(Duration::from_secs(1));
         }
     }
 
-    pub fn socket_message(&self, message: &FollowerMessageKind) -> Result<LeaderMessageKind> {
+    pub fn version_check(&self) -> Result<()> {
+        self.socket_message(&FollowerMessageKind::get_version())?;
+        Ok(())
+    }
+
+    pub fn session_subgraphs(&self) -> Result<Option<SubgraphKeys>> {
+        self.socket_message(&FollowerMessageKind::get_subgraphs())
+    }
+
+    pub fn add_subgraph(&self, subgraph: &SubgraphDefinition) -> Result<()> {
+        self.socket_message(&FollowerMessageKind::add_subgraph(subgraph)?)?;
+        Ok(())
+    }
+
+    pub fn update_subgraph(&self, subgraph: &SubgraphDefinition) -> Result<()> {
+        self.socket_message(&FollowerMessageKind::update_subgraph(subgraph)?)?;
+        Ok(())
+    }
+
+    pub fn remove_subgraph(&self, subgraph: &SubgraphName) -> Result<()> {
+        self.socket_message(&FollowerMessageKind::remove_subgraph(subgraph))?;
+        Ok(())
+    }
+
+    fn should_message(&self) -> bool {
+        !self.is_main_session
+    }
+
+    fn handle_leader_message(
+        &self,
+        leader_message: &LeaderMessageKind,
+    ) -> Result<Option<SubgraphKeys>> {
+        if self.should_message() {
+            leader_message.print();
+        }
+        match leader_message {
+            LeaderMessageKind::Version { version } => {
+                self.require_same_version(version)?;
+                Ok(None)
+            }
+            LeaderMessageKind::LeaderSessionInfo { subgraphs } => Ok(Some(subgraphs.to_vec())),
+            _ => Ok(None),
+        }
+    }
+
+    fn require_same_version(&self, leader_version: &str) -> Result<()> {
+        if leader_version != PKG_VERSION {
+            let mut err = RoverError::new(anyhow!("The main `rover dev` session is running version {}, and this `rover dev` session is running version {}.", &leader_version, PKG_VERSION));
+            err.set_suggestion(Suggestion::Adhoc(
+                "You should use the same version of `rover` to run `rover dev` sessions"
+                    .to_string(),
+            ));
+            Err(err)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn socket_message(
+        &self,
+        follower_message: &FollowerMessageKind,
+    ) -> Result<Option<SubgraphKeys>> {
         match self.connect() {
             Ok(stream) => {
                 stream
                     .set_nonblocking(true)
                     .context("could not set socket to non-blocking mode")?;
                 let mut stream = BufReader::new(stream);
-                tracing::info!("follower sending message: {:?}", &message);
+
+                follower_message.print(self.is_main_session);
                 // send our message over the socket
-                socket_write(message, &mut stream)?;
+                socket_write(follower_message, &mut stream)?;
 
                 // wait for our message to be read by the other socket handler
                 // then read the response that was written back to the socket
-                tracing::info!("follower waiting on leader's reponse");
                 let result = socket_read(&mut stream);
-                if result.is_err() {
-                    tracing::info!(
-                        "follower could not receive message from leader after sending {:?}",
-                        &message
-                    );
-                    let _ = self.kill_router().map_err(log_err_and_continue);
+                match result {
+                    Ok(leader_message) => self.handle_leader_message(&leader_message),
+                    Err(e) => {
+                        tracing::info!(
+                            "follower could not receive message from leader after sending {:?}",
+                            &follower_message
+                        );
+                        Err(e)
+                    }
                 }
-                result
             }
-            Err(e) => Err(e),
+            Err(e) => {
+                // if we can't connect, we are not the main session
+                follower_message.print(false);
+                match follower_message {
+                    // these two message kinds are requested on startup, if they return `None` it means
+                    // that there is no current `rover dev` session to respond with
+                    FollowerMessageKind::GetVersion | FollowerMessageKind::GetSubgraphs => Ok(None),
+                    _ => Err(e),
+                }
+            }
         }
     }
 

--- a/src/command/dev/protocol.rs
+++ b/src/command/dev/protocol.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::{command::supergraph::compose::CompositionOutput, Result};
 use apollo_federation_types::build::SubgraphDefinition;
 use interprocess::local_socket::LocalSocketStream;
 use reqwest::Url;
@@ -14,7 +14,9 @@ pub type SubgraphName = String;
 pub type SubgraphUrl = Url;
 pub type SubgraphSdl = String;
 pub type SubgraphKey = (SubgraphName, SubgraphUrl);
+pub type SubgraphKeys = Vec<SubgraphKey>;
 pub type SubgraphEntry = (SubgraphKey, SubgraphSdl);
+pub type CompositionResult = std::result::Result<Option<CompositionOutput>, String>;
 
 pub(crate) fn sdl_from_definition(subgraph_definition: &SubgraphDefinition) -> SubgraphSdl {
     subgraph_definition.sdl.to_string()
@@ -60,7 +62,6 @@ pub(crate) fn socket_read<B>(stream: &mut BufReader<LocalSocketStream>) -> Resul
 where
     B: Serialize + DeserializeOwned + Debug,
 {
-    tracing::debug!("\n----    RECEIVE     ----\n");
     let mut incoming_message = String::new();
 
     let now = Instant::now();
@@ -93,8 +94,6 @@ where
 
         std::thread::sleep(Duration::from_millis(500));
     };
-
-    tracing::debug!("\n====   END RECEIVE    ====\n");
     Ok(result)
 }
 
@@ -102,8 +101,6 @@ pub(crate) fn socket_write<A>(message: &A, stream: &mut BufReader<LocalSocketStr
 where
     A: Serialize + DeserializeOwned + Debug,
 {
-    tracing::debug!("\n----      SEND      ----\n");
-    tracing::debug!("\n{:?}\n", &message);
     let outgoing_json = serde_json::to_string(message)
         .with_context(|| format!("could not convert outgoing message {:?} to json", &message))?;
     let outgoing_string = format!("{}\n", &outgoing_json);
@@ -111,6 +108,5 @@ where
         .get_mut()
         .write_all(outgoing_string.as_bytes())
         .context("could not write outgoing message to socket")?;
-    tracing::debug!("\n====    END SEND     ====\n");
     Ok(())
 }

--- a/src/command/dev/router.rs
+++ b/src/command/dev/router.rs
@@ -173,9 +173,8 @@ impl RouterRunner {
     }
 
     pub fn kill(&mut self) -> Result<()> {
-        tracing::info!("killing the router");
-        if let Some(router_handle) = self.router_handle.as_mut() {
-            router_handle.kill();
+        if self.router_handle.is_some() {
+            tracing::info!("killing the router");
             self.router_handle = None;
             if let Ok(client) = self.client_config.get_reqwest_client() {
                 let _ = Self::wait_for_stop(client, &self.supergraph_opts.port)

--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use crate::{
     command::dev::{
-        netstat::normalize_loopback_urls, protocol::SubgraphKey, watcher::SubgraphSchemaWatcher,
+        netstat::normalize_loopback_urls, protocol::SubgraphKeys, watcher::SubgraphSchemaWatcher,
     },
     error::RoverError,
     options::OptionalSubgraphOpts,
@@ -16,7 +16,7 @@ impl OptionalSubgraphOpts {
         &self,
         socket_addr: &str,
         client: Client,
-        session_subgraphs: Option<Vec<SubgraphKey>>,
+        session_subgraphs: Option<SubgraphKeys>,
         supergraph_socket_addr: SocketAddr,
     ) -> Result<SubgraphSchemaWatcher> {
         let url = self.prompt_for_url()?;


### PR DESCRIPTION
fixes #1260 by sending a version check at the start of each `rover dev` session that ensures the two are the same. this should prevent protocol bugs if we make changes to it down the line since everything will use the same version.