### PR TITLE
fix: cleans up various error messages and suggestions

### DIFF
--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -46,8 +46,7 @@ impl StudioClient {
         variables: Q::Variables,
     ) -> Result<Q::ResponseData, RoverClientError> {
         let mut header_map = self.build_studio_headers()?;
-        Ok(self
-            .client
+        self.client
             .post::<Q>(variables, &mut header_map)
             .map_err(|e| match e {
                 IntrospectorGadgetError::SendRequest(source) => RoverClientError::SendRequest {
@@ -55,7 +54,7 @@ impl StudioClient {
                     is_studio: true,
                 },
                 e => e.into(),
-            })?)
+            })
     }
 
     /// Client method for making a GraphQL request to Apollo Studio.
@@ -67,8 +66,7 @@ impl StudioClient {
         variables: Q::Variables,
     ) -> Result<Q::ResponseData, RoverClientError> {
         let mut header_map = self.build_studio_headers()?;
-        Ok(self
-            .client
+        self.client
             .post_no_retry::<Q>(variables, &mut header_map)
             .map_err(|e| match e {
                 IntrospectorGadgetError::SendRequest(source) => RoverClientError::SendRequest {
@@ -76,7 +74,7 @@ impl StudioClient {
                     is_studio: true,
                 },
                 e => e.into(),
-            })?)
+            })
     }
 
     /// Function for building a [HeaderMap] for making http requests. Use for making

--- a/crates/rover-client/src/releases.rs
+++ b/crates/rover-client/src/releases.rs
@@ -8,7 +8,14 @@ const LATEST_RELEASE_URL: &str = "https://github.com/apollographql/rover/release
 /// Looks up and parses the latest release version
 pub fn get_latest_release(client: Client) -> Result<Version, RoverClientError> {
     // send a request to the latest GitHub release
-    let response = client.head(LATEST_RELEASE_URL).send()?;
+    let response =
+        client
+            .head(LATEST_RELEASE_URL)
+            .send()
+            .map_err(|e| RoverClientError::SendRequest {
+                source: e,
+                is_studio: false,
+            })?;
 
     // this will return a response with a redirect to the latest tagged release
     let url_path_segments = response

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -42,7 +42,7 @@ If this error occurs on a command where you aren't providing headers, please [op
 
 This error can occur in a number of places. It indicates an error occurring when actually executing a request. 
 
-This error commonly occurs when the server can't be reached, or network connection is lost. 
+This error commonly occurs when the server can't be reached, the network connection is lost, or the response type was unexpected. 
 
 To debug, use the `--log trace` flag to expose more detailed logs of the specific error that's being encountered.
 

--- a/src/command/dev/compose.rs
+++ b/src/command/dev/compose.rs
@@ -85,9 +85,7 @@ impl ComposeRunner {
             // had a successful composition, now a new successful composition
             (Some(Ok(prev_success)), Some(Ok(new_success))) => {
                 if prev_success != new_success {
-                    let _ = self
-                        .update_supergraph_schema(&new_success.supergraph_sdl)
-                        .map_err(log_err_and_continue);
+                    let _ = self.update_supergraph_schema(&new_success.supergraph_sdl);
                     Ok(Some(new_success))
                 } else {
                     Ok(None)

--- a/src/command/dev/protocol/follower/message.rs
+++ b/src/command/dev/protocol/follower/message.rs
@@ -91,13 +91,13 @@ impl FollowerMessage {
             FollowerMessageKind::AddSubgraph { subgraph_entry } => {
                 if self.is_from_main_session() {
                     eprintln!(
-                        "{}starting main `rover dev` session with subgraph '{}'",
+                        "{}starting main `rover dev` session with the '{}' subgraph",
                         Emoji::Start,
                         &subgraph_entry.0 .0
                     );
                 } else {
                     eprintln!(
-                        "{}adding subgraph '{}' to the main `rover dev` session",
+                        "{}adding the '{}' subgraph to the main `rover dev` session",
                         Emoji::New,
                         &subgraph_entry.0 .0
                     );
@@ -106,13 +106,13 @@ impl FollowerMessage {
             FollowerMessageKind::UpdateSubgraph { subgraph_entry } => {
                 if self.is_from_main_session() {
                     eprintln!(
-                        "{}updating the schema for subgraph '{}' in this `rover dev` session",
+                        "{}updating the schema for the '{}' subgraph in this `rover dev` session",
                         Emoji::Reload,
                         &subgraph_entry.0 .0
                     );
                 } else {
                     eprintln!(
-                        "{}updating the schema for subgraph '{}' in the main `rover dev` session",
+                        "{}updating the schema for the '{}' subgraph in the main `rover dev` session",
                         Emoji::Reload,
                         &subgraph_entry.0 .0
                     );
@@ -121,13 +121,13 @@ impl FollowerMessage {
             FollowerMessageKind::RemoveSubgraph { subgraph_name } => {
                 if self.is_from_main_session() {
                     eprintln!(
-                        "{}removing subgraph '{}' from this `rover dev` session",
+                        "{}removing the '{}' subgraph from this `rover dev` session",
                         Emoji::Reload,
                         &subgraph_name
                     );
                 } else {
                     tracing::debug!(
-                        "removing subgraph '{}' from the main `rover dev` session",
+                        "removing the '{}' subgraph from the main `rover dev` session",
                         &subgraph_name
                     );
                 }

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -284,7 +284,6 @@ impl LeaderSession {
                 maybe_new_schema
             })
             .map_err(|e| {
-                eprintln!("{}", e);
                 let _ = self.router_runner.kill().map_err(log_err_and_continue);
                 e
             })

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1192,8 +1192,11 @@ mod tests {
                 Some("[Films] -> Something else also went wrong".to_string()),
             ),
         ]);
-        let actual_json: JsonOutput =
-            RoverError::from(RoverClientError::BuildErrors { source }).into();
+        let actual_json: JsonOutput = RoverError::from(RoverClientError::BuildErrors {
+            source,
+            num_subgraphs: 2,
+        })
+        .into();
         let expected_json = json!(
         {
             "json_version": "1",

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -122,6 +122,7 @@ impl Compose {
             _ => unreachable!("This version of Rover does not support major versions of federation other than 1 and 2.")
         };
         supergraph_config.set_federation_version(v);
+        let num_subgraphs = supergraph_config.get_subgraph_definitions()?.len();
         let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
         let dir = TempDir::new("supergraph")?;
         tracing::debug!("temp dir created at {}", dir.path().display());
@@ -155,6 +156,7 @@ impl Compose {
                 }),
                 Err(build_errors) => Err(RoverError::from(RoverClientError::BuildErrors {
                     source: build_errors,
+                    num_subgraphs,
                 })),
             },
             Err(bad_json) => Err(anyhow!("{}", bad_json))

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -49,15 +49,37 @@ impl From<&mut saucer::Error> for Metadata {
                 RoverClientError::InvalidHeaderValue(_) => {
                     (Some(Suggestion::SubmitIssue), Some(Code::E003))
                 }
-                RoverClientError::SendRequest(e) => {
+                RoverClientError::SendRequest { source, is_studio } => {
                     // reqwest::Error's Display impl already includes the cause, so we can skip printing it
                     skip_printing_cause = true;
-                    if e.is_connect() {
-                        (Some(Suggestion::CheckServerConnection), Some(Code::E028))
-                    } else if e.is_timeout() {
+
+                    if source.is_connect() {
+                        let code = Some(Code::E028);
+                        if *is_studio {
+                            (Some(Suggestion::SubmitIssue), code)
+                        } else {
+                            (Some(Suggestion::CheckServerConnection), code)
+                        }
+                    } else if source.is_timeout() {
                         (Some(Suggestion::IncreaseClientTimeout), Some(Code::E031))
+                    } else if source.is_decode() {
+                        if *is_studio {
+                            (Some(Suggestion::SubmitIssue), Some(Code::E004))
+                        } else {
+                            (Some(Suggestion::CheckResponseType), Some(Code::E004))
+                        }
+                    } else if source.is_status() {
+                        if *is_studio {
+                            (Some(Suggestion::SubmitIssue), Some(Code::E004))
+                        } else {
+                            (Some(Suggestion::CheckServerConnection), Some(Code::E004))
+                        }
                     } else {
-                        (Some(Suggestion::SubmitIssue), Some(Code::E004))
+                        if *is_studio {
+                            (Some(Suggestion::SubmitIssue), Some(Code::E004))
+                        } else {
+                            (None, Some(Code::E004))
+                        }
                     }
                 }
                 RoverClientError::MalformedResponse { null_field: _ } => {
@@ -77,9 +99,15 @@ impl From<&mut saucer::Error> for Metadata {
                     }),
                     Some(Code::E029),
                 ),
-                RoverClientError::BuildErrors { .. } => {
-                    (Some(Suggestion::FixCompositionErrors), Some(Code::E029))
-                }
+                RoverClientError::BuildErrors {
+                    source: _,
+                    num_subgraphs,
+                } => (
+                    Some(Suggestion::FixCompositionErrors {
+                        num_subgraphs: *num_subgraphs,
+                    }),
+                    Some(Code::E029),
+                ),
                 RoverClientError::OperationCheckFailure {
                     graph_ref,
                     check_response: _,

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -74,12 +74,10 @@ impl From<&mut saucer::Error> for Metadata {
                         } else {
                             (Some(Suggestion::CheckServerConnection), Some(Code::E004))
                         }
+                    } else if *is_studio {
+                        (Some(Suggestion::SubmitIssue), Some(Code::E004))
                     } else {
-                        if *is_studio {
-                            (Some(Suggestion::SubmitIssue), Some(Code::E004))
-                        } else {
-                            (None, Some(Code::E004))
-                        }
+                        (None, Some(Code::E004))
                     }
                 }
                 RoverClientError::MalformedResponse { null_field: _ } => {

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -180,7 +180,6 @@ impl Display for Suggestion {
                     1 => "The subgraph schema you provided is invalid.",
                     _ => "The subgraph schemas you provided are incompatible with each other."
                 };
-                
                 format!("{} See {} for more information on resolving build errors.", prefix, Cyan.normal().paint("https://www.apollographql.com/docs/federation/errors/"))
             },
             Suggestion::FixOperationsInSchema { graph_ref } => format!("The changes in the schema you proposed are incompatible with graph {}. See {} for more information on resolving operation check errors.", Yellow.normal().paint(graph_ref.to_string()), Cyan.normal().paint("https://www.apollographql.com/docs/studio/schema-checks/")),


### PR DESCRIPTION
fixes #1324 by only printing composition errors once in the main session
fixes #1217 by not suggesting submitting a bug when customer infrastructure is being hit, only when studio requests are made
fixes #1237 by printing a different suggestion when there is only one subgraph being composed