### PR TITLE
chore: updates router and adds env var escape hatches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,6 +2841,7 @@ dependencies = [
  "humantime",
  "interprocess",
  "introspector-gadget",
+ "lazy_static",
  "lazycell",
  "libc",
  "netstat2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ humantime = "2.1.0"
 # interprocess = "1"
 interprocess = { git = "https://github.com/kotauskas/interprocess", rev = "7fa31fd166f74a1cac6cc06f86981050166c7424"}
 lazycell = "1"
+lazy_static = "1"
 libc = "0.2"
 netstat2 = "0.9"
 notify = "4"

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -93,11 +93,12 @@ impl SupergraphOpts {
     }
 }
 
-// TODO: make this configurable once the router is stable enough
-// and there is a way to determine the correct composition version
-// to use with a router version
-pub(crate) const DEV_ROUTER_VERSION: &str = "1.0.0-rc.1";
+lazy_static::lazy_static! {
+    pub(crate) static ref DEV_ROUTER_VERSION: String =
+      std::env::var("APOLLO_ROVER_DEV_ROUTER_VERSION").unwrap_or_else(|_| "1.0.0".to_string());
 
-// this number should be mapped to the federation version used by the router
-// https://www.apollographql.com/docs/router/federation-version-support/#support-table
-pub(crate) const DEV_COMPOSITION_VERSION: &str = "2.1.2-alpha.2";
+    // this number should be mapped to the federation version used by the router
+    // https://www.apollographql.com/docs/router/federation-version-support/#support-table
+    pub(crate) static ref DEV_COMPOSITION_VERSION: String =
+        std::env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION").unwrap_or_else(|_| "2.1.2".to_string());
+}

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -329,7 +329,7 @@ impl LeaderSession {
             .collect::<Vec<SubgraphDefinition>>()
             .into();
         supergraph_config.set_federation_version(FederationVersion::ExactFedTwo(
-            Version::parse(DEV_COMPOSITION_VERSION)
+            Version::parse(&DEV_COMPOSITION_VERSION)
                 .map_err(|e| panic!("could not parse composition version:\n{:?}", e))
                 .unwrap(),
         ));

--- a/src/command/dev/router.rs
+++ b/src/command/dev/router.rs
@@ -52,7 +52,7 @@ impl RouterRunner {
     }
 
     fn install_command(&self) -> Result<Install> {
-        let plugin = Plugin::Router(RouterVersion::Exact(Version::parse(DEV_ROUTER_VERSION)?));
+        let plugin = Plugin::Router(RouterVersion::Exact(Version::parse(&DEV_ROUTER_VERSION)?));
         Ok(Install {
             force: false,
             plugin: Some(plugin),


### PR DESCRIPTION
adds support for passing versions to the router and composition binaries with `APOLLO_ROVER_DEV_COMPOSITION_VERSION` and `APOLLO_ROVER_DEV_ROUTER_VERSION`.