### PR TITLE
chore: address gateway copy issues

### DIFF
--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -18,7 +18,7 @@ Rover commands that interact with subgraphs begin with `rover subgraph`.
 
 ## Fetching a subgraph schema
 
-These commands enable you to fetch the schema for a single subgraph in a federated graph. To instead fetch your gateway's composed supergraph schema, use the corresponding [`rover graph` commands](./graphs/).
+These commands enable you to fetch the schema for a single subgraph in a federated graph. To instead fetch the API schema for a supergraph, use [`rover graph fetch`](./graphs#graph-fetch). To fetch the supergraph schema, use [`rover supergraph fetch`](./supergraph#supergraph-fetch).
 
 ### `subgraph fetch`
 
@@ -197,7 +197,7 @@ Every subgraph name **must**:
 
 <td>
 
-The URL that your gateway uses to communicate with the subgraph in a [managed federation architecture](/federation/managed-federation/overview/).
+The URL that your supergraph uses to communicate with the subgraph in a [managed federation architecture](/federation/managed-federation/overview/).
 
 **Required** the first time you publish a particular subgraph. Provide an empty string if your subgraph isn't deployed yet, or if you aren't using managed federation.
 

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -99,7 +99,7 @@ subgraphs:
 
 By default, `rover supergraph compose` outputs a [supergraph schema](/federation/federated-types/overview/) document to `stdout`. You provide this artifact to [`@apollo/gateway`](/federation/api/apollo-gateway/) or the [🦀 Apollo Router](/router/) on startup.
 
-> ⚠️ **Your gateway fails to start up if you provide it with a supergraph schema that it doesn't support!** To ensure compatibility, we recommend that you always test launching your gateway in a CI pipeline with the supergraph schema it will ultimately use in production.
+> ⚠️ **Your router/gateway fails to start up if you provide it with a supergraph schema that it doesn't support!** To ensure compatibility, we recommend that you always test launching your router/gateway in a CI pipeline with the supergraph schema it will ultimately use in production.
 
 You can save the schema output to a local `.graphql` file like so:
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -124,23 +124,19 @@ impl RoverOutput {
             } => {
                 if publish_response.subgraph_was_created {
                     stderrln!(
-                        "A new subgraph called '{}' for the '{}' graph was created",
+                        "A new subgraph called '{}' was created in '{}'",
                         subgraph,
                         graph_ref
                     )?;
                 } else {
-                    stderrln!(
-                        "The '{}' subgraph for the '{}' graph was updated",
-                        subgraph,
-                        graph_ref
-                    )?;
+                    stderrln!("The '{}' subgraph in '{}' was updated", subgraph, graph_ref)?;
                 }
 
                 if publish_response.supergraph_was_updated {
-                    stderrln!("The gateway for the '{}' graph was updated with a new schema, composed from the updated '{}' subgraph", graph_ref, subgraph)?;
+                    stderrln!("The supergraph schema for '{}' was updated, composed from the updated '{}' subgraph", graph_ref, subgraph)?;
                 } else {
                     stderrln!(
-                        "The gateway for the '{}' graph was NOT updated with a new schema",
+                        "The supergraph schema for '{}' was NOT updated with a new schema",
                         graph_ref
                     )?;
                 }
@@ -180,13 +176,13 @@ impl RoverOutput {
                 } else {
                     if delete_response.supergraph_was_updated {
                         stderrln!(
-                            "The {} subgraph was removed from {}. Remaining subgraphs were composed.",
+                            "The '{}' subgraph was removed from '{}'. The remaining subgraphs were composed.",
                             Cyan.normal().paint(subgraph),
                             Cyan.normal().paint(graph_ref.to_string()),
                         )?
                     } else {
                         stderrln!(
-                            "{} The gateway for {} was not updated. See errors below.",
+                            "{} The supergraph schema for '{}' was not updated. See errors below.",
                             warn_prefix,
                             Cyan.normal().paint(graph_ref.to_string())
                         )?
@@ -194,8 +190,10 @@ impl RoverOutput {
 
                     if !delete_response.build_errors.is_empty() {
                         stderrln!(
-                            "{} There were build errors as a result of deleting the subgraph:",
+                            "{} There were build errors as a result of deleting the '{}' subgraph from '{}':",
                             warn_prefix,
+                            Cyan.normal().paint(subgraph),
+                            Cyan.normal().paint(graph_ref.to_string())
                         )?;
 
                         stderrln!("{}", &delete_response.build_errors)?;

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -29,9 +29,9 @@ pub struct Publish {
     #[clap(short, long)]
     convert: bool,
 
-    /// Url of a running subgraph that a gateway can route operations to
+    /// Url of a running subgraph that a supergraph can route operations to
     /// (often a deployed subgraph). May be left empty ("") or a placeholder url
-    /// if not running a gateway in managed federation mode
+    /// if not running a gateway or router in managed federation mode
     #[clap(long)]
     #[serde(skip_serializing)]
     routing_url: Option<String>,


### PR DESCRIPTION
fixes #1239

updates some rover copy to talk about the "supergraph schema" instead of a gateway or router. in cases where gateway/router terminology is still needed, refer to them both.