### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,40 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.9.0] - 2022-09-22
+
+## 🚀 Features
+
+- **`rover template` command suite - @dbanty, @michael-watson, @EverlastingBugstopper, #1287**
+
+  Two new commands have made their way to Rover: `rover template list` and `rover template use`. These commands provide a similar experience to `create-react-app`, and allow you to extract GraphQL project templates to your local machine. Check out [the docs](https://www.apollographql.com/docs/rover/commands/template/) for more on this new functionality.
+
+- **`rover dev` to facilitate developing a supergraph on your local machine - @EverlastingBugstopper, #1190**
+
+  `rover dev` allows you to join multiple running subgraph servers together into a local supergraph, providing the ability to run queries and inspect query plans with Apollo Sandbox. Check out [the docs](https://www.apollographql.com/docs/rover/commands/dev) for more on this new functionality.
+
+- **If E013 is thrown and `$APOLLO_KEY` is set, give a more helpful suggestion - @ptondereau, #1284, #1285**
+
+  If Studio fails to recognize an API key and `APOLLO_KEY` is set, recommend unsetting the environment variable to use `--profile default` instead.
+
+## 🐛 Fixes
+
+- **Remove useless stdout line for composition results - @ptondereau, #1124, #1291**
+
+## 🛠 Maintenance
+
+- **Link directly to API Keys page in Studio - @abernix, #1202**
+
+  The `rover config auth` command will now provide a link that takes you directly to the "API Keys" page where you can create a Personal API Key, rather than a page that requires you to click through to another page.
+
+- **Prefer "supergraph schema" terminology to "gateway" - @EverlastingBugstopper, #1239, #1332**
+
+  `rover subgraph publish` now refers to updating the "supergraph schema" as opposed to updating the "gateway," since supergraph schema consumers can be routers and/or gateways now.
+
+## 📚 Documentation
+
+- **Fix a few typos in `ARCHITECTURE.md` - @dbanty, #1289**
+
 # [0.8.2] - 2022-09-06
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 dependencies = [
  "ansi_term",
  "apollo-federation-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 
 ```console
 $ rover --help
-Rover 0.9.0-rc.1
+Rover 0.9.0
 Apollo Developers <opensource@apollographql.com>
 
 Rover - Your Graph Companion
@@ -69,37 +69,68 @@ USAGE:
 
 OPTIONS:
         --client-timeout <CLIENT_TIMEOUT>
-            Configure the timeout length (in seconds) when performing HTTP(S) requests [default: 30]
+            Configure the timeout length (in seconds) when performing HTTP(S) requests
+            
+            [default: 30]
 
     -h, --help
             Print help information
 
         --insecure-accept-invalid-certs
-            Accept invalid certificates when performing HTTPS requests
+            Accept invalid certificates when performing HTTPS requests.
+            
+            You should think very carefully before using this flag.
+            
+            If invalid certificates are trusted, any certificate for any site will be trusted for
+            use. This includes expired certificates. This introduces significant vulnerabilities,
+            and should only be used as a last resort.
 
         --insecure-accept-invalid-hostnames
-            Accept invalid hostnames when performing HTTPS requests
+            Accept invalid hostnames when performing HTTPS requests.
+            
+            You should think very carefully before using this flag.
+            
+            If hostname verification is not used, any valid certificate for any site will be trusted
+            for use from any other. This introduces a significant vulnerability to man-in-the-middle
+            attacks.
 
     -l, --log <LOG_LEVEL>
-            Specify Rover's log level [possible values: error, warn, info, debug, trace]
+            Specify Rover's log level
+            
+            [possible values: error, warn, info, debug, trace]
 
         --output <OUTPUT_TYPE>
-            Specify Rover's output type [default: plain] [possible values: json, plain]
+            Specify Rover's output type
+            
+            [default: plain]
+            [possible values: json, plain]
 
     -V, --version
             Print version information
 
 SUBCOMMANDS:
-    config        Configuration profile commands
-    dev           Run your supergraph locally with a router and one or more subgraphs
-    docs          Interact with Rover's documentation
-    explain       Explain error codes
-    graph         Graph API schema commands
-    help          Print this message or the help of the given subcommand(s)
-    readme        Readme commands
-    subgraph      Subgraph schema commands
-    supergraph    Supergraph schema commands
-    update        Commands related to updating rover
+    config
+            Configuration profile commands
+    dev
+            Combine multiple subgraphs into a local supergraph
+    docs
+            Interact with Rover's documentation
+    explain
+            Explain error codes
+    graph
+            Graph API schema commands
+    help
+            Print this message or the help of the given subcommand(s)
+    readme
+            Readme commands
+    subgraph
+            Subgraph schema commands
+    supergraph
+            Supergraph schema commands
+    template
+            Commands for working with templates
+    update
+            Commands related to updating rover
 ```
 
 This repo is organized as a [`cargo` workspace], containing several related projects:

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -745,15 +745,14 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.3.tgz",
-      "integrity": "sha512-+NzflVRaWl48Jdjq7FOxkmb8wLpSWtk6XKAEMfr/yDOqJS7HWxA+Rc5rTVqh2IRi6QZJyKGoaGKjOAqrGq07nA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.4.tgz",
+      "integrity": "sha512-/c2u1blMAXHVXneZjVLyE0AwdRuuFpv2P3ghNz2QtpHed+25WdSkTi7XxICwuaRsl/mMgundCzSy1352rZgWPg==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "abort-controller": "^3.0.0",
         "busboy": "^1.6.0",
-        "event-target-polyfill": "^0.0.3",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
@@ -1304,12 +1303,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-polyfill": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz",
-      "integrity": "sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==",
-      "dev": true
-    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1594,9 +1587,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.1.tgz",
-      "integrity": "sha512-AlOO/Gt0fXuSHXe/Weo6o3rIQVnH5MW7ophzeYzL+vYNlkf0NbWRJ6IIFgtSLcv9JpTlQdxSpB3t0SnM47/BHA==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.2.tgz",
+      "integrity": "sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1819,15 +1812,15 @@
       }
     },
     "node_modules/meros": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/meros/-/meros-1.2.0.tgz",
-      "integrity": "sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.2.1.tgz",
+      "integrity": "sha512-R2f/jxYqCAGI19KhAvaxSOxALBMkaXWH2a7rOyqQw+ZmizX5bKkEYWLzdhC+U82ZVVPVp6MCXe3EkVligh+12g==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=13"
       },
       "peerDependencies": {
-        "@types/node": ">=12"
+        "@types/node": ">=13"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -2485,9 +2478,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -3127,15 +3120,14 @@
       }
     },
     "@whatwg-node/fetch": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.3.tgz",
-      "integrity": "sha512-+NzflVRaWl48Jdjq7FOxkmb8wLpSWtk6XKAEMfr/yDOqJS7HWxA+Rc5rTVqh2IRi6QZJyKGoaGKjOAqrGq07nA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.4.tgz",
+      "integrity": "sha512-/c2u1blMAXHVXneZjVLyE0AwdRuuFpv2P3ghNz2QtpHed+25WdSkTi7XxICwuaRsl/mMgundCzSy1352rZgWPg==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "abort-controller": "^3.0.0",
         "busboy": "^1.6.0",
-        "event-target-polyfill": "^0.0.3",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
@@ -3544,12 +3536,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "event-target-polyfill": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz",
-      "integrity": "sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==",
-      "dev": true
-    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -3774,9 +3760,9 @@
       }
     },
     "graphql-ws": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.1.tgz",
-      "integrity": "sha512-AlOO/Gt0fXuSHXe/Weo6o3rIQVnH5MW7ophzeYzL+vYNlkf0NbWRJ6IIFgtSLcv9JpTlQdxSpB3t0SnM47/BHA==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.2.tgz",
+      "integrity": "sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==",
       "dev": true,
       "requires": {}
     },
@@ -3952,9 +3938,9 @@
       "dev": true
     },
     "meros": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/meros/-/meros-1.2.0.tgz",
-      "integrity": "sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.2.1.tgz",
+      "integrity": "sha512-R2f/jxYqCAGI19KhAvaxSOxALBMkaXWH2a7rOyqQw+ZmizX5bKkEYWLzdhC+U82ZVVPVp6MCXe3EkVligh+12g==",
       "dev": true,
       "requires": {}
     },
@@ -4397,9 +4383,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
       "dev": true,
       "requires": {}
     },

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -42,7 +42,7 @@ If this error occurs on a command where you aren't providing headers, please [op
 
 This error can occur in a number of places. It indicates an error occurring when actually executing a request. 
 
-This error commonly occurs when the server can't be reached, the network connection is lost, or the response type was unexpected. 
+This error commonly occurs when the server can't be reached, or network connection is lost. 
 
 To debug, use the `--log trace` flag to expose more detailed logs of the specific error that's being encountered.
 

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.9.0-rc.1"
+PACKAGE_VERSION="v0.9.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.9.0-rc.1'
+$package_version = 'v0.9.0'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.9.0-rc.1",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.9.0-rc.1",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.9.0-rc.1",
+  "version": "0.9.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## 🚀 Features

- **`rover template` command suite - @dbanty, @michael-watson, @EverlastingBugstopper, #1287**

  Two new commands have made their way to Rover: `rover template list` and `rover template use`. These commands provide a similar experience to `create-react-app`, and allow you to extract GraphQL project templates to your local machine. Check out [the docs](https://www.apollographql.com/docs/rover/commands/template/) for more on this new functionality.

- **`rover dev` to facilitate developing a supergraph on your local machine - @EverlastingBugstopper, #1190**

  `rover dev` allows you to join multiple running subgraph servers together into a local supergraph, providing the ability to run queries and inspect query plans with Apollo Sandbox. Check out [the docs](https://www.apollographql.com/docs/rover/commands/dev) for more on this new functionality.

- **If E013 is thrown and `$APOLLO_KEY` is set, give a more helpful suggestion - @ptondereau, #1284, #1285**

  If Studio fails to recognize an API key and `APOLLO_KEY` is set, recommend unsetting the environment variable to use `--profile default` instead.

## 🐛 Fixes

- **Remove useless stdout line for composition results - @ptondereau, #1124, #1291**

## 🛠 Maintenance

- **Link directly to API Keys page in Studio - @abernix, #1202**

  The `rover config auth` command will now provide a link that takes you directly to the "API Keys" page where you can create a Personal API Key, rather than a page that requires you to click through to another page.

- **Prefer "supergraph schema" terminology to "gateway" - @EverlastingBugstopper, #1239, #1332**

  `rover subgraph publish` now refers to updating the "supergraph schema" as opposed to updating the "gateway," since supergraph schema consumers can be routers and/or gateways now.