### PR TITLE
chore: update studio client identification headers

### DIFF
--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -96,6 +96,11 @@ fn query(fetch_document: bool) -> Result<(String, Option<String>)> {
     let response = client
         .post(graphql_endpoint)
         .json(&schema_query)
+        .header("apollo-client-name", "rover-client")
+        .header(
+            "apollo-client-version",
+            format!("{} (dev)", env!("CARGO_PKG_VERSION")),
+        )
         .send()?
         .error_for_status()?;
     let json: serde_json::Value = response.json()?;

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -85,7 +85,7 @@ impl StudioClient {
     pub fn build_studio_headers(&self) -> Result<HeaderMap, RoverClientError> {
         let mut headers = HeaderMap::new();
 
-        // The headers "apollographql-client-name" and "apollographql-client-version"
+        // The headers "apollo-client-name" and "apollo-client-version"
         // are used for client identification in Apollo Studio.
 
         // This provides metrics in Studio that help keep track of what parts of the schema
@@ -94,10 +94,10 @@ impl StudioClient {
         // https://www.apollographql.com/docs/studio/client-awareness/#using-apollo-server-and-apollo-client
 
         let client_name = HeaderValue::from_str(CLIENT_NAME)?;
-        headers.insert("apollographql-client-name", client_name);
+        headers.insert("apollo-client-name", client_name);
         tracing::debug!(?self.version);
         let client_version = HeaderValue::from_str(&self.version)?;
-        headers.insert("apollographql-client-version", client_version);
+        headers.insert("apollo-client-version", client_version);
 
         let mut api_key = HeaderValue::from_str(&self.credential.api_key)?;
         api_key.set_sensitive(true);


### PR DESCRIPTION
The public Studio API now requires that the `apollo-client-version` and `apollo-client-name` headers are sent with every request. This PR renames the headers sent by Rover commands, and adds in those headers to the build step that fetches the API schema itself.