### PR TITLE
fix: properly handle leader session startup errors

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -31,7 +31,7 @@ impl Dev {
         let (follower_message_sender, follower_message_receiver) = sync_channel(0);
         let (leader_message_sender, leader_message_receiver) = sync_channel(0);
 
-        if let Ok(mut leader_session) = LeaderSession::new(
+        if let Some(mut leader_session) = LeaderSession::new(
             &self.opts,
             override_install_path,
             &client_config,
@@ -39,7 +39,7 @@ impl Dev {
             follower_message_receiver,
             leader_message_sender,
             leader_message_receiver.clone(),
-        ) {
+        )? {
             let (ready_sender, ready_receiver) = sync_channel(1);
             let follower_messenger = FollowerMessenger::from_main_session(
                 follower_message_sender.clone(),
@@ -119,7 +119,8 @@ impl Dev {
             // watch for subgraph changes on the main thread
             // it will take care of updating the main `rover dev` session
             subgraph_refresher.watch_subgraph_for_changes()?;
-        };
+        }
+
         unreachable!()
     }
 }

--- a/src/command/dev/protocol/follower/messenger.rs
+++ b/src/command/dev/protocol/follower/messenger.rs
@@ -145,7 +145,11 @@ impl FollowerMessengerKind {
             }
             FromAttachedSession { ipc_socket_addr } => {
                 let stream = LocalSocketStream::connect(&**ipc_socket_addr).map_err(|_| {
-                    RoverError::new(anyhow!("the main `rover dev` session is no longer active"))
+                    let mut err = RoverError::new(anyhow!(
+                        "there is not a main `rover dev` process to report updates to"
+                    ));
+                    err.set_suggestion(Suggestion::SubmitIssue);
+                    err
                 })?;
 
                 let mut stream = BufReader::new(stream);


### PR DESCRIPTION
This PR fixes an issue where an inscrutable error message would be encountered if anything went wrong while starting the first `rover dev` process. These errors should now be reported and handled properly.

before:

```
$ rover dev --name products --url http://localhost:4000
error: the main rover dev session is no longer active
```

after:

```
$ rover dev --name products --url http://localhost:4000
error: You cannot bind the router to '127.0.0.1:4002' because that address is already in use by another process on this machine.
        Try setting a different port for the router to bind to with the `--supergraph-port` argument, or shut down the process bound to '127.0.0.1:4002'.
```