### PR TITLE
chore: specify all dependencies in root Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.4"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -147,6 +159,16 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "tempfile",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -265,6 +287,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
+ "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -357,6 +380,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64ct"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "basic-cookies"
@@ -510,6 +539,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,7 +653,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -617,6 +667,15 @@ dependencies = [
  "envmnt",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -735,6 +794,12 @@ dependencies = [
  "unicode-width",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "coolor"
@@ -1047,6 +1112,7 @@ checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1435,6 +1501,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -1571,6 +1638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1997,6 +2073,7 @@ checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2010,6 +2087,20 @@ checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2245,6 +2336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2364,15 @@ name = "online"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd83008f9658806ee04c639b070e031368291597ab05429b87d081d33de53540"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opener"
@@ -2398,6 +2507,29 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -2814,7 +2946,6 @@ dependencies = [
  "heck",
  "houston",
  "interprocess",
- "introspector-gadget",
  "lazy_static",
  "lazycell",
  "notify",
@@ -2843,6 +2974,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "uuid",
  "which",
 ]
 
@@ -2851,7 +2983,6 @@ name = "rover-client"
 version = "0.0.0"
 dependencies = [
  "apollo-federation-types",
- "backoff",
  "chrono",
  "git-url-parse",
  "git2",
@@ -3127,6 +3258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,6 +3444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,6 +3614,24 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa 1.0.3",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny-keccak"
@@ -4110,7 +4276,45 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
 dependencies = [
+ "aes",
  "byteorder",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.14",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.10.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.6+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,19 +39,11 @@ default = ["composition-js"]
 # because of this GitHub issue: https://github.com/denoland/deno/issues/3711
 composition-js = []
 
-[dependencies]
-# https://github.com/apollographql/federation-rs dependencies
-# apollo-federation-types = "0.5"
-# apollo-federation-types = { path = "../federation-rs/apollo-federation-types" }
-apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "fdea369a6bfa32c8620b526b3d7afe661569c069" }
-
-# https://github.com/apollographql/apollo-rs dependencies
-apollo-parser = "0.2"
-
-# https://github.com/apollographql/introspector-gadget dependencies
-introspector-gadget = "0.1"
-
-# workspace dependencies
+### cross-workspace dependencies
+# these dependencies can be used by any other workspace crate by specifying the dependency like so:
+# my-dependency = { workspace = true }
+[workspace.dependencies]
+# path dependencies
 binstall = { path = "./installers/binstall" }
 houston = { path = "./crates/houston" }
 robot-panic = { path = "./crates/robot-panic" }
@@ -59,57 +51,149 @@ rover-client = { path = "./crates/rover-client" }
 sputnik = { path = "./crates/sputnik" }
 timber = { path = "./crates/timber" }
 
-# git dependencies
+# apollo maintained dependencies
+
+# https://github.com/apollographql/apollo-rs
+apollo-parser = "0.2"
+
+# https://github.com/apollographql/federation-rs
+apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "fdea369a6bfa32c8620b526b3d7afe661569c069" }
+# apollo-federation-types = "0.5"
+# apollo-federation-types = { path = "../federation-rs/apollo-federation-types" }
+
+# https://github.com/EverlastingBugstopper/billboard
 billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
+
+# https://github.com/apollographql/introspector-gadget
+introspector-gadget = "0.1"
+
+# https://github.com/EverlastingBugstopper/awc
 saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }
-# saucer = { path = "../awc/saucer" }
 
 # crates.io dependencies
 ansi_term = "0.12"
+assert_fs = "1"
+assert_cmd = "1"
+assert-json-diff = "2"
 atty = "0.2"
+backtrace = "0.3"
+backoff = "0.4"
+base64 = "0.13"
+cargo_metadata = "0.15"
 calm_io = "0.1"
 chrono = "0.4"
+ci_info = "0.14"
 console = "0.15"
 crossbeam-channel = "0.5"
 crossterm = "0.23"
 ctrlc = "3"
 dialoguer = "0.10"
+directories-next = "2.0"
 flate2 = "1"
+git-url-parse = "0.4.0"
+git2 = "0.14"
+graphql_client = "0.11.0"
 heck = "0.4"
+humantime = "2.1.0"
+hyper = "0.14"
 interprocess = { git = "https://github.com/kotauskas/interprocess", rev = "7fa31fd166f74a1cac6cc06f86981050166c7424"}
 lazycell = "1"
-lazy_static = "1"
+lazy_static = "1.4"
 notify = "4"
+online = "3.0.1"
 opener = "0.5"
 os_info = "3.4"
+os_type = "2.4"
+predicates = "2"
 prettytable-rs = "0.9"
-reqwest = { version = "0.11", default-features = false, features = [
-    "blocking",
-    "json",
-] }
+rayon = "1"
+regex = "1"
+reqwest = "0.11"
 semver = "1"
+serial_test = "0.9"
 serde = "1.0"
 serde_json = "1.0"
+serde_json_traversal = "0.2"
 serde_yaml = "0.9"
 strsim = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
-rayon = "1"
+sha2 = "0.10"
+termcolor = "1.1"
+thiserror = "1"
+tar = "0.4"
 termimad = "0.20"
 tempdir = "0.3"
-tar = "0.4"
+tempfile = "3.3"
 toml = "0.5"
 tracing = "0.1"
-url = { version = "2", features = ["serde"] }
+tracing-core = "0.1"
+tracing-subscriber = "0.3"
 which = "4"
+wsl = "0.1"
+uuid = "1"
+url = "2"
+zip = "0.6"
+
+### rover specific dependencies
+[dependencies]
+ansi_term = { workspace = true }
+assert_fs = { workspace = true }
+apollo-federation-types = { workspace = true }
+apollo-parser = { workspace = true }
+atty = { workspace = true }
+billboard = { workspace = true }
+binstall = { workspace = true }
+calm_io = { workspace = true }
+chrono = { workspace = true }
+console = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossterm = { workspace = true }
+ctrlc = { workspace = true }
+dialoguer = { workspace = true }
+flate2 = { workspace = true }
+heck = { workspace = true }
+houston = { workspace = true }
+interprocess = { workspace = true }
+prettytable-rs = { workspace = true }
+lazycell = { workspace = true }
+lazy_static = { workspace = true }
+notify = { workspace = true }
+opener = { workspace = true }
+os_info = { workspace = true }
+rayon = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = [
+    "blocking",
+    "json",
+] }
+robot-panic = { workspace = true }
+rover-client = { workspace = true }
+saucer = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+sputnik = { workspace = true }
+strsim = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tar = { workspace = true }
+timber = { workspace = true }
+tempdir = { workspace = true }
+termimad = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+which = { workspace = true }
+uuid = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-assert_cmd = "2"
-assert_fs = "1"
-assert-json-diff = "2"
-predicates = "2"
-reqwest = { version = "0.11", default-features = false, features = [
+assert_cmd = { workspace = true }
+assert_fs = { workspace = true }
+assert-json-diff = { workspace = true }
+predicates = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = [
     "blocking",
     "native-tls-vendored",
 ] }
-serial_test = "0.9"
+serial_test = { workspace = true }

--- a/crates/houston/Cargo.toml
+++ b/crates/houston/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-directories-next = "2.0"
-saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }
-# saucer = { path = "../../../awc/saucer" }
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
-toml = "0.5"
-tracing = "0.1"
+# workspace dependencies 
+directories-next = { workspace = true }
+saucer = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-assert_fs = "1"
+assert_fs = { workspace = true }

--- a/crates/robot-panic/Cargo.toml
+++ b/crates/robot-panic/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-backtrace = "0.3"
-os_type = "2.4"
-saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }
-# saucer = { path = "../../../awc/saucer" }
-serde = "1.0"
-termcolor = "1.1"
-toml = "0.5"
-uuid = { version = "1", features = ["v4"], default-features = false }
-url = "2.2"
+backtrace = { workspace = true }
+os_type = { workspace = true }
+saucer = { workspace = true }
+serde = { workspace = true }
+termcolor = { workspace = true }
+toml = { workspace = true }
+uuid = { workspace = true, features = ["v4"], default-features = false }
+url = { workspace = true}
+

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -8,30 +8,19 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
-
-# workspace deps
-houston = { path = "../houston" }
-
-# https://github.com/apollographql/federation-rs dependencies
-# apollo-federation-types = "0.5"
-# apollo-federation-types = { path = "../../../federation-rs/apollo-federation-types" }
-apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "fdea369a6bfa32c8620b526b3d7afe661569c069" }
-
-# https://github.com/apollographql/introspector-gadget dependencies
-introspector-gadget = "0.1"
-
-# crates.io deps
-backoff = "0.4"
-chrono = { version = "0.4", features = ["serde"] }
-git-url-parse = "0.4.0"
-git2 = { version = "0.14", default-features = false, features = [
+apollo-federation-types = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+git-url-parse = { workspace = true }
+git2 = { workspace = true, default-features = false, features = [
     "vendored-openssl",
 ] }
-graphql_client = "0.11.0"
-humantime = "2.1.0"
-hyper = "0.14"
-prettytable-rs = "0.9"
-reqwest = { version = "0.11", default-features = false, features = [
+graphql_client = { workspace = true }
+houston = { workspace = true }
+humantime = { workspace = true }
+hyper = { workspace = true }
+introspector-gadget = { workspace = true }
+prettytable-rs = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = [
     "blocking",
     "brotli",
     "gzip",
@@ -39,26 +28,26 @@ reqwest = { version = "0.11", default-features = false, features = [
     "native-tls-vendored",
     "socks",
 ] }
-regex = "1"
-semver = "1"
-serde = "1"
-serde_json = "1"
-thiserror = "1"
-tracing = "0.1"
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+regex = { workspace = true }
 
 [build-dependencies]
-online = { version = "3.0.1", default-features = false, features = ["sync"] }
-reqwest = { version = "0.11", default-features = false, features = [
+saucer = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = [
     "json",
     "blocking",
     "native-tls-vendored",
 ] }
-saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }
-# saucer = { path = "../../../awc/saucer" }
-serde_json = "1"
-uuid = { version = "1", features = ["v4"] }
+online = { workspace = true, default-features = false, features = ["sync"] }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+# crates.io crates
 indoc = "1.0"
 httpmock = "0.6"
 pretty_assertions = "1.2"

--- a/crates/sputnik/Cargo.toml
+++ b/crates/sputnik/Cargo.toml
@@ -7,20 +7,19 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ci_info = { version = "0.14", features = ["serde-1"] }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "socks"] }
-rover-client = { path = "../rover-client" }
-saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }
-# saucer = { path = "../../../awc/saucer" }
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sha2 = "0.10"
-thiserror = "1.0"
-tracing = "0.1"
-url = "2.2"
-uuid = { version = "1", features = ["serde", "v4"] }
-wsl = "0.1"
+ci_info = { workspace = true, features = ["serde-1"] }
+reqwest = { workspace = true, default-features = false, features = ["blocking", "socks"] }
+rover-client = { workspace = true }
+saucer = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true}
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
+wsl = { workspace = true }
 
 [dev-dependencies]
-assert_fs = "1.0"
+assert_fs = { workspace = true }

--- a/crates/timber/Cargo.toml
+++ b/crates/timber/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-tracing-core = "0.1"
+tracing-core = { workspace = true }
 # the parking_lot feature uses a more performant mutex than std::sync::Mutex
-tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "parking_lot"] }
+tracing-subscriber = { workspace = true, features = ["ansi", "fmt", "parking_lot"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = [ "rustfmt", "clippy" ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,21 +7,20 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ansi_term = "0.12"
-assert_fs = "1"
-base64 = "0.13"
-cargo_metadata = "0.15"
-flate2 = "1"
-lazy_static = "1.4"
-regex = "1"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "native-tls"]}
-saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }
-# saucer = { path = "../../awc/saucer" }
-semver = "1"
-serde_json = "1"
-serde_json_traversal = "0.2"
-serde_yaml = "0.9"
-tar = "0.4"
-tempfile = "3.3"
-which = "4.2"
-zip = { version = "0.6", default-features = false }
+ansi_term = { workspace = true }
+assert_fs = { workspace = true }
+base64 = { workspace = true }
+cargo_metadata = { workspace = true }
+flate2 = { workspace = true }
+lazy_static = { workspace = true }
+saucer = { workspace = true }
+serde_yaml = { workspace = true }
+serde_json = { workspace = true }
+tar = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["blocking", "native-tls"] }
+semver = { workspace = true }
+serde_json_traversal = { workspace = true }
+tempfile = { workspace = true }
+which = { workspace = true }
+zip = { workspace = true, default-features = false }


### PR DESCRIPTION
in rust 1.65.0, a [new feature](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace) landed that allows workspace dependencies to be defined in the root `Cargo.toml` and re-used across all workspace crates. this PR utilizes this feature to make every dependency number stored in the root `Cargo.toml`, and any dependency that wants to use its functionality can do so without duplicating version numbers or git checkouts.