### PR TITLE
chore: removes circleci caching to save time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,17 +387,8 @@ commands:
       platform:
         type: executor
     steps:
-      - restore_cache:
-          keys:
-            - rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
-
       - run:
           command: cargo xtask << parameters.command >> << parameters.options >>
-
-      - save_cache:
-          key: rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
-          paths:
-            - target/
 
       - when:
           condition:


### PR DESCRIPTION
saving the cache sometimes takes up to 3 minutes, and when the cache _is_ downloaded, it doesn't even save that much time.