### PR TITLE
chore: dont exclude certain git remotes

### DIFF
--- a/crates/rover-client/src/shared/git_context.rs
+++ b/crates/rover-client/src/shared/git_context.rs
@@ -305,6 +305,6 @@ mod tests {
     // regression test for https://github.com/apollographql/rover/issues/670
     fn it_does_not_panic_on_remote_urls_with_no_apparent_owner() {
         let clean = GitContext::sanitize_remote_url("ssh://user@github.com/repo-name");
-        assert_eq!(clean, Some("ssh://github.com/repo-name".to_string()));
+        assert_eq!(clean, Some("ssh://github.com:repo-name".to_string()));
     }
 }

--- a/crates/rover-client/src/shared/git_context.rs
+++ b/crates/rover-client/src/shared/git_context.rs
@@ -106,8 +106,6 @@ impl GitContext {
         // try to parse url into git info
         let parsed_remote_url = parse_git_remote(remote_url);
 
-        dbg!(&parsed_remote_url);
-
         if let Some(mut parsed_remote_url) = parsed_remote_url {
             // return None for any remote that does not have a host
             parsed_remote_url.host.as_ref()?;

--- a/crates/rover-client/src/shared/git_context.rs
+++ b/crates/rover-client/src/shared/git_context.rs
@@ -110,9 +110,7 @@ impl GitContext {
 
         if let Some(mut parsed_remote_url) = parsed_remote_url {
             // return None for any remote that does not have a host
-            if parsed_remote_url.host.is_none() {
-                return None;
-            };
+            parsed_remote_url.host.as_ref()?;
 
             let optional_user = parsed_remote_url.user.clone();
             parsed_remote_url = parsed_remote_url.trim_auth();


### PR DESCRIPTION
fixes #1349 

we used to exclude any git remote other than `gitlab` `github` or `bitbucket` - but we don't need to do that anymore, I believe that the studio api can determine whether or not to ignore a given `GitContext`.