### PR TITLE
chore: restore cache before installing rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ commands:
             equal: [*windows_executor, << parameters.platform >>]
           steps:
             - save_cache:
-                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rustup-toolchain.toml" }}
+                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}
                 paths:
                   - target/
                   - ~/.cargo/
@@ -417,7 +417,7 @@ commands:
             equal: [*windows_executor, << parameters.platform >>]
           steps:
             - save_cache:
-                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rustup-toolchain.toml" }}
+                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}
                 paths:
                   - target/
                   - C:\\Users\\circleci\.cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ commands:
         type: executor
     steps:
       - run:
-          command: cargo xtask << parameters.command >> << parameters.options >>
+          command: cargo run --package xtask -- << parameters.command >> << parameters.options >>
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,7 @@ commands:
       - when:
           condition:
             equal: [ *windows_executor, << parameters.platform >> ]
+
           steps:
             - run:
                 name: Install rustup
@@ -382,7 +383,7 @@ commands:
             - run:
                 name: Configure cargo for Windows
                 command: |
-                  Add-Content -path "${Env:USERPROFILE}\.cargo\config.toml" @"
+                  Set-Content -path "${Env:USERPROFILE}\.cargo\config.toml" @"
                   [net]
                   git-fetch-with-cli = true
                   "@
@@ -406,7 +407,7 @@ commands:
             equal: [*windows_executor, << parameters.platform >>]
           steps:
             - save_cache:
-                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rustup-toolchain.toml" }}
                 paths:
                   - target/
                   - ~/.cargo/
@@ -416,7 +417,7 @@ commands:
             equal: [*windows_executor, << parameters.platform >>]
           steps:
             - save_cache:
-                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+                key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rustup-toolchain.toml" }}
                 paths:
                   - target/
                   - C:\\Users\\circleci\.cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ commands:
         type: executor
     steps:
       - run:
-          command: cargo run --package xtask -- << parameters.command >> << parameters.options >>
+          command: cargo xtask << parameters.command >> << parameters.options >>
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,10 @@ commands:
       platform:
         type: executor
     steps:
+      - restore_cache:
+          keys:
+            - rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+            - rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>
       - unless:
           condition:
             equal: [ *windows_executor, << parameters.platform >> ]
@@ -394,11 +398,6 @@ commands:
       platform:
         type: executor
     steps:
-      - restore_cache:
-          keys:
-            - rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
-            - rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>
-
       - run:
           command: cargo xtask << parameters.command >> << parameters.options >>
 


### PR DESCRIPTION
follow-up to #1351 - restore the cache before even installing rust so that we don't have to do the reinstall.