### PR TITLE
chore: fix typo in subgraph publish output

### DIFF
--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -227,7 +227,7 @@ mod tests {
             "didUpdateGateway": true,
             "serviceWasCreated": true,
             "launchUrl": "test.com/launchurl",
-            "launchCliCopy": "Monitor your schema delivery progresson studio: test.com/launchurl",
+            "launchCliCopy": "You can monitor this launch in Apollo Studio: test.com/launchurl",
         });
         let update_response: UpdateResponse = serde_json::from_value(json_response).unwrap();
         let output = build_response(update_response);
@@ -241,8 +241,7 @@ mod tests {
                 subgraph_was_created: true,
                 launch_url: Some("test.com/launchurl".to_string()),
                 launch_cli_copy: Some(
-                    "Monitor your schema delivery progresson studio: test.com/launchurl"
-                        .to_string()
+                    "You can monitor this launch in Apollo Studio: test.com/launchurl".to_string()
                 ),
             }
         );

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1022,7 +1022,7 @@ mod tests {
             subgraph_was_created: true,
             launch_url: Some("test.com/launchurl".to_string()),
             launch_cli_copy: Some(
-                "Monitor your schema delivery progresson studio: test.com/launchurl".to_string(),
+                "You can monitor this launch in Apollo Studio: test.com/launchurl".to_string(),
             ),
         };
         let actual_json: JsonOutput = RoverOutput::SubgraphPublishResponse {
@@ -1043,7 +1043,7 @@ mod tests {
                 "subgraph_was_created": true,
                 "success": true,
                 "launch_url": "test.com/launchurl",
-                "launch_cli_copy": "Monitor your schema delivery progresson studio: test.com/launchurl",
+                "launch_cli_copy": "You can monitor this launch in Apollo Studio: test.com/launchurl",
             },
             "error": null
         });


### PR DESCRIPTION
fixes the typo described in #1337 

`s/Monitor your schema delivery progresson studio/You can monitor this launch in Apollo Studio`