### PR TITLE
release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,53 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🛠 Maintenance
 
-- **Link directly to API Keys page in Studio - @abernix, #1202**
-
-  The `rover config auth` command will now provide a link that takes you directly to the "API Keys" page where you can create a Personal API Key, rather than a page that requires you to click through to another page.
-
 ## 📚 Documentation -->
+
+# [0.9.1] - 2022-09-30
+
+## 🚀 Features
+
+- **Add templates for TypeScript, Go, Kotlin, and Java - @dbanty, #1347**
+
+  The `rover template` commands now include four more languages.
+
+## 🐛 Fixes
+
+- **Properly report errors when the first `rover dev` process starts up - @EverlastingBugstopper, #1342**
+
+  If something went wrong while starting the first `rover dev` process, it would attempt to start an attached process, which would fail with an inscrutable `the main rover dev session is no longer active` error message. Now, Rover properly reports issues with starting up the first `rover dev` session.
+
+- **Properly report plugin installation errors on `rover dev` startup - @EverlastingBugstopper, #1357**
+  
+  If a plugin failed to install when starting `rover dev`, the error wouldn't be reported properly. Now, if something goes wrong, the error message will be printed properly.
+
+- **Replace some misleading error suggestions regarding ports with `rover dev` - @EverlastingBugstopper, #1340**
+
+  Some errors suggested retrying the `rover dev` command with a different `--port` argument, which doesn't exist. In these cases, `rover dev` will suggest that you specify a different `--supergraph-port` argument instead.
+
+- **Don't exclude certain git remotes from `GitContext` - @EverlastingBugstopper, #1350 fixes #1349**
+
+  In v0.8.2, we started normalizing git remotes for anonymized telemetry. Unfortunately we started excluding git remotes that were not one of BitBucket, GitLab, or GitHub. We now record all of these properly.
+
+## 🛠 Maintenance
+
+- **Fix typo in `rover subgraph publish` output - @EverlastingBugstopper, #1358 fixes #1337**
+
+  Instead of saying "Monitor your schema delivery progresson studio", `rover subgraph publish` outputs "You can monitor this launch in Apollo Studio".
+
+- **Improve caching in CI - @EverlastingBugstopper, #1351 and #1352**
+
+  In CI builds, we now cache `/target` _and_ `~/.cargo`, instead of just `/target`. 
+
+- **Specify all dependencies in root `Cargo.toml` - @EverlastingBugstopper, #1344**
+
+  All of Rover's dependencies can now be viewed and updated in the root `Cargo.toml`, rather than needing to hunt around the workspace to update crates.
+
+- **Updates dependencies - @EverlastingBugstopper, #1346**
+
+  - assert_cmd 1 -> 2
+  - git2 0.14 -> 0.15
+  - online 3.0.1 -> 4.0.0
 
 # [0.9.0] - 2022-09-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12416e40e4a1883da10af9238c3dec2fd2573015df79a969ec947c8683e2f65"
+checksum = "f901785c93a542be795c2703370ddb5f84d4e38606357fc56fefa4b42ab25151"
 dependencies = [
  "rowan",
 ]
@@ -772,13 +772,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode 0.3.6",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi 0.3.9",
@@ -876,15 +876,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
@@ -900,12 +899,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell",
 ]
 
 [[package]]
@@ -1076,7 +1074,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
 dependencies = [
- "console 0.15.1",
+ "console 0.15.2",
  "tempfile",
  "zeroize",
 ]
@@ -1758,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaead50122b06e9a973ac20bc7445074d99ad9a0a0654934876908a9cec82c"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1963,9 +1961,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
@@ -2050,9 +2048,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libgit2-sys"
@@ -2372,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2413,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -2444,9 +2442,9 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "os_type"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df761f6470298359f84fcfb60d86db02acc22c251c37265c07a3d1057d2389"
+checksum = "e24d44c0eea30167516ed8f6daca4b5e3eebcde1bde1e4e6e08b809fb02c7ba5"
 dependencies = [
  "regex",
 ]
@@ -2695,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2910,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ansi_term",
  "apollo-federation-types",
@@ -2923,7 +2921,7 @@ dependencies = [
  "binstall",
  "calm_io",
  "chrono",
- "console 0.15.1",
+ "console 0.15.2",
  "crossbeam-channel",
  "crossterm",
  "ctrlc",
@@ -2995,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.15.9"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aeb3c95eac7794161baf500b5d4647217ffb32b6660c04d3bb087c834cb58f4"
+checksum = "5811547e7ba31e903fe48c8ceab10d40d70a101f3d15523c847cce91aa71f332"
 dependencies = [
  "countme",
  "hashbrown",
@@ -3057,7 +3055,7 @@ dependencies = [
  "buildstructor",
  "camino",
  "clap",
- "console 0.15.1",
+ "console 0.15.2",
  "log",
  "rayon",
  "which",
@@ -3437,9 +3435,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3555,18 +3553,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3651,9 +3649,9 @@ checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3661,7 +3659,6 @@ dependencies = [
  "memchr",
  "mio 0.8.4",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.9.0"
+version = "0.9.1"
 default-run = "rover"
 
 publish = false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rover graph publish --schema ./path-to-valid-schema test@cats
 
 ```console
 $ rover --help
-Rover 0.9.0
+Rover 0.9.1
 Apollo Developers <opensource@apollographql.com>
 
 Rover - Your Graph Companion
@@ -70,6 +70,7 @@ USAGE:
 OPTIONS:
         --client-timeout <CLIENT_TIMEOUT>
             Configure the timeout length (in seconds) when performing HTTP(S) requests
+            
             [default: 30]
 
     -h, --help
@@ -77,9 +78,9 @@ OPTIONS:
 
         --insecure-accept-invalid-certs
             Accept invalid certificates when performing HTTPS requests.
-
+            
             You should think very carefully before using this flag.
-
+            
             If invalid certificates are trusted, any certificate for any site will be trusted for
             use. This includes expired certificates. This introduces significant vulnerabilities,
             and should only be used as a last resort.
@@ -95,10 +96,12 @@ OPTIONS:
 
     -l, --log <LOG_LEVEL>
             Specify Rover's log level
+            
             [possible values: error, warn, info, debug, trace]
 
         --output <OUTPUT_TYPE>
             Specify Rover's output type
+            
             [default: plain]
             [possible values: json, plain]
 
@@ -162,7 +165,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-curl -sSL https://rover.apollo.dev/nix/v0.9.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.9.1 | sh
 ```
 
 You will need `curl` installed on your system to run the above installation commands. You can get the latest version from [the curl downloads page](https://curl.se/download.html).
@@ -180,7 +183,7 @@ To install a specific version of Rover (note the `v` prefixing the version numbe
 > Note: If you're installing Rover in a CI environment, it's best to target a specific version rather than using the latest URL, since future major breaking changes could affect CI workflows otherwise.
 
 ```bash
-iwr 'https://rover.apollo.dev/win/v0.9.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.9.1' | iex
 ```
 
 #### npm installer

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -42,12 +42,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
-      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
+      "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.19.0",
+        "@babel/types": "^7.19.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
-      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
+      "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -231,19 +231,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
-      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
+      "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
+        "@babel/generator": "^7.19.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.1",
-        "@babel/types": "^7.19.0",
+        "@babel/parser": "^7.19.3",
+        "@babel/types": "^7.19.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -252,13 +252,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
-      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
+      "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.6.tgz",
-      "integrity": "sha512-HMA7rcJLQA3dJwWRG2271mRCdh0SLaK5+FPg+F7JIa3aF5fRdN4pVHNDaAjQeyKOQ2afjgjO5FvOyJwv/ve7Bg==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.8.tgz",
+      "integrity": "sha512-h+Uce0Np0eKj7wILOvlffRQ9jEQ4KelNXfqG8A2w+2sO2P6CbKsR7bJ4ch9lcUdCBbZ4Wg6L/K+1C4NRFfzbNw==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/batch-execute": "8.5.6",
@@ -499,15 +499,15 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.2.tgz",
-      "integrity": "sha512-ZVG3kDEJ88zLfqYtVmI36RUzaP/0bPBcJfBH8whMYL620tE6kizEQsON8iKsxcU1bWB5D7m9ZVFqW4eZ5EqVWw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.4.tgz",
+      "integrity": "sha512-7yGrJJNcqVQIplCyVLk7tW2mAgYyZ06FRmCBnzw3B61+aIjFavrm6YlnKkhdqYSYyFmIbVcigdP3vkoYIu23TA==",
       "dev": true,
       "dependencies": {
         "@ardatan/sync-fetch": "0.0.1",
-        "@graphql-tools/delegate": "9.0.6",
+        "@graphql-tools/delegate": "9.0.8",
         "@graphql-tools/utils": "8.12.0",
-        "@graphql-tools/wrap": "9.2.1",
+        "@graphql-tools/wrap": "9.2.3",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.4.0",
         "dset": "^3.1.2",
@@ -536,12 +536,12 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.1.tgz",
-      "integrity": "sha512-W8bzJijTZDNi8e1oM2AMG89CtvfTYaJ9lCe0dYMN+a+OPMhRfgR9+eO7ALcUa9y4MTu+YEDVjUq0ZboaSvesyA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.3.tgz",
+      "integrity": "sha512-aiLjcAuUwcvA1mF25c7KFDPXEdQDpo6bTDyAMCSlFXpF4T01hoxLERmfmbRmsmy/dP80ZB31a+t70aspVdqZSA==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/delegate": "9.0.6",
+        "@graphql-tools/delegate": "9.0.8",
         "@graphql-tools/schema": "9.0.4",
         "@graphql-tools/utils": "8.12.0",
         "tslib": "^2.4.0",
@@ -724,9 +724,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
+      "version": "18.7.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.4.tgz",
-      "integrity": "sha512-/c2u1blMAXHVXneZjVLyE0AwdRuuFpv2P3ghNz2QtpHed+25WdSkTi7XxICwuaRsl/mMgundCzSy1352rZgWPg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.6.tgz",
+      "integrity": "sha512-DyeD0lN4Bk2Pdd/n4iT7g3rt4ZvvwSq+Yl2eF/Ku+odw1nVS7foww5JlAlwaJA4ZEGiZYT5oDagltX52UWKaXg==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
@@ -756,7 +756,7 @@
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
-        "undici": "^5.8.0",
+        "undici": "^5.10.0",
         "web-streams-polyfill": "^3.2.0"
       }
     },
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.0.tgz",
-      "integrity": "sha512-HbWIuR5O+XO5Oj9SZ5bzgrD4nN+rfhrm2PMb0FVx+t+XIvC45n8F0oTNnztXtspWGw0i2IzHaUWFD5LzV1JB4A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+      "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -2345,9 +2345,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2549,12 +2549,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
-      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
+      "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.19.0",
+        "@babel/types": "^7.19.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       }
@@ -2675,9 +2675,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
-      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
+      "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
       "dev": true
     },
     "@babel/template": {
@@ -2692,31 +2692,31 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
-      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
+      "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
+        "@babel/generator": "^7.19.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.1",
-        "@babel/types": "^7.19.0",
+        "@babel/parser": "^7.19.3",
+        "@babel/types": "^7.19.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
-      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
+      "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2813,9 +2813,9 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.6.tgz",
-      "integrity": "sha512-HMA7rcJLQA3dJwWRG2271mRCdh0SLaK5+FPg+F7JIa3aF5fRdN4pVHNDaAjQeyKOQ2afjgjO5FvOyJwv/ve7Bg==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.8.tgz",
+      "integrity": "sha512-h+Uce0Np0eKj7wILOvlffRQ9jEQ4KelNXfqG8A2w+2sO2P6CbKsR7bJ4ch9lcUdCBbZ4Wg6L/K+1C4NRFfzbNw==",
       "dev": true,
       "requires": {
         "@graphql-tools/batch-execute": "8.5.6",
@@ -2910,15 +2910,15 @@
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.2.tgz",
-      "integrity": "sha512-ZVG3kDEJ88zLfqYtVmI36RUzaP/0bPBcJfBH8whMYL620tE6kizEQsON8iKsxcU1bWB5D7m9ZVFqW4eZ5EqVWw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.4.tgz",
+      "integrity": "sha512-7yGrJJNcqVQIplCyVLk7tW2mAgYyZ06FRmCBnzw3B61+aIjFavrm6YlnKkhdqYSYyFmIbVcigdP3vkoYIu23TA==",
       "dev": true,
       "requires": {
         "@ardatan/sync-fetch": "0.0.1",
-        "@graphql-tools/delegate": "9.0.6",
+        "@graphql-tools/delegate": "9.0.8",
         "@graphql-tools/utils": "8.12.0",
-        "@graphql-tools/wrap": "9.2.1",
+        "@graphql-tools/wrap": "9.2.3",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.4.0",
         "dset": "^3.1.2",
@@ -2941,12 +2941,12 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.1.tgz",
-      "integrity": "sha512-W8bzJijTZDNi8e1oM2AMG89CtvfTYaJ9lCe0dYMN+a+OPMhRfgR9+eO7ALcUa9y4MTu+YEDVjUq0ZboaSvesyA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.3.tgz",
+      "integrity": "sha512-aiLjcAuUwcvA1mF25c7KFDPXEdQDpo6bTDyAMCSlFXpF4T01hoxLERmfmbRmsmy/dP80ZB31a+t70aspVdqZSA==",
       "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "9.0.6",
+        "@graphql-tools/delegate": "9.0.8",
         "@graphql-tools/schema": "9.0.4",
         "@graphql-tools/utils": "8.12.0",
         "tslib": "^2.4.0",
@@ -3099,9 +3099,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
+      "version": "18.7.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3120,9 +3120,9 @@
       }
     },
     "@whatwg-node/fetch": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.4.tgz",
-      "integrity": "sha512-/c2u1blMAXHVXneZjVLyE0AwdRuuFpv2P3ghNz2QtpHed+25WdSkTi7XxICwuaRsl/mMgundCzSy1352rZgWPg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.6.tgz",
+      "integrity": "sha512-DyeD0lN4Bk2Pdd/n4iT7g3rt4ZvvwSq+Yl2eF/Ku+odw1nVS7foww5JlAlwaJA4ZEGiZYT5oDagltX52UWKaXg==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
@@ -3131,7 +3131,7 @@
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
-        "undici": "^5.8.0",
+        "undici": "^5.10.0",
         "web-streams-polyfill": "^3.2.0"
       }
     },
@@ -3319,9 +3319,9 @@
       }
     },
     "cosmiconfig-typescript-loader": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.0.tgz",
-      "integrity": "sha512-HbWIuR5O+XO5Oj9SZ5bzgrD4nN+rfhrm2PMb0FVx+t+XIvC45n8F0oTNnztXtspWGw0i2IzHaUWFD5LzV1JB4A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+      "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
       "dev": true,
       "requires": {}
     },
@@ -4278,9 +4278,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "peer": true
     },

--- a/docs/source/ci-cd.md
+++ b/docs/source/ci-cd.md
@@ -45,7 +45,7 @@ jobs:
           name: Install
           command: |
             # download and install Rover
-            curl -sSL https://rover.apollo.dev/nix/v0.9.0 | sh
+            curl -sSL https://rover.apollo.dev/nix/v0.9.1 | sh
 
             # This allows the PATH changes to persist to the next `run` step
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.9.0 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.9.1 | sh
 
           # Add Rover to the $GITHUB_PATH so it can be used in another step
           # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
@@ -206,10 +206,10 @@ Normally when installing, Rover adds the path of its executable to your `$PATH`.
 
 To avoid this issue, do one of the following:
 - Use the script, but reference `rover` by its full path (`$HOME/.rover/bin/rover`)
-- Download the latest release via cURL and extract the binary like so (this downloads Rover `0.9.0` for Linux x86 architectures):
+- Download the latest release via cURL and extract the binary like so (this downloads Rover `0.9.1` for Linux x86 architectures):
 
     ```
-    curl -L https://github.com/apollographql/rover/releases/download/v0.9.0/rover-v0.9.0-x86_64-unknown-linux-gnu.tar.gz | tar --strip-components=1 -zxv
+    curl -L https://github.com/apollographql/rover/releases/download/v0.9.1/rover-v0.9.1-x86_64-unknown-linux-gnu.tar.gz | tar --strip-components=1 -zxv
     ```
 
 #### Permission issues

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.9.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.9.1 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -37,7 +37,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.9.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.9.1' | iex
 ```
 
 ### `npm` installer

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.9.0"
+PACKAGE_VERSION="v0.9.1"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.9.0'
+$package_version = 'v0.9.1'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.9.1] - 2022-09-30

## 🚀 Features

- **Add templates for TypeScript, Go, Kotlin, and Java - @dbanty, #1347**

  The `rover template` commands now include four more languages.

## 🐛 Fixes

- **Properly report errors when the first `rover dev` process starts up - @EverlastingBugstopper, #1342**

  If something went wrong while starting the first `rover dev` process, it would attempt to start an attached process, which would fail with an inscrutable `the main rover dev session is no longer active` error message. Now, Rover properly reports issues with starting up the first `rover dev` session.

- **Properly report plugin installation errors on `rover dev` startup - @EverlastingBugstopper, #1357**
  
  If a plugin failed to install when starting `rover dev`, the error wouldn't be reported properly. Now, if something goes wrong, the error message will be printed properly.

- **Replace some misleading error suggestions regarding ports with `rover dev` - @EverlastingBugstopper, #1340**

  Some errors suggested retrying the `rover dev` command with a different `--port` argument, which doesn't exist. In these cases, `rover dev` will suggest that you specify a different `--supergraph-port` argument instead.

- **Don't exclude certain git remotes from `GitContext` - @EverlastingBugstopper, #1350 fixes #1349**

  In v0.8.2, we started normalizing git remotes for anonymized telemetry. Unfortunately we started excluding git remotes that were not one of BitBucket, GitLab, or GitHub. We now record all of these properly.

## 🛠 Maintenance

- **Fix typo in `rover subgraph publish` output - @EverlastingBugstopper, #1358 fixes #1337**

  Instead of saying "Monitor your schema delivery progresson studio", `rover subgraph publish` outputs "You can monitor this launch in Apollo Studio".

- **Improve caching in CI - @EverlastingBugstopper, #1351 and #1352**

  In CI builds, we now cache `/target` _and_ `~/.cargo`, instead of just `/target`. 

- **Specify all dependencies in root `Cargo.toml` - @EverlastingBugstopper, #1344**

  All of Rover's dependencies can now be viewed and updated in the root `Cargo.toml`, rather than needing to hunt around the workspace to update crates.

- **Updates dependencies - @EverlastingBugstopper, #1346**

  - assert_cmd 1 -> 2
  - git2 0.14 -> 0.15
  - online 3.0.1 -> 4.0.0