### PR TITLE
chore: use main variant of platform API

### DIFF
--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -72,7 +72,7 @@ fn update_schema(hash: &str, schema: &str) -> Result<()> {
 
 const QUERY: &str = r#"query FetchSchema($fetchDocument: Boolean!) {
   graph(id: "apollo-platform") {
-    variant(name: "current") {
+    variant(name: "main") {
       latestPublication {
         schema {
           hash


### PR DESCRIPTION
the platform API renamed the variant from `current` to `main`, so builds are failing on the `main` branch (again). this PR fixes it.