### PR TITLE
chore: fix implementation of header option

### DIFF
--- a/src/options/introspect.rs
+++ b/src/options/introspect.rs
@@ -20,7 +20,7 @@ pub struct IntrospectOpts {
 
     // The `name` here is for the help text and error messages, to print like
     // --header <key:value> rather than the plural field name --header <headers>
-    #[clap(name="key:value", multiple=true, long="header", short='H', parse(try_from_str = parse_header))]
+    #[clap(name="key:value", long="header", short='H', parse(try_from_str = parse_header))]
     #[serde(skip_serializing)]
     pub headers: Option<Vec<(String, String)>>,
 


### PR DESCRIPTION
Fixes #1365 by updating the application behavior for the `--header` flags used by `rover {sub}graph introspect` commands.

This PR is potentially a breaking change if you were previously passing header values as `--header "Header-1: value" "Header-2: value"`. After this change, you _must_ conform to what we have in the documentation, which indicates separate instances of the `--header` argument for each header, like so: `--header "Header-1: value" --header "Header-2: value"`.

This change was inspired by the discussion I had with the very helpful @epage on [this issue](https://github.com/clap-rs/clap/issues/4346), check it out if you'd like more context!