### PR TITLE
fix(build.rs) minor logic error

### DIFF
--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
     let hash_path = Utf8PathBuf::from(".schema/hash.id");
 
     // skip updating the schema if we already have an etag or we're offline
-    let should_update_schema = !(hash_path.exists()) || online::check(None).is_ok();
+    let should_update_schema = !(hash_path.exists()) && online::check(None).is_ok();
 
     if should_update_schema {
         if !(hash_path.exists()) {


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

I was trying to build rover in nixpkgs, where we prefetch the schema and hash.id since otherwise the build would fail. I noticed though even though the file existed it would still try and download it, and would fail as expected. 

It seems to be `||` is the wrong operator here - if the file exists already, it'll check if you're online. 