### PR TITLE
chore: updates introspector-gadget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,17 +2215,15 @@ checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "introspector-gadget"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6a5345dd15741225868a205140b730de97b4f00b7d22a8520ae9d3e6266518"
+checksum = "b9360a9dd04f347bf40cbb128bf622d4ef524fb89aee8cff836b88471d4f14dd"
 dependencies = [
  "apollo-encoder",
  "backoff",
  "graphql_client",
- "humantime",
  "hyper",
  "reqwest",
- "semver",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ apollo-federation-types = { git = "https://github.com/apollographql/federation-r
 billboard = { git = "https://github.com/EverlastingBugstopper/billboard.git", branch = "main" }
 
 # https://github.com/apollographql/introspector-gadget
-introspector-gadget = "0.1"
+introspector-gadget = "0.2"
 
 # https://github.com/EverlastingBugstopper/awc
 saucer = { git = "https://github.com/EverlastingBugstopper/awc.git", rev = "fd8df605e39fdbdf4985f255a7390afccc2600cd" }

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -8,8 +8,8 @@ use introspector_gadget::error::RoverClientError as IntrospectorGadgetError;
 use houston::{Credential, CredentialOrigin};
 
 use graphql_client::GraphQLQuery;
+use reqwest::blocking::Client as ReqwestClient;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{blocking::Client as ReqwestClient, Error as ReqwestError};
 
 /// Represents a client for making GraphQL requests to Apollo Studio.
 pub struct StudioClient {
@@ -28,13 +28,13 @@ impl StudioClient {
         version: &str,
         is_sudo: bool,
         client: ReqwestClient,
-    ) -> Result<StudioClient, ReqwestError> {
-        Ok(StudioClient {
+    ) -> StudioClient {
+        StudioClient {
             credential,
-            client: GraphQLClient::new(graphql_endpoint, client)?,
+            client: GraphQLClient::new(graphql_endpoint, client),
             version: version.to_string(),
             is_sudo,
-        })
+        }
     }
 
     /// Client method for making a GraphQL request to Apollo Studio.

--- a/crates/rover-client/tests/client.rs
+++ b/crates/rover-client/tests/client.rs
@@ -1,42 +1,5 @@
-use reqwest::blocking::Client;
-const STUDIO_PROD_API_ENDPOINT: &str = "https://api.apollographql.com/graphql";
-
-pub(crate) fn get_client() -> Client {
-    Client::builder()
-        .gzip(true)
-        .brotli(true)
-        .build()
-        .expect("Could not create reqwest Client")
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use houston::{Credential, CredentialOrigin};
-    use rover_client::blocking::{GraphQLClient, StudioClient};
-
-    use crate::STUDIO_PROD_API_ENDPOINT;
-
-    #[test]
-    fn it_can_build_client() {
-        assert!(GraphQLClient::new(STUDIO_PROD_API_ENDPOINT, get_client()).is_ok(),);
-    }
-
-    #[test]
-    fn it_can_build_studio_client() {
-        assert!(StudioClient::new(
-            Credential {
-                api_key: "api:key:here".to_string(),
-                origin: CredentialOrigin::EnvVar,
-            },
-            "0.1.0",
-            STUDIO_PROD_API_ENDPOINT,
-            false,
-            get_client(),
-        )
-        .is_ok());
-    }
-
     #[test]
     fn schema_at_stable_path() {
         // this path must remain stable as we upload it as part of our release process

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -29,7 +29,7 @@ impl Introspect {
     }
 
     pub fn exec(&self, client: &Client, should_retry: bool) -> Result<String> {
-        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone())?;
+        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone());
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -31,7 +31,7 @@ impl Introspect {
     }
 
     pub fn exec(&self, client: &Client, should_retry: bool) -> Result<String> {
-        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone())?;
+        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone());
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -68,7 +68,7 @@ pub(crate) fn resolve_supergraph_yaml(
                 // given a federated introspection URL, use subgraph introspect to
                 // obtain SDL and add it to subgraph_definition.
                 let client =
-                    GraphQLClient::new(subgraph_url.as_ref(), client_config.get_reqwest_client()?)?;
+                    GraphQLClient::new(subgraph_url.as_ref(), client_config.get_reqwest_client()?);
 
                 let introspection_response = introspect::run(
                     SubgraphIntrospectInput {

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -162,6 +162,6 @@ impl StudioClientConfig {
             &self.version,
             self.is_sudo,
             self.get_reqwest_client()?,
-        )?)
+        ))
     }
 }


### PR DESCRIPTION
This PR updates `introspector-gadget` to `v0.2.0` that removes the `Result` type from its return signature. This considerably simplifies implementation code since unnecessary results don't need to be handled.