### PR TITLE
chore: only cache deps, not target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ parameters:
   cache_version:
     type: string
     # increment this version to invalidate all caches
-    default: v1.{{ checksum "rust-toolchain.toml" }}
+    default: v2.{{ checksum "rust-toolchain.toml" }}
 
 # The main workflows executed for Rover
 workflows:
@@ -409,7 +409,6 @@ commands:
             - save_cache:
                 key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}
                 paths:
-                  - target/
                   - ~/.cargo/
       
       - when:
@@ -419,7 +418,6 @@ commands:
             - save_cache:
                 key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}
                 paths:
-                  - target/
                   - C:\\Users\\circleci\.cargo
 
 


### PR DESCRIPTION
in CI - the router only caches `~/.cargo` and not `/target`, because `/target` makes the cache much too big, resulting in large download/upload times. caching only `~/.cargo` is likely the best path forward here.