### PR TITLE
chore: parallelize supergraph.yaml resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "344a1afec31ce0273dc2061105b04e5c4ab620fe0748a76244338aa893db42f3"
 [[package]]
 name = "apollo-federation-types"
 version = "0.6.1"
-source = "git+https://github.com/apollographql/federation-rs?rev=fdea369a6bfa32c8620b526b3d7afe661569c069#fdea369a6bfa32c8620b526b3d7afe661569c069"
+source = "git+https://github.com/apollographql/federation-rs?rev=ad0626a7f7e1851f2179aba2b87e22b5b371718a#ad0626a7f7e1851f2179aba2b87e22b5b371718a"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ timber = { path = "./crates/timber" }
 apollo-parser = "0.2"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "fdea369a6bfa32c8620b526b3d7afe661569c069" }
+apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", rev = "ad0626a7f7e1851f2179aba2b87e22b5b371718a" }
 # apollo-federation-types = "0.5"
 # apollo-federation-types = { path = "../federation-rs/apollo-federation-types" }
 

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -1,6 +1,6 @@
 use crate::command::supergraph::resolve_supergraph_yaml;
 use crate::utils::emoji::Emoji;
-use crate::utils::{client::StudioClientConfig, parsers::FileDescriptorType};
+use crate::utils::{client::StudioClientConfig, color::Style, parsers::FileDescriptorType};
 use crate::{
     anyhow,
     command::{
@@ -80,6 +80,11 @@ impl Compose {
         override_install_path: Option<Utf8PathBuf>,
         client_config: StudioClientConfig,
     ) -> Result<RoverOutput> {
+        eprintln!(
+            "{}resolving SDL for subgraphs defined in {}",
+            Emoji::Hourglass,
+            Style::Path.paint(&self.supergraph_yaml.to_string())
+        );
         let mut supergraph_config = resolve_supergraph_yaml(
             &self.supergraph_yaml,
             client_config.clone(),

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -1,8 +1,9 @@
 use apollo_federation_types::{
     build::SubgraphDefinition,
-    config::{FederationVersion, SchemaSource, SupergraphConfig},
+    config::{FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig},
 };
 use apollo_parser::{ast, Parser};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use saucer::Fs;
 
 use std::{collections::HashMap, str::FromStr};
@@ -23,8 +24,6 @@ pub(crate) fn resolve_supergraph_yaml(
     client_config: StudioClientConfig,
     profile_opt: &ProfileOpt,
 ) -> Result<SupergraphConfig> {
-    let mut subgraph_definitions = Vec::new();
-
     let err_no_routing_url = || {
         let err = anyhow!("No routing_url found for schema file.");
         let mut err = RoverError::new(err);
@@ -35,102 +34,138 @@ pub(crate) fn resolve_supergraph_yaml(
         .read_file_descriptor("supergraph config", &mut std::io::stdin())?;
     let supergraph_config = SupergraphConfig::new_from_yaml(&contents)?;
     let maybe_specified_federation_version = supergraph_config.get_federation_version();
+    let supergraph_config = supergraph_config
+        .into_iter()
+        .collect::<Vec<(String, SubgraphConfig)>>();
 
-    for (subgraph_name, subgraph_data) in supergraph_config.into_iter() {
-        match &subgraph_data.schema {
-            SchemaSource::File { file } => {
-                let relative_schema_path = match unresolved_supergraph_yaml {
-                    FileDescriptorType::File(config_path) => match config_path.parent() {
-                        Some(parent) => {
-                            let mut schema_path = parent.to_path_buf();
-                            schema_path.push(file);
-                            schema_path
-                        }
-                        None => file.clone(),
-                    },
-                    FileDescriptorType::Stdin => file.clone(),
-                };
+    let subgraph_definition_results: Vec<Result<SubgraphDefinition>> = supergraph_config
+        .into_par_iter()
+        .map(|(subgraph_name, subgraph_data)| {
+            match &subgraph_data.schema {
+                SchemaSource::File { file } => {
+                    let relative_schema_path = match unresolved_supergraph_yaml {
+                        FileDescriptorType::File(config_path) => match config_path.parent() {
+                            Some(parent) => {
+                                let mut schema_path = parent.to_path_buf();
+                                schema_path.push(file);
+                                schema_path
+                            }
+                            None => file.clone(),
+                        },
+                        FileDescriptorType::Stdin => file.clone(),
+                    };
 
-                let schema = Fs::read_file(&relative_schema_path, "").map_err(|e| {
-                    let mut err = RoverError::new(e);
-                    err.set_suggestion(Suggestion::ValidComposeFile);
-                    err
-                })?;
+                    Fs::read_file(&relative_schema_path, "")
+                        .map_err(|e| {
+                            let mut err = RoverError::new(e);
+                            err.set_suggestion(Suggestion::ValidComposeFile);
+                            err
+                        })
+                        .and_then(|schema| {
+                            subgraph_data
+                                .routing_url
+                                .clone()
+                                .ok_or_else(err_no_routing_url)
+                                .map(|url| SubgraphDefinition::new(subgraph_name, url, &schema))
+                        })
+                }
+                SchemaSource::SubgraphIntrospection { subgraph_url } => {
+                    client_config
+                        .get_reqwest_client()
+                        .map_err(RoverError::from)
+                        .and_then(|reqwest_client| {
+                            let client = GraphQLClient::new(subgraph_url.as_ref(), reqwest_client);
 
-                let url = &subgraph_data
+                            // given a federated introspection URL, use subgraph introspect to
+                            // obtain SDL and add it to subgraph_definition.
+                            introspect::run(
+                                SubgraphIntrospectInput {
+                                    headers: HashMap::new(),
+                                },
+                                &client,
+                                false,
+                            )
+                            .map(|introspection_response| {
+                                let schema = introspection_response.result;
+
+                                // We don't require a routing_url in config for this variant of a schema,
+                                // if one isn't provided, just use the URL they passed for introspection.
+                                let url = &subgraph_data
+                                    .routing_url
+                                    .clone()
+                                    .unwrap_or_else(|| subgraph_url.to_string());
+                                SubgraphDefinition::new(subgraph_name, url, &schema)
+                            })
+                            .map_err(RoverError::from)
+                        })
+                }
+                SchemaSource::Subgraph {
+                    graphref: graph_ref,
+                    subgraph,
+                } => {
+                    client_config
+                        .get_authenticated_client(profile_opt)
+                        .map_err(RoverError::from)
+                        .and_then(|authenticated_client| {
+                            // given a graph_ref and subgraph, run subgraph fetch to
+                            // obtain SDL and add it to subgraph_definition.
+                            fetch::run(
+                                SubgraphFetchInput {
+                                    graph_ref: GraphRef::from_str(graph_ref)?,
+                                    subgraph_name: subgraph.clone(),
+                                },
+                                &authenticated_client,
+                            )
+                            .map_err(RoverError::from)
+                            .and_then(|result| {
+                                // We don't require a routing_url in config for this variant of a schema,
+                                // if one isn't provided, just use the routing URL from the graph registry (if it exists).
+                                if let rover_client::shared::SdlType::Subgraph {
+                                    routing_url: Some(graph_registry_routing_url),
+                                } = result.sdl.r#type
+                                {
+                                    let url = subgraph_data
+                                        .routing_url
+                                        .clone()
+                                        .unwrap_or(graph_registry_routing_url);
+                                    Ok(SubgraphDefinition::new(
+                                        subgraph_name,
+                                        url,
+                                        &result.sdl.contents,
+                                    ))
+                                } else {
+                                    Err(err_no_routing_url())
+                                }
+                            })
+                        })
+                }
+                SchemaSource::Sdl { sdl } => subgraph_data
                     .routing_url
                     .clone()
-                    .ok_or_else(err_no_routing_url)?;
-
-                subgraph_definitions.push(SubgraphDefinition::new(subgraph_name, url, &schema));
+                    .ok_or_else(err_no_routing_url)
+                    .map(|url| SubgraphDefinition::new(subgraph_name, url, sdl)),
             }
-            SchemaSource::SubgraphIntrospection { subgraph_url } => {
-                // given a federated introspection URL, use subgraph introspect to
-                // obtain SDL and add it to subgraph_definition.
-                let client =
-                    GraphQLClient::new(subgraph_url.as_ref(), client_config.get_reqwest_client()?);
+        })
+        .collect();
 
-                let introspection_response = introspect::run(
-                    SubgraphIntrospectInput {
-                        headers: HashMap::new(),
-                    },
-                    &client,
-                    false,
-                )?;
-                let schema = introspection_response.result;
+    let mut subgraph_definitions = Vec::new();
+    let mut subgraph_definition_errors = Vec::new();
 
-                // We don't require a routing_url in config for this variant of a schema,
-                // if one isn't provided, just use the URL they passed for introspection.
-                let url = &subgraph_data
-                    .routing_url
-                    .clone()
-                    .unwrap_or_else(|| subgraph_url.to_string());
-
-                subgraph_definitions.push(SubgraphDefinition::new(subgraph_name, url, &schema));
-            }
-            SchemaSource::Subgraph {
-                graphref: graph_ref,
-                subgraph,
-            } => {
-                // given a graph_ref and subgraph, run subgraph fetch to
-                // obtain SDL and add it to subgraph_definition.
-                let client = client_config.get_authenticated_client(profile_opt)?;
-                let result = fetch::run(
-                    SubgraphFetchInput {
-                        graph_ref: GraphRef::from_str(graph_ref)?,
-                        subgraph_name: subgraph.clone(),
-                    },
-                    &client,
-                )?;
-
-                // We don't require a routing_url in config for this variant of a schema,
-                // if one isn't provided, just use the routing URL from the graph registry (if it exists).
-                let url = if let rover_client::shared::SdlType::Subgraph {
-                    routing_url: Some(graph_registry_routing_url),
-                } = result.sdl.r#type
-                {
-                    Ok(subgraph_data
-                        .routing_url
-                        .clone()
-                        .unwrap_or(graph_registry_routing_url))
-                } else {
-                    Err(err_no_routing_url())
-                }?;
-
-                subgraph_definitions.push(SubgraphDefinition::new(
-                    subgraph_name,
-                    url,
-                    &result.sdl.contents,
-                ));
-            }
-            SchemaSource::Sdl { sdl } => {
-                let url = &subgraph_data
-                    .routing_url
-                    .clone()
-                    .ok_or_else(err_no_routing_url)?;
-                subgraph_definitions.push(SubgraphDefinition::new(subgraph_name, url, sdl))
-            }
+    for subgraph_definition_result in subgraph_definition_results {
+        match subgraph_definition_result {
+            Ok(subgraph_definition) => subgraph_definitions.push(subgraph_definition),
+            Err(e) => subgraph_definition_errors.push(e),
         }
+    }
+
+    if !subgraph_definition_errors.is_empty() {
+        for subgraph_definition_error in &subgraph_definition_errors {
+            subgraph_definition_error.print()?;
+        }
+        return Err(RoverError::new(anyhow!(
+            "Failed to resolve schemas for {} subgraphs.",
+            subgraph_definition_errors.len()
+        )));
     }
 
     let mut resolved_supergraph_config: SupergraphConfig = subgraph_definitions.into();

--- a/src/error/metadata/code.rs
+++ b/src/error/metadata/code.rs
@@ -43,6 +43,7 @@ pub enum Code {
     E035,
     E036,
     E037,
+    E038,
 }
 
 impl Display for Code {
@@ -93,6 +94,7 @@ impl Code {
             (Code::E035, include_str!("./codes/E035.md").to_string()),
             (Code::E036, include_str!("./codes/E036.md").to_string()),
             (Code::E037, include_str!("./codes/E037.md").to_string()),
+            (Code::E038, include_str!("./codes/E038.md").to_string()),
         ];
         contents.into_iter().collect()
     }

--- a/src/error/metadata/code.rs
+++ b/src/error/metadata/code.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display};
 use strum_macros::EnumString;
 
 /// `Code` contains the error codes associated with specific errors.
-#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, EnumString)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, EnumString)]
 pub enum Code {
     E001,
     E002,

--- a/src/error/metadata/codes/E038.md
+++ b/src/error/metadata/codes/E038.md
@@ -1,0 +1,3 @@
+This error occurs when a supergraph configuration file failed to resolve all of the subgraph schemas.
+
+This error should include information about _why_ the schemas could not be resolved, and include the name of the subgraph that could not be resolved. See [the docs](https://www.apollographql.com/docs/rover/commands/supergraphs#yaml-configuration-file) for more information on the configuration format.

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -102,7 +102,10 @@ impl From<&mut saucer::Error> for Metadata {
                     num_subgraphs,
                 } => {
                     if source.is_config {
-                        (Some(Suggestion::FixSupergraphConfigErrors), None)
+                        (
+                            Some(Suggestion::FixSupergraphConfigErrors),
+                            Some(Code::E038),
+                        )
                     } else {
                         (
                             Some(Suggestion::FixCompositionErrors {

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -98,14 +98,20 @@ impl From<&mut saucer::Error> for Metadata {
                     Some(Code::E029),
                 ),
                 RoverClientError::BuildErrors {
-                    source: _,
+                    source,
                     num_subgraphs,
-                } => (
-                    Some(Suggestion::FixCompositionErrors {
-                        num_subgraphs: *num_subgraphs,
-                    }),
-                    Some(Code::E029),
-                ),
+                } => {
+                    if source.is_config {
+                        (Some(Suggestion::FixSupergraphConfigErrors), None)
+                    } else {
+                        (
+                            Some(Suggestion::FixCompositionErrors {
+                                num_subgraphs: *num_subgraphs,
+                            }),
+                            Some(Code::E029),
+                        )
+                    }
+                }
                 RoverClientError::OperationCheckFailure {
                     graph_ref,
                     check_response: _,

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -185,7 +185,7 @@ impl Display for Suggestion {
             Suggestion::FixCompositionErrors { num_subgraphs } => {
                 let prefix = match num_subgraphs {
                     1 => "The subgraph schema you provided is invalid.".to_string(),
-                    _ => format!("The subgraph schemas you provided are incompatible with each other.")
+                    _ => "The subgraph schemas you provided are incompatible with each other.".to_string()
                 };
                 format!("{} See {} for more information on resolving build errors.", prefix, Style::Link.paint("https://www.apollographql.com/docs/federation/errors/"))
             },

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -9,7 +9,7 @@ use crate::utils::env::RoverEnvKey;
 use serde::Serialize;
 
 /// `Suggestion` contains possible suggestions for remedying specific errors.
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub enum Suggestion {
     SubmitIssue,
     SetConfigHome,
@@ -41,6 +41,7 @@ pub enum Suggestion {
         graph_ref: GraphRef,
         subgraph: String,
     },
+    FixSupergraphConfigErrors,
     FixCompositionErrors {
         num_subgraphs: usize,
     },
@@ -178,10 +179,13 @@ impl Display for Suggestion {
             Suggestion::ConvertGraphToSubgraph => "If you are sure you want to convert a non-federated graph to a subgraph, you can re-run the same command with a `--convert` flag.".to_string(),
             Suggestion::CheckGnuVersion => "This is likely an issue with your current version of `glibc`. Try running `ldd --version`, and if the version >= 2.17, we suggest installing the Rover binary built for `x86_64-unknown-linux-gnu`".to_string(),
             Suggestion::FixSubgraphSchema { graph_ref, subgraph } => format!("The changes in the schema you proposed for subgraph {} are incompatible with supergraph {}. See {} for more information on resolving build errors.", Style::Link.paint(subgraph), Style::Link.paint(graph_ref.to_string()), Style::Link.paint("https://www.apollographql.com/docs/federation/errors/")),
+            Suggestion::FixSupergraphConfigErrors => {
+                format!("See {} for information on the config format.", Style::Link.paint("https://www.apollographql.com/docs/rover/commands/supergraphs#yaml-configuration-file"))
+            }
             Suggestion::FixCompositionErrors { num_subgraphs } => {
                 let prefix = match num_subgraphs {
-                    1 => "The subgraph schema you provided is invalid.",
-                    _ => "The subgraph schemas you provided are incompatible with each other."
+                    1 => "The subgraph schema you provided is invalid.".to_string(),
+                    _ => format!("The subgraph schemas you provided are incompatible with each other.")
                 };
                 format!("{} See {} for more information on resolving build errors.", prefix, Style::Link.paint("https://www.apollographql.com/docs/federation/errors/"))
             },

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -19,6 +19,7 @@ use std::io;
 use crate::command::output::JsonVersion;
 use crate::utils::color::Style;
 
+use self::metadata::Code;
 pub use self::metadata::Suggestion;
 
 use apollo_federation_types::build::BuildErrors;
@@ -74,8 +75,16 @@ impl RoverError {
         self.metadata.suggestion = Some(suggestion);
     }
 
-    pub fn suggestion(&mut self) -> &Option<Suggestion> {
-        &self.metadata.suggestion
+    pub fn suggestion(&self) -> Option<Suggestion> {
+        self.metadata.suggestion.clone()
+    }
+
+    pub fn message(&self) -> String {
+        self.error.to_string()
+    }
+
+    pub fn code(&self) -> Option<Code> {
+        self.metadata.code.clone()
     }
 
     pub fn print(&self) -> io::Result<()> {

--- a/src/utils/emoji.rs
+++ b/src/utils/emoji.rs
@@ -4,6 +4,7 @@ use console::Emoji as ConsoleEmoji;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Emoji {
+    Hourglass,
     Person,
     Web,
     Note,
@@ -25,6 +26,7 @@ impl Emoji {
     fn get(&self) -> &str {
         use Emoji::*;
         match self {
+            Hourglass => "⌛ ",
             Person => "🧑 ",
             Web => "🕸️  ",
             Note => "🗒️  ",


### PR DESCRIPTION
fixes #992 by parallelizing schema resolution

This PR parallelizes schema resolution that occurs on `rover supergraph compose` and `rover dev` invocations. For large graphs with many fetches, this should be a significant speed-up. 

This PR also improves error handling for subgraph schema resolution. Since they are now resolved in parallel, all of the errors are reported at once instead of failing on the first encountered error. The new error code is `E038`.

cc @theJC - if you would like to try this out, you can check out this branch and run `cargo install-rover` if you have [rustup](https://rustup.rs) intalled. For me, it brought resolution time from 180 seconds to 2 seconds.
