### PR TITLE
chore: updates rust to 1.65.0

### DIFF
--- a/crates/houston/src/profile/sensitive.rs
+++ b/crates/houston/src/profile/sensitive.rs
@@ -21,7 +21,7 @@ impl Sensitive {
         let data = toml::to_string(self)?;
 
         if let Some(dirs) = &path.parent() {
-            Fs::create_dir_all(&dirs, "")?;
+            Fs::create_dir_all(dirs, "")?;
         }
 
         Fs::write_file(&path, &data, "")?;

--- a/installers/binstall/src/system/unix.rs
+++ b/installers/binstall/src/system/unix.rs
@@ -157,7 +157,7 @@ impl Zsh {
             }
         } else {
             match std::process::Command::new("zsh")
-                .args(&["-c", "'echo $ZDOTDIR'"])
+                .args(["-c", "'echo $ZDOTDIR'"])
                 .output()
             {
                 Ok(io) if !io.stdout.is_empty() => {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.65.0"
 components = [ "rustfmt", "clippy" ]

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -79,7 +79,7 @@ impl LeaderSession {
 
         let router_socket_addr = opts.supergraph_opts.router_socket_addr()?;
 
-        if TcpListener::bind(&router_socket_addr).is_err() {
+        if TcpListener::bind(router_socket_addr).is_err() {
             let mut err =
                 RoverError::new(anyhow!("You cannot bind the router to '{}' because that address is already in use by another process on this machine.", &router_socket_addr));
             err.set_suggestion(Suggestion::Adhoc(

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -199,7 +199,7 @@ impl RoverOutput {
             }
             RoverOutput::CoreSchema(csdl) => {
                 print_descriptor("CoreSchema")?;
-                print_content(&csdl)?;
+                print_content(csdl)?;
             }
             RoverOutput::CompositionResult(composition_output) => {
                 let warn_prefix = Style::HintPrefix.paint("HINT:");
@@ -307,7 +307,7 @@ impl RoverOutput {
             }
             RoverOutput::Introspection(introspection_response) => {
                 print_descriptor("Introspection Response")?;
-                print_content(&introspection_response)?;
+                print_content(introspection_response)?;
             }
             RoverOutput::ErrorExplanation(explanation) => {
                 // underline bolded md
@@ -322,7 +322,7 @@ impl RoverOutput {
                 last_updated_time: _,
             } => {
                 print_descriptor("Readme")?;
-                print_content(&content)?;
+                print_content(content)?;
             }
             RoverOutput::ReadmePublishResponse {
                 graph_ref,

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -149,7 +149,7 @@ impl Compose {
         );
 
         let output = Command::new(&exe)
-            .args(&["compose", yaml_path.as_ref()])
+            .args(["compose", yaml_path.as_ref()])
             .output()
             .context("Failed to execute command")?;
         let stdout = str::from_utf8(&output.stdout)

--- a/src/options/template.rs
+++ b/src/options/template.rs
@@ -78,7 +78,7 @@ impl GithubTemplate {
         let tar = flate2::read::GzDecoder::new(f);
         let mut archive = tar::Archive::new(tar);
         archive
-            .unpack(&template_path)
+            .unpack(template_path)
             .with_context(|| format!("could not unpack tarball to '{}'", &template_path))?;
 
         let tar_path = template_path.join(format!("{}-main", git_repo_slug));

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -81,7 +81,7 @@ fn do_update_check(
 }
 
 fn get_last_checked_time_from_disk(version_file: &Utf8PathBuf) -> Option<SystemTime> {
-    match Fs::read_file(&version_file, "") {
+    match Fs::read_file(version_file, "") {
         Ok(contents) => match toml::from_str(&contents) {
             Ok(last_checked_version) => Some(last_checked_version),
             Err(_) => {

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -102,7 +102,7 @@ impl Package {
             };
             crate::info!("Adding {} to tarball", &resolved_path);
             ar.append_file(
-                Path::new("dist").join(&filename),
+                Path::new("dist").join(filename),
                 &mut std::fs::File::open(resolved_path).context("could not open file")?,
             )
             .context("could not add file to TGZ archive")?;

--- a/xtask/src/commands/prep/docs.rs
+++ b/xtask/src/commands/prep/docs.rs
@@ -32,7 +32,7 @@ impl DocsRunner {
             .join("codes");
 
         // sort code files alphabetically
-        let raw_code_files = Fs::get_dir_entries(&codes_dir, "")?;
+        let raw_code_files = Fs::get_dir_entries(codes_dir, "")?;
 
         let mut code_files = Vec::new();
         for raw_code_file in raw_code_files {
@@ -90,7 +90,7 @@ impl DocsRunner {
     ) -> Result<()> {
         // build up a new docs page with existing content line-by-line
         // and then concat the replacement content
-        let destination_content = Fs::read_file(&destination_path, "").with_context(|| {
+        let destination_content = Fs::read_file(destination_path, "").with_context(|| {
             format!(
                 "Could not read contents of {} to a String",
                 &destination_path
@@ -106,7 +106,7 @@ impl DocsRunner {
         }
         new_content.push_str(source_content);
 
-        Fs::write_file(&destination_path, new_content, "")?;
+        Fs::write_file(destination_path, new_content, "")?;
         Ok(())
     }
 }


### PR DESCRIPTION
updates `rust-toolchain.toml` and addresses the new clippy lints that came with the new release.