### PR TITLE
chore: updates router and composition versions

### DIFF
--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -3,7 +3,7 @@
     "repository": "https://github.com/apollographql/federation-rs",
     "versions": {
       "latest-0": "v0.37.1",
-      "latest-2": "v2.1.2"
+      "latest-2": "v2.1.4"
     }
   }
 }

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -104,10 +104,10 @@ impl SupergraphOpts {
 
 lazy_static::lazy_static! {
     pub(crate) static ref DEV_ROUTER_VERSION: String =
-      std::env::var("APOLLO_ROVER_DEV_ROUTER_VERSION").unwrap_or_else(|_| "1.0.0".to_string());
+      std::env::var("APOLLO_ROVER_DEV_ROUTER_VERSION").unwrap_or_else(|_| "1.3.0".to_string());
 
     // this number should be mapped to the federation version used by the router
     // https://www.apollographql.com/docs/router/federation-version-support/#support-table
     pub(crate) static ref DEV_COMPOSITION_VERSION: String =
-        std::env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION").unwrap_or_else(|_| "2.1.2".to_string());
+        std::env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION").unwrap_or_else(|_| "2.1.4".to_string());
 }


### PR DESCRIPTION
in `rover dev`:
updates router from 1.0.0 to 1.3.0
updates composition from 2.1.2 to 2.1.4

in `rover supergraph compose`:
updates "latest" federation 2 composition from 2.1.2 to 2.1.4