### PR TITLE
chore: dont use registry url in build-rs

### DIFF
--- a/crates/rover-client/build.rs
+++ b/crates/rover-client/build.rs
@@ -86,10 +86,8 @@ const QUERY: &str = r#"query FetchSchema($fetchDocument: Boolean!) {
 }"#;
 
 fn query(fetch_document: bool) -> Result<(String, Option<String>)> {
-    let graphql_endpoint = option_env!("APOLLO_GRAPHQL_SCHEMA_URL").unwrap_or_else(|| {
-        option_env!("APOLLO_REGISTRY_URL")
-            .unwrap_or_else(|| "https://api.apollographql.com/api/graphql")
-    });
+    let graphql_endpoint = option_env!("APOLLO_GRAPHQL_SCHEMA_URL")
+        .unwrap_or_else(|| "https://api.apollographql.com/api/graphql");
     let client = Client::new();
     let schema_query = serde_json::json!({
         "variables": {"fetchDocument": fetch_document},


### PR DESCRIPTION
sometimes you may want to run a command against staging from a fresh build of rover, in this case you could run

`APOLLO_REGISTRY_URL="https://staging.url" cargo rover config whoami`. Unfortunately this would cause the schema to fail to fetch because `build.rs` was reading `APOLLO_REGISTRY_URL` to fetch the build schema, and that schema doesn't exist in staging. we want the schema to come from prod, and we can send the request wherever we want.