### PR TITLE
feat: adds -n alias for --name for dev

### DIFF
--- a/src/options/subgraph.rs
+++ b/src/options/subgraph.rs
@@ -33,7 +33,7 @@ pub struct OptionalSubgraphOpts {
     /// The name of the subgraph.
     ///
     /// This must be unique to each `rover dev` process.
-    #[arg(long = "name")]
+    #[arg(long = "name", short = 'n')]
     #[serde(skip_serializing)]
     subgraph_name: Option<String>,
 


### PR DESCRIPTION
fixes #1419 by adding a `-n` alias to the `--name` argument in `rover dev`