### PR TITLE
Support check workflows with no operation check

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::shared::{CheckResponse, GraphRef};
+use crate::shared::{GraphRef, OperationCheckResponse};
 
 use apollo_federation_types::build::BuildErrors;
 
@@ -142,7 +142,7 @@ pub enum RoverClientError {
     #[error("{}", operation_check_error_msg(.check_response))]
     OperationCheckFailure {
         graph_ref: GraphRef,
-        check_response: CheckResponse,
+        check_response: OperationCheckResponse,
     },
 
     /// While checking the proposed schema, we encountered changes that would cause checks to fail in
@@ -202,7 +202,7 @@ pub enum RoverClientError {
     ChecksTimeoutError { url: Option<String> },
 }
 
-fn operation_check_error_msg(check_response: &CheckResponse) -> String {
+fn operation_check_error_msg(check_response: &OperationCheckResponse) -> String {
     let failure_count = check_response.get_failure_count();
     let plural = match failure_count {
         1 => "",

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::blocking::StudioClient;
 use crate::operations::graph::check_workflow::types::{CheckWorkflowInput, QueryResponseData};
-use crate::shared::{CheckResponse, GraphRef, SchemaChange};
+use crate::shared::{GraphRef, OperationCheckResponse, SchemaChange};
 use crate::RoverClientError;
 
 use graphql_client::*;
@@ -32,7 +32,7 @@ pub(crate) struct GraphCheckWorkflowQuery;
 pub fn run(
     input: CheckWorkflowInput,
     client: &StudioClient,
-) -> Result<CheckResponse, RoverClientError> {
+) -> Result<OperationCheckResponse, RoverClientError> {
     let graph_ref = input.graph_ref.clone();
     let mut data;
     let now = Instant::now();
@@ -59,7 +59,7 @@ pub fn run(
 fn get_check_response_from_data(
     data: QueryResponseData,
     graph_ref: GraphRef,
-) -> Result<CheckResponse, RoverClientError> {
+) -> Result<OperationCheckResponse, RoverClientError> {
     let graph = data.graph.ok_or(RoverClientError::GraphNotFound {
         graph_ref: graph_ref.clone(),
     })?;
@@ -108,7 +108,7 @@ fn get_check_response_from_data(
         // `check_response.rs` to format better console messages.
         let core_schema_modified = false;
 
-        CheckResponse::try_new(
+        OperationCheckResponse::try_new(
             operations_target_url,
             number_of_checked_operations,
             changes,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -99,6 +99,11 @@ fn get_check_response_from_data(
                     number_of_checked_operations =
                         result.number_of_checked_operations.try_into().unwrap();
                     operations_result = Some(result);
+                } else {
+                    // We can early exit because we know this is a race condition and throw an error
+                    return Err(RoverClientError::AdhocError {
+                        msg: "Operations check task has no result.".to_string(),
+                    });
                 }
             }
             CompositionCheckTask(typed_task) => {

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -10,10 +10,45 @@ use serde::{Deserialize, Serialize};
 use prettytable::{row, Table};
 use serde_json::{json, Value};
 
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+pub enum CheckResponse {
+    OpeartionCheckResponse(OperationCheckResponse),
+    OpeartionLessCheckResponse(OpeartionLessCheckResponse),
+}
+
+impl CheckResponse {
+    pub fn get_json(&self) -> Value {
+        match self {
+            CheckResponse::OpeartionCheckResponse(operation_check_response) => {
+                operation_check_response.get_json()
+            }
+            CheckResponse::OpeartionLessCheckResponse(operation_less_check_response) => {
+                operation_less_check_response.get_json()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+pub struct OpeartionLessCheckResponse {
+    pub target_url: Option<String>,
+    pub core_schema_modified: bool,
+}
+
+impl OpeartionLessCheckResponse {
+    pub fn to_output(&self) -> String {
+        "".to_string()
+    }
+
+    pub fn get_json(&self) -> Value {
+        json!(self)
+    }
+}
+
 /// CheckResponse is the return type of the
 /// `graph` and `subgraph` check operations
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
-pub struct CheckResponse {
+pub struct OperationCheckResponse {
     target_url: Option<String>,
     operation_check_count: u64,
     changes: Vec<SchemaChange>,
@@ -23,7 +58,7 @@ pub struct CheckResponse {
     core_schema_modified: bool,
 }
 
-impl CheckResponse {
+impl OperationCheckResponse {
     pub fn try_new(
         target_url: Option<String>,
         operation_check_count: u64,
@@ -31,7 +66,7 @@ impl CheckResponse {
         result: ChangeSeverity,
         graph_ref: GraphRef,
         core_schema_modified: bool,
-    ) -> Result<CheckResponse, RoverClientError> {
+    ) -> Result<OperationCheckResponse, RoverClientError> {
         let mut failure_count = 0;
         for change in &changes {
             if let ChangeSeverity::FAIL = change.severity {
@@ -39,7 +74,7 @@ impl CheckResponse {
             }
         }
 
-        let check_response = CheckResponse {
+        let check_response = OperationCheckResponse {
             target_url,
             operation_check_count,
             changes,

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -6,7 +6,8 @@ mod graph_ref;
 
 pub use async_check_response::CheckRequestSuccessResult;
 pub use check_response::{
-    ChangeSeverity, CheckConfig, CheckResponse, SchemaChange, ValidationPeriod,
+    ChangeSeverity, CheckConfig, CheckResponse, OpeartionLessCheckResponse, OperationCheckResponse,
+    SchemaChange, ValidationPeriod,
 };
 pub use fetch_response::{FetchResponse, Sdl, SdlType};
 pub use git_context::GitContext;

--- a/src/command/graph/check.rs
+++ b/src/command/graph/check.rs
@@ -1,11 +1,14 @@
 use clap::Parser;
 use serde::Serialize;
 
-use rover_client::operations::graph::{
-    check::{self, CheckSchemaAsyncInput},
-    check_workflow::{self, CheckWorkflowInput},
-};
 use rover_client::shared::{CheckConfig, GitContext};
+use rover_client::{
+    operations::graph::{
+        check::{self, CheckSchemaAsyncInput},
+        check_workflow::{self, CheckWorkflowInput},
+    },
+    shared::CheckResponse,
+};
 
 use crate::options::{CheckConfigOpts, GraphRefOpt, ProfileOpt, SchemaOpt};
 use crate::utils::client::StudioClientConfig;
@@ -67,7 +70,9 @@ impl Check {
                 },
                 &client,
             )?;
-            Ok(RoverOutput::CheckResponse(check_res))
+            Ok(RoverOutput::CheckResponse(
+                CheckResponse::OpeartionCheckResponse(check_res),
+            ))
         }
     }
 }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -284,7 +284,14 @@ impl RoverOutput {
             }
             RoverOutput::CheckResponse(check_response) => {
                 print_descriptor("Check Result")?;
-                print_content(check_response.get_table())?;
+                match check_response {
+                    CheckResponse::OpeartionCheckResponse(operation_check_response) => {
+                        print_content(operation_check_response.get_table())?;
+                    }
+                    CheckResponse::OpeartionLessCheckResponse(operation_less_check_response) => {
+                        print_content(operation_less_check_response.to_output())?;
+                    }
+                }
             }
             RoverOutput::AsyncCheckResponse(check_response) => {
                 print_descriptor("Check Started")?;
@@ -579,7 +586,7 @@ mod tests {
                 list::{SubgraphInfo, SubgraphUpdatedAt},
             },
         },
-        shared::{ChangeSeverity, SchemaChange, Sdl},
+        shared::{ChangeSeverity, OperationCheckResponse, SchemaChange, Sdl},
     };
 
     use apollo_federation_types::build::{BuildError, BuildErrors};
@@ -850,7 +857,7 @@ mod tests {
             name: "name".to_string(),
             variant: "current".to_string(),
         };
-        let mock_check_response = CheckResponse::try_new(
+        let mock_check_response = OperationCheckResponse::try_new(
             Some("https://studio.apollographql.com/graph/my-graph/composition/big-hash?variant=current".to_string()),
             10,
             vec![
@@ -870,7 +877,10 @@ mod tests {
             true,
         );
         if let Ok(mock_check_response) = mock_check_response {
-            let actual_json: JsonOutput = RoverOutput::CheckResponse(mock_check_response).into();
+            let actual_json: JsonOutput = RoverOutput::CheckResponse(
+                CheckResponse::OpeartionCheckResponse(mock_check_response),
+            )
+            .into();
             let expected_json = json!(
             {
                 "json_version": "1",
@@ -907,7 +917,7 @@ mod tests {
             name: "name".to_string(),
             variant: "current".to_string(),
         };
-        let check_response = CheckResponse::try_new(
+        let check_response = OperationCheckResponse::try_new(
             Some("https://studio.apollographql.com/graph/my-graph/composition/big-hash?variant=current".to_string()),
             10,
             vec![


### PR DESCRIPTION
We want to allow checks there to be Check Workflows that don't have operation check tasks in them. Currently, rover output assumes we can output a diff table that contains an operation check response.

This pr adds a quick fix to subgraph checks (since this will be the only thing supporting it in the short term) to display a successful check response in the absence of an operation check task.

