### PR TITLE
[wip] feat: add optional graph ref to rover dev

### DIFF
--- a/src/command/dev/compose.rs
+++ b/src/command/dev/compose.rs
@@ -8,7 +8,7 @@ use rover_std::{Emoji, Fs};
 
 use crate::command::dev::do_dev::log_err_and_continue;
 use crate::command::supergraph::compose::{Compose, CompositionOutput};
-use crate::options::PluginOpts;
+use crate::options::{ProfileOpt, PluginOpts};
 use crate::utils::client::StudioClientConfig;
 use crate::{RoverError, RoverResult};
 
@@ -25,12 +25,13 @@ pub struct ComposeRunner {
 impl ComposeRunner {
     pub fn new(
         compose_opts: PluginOpts,
+        profile_opt: ProfileOpt,
         override_install_path: Option<Utf8PathBuf>,
         client_config: StudioClientConfig,
         write_path: Utf8PathBuf,
     ) -> Self {
         Self {
-            compose: Compose::new(compose_opts),
+            compose: Compose::new(compose_opts, profile_opt),
             override_install_path,
             client_config,
             write_path,

--- a/src/command/dev/introspect.rs
+++ b/src/command/dev/introspect.rs
@@ -4,7 +4,7 @@ use rover_std::Style;
 
 use crate::command::dev::protocol::{SubgraphSdl, SubgraphUrl};
 use crate::command::graph::Introspect as GraphIntrospect;
-use crate::command::subgraph::Introspect as SubgraphIntrospect;
+use crate::command::subgraph::SubgraphIntrospectCommand as SubgraphIntrospect;
 use crate::options::IntrospectOpts;
 use crate::{RoverError, RoverErrorSuggestion, RoverResult};
 
@@ -94,7 +94,7 @@ pub struct SubgraphIntrospectRunner {
 impl SubgraphIntrospectRunner {
     pub fn run(&self) -> RoverResult<String> {
         tracing::debug!(
-            "running `rover subgraph introspect --endpoint {}`",
+            "running `rover subgraph introspect {}`",
             &self.endpoint
         );
         SubgraphIntrospect {
@@ -117,7 +117,7 @@ pub struct GraphIntrospectRunner {
 impl GraphIntrospectRunner {
     pub fn run(&self) -> RoverResult<String> {
         tracing::debug!(
-            "running `rover graph introspect --endpoint {}`",
+            "running `rover graph introspect {}`",
             &self.endpoint
         );
         GraphIntrospect {

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -25,11 +25,12 @@ mod do_dev;
 #[cfg(not(feature = "composition-js"))]
 mod no_dev;
 
-use crate::options::{OptionalSubgraphOpts, PluginOpts};
+use crate::options::{OptionalSubgraphOpts, PluginOpts, ProfileOpt};
 
 use camino::Utf8PathBuf;
 use clap::Parser;
 use serde::Serialize;
+use rover_client::shared::GraphRef;
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Dev {
@@ -39,6 +40,18 @@ pub struct Dev {
 
 #[derive(Debug, Serialize, Parser)]
 pub struct DevOpts {
+    /// <NAME>@<VARIANT> of graph in Apollo Studio.
+    /// @<VARIANT> may be left off, defaulting to @current
+    /// 
+    /// This argument is used to fetch a graph ref and add it to your
+    /// `rover dev` session
+    #[arg(value_name = "GRAPH_REF")]
+    #[serde(skip_serializing)]
+    pub maybe_graph_ref: Option<GraphRef>,
+    
+    #[clap(flatten)]
+    pub profile: ProfileOpt,
+
     #[clap(flatten)]
     pub plugin_opts: PluginOpts,
 

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -5,7 +5,7 @@ use crate::{
         router::{RouterConfigHandler, RouterRunner},
         OVERRIDE_DEV_COMPOSITION_VERSION,
     },
-    options::PluginOpts,
+    options::{PluginOpts, ProfileOpt},
     utils::client::StudioClientConfig,
     RoverError, RoverErrorSuggestion, RoverResult, PKG_VERSION,
 };
@@ -56,6 +56,7 @@ impl LeaderSession {
         leader_channel: LeaderChannel,
         follower_channel: FollowerChannel,
         plugin_opts: PluginOpts,
+        profile_opt: ProfileOpt,
         router_config_handler: RouterConfigHandler,
     ) -> RoverResult<Option<Self>> {
         let ipc_socket_addr = router_config_handler.get_ipc_address()?;
@@ -89,6 +90,7 @@ impl LeaderSession {
         // create a [`ComposeRunner`] that will be in charge of composing our supergraph
         let mut compose_runner = ComposeRunner::new(
             plugin_opts.clone(),
+            profile_opt.clone(),
             override_install_path.clone(),
             client_config.clone(),
             router_config_handler.get_supergraph_schema_path(),

--- a/src/command/subgraph/check.rs
+++ b/src/command/subgraph/check.rs
@@ -10,7 +10,7 @@ use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize, Parser)]
-pub struct Check {
+pub struct SubgraphCheckCommand {
     #[clap(flatten)]
     graph: GraphRefOpt,
 
@@ -28,7 +28,7 @@ pub struct Check {
     config: CheckConfigOpts,
 }
 
-impl Check {
+impl SubgraphCheckCommand {
     pub fn run(
         &self,
         client_config: StudioClientConfig,

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -9,7 +9,7 @@ use rover_client::operations::subgraph::delete::{self, SubgraphDeleteInput};
 use rover_std::{prompt, Style};
 
 #[derive(Debug, Serialize, Parser)]
-pub struct Delete {
+pub struct SubgraphDeleteCommand {
     #[clap(flatten)]
     graph: GraphRefOpt,
 
@@ -26,7 +26,7 @@ pub struct Delete {
     confirm: bool,
 }
 
-impl Delete {
+impl SubgraphDeleteCommand {
     pub fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
         eprintln!(

--- a/src/command/subgraph/fetch.rs
+++ b/src/command/subgraph/fetch.rs
@@ -9,18 +9,18 @@ use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize, Parser)]
-pub struct Fetch {
+pub struct SubgraphFetchCommand {
     #[clap(flatten)]
-    graph: GraphRefOpt,
+    pub graph: GraphRefOpt,
 
     #[clap(flatten)]
-    subgraph: SubgraphOpt,
+    pub subgraph: SubgraphOpt,
 
     #[clap(flatten)]
-    profile: ProfileOpt,
+    pub profile: ProfileOpt,
 }
 
-impl Fetch {
+impl SubgraphFetchCommand {
     pub fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
         let graph_ref = self.graph.graph_ref.to_string();

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -12,12 +12,12 @@ use crate::options::{IntrospectOpts, OutputOpts};
 use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize, Parser)]
-pub struct Introspect {
+pub struct SubgraphIntrospectCommand {
     #[clap(flatten)]
     pub opts: IntrospectOpts,
 }
 
-impl Introspect {
+impl SubgraphIntrospectCommand {
     pub fn run(&self, client: Client, output_opts: &OutputOpts) -> RoverResult<RoverOutput> {
         if self.opts.watch {
             self.exec_and_watch(&client, output_opts)

--- a/src/command/subgraph/list.rs
+++ b/src/command/subgraph/list.rs
@@ -9,15 +9,15 @@ use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize, Parser)]
-pub struct List {
+pub struct SubgraphListSubcommand {
     #[clap(flatten)]
-    graph: GraphRefOpt,
+    pub graph: GraphRefOpt,
 
     #[clap(flatten)]
-    profile: ProfileOpt,
+    pub profile: ProfileOpt,
 }
 
-impl List {
+impl SubgraphListSubcommand {
     pub fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
 

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -5,12 +5,12 @@ mod introspect;
 mod list;
 mod publish;
 
-pub use check::Check;
-pub use delete::Delete;
-pub use fetch::Fetch;
-pub use introspect::Introspect;
-pub use list::List;
-pub use publish::Publish;
+pub use check::SubgraphCheckCommand;
+pub use delete::SubgraphDeleteCommand;
+pub use fetch::SubgraphFetchCommand;
+pub use introspect::SubgraphIntrospectCommand;
+pub use list::SubgraphListSubcommand;
+pub use publish::SubgraphPublishCommand;
 
 use clap::Parser;
 use serde::Serialize;
@@ -24,29 +24,29 @@ use rover_client::shared::GitContext;
 #[derive(Debug, Serialize, Parser)]
 pub struct Subgraph {
     #[clap(subcommand)]
-    command: Command,
+    command: SubgraphSubcommand,
 }
 
 #[derive(Debug, Serialize, Parser)]
-pub enum Command {
+pub enum SubgraphSubcommand {
     /// Check for build errors and breaking changes caused by an updated subgraph schema
     /// against the federated graph in the Apollo graph registry
-    Check(check::Check),
+    Check(SubgraphCheckCommand),
 
     /// Delete a subgraph from the Apollo registry and trigger composition in the graph router
-    Delete(delete::Delete),
+    Delete(SubgraphDeleteCommand),
 
     /// Fetch a subgraph schema from the Apollo graph registry
-    Fetch(fetch::Fetch),
+    Fetch(SubgraphFetchCommand),
 
     /// Introspect a running subgraph endpoint to retrieve its schema definition (SDL)
-    Introspect(introspect::Introspect),
+    Introspect(SubgraphIntrospectCommand),
 
     /// List all subgraphs for a federated graph
-    List(list::List),
+    List(SubgraphListSubcommand),
 
     /// Publish an updated subgraph schema to the Apollo graph registry and trigger composition in the graph router
-    Publish(publish::Publish),
+    Publish(SubgraphPublishCommand),
 }
 
 impl Subgraph {
@@ -58,16 +58,16 @@ impl Subgraph {
         output_opts: &OutputOpts,
     ) -> RoverResult<RoverOutput> {
         match &self.command {
-            Command::Check(command) => {
+            SubgraphSubcommand::Check(command) => {
                 command.run(client_config, git_context, checks_timeout_seconds)
             }
-            Command::Delete(command) => command.run(client_config),
-            Command::Introspect(command) => {
+            SubgraphSubcommand::Delete(command) => command.run(client_config),
+            SubgraphSubcommand::Introspect(command) => {
                 command.run(client_config.get_reqwest_client()?, output_opts)
             }
-            Command::Fetch(command) => command.run(client_config),
-            Command::List(command) => command.run(client_config),
-            Command::Publish(command) => command.run(client_config, git_context),
+            SubgraphSubcommand::Fetch(command) => command.run(client_config),
+            SubgraphSubcommand::List(command) => command.run(client_config),
+            SubgraphSubcommand::Publish(command) => command.run(client_config, git_context),
         }
     }
 }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -10,7 +10,7 @@ use rover_client::shared::GitContext;
 use rover_std::Style;
 
 #[derive(Debug, Serialize, Parser)]
-pub struct Publish {
+pub struct SubgraphPublishCommand {
     #[clap(flatten)]
     graph: GraphRefOpt,
 
@@ -36,7 +36,7 @@ pub struct Publish {
     routing_url: Option<String>,
 }
 
-impl Publish {
+impl SubgraphPublishCommand {
     pub fn run(
         &self,
         client_config: StudioClientConfig,

--- a/src/options/compose.rs
+++ b/src/options/compose.rs
@@ -1,4 +1,3 @@
-use super::ProfileOpt;
 use crate::options::LicenseAccepter;
 
 use clap::Parser;
@@ -9,9 +8,6 @@ use crate::{utils::client::StudioClientConfig, RoverResult};
 
 #[derive(Debug, Clone, Serialize, Parser)]
 pub struct PluginOpts {
-    #[clap(flatten)]
-    pub profile: ProfileOpt,
-
     #[clap(flatten)]
     pub elv2_license_accepter: LicenseAccepter,
 


### PR DESCRIPTION
starts in on #1494 by adding an optional `<GRAPH_REF>` argument to `rover dev`. 

This is a naive implementation that was done by combining `rover subgraph list` and `rover subgraph fetch` commands to bootstrap composition locally.