### PR TITLE
Update Router latest version to v1.10.0

### DIFF
--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -9,7 +9,7 @@
   "router": {
     "repository": "https://github.com/apollographql/router",
     "versions": {
-      "latest-1": "v1.6.0"
+      "latest-1": "v1.10.0"
     }
   }
 }


### PR DESCRIPTION
> **Note**
>
> I'm **unsure** what the normal ordering of operations in making this bump and merging this PR, so I'm mostly opening this as a point of order and for discussion.
> For example, this hasn't been updated in several versions so far.  That's probably because of a missing bullet-point in our release instructions on our end.  At the very least we should probably add that to our `RELEASE_CHECKLIST.md`, but I want to automate some aspect of the "opening a PR for this" (basically, what I'm doing).  I am definitely wanting to just reach for Renovate to do that.  If that seems reasonable, I may _just_ do that.  Drop me a note!

This updates Rover's understanding of `latest` to the latest version of the Router which was just released:

Ref: https://github.com/apollographql/router/releases/tag/v1.10.0
