### PR TITLE
fix: Update Router health_check config in `rover dev`

### DIFF
--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -235,12 +235,12 @@ impl RouterConfigReader {
 
                 // disable the health check unless they have their own config
                 if input_yaml
-                    .get("health-check")
+                    .get("health_check")
                     .and_then(|h| h.as_mapping())
                     .is_none()
                 {
                     input_yaml.insert(
-                        serde_yaml::to_value("health-check")?,
+                        serde_yaml::to_value("health_check")?,
                         serde_yaml::to_value(json!({"enabled": false}))?,
                     );
                 }
@@ -298,7 +298,7 @@ impl RouterConfigReader {
 ---
 supergraph:
   listen: {ip}:{port}
-health-check:
+health_check:
   enabled: false
 "#,
         );

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -236,6 +236,7 @@ impl RouterConfigReader {
                 // disable the health check unless they have their own config
                 if input_yaml
                     .get("health_check")
+                    .or_else(|| input_yaml.get("health-check"))
                     .and_then(|h| h.as_mapping())
                     .is_none()
                 {


### PR DESCRIPTION
Gets rid of this warning when running `rover dev` with the latest router:

```
WARN: router configuration contains deprecated options: 

  1. health-check renamed to health_check

These will become errors in the future. Run `router config upgrade <path_to_router.yaml>` to see a suggested upgraded configuration.
```