### PR TITLE
chore: fix newline in skipped opcheck output

### DIFF
--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -38,15 +38,17 @@ pub struct SkipOperationsCheckResponse {
 impl SkipOperationsCheckResponse {
     pub fn to_output(&self) -> String {
         let mut msg = if self.core_schema_modified {
-            "Core schema was updated".to_string()
+            "There were no changes detected in the composed API schema, but the core schema was modified.".to_string()
         } else {
-            "Core schema wasn't updated".to_string()
+            "There were no changes detected in the composed schema.".to_string()
         };
 
         if let Some(url) = &self.target_url {
+            msg.push_str("\n\n");
             msg.push_str("View full details at: ");
             msg.push_str(url);
         };
+
         msg
     }
 


### PR DESCRIPTION
fixes newline in skipped operation check output, and aligns output with other `if self.core_schema_modified` usage in Rover.