### PR TITLE
feat: warn when `--routing-url` is unroutable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules
 
 # JetBrains IDEs
 .idea
+
+# MacOS DS_Store files
+.DS_Store

--- a/crates/rover-client/src/operations/subgraph/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/mod.rs
@@ -13,6 +13,9 @@ pub mod fetch;
 /// "subgraph publish" command execution
 pub mod publish;
 
+/// "subgraph publish" no (--routing-url) command execution
+pub mod routing_url;
+
 /// "subgraph list"
 pub mod list;
 

--- a/crates/rover-client/src/operations/subgraph/routing_url/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/routing_url/mod.rs
@@ -1,0 +1,5 @@
+mod runner;
+mod types;
+
+pub use runner::run;
+pub use types::SubgraphRoutingUrlInput;

--- a/crates/rover-client/src/operations/subgraph/routing_url/routing_url_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/routing_url/routing_url_query.graphql
@@ -1,0 +1,10 @@
+query SubgraphRoutingUrlQuery($graph_ref: ID!, $subgraph_name: ID!) {
+  variant(ref: $graph_ref) {
+    __typename
+    ... on GraphVariant {
+      subgraph(name: $subgraph_name) {
+        url
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/operations/subgraph/routing_url/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/routing_url/runner.rs
@@ -50,7 +50,7 @@ fn get_routing_url_from_response_data(
         match maybe_variant {
             SubgraphRoutingUrlGraphVariant::GraphVariant(variant) => {
                 if let Some(subgraph) = variant.subgraph {
-                    Ok(subgraph.url.clone())
+                    Ok(subgraph.url)
                 } else {
                     Err(RoverClientError::ExpectedFederatedGraph {
                         graph_ref: input.graph_ref,

--- a/crates/rover-client/src/operations/subgraph/routing_url/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/routing_url/runner.rs
@@ -1,0 +1,116 @@
+use super::types::*;
+use crate::blocking::StudioClient;
+use crate::operations::config::is_federated::{self, IsFederatedInput};
+use crate::RoverClientError;
+
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+// The paths are relative to the directory where your `Cargo.toml` is located.
+// Both json and the GraphQL schema language are supported as sources for the schema
+#[graphql(
+    query_path = "src/operations/subgraph/routing_url/routing_url_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+/// This struct is used to generate the module containing `Variables` and
+/// `ResponseData` structs.
+/// Snake case of this name is the mod name. i.e. subgraph_routing_url_query
+pub(crate) struct SubgraphRoutingUrlQuery;
+
+/// Fetches a subgraph's routing URL (String)
+pub fn run(
+    input: SubgraphRoutingUrlInput,
+    client: &StudioClient,
+) -> Result<Option<String>, RoverClientError> {
+    // This response is used to check whether or not the current graph is federated.
+    let is_federated = is_federated::run(
+        IsFederatedInput {
+            graph_ref: input.graph_ref.clone(),
+        },
+        client,
+    )?;
+    if !is_federated {
+        return Err(RoverClientError::ExpectedFederatedGraph {
+            graph_ref: input.graph_ref,
+            can_operation_convert: false,
+        });
+    }
+    let variables = input.clone().into();
+    let response_data = client.post::<SubgraphRoutingUrlQuery>(variables)?;
+    get_routing_url_from_response_data(input, response_data)
+}
+
+fn get_routing_url_from_response_data(
+    input: SubgraphRoutingUrlInput,
+    response_data: SubgraphRoutingUrlResponseData,
+) -> Result<Option<String>, RoverClientError> {
+    if let Some(maybe_variant) = response_data.variant {
+        match maybe_variant {
+            SubgraphRoutingUrlGraphVariant::GraphVariant(variant) => {
+                if let Some(subgraph) = variant.subgraph {
+                    Ok(subgraph.url.clone())
+                } else {
+                    Err(RoverClientError::ExpectedFederatedGraph {
+                        graph_ref: input.graph_ref,
+                        can_operation_convert: true,
+                    })
+                }
+            }
+            _ => Err(RoverClientError::InvalidGraphRef),
+        }
+    } else {
+        Err(RoverClientError::GraphNotFound {
+            graph_ref: input.graph_ref,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::GraphRef;
+    use serde_json::json;
+
+    #[test]
+    fn get_routing_url_from_response_data_works() {
+        let url = "http://my.subgraph.com".to_string();
+        let input = mock_input();
+        let json_response = json!({
+            "variant": {
+                "__typename": "GraphVariant",
+                "subgraph": {
+                    "url": &url,
+                }
+            }
+        });
+        let data: SubgraphRoutingUrlResponseData = serde_json::from_value(json_response).unwrap();
+        let output = get_routing_url_from_response_data(input, data);
+
+        assert!(output.is_ok());
+        assert_eq!(output.unwrap(), Some(url));
+    }
+
+    #[test]
+    fn get_services_from_response_data_errs_with_no_variant() {
+        let json_response = json!({ "variant": null });
+        let data: SubgraphRoutingUrlResponseData = serde_json::from_value(json_response).unwrap();
+        let output = get_routing_url_from_response_data(mock_input(), data);
+        assert!(output.is_err());
+    }
+
+    fn mock_input() -> SubgraphRoutingUrlInput {
+        let graph_ref = GraphRef {
+            name: "mygraph".to_string(),
+            variant: "current".to_string(),
+        };
+
+        let subgraph_name = "products".to_string();
+
+        SubgraphRoutingUrlInput {
+            graph_ref,
+            subgraph_name,
+        }
+    }
+}

--- a/crates/rover-client/src/operations/subgraph/routing_url/types.rs
+++ b/crates/rover-client/src/operations/subgraph/routing_url/types.rs
@@ -1,0 +1,23 @@
+use crate::shared::GraphRef;
+
+use super::runner::subgraph_routing_url_query;
+
+pub(crate) type SubgraphRoutingUrlResponseData = subgraph_routing_url_query::ResponseData;
+pub(crate) type SubgraphRoutingUrlGraphVariant =
+    subgraph_routing_url_query::SubgraphRoutingUrlQueryVariant;
+pub(crate) type QueryVariables = subgraph_routing_url_query::Variables;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SubgraphRoutingUrlInput {
+    pub graph_ref: GraphRef,
+    pub subgraph_name: String,
+}
+
+impl From<SubgraphRoutingUrlInput> for QueryVariables {
+    fn from(input: SubgraphRoutingUrlInput) -> Self {
+        Self {
+            graph_ref: input.graph_ref.to_string(),
+            subgraph_name: input.subgraph_name,
+        }
+    }
+}

--- a/crates/rover-std/src/prompt.rs
+++ b/crates/rover-std/src/prompt.rs
@@ -3,7 +3,7 @@ pub fn confirm_delete() -> std::io::Result<bool> {
 }
 
 pub fn prompt_confirm_default_no(message: &str) -> std::io::Result<bool> {
-    eprintln!("{} [y/N]", message);
+    eprint!("{} [y/N] ", message);
     let term = console::Term::stdout();
     let confirm = term.read_line()?;
     if confirm.to_lowercase() == *"y" {
@@ -14,7 +14,7 @@ pub fn prompt_confirm_default_no(message: &str) -> std::io::Result<bool> {
 }
 
 pub fn prompt_confirm_default_yes(message: &str) -> std::io::Result<bool> {
-    eprintln!("{} [Y/n]", message);
+    eprint!("{} [Y/n] ", message);
     let term = console::Term::stdout();
     let confirm = term.read_line()?;
     if confirm.to_lowercase() == *"n" {

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -164,7 +164,7 @@ impl Publish {
             None
         } else {
             match prompt_confirm_default_no(
-                "Found an invalid URL, would you still like to publish? [y/N]: ",
+                "Found an invalid URL, would you still like to publish?",
             ) {
                 Ok(response) => Some(response),
                 _ => panic!("Expected a response in TTY environment"),

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -161,16 +161,14 @@ impl Publish {
 
     pub fn prompt_for_publish() -> Option<bool> {
         if !atty::is(atty::Stream::Stdout) {
-            // q for Avery: not actually sure why I can't implicitly return
-            // `None` here
-            return None;
-        }
-
-        match prompt_confirm_default_no(
-            "Found an invalid URL, would you still like to publish? [y/N]: ",
-        ) {
-            Ok(response) => Some(response),
-            _ => panic!("Expected a response in TTY environment"),
+            None
+        } else {
+            match prompt_confirm_default_no(
+                "Found an invalid URL, would you still like to publish? [y/N]: ",
+            ) {
+                Ok(response) => Some(response),
+                _ => panic!("Expected a response in TTY environment"),
+            }
         }
     }
 }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -36,10 +36,12 @@ pub struct Publish {
     /// (often a deployed subgraph). May be left empty ("") or a placeholder url
     /// if not running a gateway or router in managed federation mode
     #[arg(long)]
+    #[serde(skip_serializing)]
     routing_url: Option<String>,
-    /// Url of a running subgraph that a supergraph can route operations to
-    /// (often a deployed subgraph). May be left empty ("") or a placeholder url
-    /// if not running a gateway or router in managed federation mode
+    /// Bypasses warnings and the prompt to confirm publish when the routing url
+    /// is invalid in TTY environment. In a future major version, this flag will
+    /// be required to publish in a non-TTY environment. For now it will warn
+    /// and publish anyway.
     #[arg(long, requires("routing_url"))]
     allow_invalid_routing_url: bool,
 }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -1,11 +1,15 @@
 use clap::Parser;
+use rover_std::prompt::prompt_confirm_default_no;
 use serde::Serialize;
+use url::{ParseError, Url};
 
 use crate::options::{GraphRefOpt, ProfileOpt, SchemaOpt, SubgraphOpt};
 use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
+use rover_client::operations::subgraph::fetch::{self, SubgraphFetchInput};
 use rover_client::operations::subgraph::publish::{self, SubgraphPublishInput};
+
 use rover_client::shared::GitContext;
 use rover_std::Style;
 
@@ -32,8 +36,12 @@ pub struct Publish {
     /// (often a deployed subgraph). May be left empty ("") or a placeholder url
     /// if not running a gateway or router in managed federation mode
     #[arg(long)]
-    #[serde(skip_serializing)]
     routing_url: Option<String>,
+    /// Url of a running subgraph that a supergraph can route operations to
+    /// (often a deployed subgraph). May be left empty ("") or a placeholder url
+    /// if not running a gateway or router in managed federation mode
+    #[arg(long, requires("routing-url"))]
+    allow_invalid_routing_url: bool,
 }
 
 impl Publish {
@@ -42,7 +50,41 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> RoverResult<RoverOutput> {
+        // if a --routing-url is provided AND unparseable AND
+        // --allow-invalid-routing-url is not provided, we need to make some
+        // decisions, otherwise we can assume a publish
+        if self.routing_url.is_some()
+            && Url::parse(&self.routing_url.as_ref().unwrap()).is_err()
+            && !self.allow_invalid_routing_url
+        {
+            if let Some(result) = Self::warn_maybe_prompt() {
+                return Ok(result);
+            }
+        }
+
         let client = client_config.get_authenticated_client(&self.profile)?;
+
+        if self.routing_url.is_none() {
+            let fetch_response = fetch::run(
+                SubgraphFetchInput {
+                    graph_ref: self.graph.graph_ref.clone(),
+                    subgraph_name: self.subgraph.subgraph_name.clone(),
+                },
+                &client,
+            )?;
+
+            if let rover_client::shared::SdlType::Subgraph {
+                routing_url: Some(graph_registry_routing_url),
+            } = fetch_response.sdl.r#type
+            {
+                if let Err(_err) = Url::parse(&graph_registry_routing_url) {
+                    if let Some(result) = Self::warn_maybe_prompt() {
+                        return Ok(result);
+                    }
+                }
+            }
+        }
+
         eprintln!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
             Style::Link.paint(&self.graph.graph_ref.to_string()),
@@ -74,4 +116,49 @@ impl Publish {
             publish_response,
         })
     }
+
+    pub fn warn_maybe_prompt() -> Option<RoverOutput> {
+        // if we're in a tty, prompt the user
+        if atty::is(atty::Stream::Stdout) {
+            match prompt_confirm_default_no(
+                "Found an invalid URL, would you still like to publish? [y/N]: ",
+            ) {
+                Ok(response) => {
+                    if response {
+                        return None;
+                    } else {
+                        eprintln!("Publish cancelled by user");
+                        return Some(RoverOutput::EmptySuccess);
+                    }
+                }
+                Err(e) => {
+                    return Some(RoverOutput::ErrorExplanation(e.to_string()));
+                }
+            }
+        } else {
+            // if we're not in a tty, we can't prompt. let's print a warning but publish anyway.
+            println!(
+                "{} Found an invalid URL, but we can't prompt in a non-interactive environment. Publishing anyway.",
+                Style::WarningPrefix.paint("WARN:")
+            );
+            return None;
+        }
+    }
 }
+
+// FIXME: remove this
+// old prompt code
+// if atty::is(atty::Stream::Stdout) {
+//     if !prompt_confirm_default_no(
+//         "Found an invalid URL, would you still like to publish? [y/N]: ",
+//     )? {
+//         eprintln!("Publish cancelled by user");
+//         return Ok(RoverOutput::EmptySuccess);
+//     }
+// } else {
+//     // if we're not in a tty, we can't prompt. let's print a warning but publish anyway.
+//     println!(
+//         "{} Found an invalid URL, but we can't prompt in a non-interactive environment. Publishing anyway.",
+//         Style::WarningPrefix.paint("WARN:")
+//     );
+// }


### PR DESCRIPTION
Fixes #1477

This feature addition adds URL validation to the `rover subgraph publish --routing-url` flag. It also introduces a dependent flag to bypass warnings/prompts `--allow-invalid-routing-url`.

Taken from @EverlastingBugstopper 's [very helpful comment](https://github.com/apollographql/rover/issues/1477#issuecomment-1397506739):
**When a `--routing-url` is passed to `rover subgraph publish`:**

- In the case where a human is manually doing a publish (this can be determined by checking for a TTY) then Rover prints a warning that the URL is invalid with a prompt (`[y/N]`) to continue with the publish. 

- In the case where CI or a script is doing the publish (check for a TTY) then Rover prints a warning saying the routing url is invalid, but still allow the publish to go through. We might also want to make the warning include a notice that this behavior may break in future versions of Rover if the `--allow-invalid-routing-url` flag is not passed.

- In both scenarios (and in future versions of Rover), passing the `--allow-invalid-routing-url` flag should disable the warnings entirely and allow the invalid routing url to be used. 

**When a `--routing-url` is _not_ passed to `rover subgraph publish`:**

- Perform a GraphQL query against the platform API to get the routing url for that subgraph
- If that URL is invalid, follow the same error/warn procedure as described above