### PR TITLE
feat: Allow custom headers when introspecting in `supergraph compose`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,7 +2718,7 @@ dependencies = [
  "ring",
  "secrecy",
  "serde",
- "shellexpand",
+ "shellexpand 2.1.2",
  "thiserror",
  "tokio",
  "typed-builder",
@@ -3808,6 +3808,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.19",
  "serial_test",
+ "shellexpand 3.1.0",
  "sputnik",
  "strsim",
  "strum",
@@ -4200,6 +4201,15 @@ name = "shellexpand"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
  "dirs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,8 +87,7 @@ dependencies = [
 [[package]]
 name = "apollo-federation-types"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ea95a50de01d5be77084ce819d370b7b596b16154c860ef354b0374fe92bef"
+source = "git+https://github.com/dbanty/federation-rs?branch=supergraph-config-headers#7c97c76359ead616666af8493cfe13c61cabde1d"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,8 +86,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.7.1"
-source = "git+https://github.com/dbanty/federation-rs?branch=supergraph-config-headers#7c97c76359ead616666af8493cfe13c61cabde1d"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ece76b83baa268123ea3f612ae2f6ae0c9e469a93303ddbd41e02764afadea"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ timber = { path = "./crates/timber" }
 apollo-parser = "0.5"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = { git = "https://github.com/dbanty/federation-rs", branch = "supergraph-config-headers", version = "0.7.1" }
+apollo-federation-types = "0.8.0"
 
 # https://github.com/apollographql/introspector-gadget
 introspector-gadget = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+shellexpand = "3.1.0"
 sputnik = { workspace = true }
 strsim = { workspace = true }
 strum = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ timber = { path = "./crates/timber" }
 apollo-parser = "0.5"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.7.1"
+apollo-federation-types = { git = "https://github.com/dbanty/federation-rs", branch = "supergraph-config-headers", version = "0.7.1" }
 
 # https://github.com/apollographql/introspector-gadget
 introspector-gadget = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ strsim = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
 sha2 = "0.10"
+shellexpand = "3.1"
 termcolor = "1.2"
 thiserror = "1"
 tar = "0.4"
@@ -179,7 +180,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-shellexpand = "3.1.0"
+shellexpand = { workspace = true }
 sputnik = { workspace = true }
 strsim = { workspace = true }
 strum = { workspace = true }

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -89,7 +89,9 @@ subgraphs:
       subgraph_url: https://example.com/people
       introspection_headers:  # Optional headers to include in introspection request
         Accept: application/json  # You can hard code values
-        Authorization: ${env.PEOPLE_AUTH_TOKEN}  # Or use environment variables
+        Special-Header: ${env.PEOPLE_AUTH_TOKEN}  # Or use environment variables
+        Authorization: Bearer ${env.PEOPLE_AUTH_TOKEN}  # you can also mix env vars with static strings
+        Complicated: ${env.${env.ENV_VAR_KEY}}  # If you nest vars, inner will be resolved first
 
   # Apollo Studio graph ref
   actors:

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -87,6 +87,9 @@ subgraphs:
     routing_url: https://example.com/people
     schema:
       subgraph_url: https://example.com/people
+      introspection_headers:  # Optional headers to include in introspection request
+        Accept: application/json  # You can hard code values
+        Authorization: ${env.PEOPLE_AUTH_TOKEN}  # Or use environment variables
 
   # Apollo Studio graph ref
   actors:

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -88,10 +88,7 @@ subgraphs:
     schema:
       subgraph_url: https://example.com/people
       introspection_headers:  # Optional headers to include in introspection request
-        Accept: application/json  # You can hard code values
-        Special-Header: ${env.PEOPLE_AUTH_TOKEN}  # Or use environment variables
-        Authorization: Bearer ${env.PEOPLE_AUTH_TOKEN}  # you can also mix env vars with static strings
-        Complicated: ${env.${env.ENV_VAR_KEY}}  # If you nest vars, inner will be resolved first
+        Authorization: Bearer ${env.PEOPLE_AUTH_TOKEN}
 
   # Apollo Studio graph ref
   actors:
@@ -100,6 +97,10 @@ subgraphs:
       graphref: mygraph@current
       subgraph: actors
 ```
+
+#### Variable expansion
+
+The `introspection_headers` field supports variable expansion using [the same syntax as Apollo Router](https://www.apollographql.com/docs/router/configuration/overview/#variable-expansion). If you need variable expansion in more places, please comment [on the tracking issue](https://github.com/apollographql/rover/issues/1578).
 
 ### Output format
 

--- a/src/utils/expansion.rs
+++ b/src/utils/expansion.rs
@@ -1,0 +1,113 @@
+use anyhow::{anyhow, bail, Context, Error};
+use std::env;
+use std::fs::read_to_string;
+use std::path::Path;
+
+use shellexpand::env_with_context;
+
+use crate::RoverResult;
+
+/// Implements router-config-style
+/// [variable expansion](https://www.apollographql.com/docs/router/configuration/overview/#variable-expansion)
+/// for use in Rover configs (like `supergraph.yaml`).
+pub(crate) fn expand(value: &str) -> RoverResult<String> {
+    env_with_context(value, context)
+        .map_err(|e| anyhow!(e).context("While expanding variables").into())
+        .map(|cow| cow.into_owned())
+}
+
+fn context(key: &str) -> Result<Option<String>, Error> {
+    if let Some(env_var_key) = key.strip_prefix("env.") {
+        env::var(env_var_key).map(Some).with_context(|| {
+            format!(
+                "While reading env var {} for variable expansion",
+                env_var_key
+            )
+        })
+    } else if let Some(file_name) = key.strip_prefix("file.") {
+        if !Path::new(key).exists() {
+            Ok(None)
+        } else {
+            read_to_string(file_name).map(Some).with_context(|| {
+                format!("While reading file at {} for variable expansion", file_name)
+            })
+        }
+    } else {
+        bail!("Invalid variable expansion key: {}", key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Env vars are global, so if you're going to reuse them you'd better make them constants
+    // These point at each other for testing nested values
+    const ENV_VAR_KEY_1: &str = "RESOLVE_HEADER_VALUE_TEST_VAR_1";
+    const ENV_VAR_VALUE_1: &str = "RESOLVE_HEADER_VALUE_TEST_VAR_2";
+    const ENV_VAR_KEY_2: &str = "RESOLVE_HEADER_VALUE_TEST_VAR_2";
+    const ENV_VAR_VALUE_2: &str = "RESOLVE_HEADER_VALUE_TEST_VAR_1";
+
+    #[test]
+    fn valid_env_var() {
+        let value = format!("${{env.{}}}", ENV_VAR_KEY_1);
+        env::set_var(ENV_VAR_KEY_1, ENV_VAR_VALUE_1);
+        assert_eq!(expand(&value).unwrap(), ENV_VAR_VALUE_1);
+    }
+
+    #[test]
+    fn partial_env_var_partial_static() {
+        let value = format!("static-part-${{env.{}}}", ENV_VAR_KEY_1);
+        env::set_var(ENV_VAR_KEY_1, ENV_VAR_VALUE_1);
+        assert_eq!(
+            expand(&value).unwrap(),
+            format!("static-part-{}", ENV_VAR_VALUE_1)
+        );
+    }
+
+    #[test]
+    fn multiple_env_vars() {
+        let value = format!(
+            "${{env.{}}}-static-part-${{env.{}}}",
+            ENV_VAR_KEY_1, ENV_VAR_KEY_2
+        );
+        env::set_var(ENV_VAR_KEY_1, ENV_VAR_VALUE_1);
+        env::set_var(ENV_VAR_KEY_2, ENV_VAR_VALUE_2);
+        assert_eq!(
+            expand(&value).unwrap(),
+            format!("{}-static-part-{}", ENV_VAR_VALUE_1, ENV_VAR_VALUE_2)
+        );
+    }
+
+    #[test]
+    fn nested_env_vars() {
+        let value = format!("${{env.${{env.{}}}}}", ENV_VAR_KEY_1);
+        env::set_var(ENV_VAR_KEY_1, ENV_VAR_VALUE_1);
+        env::set_var(ENV_VAR_KEY_2, ENV_VAR_VALUE_2);
+        assert!(expand(&value).is_err());
+    }
+
+    #[test]
+    fn not_env_var() {
+        let value = "test_value";
+        assert_eq!(expand(value).unwrap(), value);
+    }
+
+    #[test]
+    fn env_var_not_found() {
+        let value = "${env.RESOLVE_HEADER_VALUE_TEST_VAR_DOES_NOT_EXIST}";
+        assert!(expand(value).is_err());
+    }
+
+    #[test]
+    fn missing_end_brace() {
+        let value = "${env.RESOLVE_HEADER_VALUE_TEST_VAR_DOES_NOT_EXIST";
+        assert_eq!(expand(value).unwrap(), value);
+    }
+
+    #[test]
+    fn missing_start_section() {
+        let value = "RESOLVE_HEADER_VALUE_TEST_VAR_DOES_NOT_EXIST}";
+        assert_eq!(expand(value).unwrap(), value);
+    }
+}

--- a/src/utils/expansion.rs
+++ b/src/utils/expansion.rs
@@ -4,9 +4,9 @@
 //! `supergraph compose`)
 use anyhow::{anyhow, bail, Context, Error};
 use std::env;
-use std::fs::read_to_string;
 use std::path::Path;
 
+use rover_std::Fs;
 use shellexpand::env_with_context;
 
 use crate::RoverResult;
@@ -32,9 +32,7 @@ fn context(key: &str) -> Result<Option<String>, Error> {
         if !Path::new(key).exists() {
             Ok(None)
         } else {
-            read_to_string(file_name).map(Some).with_context(|| {
-                format!("While reading file at {} for variable expansion", file_name)
-            })
+            Fs::read_file(file_name).map(Some)
         }
     } else {
         bail!("Invalid variable expansion key: {}", key)

--- a/src/utils/expansion.rs
+++ b/src/utils/expansion.rs
@@ -1,3 +1,7 @@
+//! The code in this file is borrowed from the router for consistent syntax. As such, it is covered
+//! by the [ELv2 license](https://www.apollographql.com/docs/resources/elastic-license-v2-faq/).
+//! Before calling this code from other functions, make sure that the license is accepted (like
+//! `supergraph compose`)
 use anyhow::{anyhow, bail, Context, Error};
 use std::env;
 use std::fs::read_to_string;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod env;
+pub(crate) mod expansion;
 pub mod parsers;
 pub mod pkg;
 pub mod stringify;


### PR DESCRIPTION
Supports [the same syntax as Apollo Router](https://www.apollographql.com/docs/router/configuration/overview/#variable-expansion) for variable expansion (e.g., `${env.MY_SECRET}`) when defining `introspection_headers`.

Closes #615
