### PR TITLE
ci: Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,7 @@
     },
     {
       "matchPackageNames": ["apollographql/federation-rs"],
-      "extractVersion": "supergraph@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+      "extractVersion": "^supergraph@(?<version>v\\d+\\.\\d+\\.\\d+)$",
     }
   ],
   "regexManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,8 @@
 {
-  "extends": ["apollo-open-source", "github>Turbo87/renovate-config//rust/updateToolchain"],
-  "enabledManagers": ["npm", "cargo"],
+  "extends": [
+    "github>apollographql/renovate-config-apollo-open-source",
+    "github>Turbo87/renovate-config//rust/updateToolchain"
+  ],
   "packageRules": [
     // Bunch up all non-major npm dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster
@@ -57,6 +59,18 @@
     {
       "paths": ["docs/package.json"],
       "extends": ["apollo-docs"],
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^latest_plugin_versions\\.json$"
+      ],
+      "matchStrings": [
+        "\"router\"(.|\\s)*?\"latest-1\": \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "apollographql/router",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>apollographql/renovate-config-apollo-open-source",
+    "github>apollographql/renovate-config-apollo-open-source:default.json5",
     "github>Turbo87/renovate-config//rust/updateToolchain"
   ],
   "packageRules": [
@@ -36,29 +36,6 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major packages >= 1.0",
       "groupSlug": "all-non-major-gte-1.0"
-    },
-    // The current Apollo Gatsby theme does not support a version of Gatsby
-    // that supports React 17.
-    {
-      "matchPaths": [
-        "docs/package.json"
-      ],
-      "matchPackageNames": ["react", "react-dom"],
-      "allowedVersions": "16.x",
-    },
-    // The current Apollo Gatsby version is pinned to v3
-    {
-      "matchPaths": [
-        "docs/package.json"
-      ],
-      "matchPackageNames": ["gatsby"],
-      "allowedVersions": "3.x",
-    }
-  ],
-  "pathRules": [
-    {
-      "paths": ["docs/package.json"],
-      "extends": ["apollo-docs"],
     }
   ],
   "regexManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,10 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major packages >= 1.0",
       "groupSlug": "all-non-major-gte-1.0"
+    },
+    {
+      "matchPackageNames": ["apollographql/federation-rs"],
+      "extractVersion": "supergraph@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
     }
   ],
   "regexManagers": [
@@ -47,6 +51,14 @@
         "\"router\"(.|\\s)*?\"latest-1\": \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
       ],
       "depNameTemplate": "apollographql/router",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["^latest_plugin_versions\\.json$"],
+      "matchStrings": [
+        "\"supergraph\"(.|\\s)*?\"latest-2\": \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "apollographql/federation-rs",
       "datasourceTemplate": "github-releases"
     }
   ]


### PR DESCRIPTION
A few changes in here:

1. Move `renovate.json5` into `.github` so that it's a little more out of the way (works the same)
2. Update the base config in `extends` to use the newer syntax (see https://github.com/apollographql/renovate-config-apollo-open-source/pull/4)
3. Remove vestigial Renovate config for `docs/package.json` file that no longer exists
4. Add support for auto-bumping both Router version and the federation supergraph plugin version (2+ only) in `latest_plugin_versions.json`. It follows the default update schedule which should be weekends.