### PR TITLE
fix: `rover dev` when used with Enterprise features

### DIFF
--- a/src/command/dev/router/command.rs
+++ b/src/command/dev/router/command.rs
@@ -1,3 +1,4 @@
+use std::env::var;
 use std::{
     io::{BufRead, BufReader},
     process::{Child, Command, Stdio},
@@ -38,6 +39,13 @@ impl BackgroundTask {
         command.args(args).env("APOLLO_ROVER", "true");
 
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        if let Ok(apollo_key) = var("APOLLO_KEY") {
+            command.env("APOLLO_KEY", apollo_key);
+        }
+        if let Ok(apollo_graph_ref) = var("APOLLO_GRAPH_REF") {
+            command.env("APOLLO_GRAPH_REF", apollo_graph_ref);
+        }
 
         let mut child = command
             .spawn()

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -110,7 +110,6 @@ impl RouterRunner {
                 .get(&endpoint)
                 .header("Content-Type", "application/json")
                 .send()
-                .and_then(|r| r.error_for_status())
                 .map(|_| {
                     ready = true;
                 });


### PR DESCRIPTION
Specifically, pass through `APOLLO_KEY` and `APOLLO_GRAPH_REF` for entitlements and don't fail startup on 400 errors when those could be caused by plugins/coprocessors (which the user will want to debug using `rover dev`).