### PR TITLE
[Feature] Tools: Schema Merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ name = "rover"
 version = "0.15.0"
 dependencies = [
  "anyhow",
+ "apollo-encoder",
  "apollo-federation-types",
  "apollo-parser",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ timber = { path = "./crates/timber" }
 
 # https://github.com/apollographql/apollo-rs
 apollo-parser = "0.5"
+apollo-encoder = "0.5"
 
 # https://github.com/apollographql/federation-rs
 apollo-federation-types = "0.9.0"
@@ -145,6 +146,7 @@ anyhow = { workspace = true }
 assert_fs = { workspace = true }
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
+apollo-encoder = { workspace = true }
 atty = { workspace = true }
 billboard = { workspace = true }
 binstall = { workspace = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,6 +195,7 @@ impl Rover {
                 self.get_checks_timeout_seconds()?,
                 &self.output_opts,
             ),
+            Command::Tools(command) => command.run(),
             Command::Template(command) => command.run(self.get_client_config()?),
             Command::Readme(command) => command.run(self.get_client_config()?),
             Command::Subgraph(command) => command.run(
@@ -376,6 +377,9 @@ pub enum Command {
 
     /// Graph API schema commands
     Graph(command::Graph),
+
+    /// Commands for manipulating schema files
+    Tools(command::Tools),
 
     /// Commands for working with templates
     Template(command::Template),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod subgraph;
 mod supergraph;
 pub(crate) mod template;
 mod update;
+mod tools;
 
 pub(crate) mod output;
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod subgraph;
 mod supergraph;
 pub(crate) mod template;
 mod update;
-mod tools;
+pub(crate) mod tools;
 
 pub(crate) mod output;
 
@@ -33,3 +33,4 @@ pub use subgraph::Subgraph;
 pub use supergraph::Supergraph;
 pub use template::Template;
 pub use update::Update;
+pub use tools::Tools;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -303,6 +303,7 @@ impl RoverOutput {
                     table, details.root_url, details.graph_ref.name
                 ))
             }
+            RoverOutput::ToolsSchemaMerge(schema) => Some(schema.to_string()),
             RoverOutput::TemplateList(templates) => {
                 let mut table = table::get_table();
 
@@ -497,6 +498,7 @@ impl RoverOutput {
                 json!(delete_response)
             }
             RoverOutput::SubgraphList(list_response) => json!(list_response),
+            RoverOutput::ToolsSchemaMerge(merge_response) => json!({ "schema_merge_response": merge_response }),
             RoverOutput::TemplateList(templates) => json!({ "templates": templates }),
             RoverOutput::TemplateUseSuccess { template_id, path } => {
                 json!({ "template_id": template_id, "path": path })

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -69,6 +69,7 @@ pub enum RoverOutput {
         dry_run: bool,
         delete_response: SubgraphDeleteResponse,
     },
+    ToolsSchemaMerge(String),
     TemplateList(Vec<ListTemplatesForLanguageTemplates>),
     TemplateUseSuccess {
         template_id: String,

--- a/src/command/tools/merge.rs
+++ b/src/command/tools/merge.rs
@@ -1,9 +1,6 @@
 use apollo_parser::ast;
 use apollo_parser::Parser as ApolloParser;
-use apollo_encoder::Document;
-// use apollo_parser::ast::Document;
 use clap::Parser;
-use clap::parser;
 use serde::Serialize;
 
 use std::fs;
@@ -52,7 +49,7 @@ impl Merge {
         let mut schema = apollo_encoder::Document::new();
         for schema_path in schemas {
             let schema_content = fs::read_to_string(schema_path)?;
-            let parser = ApolloParser::new(schema_content.as_str());
+            let parser = ApolloParser::new(&schema_content);
             let ast = parser.parse();
             let doc = ast.document();
             

--- a/src/command/tools/merge.rs
+++ b/src/command/tools/merge.rs
@@ -1,0 +1,20 @@
+use clap::Parser;
+use serde::Serialize;
+
+use crate::options::MergeOpt;
+use crate::{RoverOutput, RoverResult};
+
+use super::tools::merge_schemas;
+
+#[derive(Clone, Debug, Parser, Serialize)]
+pub struct Merge {
+    #[clap(flatten)]
+    options: MergeOpt,
+}
+
+impl Merge {
+    pub fn run(&self) -> RoverResult<RoverOutput> {
+        let schema = merge_schemas(self.options.schemas.clone())?;
+        Ok(RoverOutput::ToolsSchemaMerge(schema))
+    }
+}

--- a/src/command/tools/merge.rs
+++ b/src/command/tools/merge.rs
@@ -1,20 +1,117 @@
+use apollo_parser::ast;
+use apollo_parser::Parser as ApolloParser;
+use apollo_encoder::Document;
+// use apollo_parser::ast::Document;
 use clap::Parser;
+use clap::parser;
 use serde::Serialize;
 
-use crate::options::MergeOpt;
-use crate::{RoverOutput, RoverResult};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
 
-use super::tools::merge_schemas;
+use crate::options::ToolsMergeOpt;
+use crate::{RoverOutput, RoverResult};
 
 #[derive(Clone, Debug, Parser, Serialize)]
 pub struct Merge {
     #[clap(flatten)]
-    options: MergeOpt,
+    options: ToolsMergeOpt,
 }
 
 impl Merge {
     pub fn run(&self) -> RoverResult<RoverOutput> {
-        let schema = merge_schemas(self.options.schemas.clone())?;
+        // find files by extension
+        let schemas = self.find_files_by_extensions(self.options.schemas.clone(), &["graphql", "gql"])?;
+        // merge schemas into one
+        let schema = self.merge_schemas_into_one(schemas)?;
         Ok(RoverOutput::ToolsSchemaMerge(schema))
+    }
+
+    fn find_files_by_extensions<P: AsRef<Path>>(&self, folder: P, extensions: &'_ [&str]) -> std::io::Result<Vec<PathBuf>> {
+        let mut result = Vec::new();
+        for entry in fs::read_dir(folder.as_ref())? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                let subfolder_result = self.find_files_by_extensions(&path, extensions);
+                if let Ok(subfolder_paths) = subfolder_result {
+                    result.extend(subfolder_paths);
+                }
+            } else if let Some(file_ext) = path.extension().and_then(OsStr::to_str) {
+                if extensions.contains(&file_ext) {
+                    result.push(path);
+                }
+            }
+        }
+    
+        Ok(result)
+    }
+
+    fn merge_schemas_into_one(&self, schemas: Vec<PathBuf>) -> RoverResult<String> {
+        let mut schema = apollo_encoder::Document::new();
+        for schema_path in schemas {
+            let schema_content = fs::read_to_string(schema_path)?;
+            let parser = ApolloParser::new(schema_content.as_str());
+            let ast = parser.parse();
+            let doc = ast.document();
+            
+            for def in doc.definitions() {
+                match def {
+                    ast::Definition::SchemaDefinition(schema_def) => {
+                        schema.schema(schema_def.try_into()?);
+                    }
+                    ast::Definition::OperationDefinition(op_def) => {
+                        schema.operation(op_def.try_into()?);
+                    }
+                    ast::Definition::FragmentDefinition(frag_def) => {
+                        schema.fragment(frag_def.try_into()?);
+                    }
+                    ast::Definition::DirectiveDefinition(dir_def) => {
+                        schema.directive(dir_def.try_into()?);
+                    }
+                    ast::Definition::ScalarTypeDefinition(scalar_type_def) => {
+                        schema.scalar(scalar_type_def.try_into()?);
+                    }
+                    ast::Definition::ObjectTypeDefinition(object_type_def) => {
+                        schema.object(object_type_def.try_into()?);
+                    }
+                    ast::Definition::InterfaceTypeDefinition(interface_type_def) => {
+                        schema.interface(interface_type_def.try_into()?);
+                    }
+                    ast::Definition::UnionTypeDefinition(union_type_def) => {
+                        schema.union(union_type_def.try_into()?);
+                    }
+                    ast::Definition::EnumTypeDefinition(enum_type_def) => {
+                        schema.enum_(enum_type_def.try_into()?);
+                    }
+                    ast::Definition::InputObjectTypeDefinition(input_object_type_def) => {
+                        schema.input_object(input_object_type_def.try_into()?);
+                    }
+                    ast::Definition::SchemaExtension(schema_extension_def) => {
+                        schema.schema(schema_extension_def.try_into()?);
+                    }
+                    ast::Definition::ScalarTypeExtension(scalar_type_extension_def) => {
+                        schema.scalar(scalar_type_extension_def.try_into()?);
+                    }
+                    ast::Definition::ObjectTypeExtension(object_type_extension_def) => {
+                        schema.object(object_type_extension_def.try_into()?);
+                    }
+                    ast::Definition::InterfaceTypeExtension(interface_type_extension_def) => {
+                        schema.interface(interface_type_extension_def.try_into()?);
+                    }
+                    ast::Definition::UnionTypeExtension(union_type_extension_def) => {
+                        schema.union(union_type_extension_def.try_into()?);
+                    }
+                    ast::Definition::EnumTypeExtension(enum_type_extension_def) => {
+                        schema.enum_(enum_type_extension_def.try_into()?);
+                    }
+                    ast::Definition::InputObjectTypeExtension(input_object_type_extension_def) => {
+                        schema.input_object(input_object_type_extension_def.try_into()?);
+                    }
+                }
+            }
+        }
+        Ok(schema.to_string())
     }
 }

--- a/src/command/tools/mod.rs
+++ b/src/command/tools/mod.rs
@@ -5,7 +5,6 @@ pub use merge::Merge;
 use clap::Parser;
 use serde::Serialize;
 
-use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Clone, Parser, Serialize)]
@@ -17,13 +16,13 @@ pub struct Tools {
 #[derive(Clone, Debug, Parser, Serialize)]
 enum Command {
     /// Merge multiple schema files into one
-    Merge(Merge),
+    SchemaMerge(Merge),
 }
 
 impl Tools {
-    pub(crate) fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+    pub(crate) fn run(&self) -> RoverResult<RoverOutput> {
         match &self.command {
-            Command::Merge(merge) => merge.run(),
+            Command::SchemaMerge(merge) => merge.run(),
         }
     }
 }

--- a/src/command/tools/mod.rs
+++ b/src/command/tools/mod.rs
@@ -1,0 +1,29 @@
+mod merge;
+
+pub use merge::Merge;
+
+use clap::Parser;
+use serde::Serialize;
+
+use crate::utils::client::StudioClientConfig;
+use crate::{RoverOutput, RoverResult};
+
+#[derive(Debug, Clone, Parser, Serialize)]
+pub struct Tools {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Clone, Debug, Parser, Serialize)]
+enum Command {
+    /// Merge multiple schema files into one
+    Merge(Merge),
+}
+
+impl Tools {
+    pub(crate) fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        match &self.command {
+            Command::Merge(merge) => merge.run(),
+        }
+    }
+}

--- a/src/command/tools/mod.rs
+++ b/src/command/tools/mod.rs
@@ -16,13 +16,13 @@ pub struct Tools {
 #[derive(Clone, Debug, Parser, Serialize)]
 enum Command {
     /// Merge multiple schema files into one
-    SchemaMerge(Merge),
+    Merge(Merge),
 }
 
 impl Tools {
     pub(crate) fn run(&self) -> RoverResult<RoverOutput> {
         match &self.command {
-            Command::SchemaMerge(merge) => merge.run(),
+            Command::Merge(merge) => merge.run(),
         }
     }
 }

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -8,6 +8,7 @@ mod profile;
 mod schema;
 mod subgraph;
 mod template;
+mod tools;
 
 pub(crate) use check::*;
 pub(crate) use compose::*;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -20,3 +20,4 @@ pub(crate) use profile::*;
 pub(crate) use schema::*;
 pub(crate) use subgraph::*;
 pub(crate) use template::*;
+pub(crate) use tools::*;

--- a/src/options/tools.rs
+++ b/src/options/tools.rs
@@ -1,0 +1,25 @@
+use clap::Parser;
+
+// use crate::{utils::parsers::FileDescriptorType, RoverResult};
+
+use std::{io::Read, any::Any};
+
+use crate::RoverResult;
+
+#[derive(Debug, Parser)]
+pub struct ToolsMergeOpt {
+    /// The path to schema files to merge.
+    #[arg(long, short = 's')]
+    schemas: String,
+}
+
+impl ToolsMergeOpt {
+    pub(crate) fn read_file_descriptor(
+        &self,
+        file_description: &str,
+        stdin: &mut impl Read,
+    ) -> RoverResult<String> {
+        // not implemented
+        Ok("".to_string())
+    }
+}

--- a/src/options/tools.rs
+++ b/src/options/tools.rs
@@ -1,25 +1,17 @@
 use clap::Parser;
+use serde::{Serialize, Deserialize};
 
-// use crate::{utils::parsers::FileDescriptorType, RoverResult};
+// use std::{io::Read};
 
-use std::{io::Read, any::Any};
+// use crate::RoverResult;
 
-use crate::RoverResult;
-
-#[derive(Debug, Parser)]
+#[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct ToolsMergeOpt {
     /// The path to schema files to merge.
     #[arg(long, short = 's')]
-    schemas: String,
+    pub schemas: String,
 }
 
 impl ToolsMergeOpt {
-    pub(crate) fn read_file_descriptor(
-        &self,
-        file_description: &str,
-        stdin: &mut impl Read,
-    ) -> RoverResult<String> {
-        // not implemented
-        Ok("".to_string())
-    }
+    
 }

--- a/tests/tools/merge.rs
+++ b/tests/tools/merge.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+
+#[test]
+fn it_has_a_tools_merge_command() {
+    let mut cmd = Command::cargo_bin("rover").unwrap();
+    cmd.arg("tools")
+        .arg("merge")
+        .arg("--help")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
This adds a `tools` command for manipulating schema files.

It also adds a `tools merge` subcommand to merge multiple `.graphql/.gql` files together into a single file. (implemented with apollo-rs 🎉 )

It outputs the merged schema as rover command result.

Example:
```bash
rover tools merge --schemas /path/containing/schemas
```