### PR TITLE
chore: write lint report to string before printing it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -440,7 +440,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "pin-utils",
- "socket2",
+ "socket2 0.4.9",
  "trust-dns-resolver 0.21.2",
 ]
 
@@ -719,9 +719,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bzip2"
@@ -1244,7 +1244,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2",
+ "socket2 0.4.9",
  "winapi 0.3.9",
 ]
 
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2181,9 +2181,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpmock"
-version = "0.6.7"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b56b6265f15908780cbee987912c1e98dbca675361f748291605a8a3a1df09"
+checksum = "c159c4fc205e6c1a9b325cb7ec135d13b5f47188ce175dabb76ec847f331d9bd"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -2230,7 +2230,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2279,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2475,14 +2475,14 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.3",
  "widestring",
- "winapi 0.3.9",
- "winreg 0.10.1",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2663,9 +2663,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.145"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libgit2-sys"
@@ -2725,9 +2725,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3093,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
@@ -3298,15 +3298,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3550,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -4118,18 +4118,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4368,7 +4368,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -4434,6 +4434,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4600,15 +4610,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4730,9 +4741,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -4799,7 +4810,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4837,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
@@ -5440,9 +5451,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -5767,7 +5778,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.21",
+ "time 0.3.22",
  "zstd",
 ]
 

--- a/crates/rover-client/src/shared/lint_response.rs
+++ b/crates/rover-client/src/shared/lint_response.rs
@@ -64,7 +64,7 @@ impl LintResponse {
                 )?;
 
                 if i == self.diagnostics.len() - 1 {
-                    write!(output, "\n")?;
+                    writeln!(output)?;
                 }
             }
 

--- a/crates/rover-client/src/shared/lint_response.rs
+++ b/crates/rover-client/src/shared/lint_response.rs
@@ -1,4 +1,7 @@
-use std::ops::Range;
+use std::{
+    io::{self, BufWriter, Write},
+    ops::Range,
+};
 
 use ariadne::{ColorGenerator, Label, Report, ReportKind, Source};
 use serde::Serialize;
@@ -13,9 +16,9 @@ pub struct LintResponse {
 }
 
 impl LintResponse {
-    pub fn print_ariadne(&self) -> String {
+    pub fn print_ariadne(&self) -> io::Result<String> {
         if self.diagnostics.is_empty() {
-            "No lint errors found in this schema".to_owned()
+            Ok("No lint errors found in this schema".to_string())
         } else {
             let mut colors = ColorGenerator::new();
             let error_color = colors.next();
@@ -23,9 +26,12 @@ impl LintResponse {
             let ignored_color = colors.next();
             let file_name = self.file_name.as_str();
 
-            let mut result = true;
+            let mut output = BufWriter::new(Vec::new())
+                .into_inner()
+                // this shouldn't happen because `Vec` is not a fixed size and should grow to whatever we write to it
+                .expect("could not write lint report to buffer");
 
-            for diagnostic in &self.diagnostics {
+            for (i, diagnostic) in self.diagnostics.iter().enumerate() {
                 let range = Range {
                     start: diagnostic.start_byte_offset,
                     end: diagnostic.end_byte_offset,
@@ -50,18 +56,20 @@ impl LintResponse {
                             &_ => colors.next(),
                         }),
                 )
-                .finish()
-                .eprint((file_name, Source::from(self.proposed_schema.as_str())));
-                if report.is_err() {
-                    result = false;
+                .finish();
+
+                report.write(
+                    (file_name, Source::from(self.proposed_schema.as_str())),
+                    &mut output,
+                )?;
+
+                if i == self.diagnostics.len() - 1 {
+                    write!(output, "\n")?;
                 }
             }
 
-            if result {
-                String::new()
-            } else {
-                "Display of results failed".to_owned()
-            }
+            Ok(String::from_utf8(output)
+                .map_err(|source| io::Error::new(io::ErrorKind::InvalidData, source))?)
         }
     }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fmt::Debug;
 use std::io;
 
 use crate::command::supergraph::compose::CompositionOutput;
@@ -345,7 +344,7 @@ impl RoverOutput {
                 "Check successfully started with workflow ID: {}\nView full details at {}",
                 check_response.workflow_id, check_response.target_url
             )),
-            RoverOutput::LintResponse(lint_response) => Some(lint_response.print_ariadne()),
+            RoverOutput::LintResponse(lint_response) => Some(lint_response.print_ariadne()?),
             RoverOutput::Profiles(profiles) => {
                 if profiles.is_empty() {
                     stderrln!("No profiles found.")?;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -14,7 +14,6 @@ use serde_json::{json, Value};
 use std::borrow::BorrowMut;
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
-use std::io;
 
 use apollo_federation_types::build::BuildErrors;
 
@@ -83,7 +82,7 @@ impl RoverError {
         self.metadata.code.clone()
     }
 
-    pub fn print(&self) -> io::Result<()> {
+    pub fn print(&self) -> RoverResult<()> {
         if let Some(RoverClientError::OperationCheckFailure {
             graph_ref: _,
             check_response,
@@ -94,7 +93,7 @@ impl RoverError {
         if let Some(RoverClientError::LintFailures { lint_response }) =
             self.error.downcast_ref::<RoverClientError>()
         {
-            stdoutln!("{}", lint_response.print_ariadne())?;
+            stdoutln!("{}", lint_response.print_ariadne()?)?;
         }
 
         stderr!("{}", self)?;


### PR DESCRIPTION
Saw @swcollard's comment on #1620 explaining the difficulties he had when trying to return a string rather than printing a report directly. To address this, I took a look at the [API docs for ariadne](https://docs.rs/ariadne/latest/ariadne/struct.Report.html), and found [the write method](https://docs.rs/ariadne/latest/ariadne/struct.Report.html#method.write) which lets you write to a buffer. This PR does just that, it creates a a `BufWriter::new(Vec::new())` at the beginning of the loop, and then each report calls `report.write`, passing in a mutable reference to the `BufWriter` we created, `ariadne` takes care of writing bytes directly to the buffer (`[u8]`). At the very end, this buffer is converted to a string using `String::from_utf8`.