### PR TITLE
fix: YAML federation_version doesn't require version to be quoted

### DIFF
--- a/examples/supergraph-demo/supergraph.yaml
+++ b/examples/supergraph-demo/supergraph.yaml
@@ -1,4 +1,4 @@
-federation_version: =2.4.3
+federation_version: 2
 subgraphs:
   products:
     routing_url: 'http://localhost:4002'

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -272,3 +272,30 @@ pub(crate) fn resolve_supergraph_yaml(
 
     Ok(resolved_supergraph_config)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_parse_valid_config_fed_two() {
+        let raw_good_yaml = r#"---
+federation_version: 2
+subgraphs:
+  films:
+    routing_url: https://films.example.com
+    schema:
+      file: ./good-films.graphql
+  people:
+    routing_url: https://people.example.com
+    schema:
+      file: ./good-people.graphql
+"#;
+
+        let config = expand_supergraph_yaml(raw_good_yaml).unwrap();
+        assert_eq!(
+            config.get_federation_version(),
+            Some(FederationVersion::LatestFedTwo)
+        );
+    }
+}

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -24,7 +24,11 @@ pub(crate) fn expand_supergraph_yaml(content: &str) -> RoverResult<SupergraphCon
     serde_yaml::from_str(content)
         .map_err(RoverError::from)
         .and_then(expand)
-        .and_then(|v| serde_yaml::from_value(v).map_err(RoverError::from))
+        .and_then(|v| {
+            Ok(SupergraphConfig::new_from_yaml(&serde_yaml::to_string(
+                &v,
+            )?)?)
+        })
 }
 
 pub(crate) fn resolve_supergraph_yaml(

--- a/src/utils/expansion.rs
+++ b/src/utils/expansion.rs
@@ -85,6 +85,29 @@ subgraphs:
         .unwrap();
         assert_eq!(expanded, expected);
     }
+
+    /// No environment variables results in same YAML after expansion
+    #[test]
+    fn supergraph_config_remains_same_with_no_env_expansion() {
+        let yaml = r#"federation_version: 2
+subgraphs:
+  products:
+    routing_url: http://localhost:4001
+    schema:
+      subgraph_url: http://localhost:4001"#;
+        let value = serde_yaml::from_str(yaml).unwrap();
+        let expanded = super::expand(value).unwrap();
+        let expected: Value = serde_yaml::from_str(
+            r#"federation_version: 2
+subgraphs:
+  products:
+    routing_url: http://localhost:4001
+    schema:
+      subgraph_url: http://localhost:4001"#,
+        )
+        .unwrap();
+        assert_eq!(expanded, expected);
+    }
 }
 
 /// Implements router-config-style


### PR DESCRIPTION
fixes #1647

Pre-0.16.0, we allowed `federation_version: 2` in `supergraph.yaml`, this was broken when introducing environment variable expansion. This PR fixes this behavior and re-allows passing `federation_version: 2`.