### PR TITLE
chore: bumps apollo-federation-types to 0.9.2, fixing compose regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,8 +144,7 @@ dependencies = [
 [[package]]
 name = "apollo-federation-types"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b704a237e424578536476b6df7f59b8b09efb32ade4f032b929f9d3349d1a745"
+source = "git+https://github.com/apollographql/federation-rs?branch=avery/make-code-optional#39fb9e8075d3285509f3bf734d920825e408f43c"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ timber = { path = "./crates/timber" }
 apollo-parser = "0.5"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.9.1"
+apollo-federation-types = "0.9.2"
 
 # https://github.com/apollographql/introspector-gadget
 introspector-gadget = "0.2"

--- a/examples/supergraph-demo/users/users.graphql
+++ b/examples/supergraph-demo/users/users.graphql
@@ -3,5 +3,5 @@ directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT
 type User @key(fields:"email") {
     email:ID! @tag(name: "test-from-users")
     name: String
-    totalProductsCreated: Intttt
+    totalProductsCreated: Int
 }


### PR DESCRIPTION
fixes #1654 by bumping `apollo-federation-types` to 0.9.2 which makes the `code` message optional. this allows `rover supergraph compose` to handle the existence and absence of a `code` instead of crashing when a `code` is not provided by an old plugin version.