### PR TITLE
fix: use notarytool instead of altool to codesign macos binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,12 +4830,11 @@ checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokio"
-version = "1.29.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
- "backtrace",
  "bytes",
  "libc",
  "mio 0.8.8",

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -1,11 +1,11 @@
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{ensure, Context, Result};
 use base64::Engine;
 use clap::Parser;
-use serde_json_traversal::serde_json_traversal;
 use std::io::Write as _;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use crate::tools::XcrunRunner;
 use crate::utils::{PKG_PROJECT_ROOT, PKG_VERSION};
 
 const ENTITLEMENTS: &str = "macos-entitlements.plist";
@@ -23,10 +23,6 @@ pub struct PackageMacos {
     /// Certificate bundle keychain_password.
     #[arg(long, env = "MACOS_CERT_BUNDLE_PASSWORD", hide_env_values = true)]
     cert_bundle_password: String,
-
-    /// Primary bundle ID.
-    #[arg(long, env = "MACOS_PRIMARY_BUNDLE_ID")]
-    primary_bundle_id: String,
 
     /// Apple team ID.
     #[arg(long, env = "APPLE_TEAM_ID")]
@@ -205,82 +201,19 @@ impl PackageMacos {
         )?;
         zip.finish()?;
 
-        crate::info!("Beginning notarization process...");
-        let output = Command::new("xcrun")
-            .args(["altool", "--notarize-app", "--primary-bundle-id"])
-            .arg(&self.primary_bundle_id)
-            .arg("--username")
-            .arg(&self.apple_username)
-            .arg("--password")
-            .arg(&self.notarization_password)
-            .arg("--asc-provider")
-            .arg(&self.apple_team_id)
-            .arg("--file")
-            .arg(&dist_zip)
-            .args(["--output-format", "json"])
-            .stderr(Stdio::inherit())
-            .output()
-            .context("could not start command xcrun")?;
-        let _ = std::io::stdout().write(&output.stdout);
-        ensure!(output.status.success(), "command exited with error",);
-        let json: serde_json::Value =
-            serde_json::from_slice(&output.stdout).context("could not parse json output")?;
-        let success_message = serde_json_traversal!(json => success-message)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let request_uuid = serde_json_traversal!(json => notarization-upload => RequestUUID)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        crate::info!("Success message: {}", success_message);
-        crate::info!("Request UUID: {}", request_uuid);
+        let dist_zip = dist_zip.to_str().unwrap_or_else(|| {
+            panic!(
+                "path to zipped directory '{}' is not valid utf-8",
+                dist_zip.display()
+            )
+        });
 
-        let start_time = std::time::Instant::now();
-        let duration = std::time::Duration::from_secs(60 * 10);
-        let result = loop {
-            crate::info!("Checking notarization status...");
-            let output = Command::new("xcrun")
-                .args(["altool", "--notarization-info"])
-                .arg(request_uuid)
-                .arg("--username")
-                .arg(&self.apple_username)
-                .arg("--password")
-                .arg(&self.notarization_password)
-                .args(["--output-format", "json"])
-                .stderr(Stdio::inherit())
-                .output()
-                .context("could not start command xcrun")?;
-
-            let status = if !output.status.success() {
-                // NOTE: if the exit status is failure we need to keep trying otherwise the
-                //       process becomes a bit flaky
-                crate::info!("command exited with error");
-                None
-            } else {
-                let json: serde_json::Value = serde_json::from_slice(&output.stdout)
-                    .context("could not parse json output")?;
-                serde_json_traversal!(json => notarization-info => Status)
-                    .ok()
-                    .and_then(|x| x.as_str())
-                    .map(|x| x.to_string())
-            };
-
-            if !matches!(
-                status.as_deref(),
-                Some("in progress") | None if start_time.elapsed() < duration
-            ) {
-                break status;
-            }
-
-            std::thread::sleep(std::time::Duration::from_secs(5));
-        };
-        match result.as_deref() {
-            Some("success") => crate::info!("Notarization successful"),
-            Some("in progress") => bail!("Notarization timeout"),
-            Some(other) => bail!("Notarization failed: {}", other),
-            None => bail!("Notarization failed without status message"),
-        }
+        XcrunRunner::new().notarize(
+            dist_zip,
+            &self.apple_username,
+            &self.apple_team_id,
+            &self.notarization_password,
+        )?;
 
         Ok(())
     }

--- a/xtask/src/tools/mod.rs
+++ b/xtask/src/tools/mod.rs
@@ -4,11 +4,17 @@ mod make;
 mod npm;
 mod runner;
 
+#[cfg(target_os = "macos")]
+mod xcrun;
+
 pub(crate) use cargo::CargoRunner;
 pub(crate) use git::GitRunner;
 pub(crate) use make::MakeRunner;
 pub(crate) use npm::NpmRunner;
 pub(crate) use runner::Runner;
+
+#[cfg(target_os = "macos")]
+pub(crate) use xcrun::XcrunRunner;
 
 #[cfg(not(windows))]
 mod lychee;

--- a/xtask/src/tools/xcrun.rs
+++ b/xtask/src/tools/xcrun.rs
@@ -1,0 +1,48 @@
+use crate::tools::Runner;
+use crate::utils::PKG_PROJECT_ROOT;
+
+use anyhow::Result;
+
+pub(crate) struct XcrunRunner {
+    runner: Runner,
+}
+
+impl XcrunRunner {
+    pub(crate) fn new() -> Self {
+        let runner = Runner::new("xcrun");
+
+        XcrunRunner { runner }
+    }
+
+    pub(crate) fn notarize(
+        &mut self,
+        dist_zip: &str,
+        apple_username: &str,
+        apple_team_id: &str,
+        notarization_password: &str,
+    ) -> Result<()> {
+        crate::info!("Beginning notarization process...");
+        self.runner.set_bash_descriptor(format!("xcrun notarytool submit {dist_zip} --apple-id {apple_username} --apple-team-id {apple_team_id} --password xxxx-xxxx-xxxx-xxxx --wait --timeout 20m"));
+        let project_root = PKG_PROJECT_ROOT.clone();
+        self.runner.exec(
+            &[
+                "notarytool",
+                "submit",
+                dist_zip,
+                "--apple-id",
+                apple_username,
+                "--team-id",
+                apple_team_id,
+                "--password",
+                notarization_password,
+                "--wait",
+                "--timeout",
+                "20m",
+            ],
+            &project_root,
+            None,
+        )?;
+        crate::info!("Notarization successful.");
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #1657 by migrating from `altool` to `notarytool`.