### PR TITLE
chore: removes unused MACOS_PRIMARY_BUNDLE_ID from circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ executors:
       XTASK_TARGET: "x86_64-apple-darwin"
       APPLE_TEAM_ID: "YQK948L752"
       APPLE_USERNAME: "opensource@apollographql.com"
-      MACOS_PRIMARY_BUNDLE_ID: com.apollographql.rover
 
   # this is the exact same executor as amd_macos_executor (except $XTASK_TARGET)
   # until there is official support for building on real ARM Macs
@@ -70,7 +69,6 @@ executors:
       XTASK_TARGET: "aarch64-apple-darwin"
       APPLE_TEAM_ID: "YQK948L752"
       APPLE_USERNAME: "opensource@apollographql.com"
-      MACOS_PRIMARY_BUNDLE_ID: com.apollographql.rover
 
   amd_windows: &amd_windows_executor
     machine:

--- a/xtask/src/tools/xcrun.rs
+++ b/xtask/src/tools/xcrun.rs
@@ -47,7 +47,7 @@ impl XcrunRunner {
                 anyhow!(
                     "{}",
                     e.to_string()
-                        .replace(&notarization_password, "xxxx-xxxx-xxxx-xxxx")
+                        .replace(notarization_password, "xxxx-xxxx-xxxx-xxxx")
                 )
             })?;
         crate::info!("Notarization successful.");

--- a/xtask/src/tools/xcrun.rs
+++ b/xtask/src/tools/xcrun.rs
@@ -1,7 +1,7 @@
 use crate::tools::Runner;
 use crate::utils::PKG_PROJECT_ROOT;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 pub(crate) struct XcrunRunner {
     runner: Runner,
@@ -24,24 +24,32 @@ impl XcrunRunner {
         crate::info!("Beginning notarization process...");
         self.runner.set_bash_descriptor(format!("xcrun notarytool submit {dist_zip} --apple-id {apple_username} --apple-team-id {apple_team_id} --password xxxx-xxxx-xxxx-xxxx --wait --timeout 20m"));
         let project_root = PKG_PROJECT_ROOT.clone();
-        self.runner.exec(
-            &[
-                "notarytool",
-                "submit",
-                dist_zip,
-                "--apple-id",
-                apple_username,
-                "--team-id",
-                apple_team_id,
-                "--password",
-                notarization_password,
-                "--wait",
-                "--timeout",
-                "20m",
-            ],
-            &project_root,
-            None,
-        )?;
+        self.runner
+            .exec(
+                &[
+                    "notarytool",
+                    "submit",
+                    dist_zip,
+                    "--apple-id",
+                    apple_username,
+                    "--team-id",
+                    apple_team_id,
+                    "--password",
+                    notarization_password,
+                    "--wait",
+                    "--timeout",
+                    "20m",
+                ],
+                &project_root,
+                None,
+            )
+            .map_err(|e| {
+                anyhow!(
+                    "{}",
+                    e.to_string()
+                        .replace(&notarization_password, "xxxx-xxxx-xxxx-xxxx")
+                )
+            })?;
         crate::info!("Notarization successful.");
         Ok(())
     }


### PR DESCRIPTION
follow-up to the recent PR to fix macos builds removing an unneeded environment variable