### PR TITLE
Allow `rover dev` to use introspection URL as `routing_url`

### DIFF
--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -59,9 +59,8 @@ subgraphs:
     schema:
       file: ./products.graphql # Schema provided via file
   reviews:
-    routing_url: http://localhost:4001
     schema:
-      subgraph_url: http://localhost:4001 # Schema provided via introspection
+      subgraph_url: http://localhost:4001 # Schema provided via introspection, routing_url can be omitted
 ```
 
 You provide this file to `rover dev` like so:

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -94,7 +94,7 @@ subgraphs:
 
   # Apollo Studio graph ref
   actors:
-    routing_url: https://localhost:4005  # <- can be omitted if matches existing URL in Studio
+    routing_url: http://localhost:4005  # <- can be omitted if matches existing URL in Studio
     schema:
       graphref: mygraph@current
       subgraph: actors

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -86,15 +86,15 @@ subgraphs:
 
   # Subgraph introspection
   people:
-    routing_url: https://example.com/people
+    routing_url: https://example.com/people  # <- can be omitted if the same as introspection URL
     schema:
-      subgraph_url: https://example.com/people
+      subgraph_url: http://127.0.0.1:4002
       introspection_headers:  # Optional headers to include in introspection request
         Authorization: Bearer ${env.PEOPLE_AUTH_TOKEN}
 
   # Apollo Studio graph ref
   actors:
-    routing_url: https://localhost:4005
+    routing_url: https://localhost:4005  # <- can be omitted if matches existing URL in Studio
     schema:
       graphref: mygraph@current
       subgraph: actors


### PR DESCRIPTION
This matches the behavior of `supergraph compose` and, I believe, closes #1634

Also added notes about the URL inheritance behavior to the docs (I didn't realize `supergraph compose` already did this until I tried it 😅)
