### PR TITLE
feat(install): support configs for binary mirrors

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -52,7 +52,7 @@ If you are behind a proxy and install dependencies through a mirror or proxy of 
 apollo_rover_download_host=https://your.mirror.com/repository
 ```
 
-You can also set this value using the `APOLLO_ROVER_DOWNLOAD_HOST` environment var.
+You can also set this value using the `APOLLO_ROVER_DOWNLOAD_HOST` environment variable.
 
 #### `devDependencies` install
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -44,6 +44,16 @@ iwr 'https://rover.apollo.dev/win/v0.17.2' | iex
 
 Rover is distributed on npm for integration with your JavaScript projects.
 
+#### Installation from NPM mirror
+
+If you are behind a proxy and install dependencies through a mirror or proxy of npm, add the following to your global or local `.npmrc`:
+
+```ini
+apollo_rover_download_host=https://your.mirror.com/repository
+```
+
+You can also set this value using the `APOLLO_ROVER_DOWNLOAD_HOST` environment var.
+
 #### `devDependencies` install
 
 Run the following to install `rover` as one of your project's `devDependencies`:

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -95,9 +95,10 @@ const getPlatform = () => {
 
 const getBinary = () => {
   const platform = getPlatform();
+  const download_host = process.env.npm_config_apollo_rover_download_host || process.env.APOLLO_ROVER_DOWNLOAD_HOST || 'https://rover.apollo.dev'
   // the url for this binary is constructed from values in `package.json`
   // https://rover.apollo.dev/tar/rover/x86_64-unknown-linux-gnu/v0.4.8
-  const url = `https://rover.apollo.dev/tar/${name}/${platform.RUST_TARGET}/v${version}`;
+  const url = `${download_host}/tar/${name}/${platform.RUST_TARGET}/v${version}`;
   let binary = new Binary(platform.BINARY_NAME, url);
 
   // setting this allows us to extract supergraph plugins to the proper directory


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

This adds the ability to install the rover binary utilizing npm in situations where a custom registry is defined and you sit behind a outgoing firewall/proxy. In these situations, organizations typically have some sort of artifact repository acting as a proxy/mirror for npm and internet endpoints, and users need to be able to specify what proxy to pull the binary from to react `rover.apollo.dev`.  

(This is the same way popular packages that have binaries work, such as Playwright, Cypress, Canvas, Electron, etc...)

This PR adds the ability to specify via npm configs, the apollo rover download host.  (see updates to getting-started.md)
