### PR TITLE
fix: use correct subgraph name when composing a subgraph from GraphOS

### DIFF
--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -119,7 +119,7 @@ impl SupergraphOpts {
         let mut studio_client: Option<StudioClient> = None;
         supergraph_config
             .into_iter()
-            .map(|(name, subgraph_config)| {
+            .map(|(yaml_subgraph_name, subgraph_config)| {
                 let routing_url = subgraph_config
                     .routing_url
                     .map(|url_str| Url::parse(&url_str).map_err(RoverError::from))
@@ -130,7 +130,7 @@ impl SupergraphOpts {
                             anyhow!("`routing_url` must be set when using a local schema file")
                         })?;
                         SubgraphSchemaWatcher::new_from_file_path(
-                            (name, routing_url),
+                            (yaml_subgraph_name, routing_url),
                             file,
                             follower_messenger.clone(),
                         )
@@ -139,7 +139,7 @@ impl SupergraphOpts {
                         subgraph_url,
                         introspection_headers,
                     } => SubgraphSchemaWatcher::new_from_url(
-                        (name, subgraph_url),
+                        (yaml_subgraph_name, subgraph_url),
                         client.clone(),
                         follower_messenger.clone(),
                         polling_interval,
@@ -150,12 +150,15 @@ impl SupergraphOpts {
                             anyhow!("`routing_url` must be set when providing SDL directly")
                         })?;
                         SubgraphSchemaWatcher::new_from_sdl(
-                            (name, routing_url),
+                            (yaml_subgraph_name, routing_url),
                             sdl,
                             follower_messenger.clone(),
                         )
                     }
-                    SchemaSource::Subgraph { graphref, subgraph } => {
+                    SchemaSource::Subgraph {
+                        graphref,
+                        subgraph: graphos_subgraph_name,
+                    } => {
                         let studio_client = if let Some(studio_client) = studio_client.as_ref() {
                             studio_client
                         } else {
@@ -166,8 +169,9 @@ impl SupergraphOpts {
 
                         SubgraphSchemaWatcher::new_from_graph_ref(
                             &graphref,
+                            graphos_subgraph_name,
                             routing_url,
-                            subgraph,
+                            yaml_subgraph_name,
                             follower_messenger.clone(),
                             studio_client,
                         )

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -76,8 +76,9 @@ impl SubgraphSchemaWatcher {
 
     pub fn new_from_graph_ref(
         graph_ref: &str,
+        graphos_subgraph_name: String,
         routing_url: Option<Url>,
-        subgraph_name: String,
+        yaml_subgraph_name: String,
         message_sender: FollowerMessenger,
         client: &StudioClient,
     ) -> RoverResult<Self> {
@@ -86,7 +87,7 @@ impl SubgraphSchemaWatcher {
         let response = fetch::run(
             SubgraphFetchInput {
                 graph_ref: GraphRef::from_str(graph_ref)?,
-                subgraph_name: subgraph_name.clone(),
+                subgraph_name: graphos_subgraph_name.clone(),
             },
             client,
         )
@@ -104,19 +105,19 @@ impl SubgraphSchemaWatcher {
             ))?,
             (None, _) => {
                 return Err(RoverError::new(anyhow!(
-                    "Could not find routing URL in GraphOS for subgraph {subgraph_name}"
+                    "Could not find routing URL in GraphOS for subgraph {graphos_subgraph_name}"
                 ))
                 .with_suggestion(RoverErrorSuggestion::AddRoutingUrlToSupergraphYaml)
                 .with_suggestion(
                     RoverErrorSuggestion::PublishSubgraphWithRoutingUrl {
-                        subgraph_name,
+                        subgraph_name: yaml_subgraph_name,
                         graph_ref: graph_ref.to_string(),
                     },
                 ));
             }
         };
         Self::new_from_sdl(
-            (subgraph_name, routing_url),
+            (yaml_subgraph_name, routing_url),
             response.sdl.contents,
             message_sender,
         )

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -87,7 +87,7 @@ impl SubgraphSchemaWatcher {
         let response = fetch::run(
             SubgraphFetchInput {
                 graph_ref: GraphRef::from_str(graph_ref)?,
-                subgraph_name: graphos_subgraph_name.clone(),
+                subgraph_name: graphos_subgraph_name,
             },
             client,
         )


### PR DESCRIPTION
renames subgraph name variables to be a bit clearer and uses the correct subgraph name to fetch the schema from GraphOS and the correct subgraph name to use when composing a local supergraph.