### PR TITLE
pq publish: remove preview phase message

### DIFF
--- a/src/command/persisted_queries/publish.rs
+++ b/src/command/persisted_queries/publish.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use rover_client::operations::persisted_queries::name::{self, PersistedQueryListNameInput};
-use rover_std::{Emoji, Style};
+use rover_std::Style;
 use serde::Serialize;
 
 use crate::options::{OptionalGraphRefOpt, ProfileOpt};
@@ -40,7 +40,6 @@ pub struct Publish {
 
 impl Publish {
     pub fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
-        eprintln!("{} This feature is currently in a preview phase; it must be enabled for your GraphOS account to function properly.", Emoji::Warn);
         let client = client_config.get_authenticated_client(&self.profile)?;
 
         let raw_manifest = self


### PR DESCRIPTION
The feature will be moving from private preview to public preview soon, and you will no longer need the feature to be enabled on your GraphOS account. And until that happens, an attempt to use it on a graph without the feature activated will still get the following error from GraphOS servers:

    error: Exception while fetching data (/_entities[0]/persistedQueryList) :
    Persisted Query Lists are a Preview-stage feature which is not enabled
    for graph GRAPH. If you are interested in this upcoming functionality,
    please reach out to support@apollographql.com.

So we don't need this additional unconditional message.
