### PR TITLE
Remove dev dep on `@graphql-tools/delegate`

### DIFF
--- a/crates/rover-client/package.json
+++ b/crates/rover-client/package.json
@@ -9,8 +9,7 @@
   "devDependencies": {
     "@graphql-eslint/eslint-plugin": "3.19.1",
     "eslint": "8.42.0",
-    "graphql": "16.6.0",
-    "@graphql-tools/delegate": "7.0.6"
+    "graphql": "16.6.0"
   },
   "engines": {
     "node": "<19",


### PR DESCRIPTION
The release PR #1680 added a dependency on an old version of `@graphql-tools/delegate` without explaining why or using the package in the PR at all. The package has a peer dep on `graphql` with a range that doesn't match the `graphql` used in the line immediately above, which has broken various pieces of CI. It seems like this was likely a mistake; this PR removes this dev dependency in hopes of fixing CI.
