### PR TITLE
fix: Update error code for check failure

### DIFF
--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -321,6 +321,6 @@ The schema you're linting has violated some of the rules configured for your gra
 
 ### E043
 
-This error occurs when a check fails because the proposed schema resulted in one of build, operations, linter or downstream task to fail.
+This error occurs when a build, operation, and/or linter check step fails due to a change in the schema.
 
 Please view the check in [Apollo Studio](https://studio.apollographql.com/) at the provided link to see the failure reason. You can read more about client checks [here](https://www.apollographql.com/docs/studio/schema-checks/).

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -319,4 +319,8 @@ This error occurs when a schema file has lint rule violations.
 
 The schema you're linting has violated some of the rules configured for your graph. Fix the errors and re-run the lint command to verify the violations have been addressed. See [the docs](https://www.apollographql.com/docs/graphos/delivery/schema-linter/) for more information about schema linting.
 
+### E043
 
+This error occurs when a check fails because the proposed schema resulted in one of build, operations, linter or downstream task to fail.
+
+Please view the check in [Apollo Studio](https://studio.apollographql.com/) at the provided link to see the failure reason. You can read more about client checks [here](https://www.apollographql.com/docs/studio/schema-checks/).

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1124,7 +1124,7 @@ mod tests {
             },
             "error": {
                 "message": "The changes in the schema you proposed caused operation and linter checks to fail.",
-                "code": "E042",
+                "code": "E043",
             }
         });
         assert_json_eq!(expected_json, actual_json);

--- a/src/error/metadata/code.rs
+++ b/src/error/metadata/code.rs
@@ -48,6 +48,7 @@ pub enum RoverErrorCode {
     E040,
     E041,
     E042,
+    E043,
 }
 
 impl Display for RoverErrorCode {
@@ -228,6 +229,10 @@ impl RoverErrorCode {
             (
                 RoverErrorCode::E042,
                 include_str!("./codes/E042.md").to_string(),
+            ),
+            (
+                RoverErrorCode::E043,
+                include_str!("./codes/E043.md").to_string(),
             ),
         ];
         contents.into_iter().collect()

--- a/src/error/metadata/codes/E043.md
+++ b/src/error/metadata/codes/E043.md
@@ -1,0 +1,3 @@
+This error occurs when a check fails because the proposed schema resulted in one of build, operations, linter or downstream task to fail.
+
+Please view the check in [Apollo Studio](https://studio.apollographql.com/) at the provided link to see the failure reason. You can read more about client checks [here](https://www.apollographql.com/docs/studio/schema-checks/).

--- a/src/error/metadata/codes/E043.md
+++ b/src/error/metadata/codes/E043.md
@@ -1,3 +1,3 @@
-This error occurs when a check fails because the proposed schema resulted in one of build, operations, linter or downstream task to fail.
+This error occurs when a build, operation, and/or linter check step fails due to a change in the schema.
 
-Please view the check in [Apollo Studio](https://studio.apollographql.com/) at the provided link to see the failure reason. You can read more about client checks [here](https://www.apollographql.com/docs/studio/schema-checks/).
+Please view the check in [Apollo Studio](https://studio.apollographql.com/) at the provided link to see the failure reason. You can read more about schema checks [here](https://www.apollographql.com/docs/studio/schema-checks/).

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -150,7 +150,7 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                     check_response: _,
                 } => (
                     Some(RoverErrorSuggestion::FixCheckFailures),
-                    Some(RoverErrorCode::E042),
+                    Some(RoverErrorCode::E043),
                 ),
                 RoverClientError::LintFailures { lint_response: _ } => (
                     Some(RoverErrorSuggestion::FixLintFailure),


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

`rover {sub}graph check` is outputting error code [042](https://www.apollographql.com/docs/rover/errors/#e042) which is a  linter error code. 

This PR creates a new error code `043` and assigns it to the output of check failures.
