### PR TITLE
feat(breaking): prevent publishing unparseable routing URLs without explicit flag

### DIFF
--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -221,6 +221,19 @@ This option has no effect if you publish to a non-monolithic variant.
 
 </td>
 </tr>
+<tr>
+<td>
+
+###### `--allow-invalid-routing-url`
+
+</td>
+
+<td>
+
+By default, `rover subgraph publish` will fail if an unparsable routing URL is associated with a subgraph. If you need to disable this warning and allow the invalid URL to be published anyway, you can pass this option.
+
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -83,6 +83,7 @@ pub enum RoverErrorSuggestion {
         subgraph_name: String,
         graph_ref: String,
     },
+    AllowInvalidRoutingUrlOrSpecifyValidUrl,
 }
 
 impl Display for RoverErrorSuggestion {
@@ -252,6 +253,7 @@ UpgradePlan => "Rover has likely reached rate limits while running graph or subg
             PublishSubgraphWithRoutingUrl { graph_ref, subgraph_name } => {
                 format!("Try publishing the subgraph with a routing URL like so `rover subgraph publish {graph_ref} --name {subgraph_name} --routing-url <url>`")
             },
+            AllowInvalidRoutingUrlOrSpecifyValidUrl => format!("Try publishing the subgraph with a valid routing URL. If you are sure you want to publish an invalid routing URL, re-run this command with the {} option.", Style::Command.paint("`--allow-invalid-routing-url`"))
         };
         write!(formatter, "{}", &suggestion)
     }


### PR DESCRIPTION
**!! BREAKING !!**

fixes #1689 by converting the warnings emitted for an invalid routing URL to a hard error. this error can be ignored by passing `--allow-invalid-routing-url`.