### PR TITLE
chore: relax subgraph publish requirement and update docs

### DIFF
--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -198,7 +198,7 @@ Every subgraph name **must**:
 
 The URL that your supergraph uses to communicate with the subgraph in a [managed federation architecture](/federation/managed-federation/overview/).
 
-**Required** the first time you publish a particular subgraph. Provide an empty string if your subgraph isn't deployed yet, or if you aren't using managed federation.
+**Required** the first time you publish a particular subgraph. You can provide an empty string if your subgraph isn't deployed yet, or if you aren't using managed federation, though you will need to pass the `--allow-invalid-routing-url` flag.
 
 **Optional** after your first publish. Provide only if you need to change the subgraph's routing URL.
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -198,7 +198,7 @@ Every subgraph name **must**:
 
 The URL that your supergraph uses to communicate with the subgraph in a [managed federation architecture](/federation/managed-federation/overview/).
 
-**Required** the first time you publish a particular subgraph. You can provide an empty string if your subgraph isn't deployed yet, or if you aren't using managed federation, though you will need to pass the `--allow-invalid-routing-url` flag.
+**Required** the first time you publish a particular subgraph. If your subgraph isn't deployed yet, or if you aren't using managed federation, you can pass an empty string. Passing an empty string requires you to set the `--allow-invalid-routing-url` flag.
 
 **Optional** after your first publish. Provide only if you need to change the subgraph's routing URL.
 

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -37,11 +37,12 @@ pub struct Publish {
     #[arg(long)]
     #[serde(skip_serializing)]
     routing_url: Option<String>,
+
     /// Bypasses warnings and the prompt to confirm publish when the routing url
     /// is invalid in TTY environment. In a future major version, this flag will
     /// be required to publish in a non-TTY environment. For now it will warn
     /// and publish anyway.
-    #[arg(long, requires("routing_url"))]
+    #[arg(long)]
     allow_invalid_routing_url: bool,
 }
 


### PR DESCRIPTION
`rover subgraph publish --allow-invalid-routing-url` is now allowed without passing a `--routing-url`.

Also updated the documentation for `rover subgraph publish` to describe the expected usage for `--routing-url`.