### PR TITLE
feat(install): plugins support APOLLO_ROVER_DOWNLOAD_HOST

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -49,6 +49,7 @@ Rover is distributed on npm for integration with your JavaScript projects.
 Internally, the `npm` installer downloads router binaries from `https://rover.apollo.dev`. If this URL is unavailable, for example, in a private network, you can point the `npm` installer at another URL in one of two ways:
 
 - by setting the `APOLLO_ROVER_DOWNLOAD_HOST` environment variable
+ - *note*: This value must be set if you also want the rover plugins to be downloaded from this host
 - by adding the following to your global or local `.npmrc`:
   
 ```ini

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -92,11 +92,16 @@ impl Plugin {
 
     pub fn get_tarball_url(&self) -> RoverResult<String> {
         Ok(format!(
-            "https://rover.apollo.dev/tar/{name}/{target_arch}/{version}",
+            "{host}/tar/{name}/{target_arch}/{version}",
+            host = self.get_host(),
             name = self.get_name(),
             target_arch = self.get_target_arch()?,
             version = self.get_tarball_version()
         ))
+    }
+
+    fn get_host($self) -> String {
+        std::env::var("APOLLO_ROVER_DOWNLOAD_HOST").unwrap_or_else(|| "https://rover.apollo.dev".to_string())
     }
 }
 

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -101,7 +101,8 @@ impl Plugin {
     }
 
     fn get_host(&self) -> String {
-        std::env::var("APOLLO_ROVER_DOWNLOAD_HOST").unwrap_or_else(|_| "https://rover.apollo.dev".to_string())
+        std::env::var("APOLLO_ROVER_DOWNLOAD_HOST")
+            .unwrap_or_else(|_| "https://rover.apollo.dev".to_string())
     }
 }
 

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -101,7 +101,7 @@ impl Plugin {
     }
 
     fn get_host(&self) -> String {
-        std::env::var("APOLLO_ROVER_DOWNLOAD_HOST").unwrap_or_else(|| "https://rover.apollo.dev".to_string())
+        std::env::var("APOLLO_ROVER_DOWNLOAD_HOST").unwrap_or_else(|_| "https://rover.apollo.dev".to_string())
     }
 }
 

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -100,7 +100,7 @@ impl Plugin {
         ))
     }
 
-    fn get_host($self) -> String {
+    fn get_host(&self) -> String {
         std::env::var("APOLLO_ROVER_DOWNLOAD_HOST").unwrap_or_else(|| "https://rover.apollo.dev".to_string())
     }
 }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

This PR adds the ability for rover plugins to be downloaded through a user-designated mirror/proxy of `rover.apollo.dev`. related #1638, and possibly related: #1253 #1583

Documentation was updated for the `npm` section, although this variable is respected for plugin downloads regardless of installation method of `rover`, so additional documentation may be needed at a higher level to address the proxy/mirror pattern of managing rover installations. 
