### PR TITLE
chore: install volta via chocolatey instead of flaky MSI installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,8 +378,20 @@ commands:
                   $msi_path = "$installer_dir\volta-init.msi"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$msi_path")
                   echo "Installing volta"
-                  Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i `"$msi_path`" /qn" -Wait -NoNewWindow
+                  $msi_arguments = @(
+                    "/i"
+                    "$msi_path"
+                    "/qn"
+                    "/norestart"
+                    "/L*V"
+                    "C:\volta.log"
+                  )
+                  Start-Process msiexec.exe -Wait -ArgumentList "$msi_arguments"
                   exit $LASTEXITCODE
+            - run:
+                name: Print Volta Install Logs
+                command: |
+                  Get-Content -Path C:\volta.log | Out-Printer
       - unless:
           condition:
             equal: [*arm_ubuntu_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ executors:
 
   amd_windows: &amd_windows_executor
     machine:
-      image: "windows-server-2022-gui:current"
+      image: "windows-server-2019-vs2019:stable"
     resource_class: windows.xlarge
     shell: powershell.exe -ExecutionPolicy Bypass
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ commands:
                   $msi_path = "$installer_dir\volta-init.msi"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$msi_path")
                   echo "Installing volta"
-                  Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i `"$msi_path"` /qn /forcerestart" -Wait -NoNewWindow
+                  Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i `"$msi_path`" /qn" -Wait -NoNewWindow
                   exit $LASTEXITCODE
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,8 +375,7 @@ commands:
 
       - unless:
           condition:
-            or:
-              - equal: [*arm_ubuntu_executor, << parameters.platform >>]
+            equal: [*arm_ubuntu_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install default versions of npm and node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,13 +378,20 @@ commands:
                   $msi_path = "$installer_dir\volta-init.msi"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$msi_path")
                   echo "Installing volta"
+                  $log_file = "C:\volta.log"
                   $msi_arguments = @(
                     "/i"
                     "$msi_path"
                     "/qn"
                     "/norestart"
+                    "L*v"
+                    "$log_file"
                   )
-                  Start-Process msiexec.exe -Wait -ArgumentList "$msi_arguments"
+                  $installer_process = Start-Process msiexec.exe -NoNewWindow -PassThru -ArgumentList "$msi_arguments"
+                  $log_process = Start-Process "powershell" "Get-Content -Path $log_file -Wait" -NoNewWindow -PassThru
+                  $installer_process.WaitForExit()
+                  $log_process.Kill()
+                  exit $installer_process.ExitCode
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ commands:
                   $msi_path = "$installer_dir\volta-init.msi"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$msi_path")
                   echo "Installing volta"
-                  msiexec.exe /i "$msi_path" /qn
+                  msiexec.exe /i "$msi_path" /qn | Out-Null
                   exit $LASTEXITCODE
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,10 +376,14 @@ commands:
                   $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
                   echo "Downloading volta"
                   $zip_path = "$installer_dir\volta.zip"
-                  $dest_path = "$Env:USERPROFILE\AppData\Local\Microsoft\WindowsApps"
+                  $dest_path = "$Env:USERPROFILE\AppData\Local\Volta"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
+                  echo "running volta setup"
+                  volta setup
+                  New-Item $Profile.CurrentUserAllHosts -Force
+                  Add-Content -Path $Profile.CurrentUserAllHosts -Value "`$env:PATH = `"$dest_path;`$env:PATH`"
                   echo "running volta --version"
                   volta --version
 
@@ -474,7 +478,6 @@ commands:
                 key: rust-<< pipeline.parameters.cache_version >>-<< parameters.platform >>-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}
                 paths:
                   - C:\\Users\\circleci\.cargo
-
 
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,8 +380,7 @@ commands:
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
-                  ls $dest_path
-                  echo $Env:PATH
+                  echo "running volta --version"
                   volta --version
 
       - unless:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ commands:
                   $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
                   echo "Downloading volta"
                   $zip_path = "$installer_dir\volta.zip"
-                  $dest_path = "$Env:USERPROFILE\bin"
+                  $dest_path = "$Env:USERPROFILE\AppData\Local\Microsoft\WindowsApps"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,22 +376,14 @@ commands:
                   $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
                   echo "Downloading volta"
                   $zip_path = "$installer_dir\volta.zip"
-                  $dest_path = "$Env:CIRCLE_WORKING_DIRECTORY\volta"
+                  $dest_path = "$Env:USERPROFILE\bin"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
-            - run:
-                name: Install default versions of npm and node
-                shell: bash.exe
-                command: |
-                  volta="$CIRCLE_WORKING_DIRECTORY\volta\volta.exe"
-                  $volta install node@16
-                  $volta install npm@7
 
       - unless:
           condition:
             or:
-              - equal: [*amd_windows_executor, << parameters.platform >>]
               - equal: [*arm_ubuntu_executor, << parameters.platform >>]
           steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,18 +376,23 @@ commands:
                   $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
                   echo "Downloading volta"
                   $zip_path = "$installer_dir\volta.zip"
-                  $dest_path = "$Env:CIRCLE_WORKING_DIRECTORY"
+                  $dest_path = "$Env:CIRCLE_WORKING_DIRECTORY\volta"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
                   echo "Adding $dest_path to PATH"
                   $env:Path = "$dest_path" + ";" + $env:PATH
-                  New-Item $Profile.CurrentUserAllHosts -Force
-                  Add-Content -Path $Profile.CurrentUserAllHosts -Value '$env:PATH = "$env:PATH"'
+            - run:
+                name: Install default versions of npm and node
+                command: |
+                  volta install node@16
+                  volta install npm@7
 
       - unless:
           condition:
-            equal: [*arm_ubuntu_executor, << parameters.platform >>]
+            or:
+              - equal: [*amd_windows_executor, << parameters.platform >>]
+              - equal: [*arm_ubuntu_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install default versions of npm and node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ commands:
                 name: Install default versions of npm and node
                 shell: bash.exe
                 command: |
-                  $volta="$CIRCLE_WORKING_DIRECTORY\volta\volta.exe"
+                  volta="$CIRCLE_WORKING_DIRECTORY\volta\volta.exe"
                   $volta install node@16
                   $volta install npm@7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ commands:
                   $msi_path = "$installer_dir\volta-init.msi"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$msi_path")
                   echo "Installing volta"
-                  msiexec.exe /i "$msi_path" /qn | Out-Null
+                  Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i `"$msi_path"` /qn /forcerestart" -Wait -NoNewWindow
                   exit $LASTEXITCODE
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ commands:
                   $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
                   echo "Downloading volta"
                   $zip_path = "$installer_dir\volta.zip"
-                  $dest_path = "$installer_dir\volta_dir"
+                  $dest_path = "$Env:CIRCLE_WORKING_DIRECTORY"
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,8 +382,9 @@ commands:
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
             - run:
                 name: Install default versions of npm and node
+                shell: bash.exe
                 command: |
-                  $volta = "$Env:CIRCLE_WORKING_DIRECTORY\volta\volta.exe"
+                  $volta="$CIRCLE_WORKING_DIRECTORY\volta\volta.exe"
                   $volta install node@16
                   $volta install npm@7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ executors:
 
   amd_windows: &amd_windows_executor
     machine:
-      image: "windows-server-2019-vs2019:stable"
+      image: "windows-server-2022-gui:current"
     resource_class: windows.xlarge
     shell: powershell.exe -ExecutionPolicy Bypass
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,15 +383,9 @@ commands:
                     "$msi_path"
                     "/qn"
                     "/norestart"
-                    "/L*V"
-                    "C:\volta.log"
                   )
                   Start-Process msiexec.exe -Wait -ArgumentList "$msi_arguments"
-                  exit $LASTEXITCODE
-            - run:
-                name: Print Volta Install Logs
-                command: |
-                  Get-Content -Path C:\volta.log | Out-Printer
+
       - unless:
           condition:
             equal: [*arm_ubuntu_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ commands:
             - run:
                 name: Install volta
                 command: |
-                  choco install volta
+                  choco install volta -y
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,8 +380,10 @@ commands:
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
-                  echo "Adding $dest_path to $PATH"
-                  $env:Path = "$dest_path" + ";" + $env:Path
+                  echo "Adding $dest_path to PATH"
+                  $env:Path = "$dest_path" + ";" + $env:PATH
+                  New-Item $Profile.CurrentUserAllHosts -Force
+                  Add-Content -Path $Profile.CurrentUserAllHosts -Value '$env:PATH = "$env:PATH"'
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,6 +380,8 @@ commands:
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
+                  ls $dest_path
+                  volta --version
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,22 +371,7 @@ commands:
             - run:
                 name: Install volta
                 command: |
-                  $installer_dir = "$Env:TEMP"
-                  $latest_version = ((Invoke-WebRequest -URI https://volta.sh/latest-version).Content -split '\n')[0]
-                  $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
-                  echo "Downloading volta"
-                  $zip_path = "$installer_dir\volta.zip"
-                  $dest_path = "$Env:USERPROFILE\AppData\Local\Volta"
-                  (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
-                  echo "Extracting $zip_path to $dest_path"
-                  Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
-                  New-Item $Profile.CurrentUserAllHosts -Force
-                  echo "`$env:PATH = `"$dest_path;`$env:PATH`""
-                  Add-Content -Path $Profile.CurrentUserAllHosts -Value "`$env:PATH = `"$dest_path;`$env:PATH`""
-                  echo "running volta --version"
-                  volta --version
-                  echo "running volta setup"
-                  volta setup
+                  choco install volta
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,13 +380,12 @@ commands:
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
-                  echo "Adding $dest_path to PATH"
-                  $env:Path = "$dest_path" + ";" + $env:PATH
             - run:
                 name: Install default versions of npm and node
                 command: |
-                  volta install node@16
-                  volta install npm@7
+                  $volta = "$Env:CIRCLE_WORKING_DIRECTORY\volta\volta.exe"
+                  $volta install node@16
+                  $volta install npm@7
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ commands:
                     "$msi_path"
                     "/qn"
                     "/norestart"
-                    "L*v"
+                    "/L*v"
                     "$log_file"
                   )
                   $installer_process = Start-Process msiexec.exe -NoNewWindow -PassThru -ArgumentList "$msi_arguments"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,7 @@ commands:
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
                   New-Item $Profile.CurrentUserAllHosts -Force
+                  echo "`$env:PATH = `"$dest_path;`$env:PATH`""
                   Add-Content -Path $Profile.CurrentUserAllHosts -Value "`$env:PATH = `"$dest_path;`$env:PATH`""
                   echo "running volta --version"
                   volta --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,27 +371,17 @@ commands:
             - run:
                 name: Install volta
                 command: |
-                  $installer_dir = "$Env:TEMP".Path
+                  $installer_dir = "$Env:TEMP"
                   $latest_version = ((Invoke-WebRequest -URI https://volta.sh/latest-version).Content -split '\n')[0]
-                  $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows-x86_64.msi"
+                  $download_url = "https://github.com/volta-cli/volta/releases/download/v$latest_version/volta-$latest_version-windows.zip"
                   echo "Downloading volta"
-                  $msi_path = "$installer_dir\volta-init.msi"
-                  (New-Object System.Net.WebClient).DownloadFile("$download_url", "$msi_path")
-                  echo "Installing volta"
-                  $log_file = "C:\volta.log"
-                  $msi_arguments = @(
-                    "/i"
-                    "$msi_path"
-                    "/qn"
-                    "/norestart"
-                    "/L*v"
-                    "$log_file"
-                  )
-                  $installer_process = Start-Process msiexec.exe -NoNewWindow -PassThru -ArgumentList "$msi_arguments"
-                  $log_process = Start-Process "powershell" "Get-Content -Path $log_file -Wait" -NoNewWindow -PassThru
-                  $installer_process.WaitForExit()
-                  $log_process.Kill()
-                  exit $installer_process.ExitCode
+                  $zip_path = "$installer_dir\volta.zip"
+                  $dest_path = "$installer_dir\volta_dir"
+                  (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
+                  echo "Extracting $zip_path to $dest_path"
+                  Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
+                  echo "Adding $dest_path to $PATH"
+                  $env:Path = "$dest_path" + ";" + $env:Path
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,7 @@ commands:
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
                   ls $dest_path
+                  echo $Env:PATH
                   volta --version
 
       - unless:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ commands:
                   echo "running volta setup"
                   volta setup
                   New-Item $Profile.CurrentUserAllHosts -Force
-                  Add-Content -Path $Profile.CurrentUserAllHosts -Value "`$env:PATH = `"$dest_path;`$env:PATH`"
+                  Add-Content -Path $Profile.CurrentUserAllHosts -Value "`$env:PATH = `"$dest_path;`$env:PATH`""
                   echo "running volta --version"
                   volta --version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,12 +380,12 @@ commands:
                   (New-Object System.Net.WebClient).DownloadFile("$download_url", "$zip_path")
                   echo "Extracting $zip_path to $dest_path"
                   Expand-Archive -LiteralPath $zip_path -DestinationPath $dest_path
-                  echo "running volta setup"
-                  volta setup
                   New-Item $Profile.CurrentUserAllHosts -Force
                   Add-Content -Path $Profile.CurrentUserAllHosts -Value "`$env:PATH = `"$dest_path;`$env:PATH`""
                   echo "running volta --version"
                   volta --version
+                  echo "running volta setup"
+                  volta setup
 
       - unless:
           condition:


### PR DESCRIPTION
Volta installs have been flaky on windows for a while and I hope this PR fixes that.

I've updated our install method from the MSI that they provide to a direct download via the package manager chocolatey.