### PR TITLE
fixup: re-add .npmrc note

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -48,9 +48,11 @@ Rover is distributed on npm for integration with your JavaScript projects.
 
 Internally, the `npm` installer downloads router binaries from `https://rover.apollo.dev`. If this URL is unavailable, for example, in a private network, you can point the `npm` installer at another URL in one of two ways:
 
-- by setting the `APOLLO_ROVER_DOWNLOAD_HOST` environment variable
+1. by setting the `APOLLO_ROVER_DOWNLOAD_HOST` environment variable
 
-> **Note**: This environment variable also changes the host that plugins for `rover supergraph compose` and `rover dev` are downloaded from.
+    > **Note**: This environment variable also changes the host that plugins for `rover supergraph compose` and `rover dev` are downloaded from.
+
+1. by adding the following to your global or local `.npmrc`:
 
 ```ini
 apollo_rover_download_host=https://your.mirror.com/repository


### PR DESCRIPTION
accidentally removed the bit about adding to `.npmrc` - this adds that back. good catch @LongLiveCHIEF 