### PR TITLE
Fix: Print path for empty file rather than contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,6 +3940,7 @@ dependencies = [
  "crossbeam-channel",
  "notify",
  "rayon",
+ "thiserror",
  "tracing",
 ]
 

--- a/crates/houston/src/error.rs
+++ b/crates/houston/src/error.rs
@@ -1,3 +1,4 @@
+use rover_std::RoverStdError;
 use thiserror::Error;
 
 use std::io;
@@ -53,7 +54,11 @@ pub enum HoustonProblem {
     #[error(transparent)]
     IoError(#[from] io::Error),
 
-    /// AdhocError comes from saucer::Error
+    /// AdhocError comes from anyhow::Error
     #[error(transparent)]
     AdhocError(#[from] anyhow::Error),
+
+    /// RoverStdError comes from RoverStdError
+    #[error(transparent)]
+    RoverStdError(#[from] RoverStdError),
 }

--- a/crates/rover-std/Cargo.toml
+++ b/crates/rover-std/Cargo.toml
@@ -14,4 +14,5 @@ console = { workspace = true }
 crossbeam-channel = { workspace = true }
 notify = { workspace = true }
 rayon = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rover-std/src/error.rs
+++ b/crates/rover-std/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RoverStdError {
+
+    /// AdhocError comes from the anyhow crate
+    #[error(transparent)]
+    AdhocError(#[from] anyhow::Error),
+
+    /// This error is thrown when there is an empty file
+    #[error("\"{empty_file}\" is an empty file.")]
+    EmptyFile {
+        /// The empty file path
+        empty_file: String,
+    }
+}

--- a/crates/rover-std/src/error.rs
+++ b/crates/rover-std/src/error.rs
@@ -2,7 +2,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum RoverStdError {
-
     /// AdhocError comes from the anyhow crate
     #[error(transparent)]
     AdhocError(#[from] anyhow::Error),
@@ -12,5 +11,5 @@ pub enum RoverStdError {
     EmptyFile {
         /// The empty file path
         empty_file: String,
-    }
+    },
 }

--- a/crates/rover-std/src/fs.rs
+++ b/crates/rover-std/src/fs.rs
@@ -30,7 +30,9 @@ impl Fs {
                     let contents = fs::read_to_string(path)
                         .with_context(|| format!("could not read {}", &path))?;
                     if contents.is_empty() {
-                        Err(RoverStdError::EmptyFile { empty_file: path.to_string() })
+                        Err(RoverStdError::EmptyFile {
+                            empty_file: path.to_string(),
+                        })
                     } else {
                         Ok(contents)
                     }
@@ -108,7 +110,8 @@ impl Fs {
         F: AsRef<Utf8Path>,
     {
         let file = file.as_ref();
-        Ok(fs::metadata(file).with_context(|| format!("could not find a file at the path '{}'", file))?)
+        Ok(fs::metadata(file)
+            .with_context(|| format!("could not find a file at the path '{}'", file))?)
     }
 
     /// copies one file to another
@@ -138,10 +141,7 @@ impl Fs {
             fs::remove_dir_all(dir).with_context(|| format!("could not remove {}", dir))?;
             Ok(())
         } else {
-            Err(anyhow!(
-                "could not remove {} because it is not a directory",
-                dir
-            ).into())
+            Err(anyhow!("could not remove {} because it is not a directory", dir).into())
         }
     }
 

--- a/crates/rover-std/src/fs.rs
+++ b/crates/rover-std/src/fs.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context};
 use camino::{ReadDirUtf8, Utf8Path};
 use crossbeam_channel::Sender;
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use crate::Emoji;
+use crate::{Emoji, RoverStdError};
 
 /// Interact with a file system
 #[derive(Default, Copy, Clone)]
@@ -18,7 +18,7 @@ pub struct Fs {}
 
 impl Fs {
     /// reads a file from disk
-    pub fn read_file<P>(path: P) -> Result<String>
+    pub fn read_file<P>(path: P) -> Result<String, RoverStdError>
     where
         P: AsRef<Utf8Path>,
     {
@@ -30,20 +30,20 @@ impl Fs {
                     let contents = fs::read_to_string(path)
                         .with_context(|| format!("could not read {}", &path))?;
                     if contents.is_empty() {
-                        Err(anyhow!("'{}' was empty", contents))
+                        Err(RoverStdError::EmptyFile { empty_file: path.to_string() })
                     } else {
                         Ok(contents)
                     }
                 } else {
-                    Err(anyhow!("'{}' is not a file", path))
+                    Err(anyhow!("'{}' is not a file", path).into())
                 }
             }
-            Err(e) => Err(anyhow!("could not find '{}'", path).context(e)),
+            Err(e) => Err(anyhow!("could not find '{}'", path).context(e).into()),
         }
     }
 
     /// writes a file to disk
-    pub fn write_file<P, C>(path: P, contents: C) -> Result<()>
+    pub fn write_file<P, C>(path: P, contents: C) -> Result<(), RoverStdError>
     where
         P: AsRef<Utf8Path>,
         C: AsRef<[u8]>,
@@ -69,7 +69,7 @@ impl Fs {
     }
 
     /// creates a directory
-    pub fn create_dir_all<P>(path: P) -> Result<()>
+    pub fn create_dir_all<P>(path: P) -> Result<(), RoverStdError>
     where
         P: AsRef<Utf8Path>,
     {
@@ -81,7 +81,7 @@ impl Fs {
     }
 
     /// get contents of a directory
-    pub fn get_dir_entries<D>(dir: D) -> Result<ReadDirUtf8>
+    pub fn get_dir_entries<D>(dir: D) -> Result<ReadDirUtf8, RoverStdError>
     where
         D: AsRef<Utf8Path>,
     {
@@ -93,7 +93,7 @@ impl Fs {
     }
 
     /// assert that a file exists
-    pub fn assert_path_exists<F>(file: F) -> Result<()>
+    pub fn assert_path_exists<F>(file: F) -> Result<(), RoverStdError>
     where
         F: AsRef<Utf8Path>,
     {
@@ -103,16 +103,16 @@ impl Fs {
     }
 
     /// get metadata about a file path
-    pub fn metadata<F>(file: F) -> Result<fs::Metadata>
+    pub fn metadata<F>(file: F) -> Result<fs::Metadata, RoverStdError>
     where
         F: AsRef<Utf8Path>,
     {
         let file = file.as_ref();
-        fs::metadata(file).with_context(|| format!("could not find a file at the path '{}'", file))
+        Ok(fs::metadata(file).with_context(|| format!("could not find a file at the path '{}'", file))?)
     }
 
     /// copies one file to another
-    pub fn copy<I, O>(in_path: I, out_path: O) -> Result<()>
+    pub fn copy<I, O>(in_path: I, out_path: O) -> Result<(), RoverStdError>
     where
         I: AsRef<Utf8Path>,
         O: AsRef<Utf8Path>,
@@ -129,7 +129,7 @@ impl Fs {
     }
 
     /// recursively removes directories
-    pub fn remove_dir_all<D>(dir: D) -> Result<()>
+    pub fn remove_dir_all<D>(dir: D) -> Result<(), RoverStdError>
     where
         D: AsRef<Utf8Path>,
     {
@@ -141,12 +141,12 @@ impl Fs {
             Err(anyhow!(
                 "could not remove {} because it is not a directory",
                 dir
-            ))
+            ).into())
         }
     }
 
     /// checks if a path is a directory, errors if the path does not exist
-    pub fn path_is_dir<D>(dir: D) -> Result<bool>
+    pub fn path_is_dir<D>(dir: D) -> Result<bool, RoverStdError>
     where
         D: AsRef<Utf8Path>,
     {
@@ -155,7 +155,7 @@ impl Fs {
     }
 
     /// copies all contents from one directory to another
-    pub fn copy_dir_all<I, O>(in_dir: I, out_dir: O) -> Result<()>
+    pub fn copy_dir_all<I, O>(in_dir: I, out_dir: O) -> Result<(), RoverStdError>
     where
         I: AsRef<Utf8Path>,
         O: AsRef<Utf8Path>,

--- a/crates/rover-std/src/lib.rs
+++ b/crates/rover-std/src/lib.rs
@@ -1,4 +1,5 @@
 mod emoji;
+mod error;
 mod fs;
 mod style;
 
@@ -7,3 +8,4 @@ pub use emoji::Emoji;
 pub use fs::Fs;
 pub use style::should_disable_color;
 pub use style::Style;
+pub use error::RoverStdError;

--- a/crates/rover-std/src/lib.rs
+++ b/crates/rover-std/src/lib.rs
@@ -5,7 +5,7 @@ mod style;
 
 pub mod prompt;
 pub use emoji::Emoji;
+pub use error::RoverStdError;
 pub use fs::Fs;
 pub use style::should_disable_color;
 pub use style::Style;
-pub use error::RoverStdError;

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use rover_std::RoverStdError;
 
 use std::io;
 
@@ -41,4 +42,8 @@ pub enum SputnikError {
     /// AdhocError comes from the anyhow crate
     #[error(transparent)]
     AdhocError(#[from] anyhow::Error),
+
+    /// RoverStdError comes from RoverStdError
+    #[error(transparent)]
+    RoverStdError(#[from] RoverStdError),
 }

--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use rover_std::RoverStdError;
+use thiserror::Error;
 
 use std::io;
 

--- a/installers/binstall/src/error.rs
+++ b/installers/binstall/src/error.rs
@@ -1,3 +1,4 @@
+use rover_std::RoverStdError;
 use thiserror::Error;
 
 use std::io;
@@ -38,4 +39,7 @@ pub enum InstallerError {
 
     #[error(transparent)]
     AdhocError(#[from] anyhow::Error),
+
+    #[error(transparent)]
+    RoverStdError(#[from] RoverStdError),
 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -354,6 +354,7 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                     Some(RoverErrorCode::E026),
                 ),
                 HoustonProblem::AdhocError(_) => (None, None),
+                HoustonProblem::RoverStdError(_) => (None, None),
             };
             return RoverErrorMetadata {
                 json_version: JsonVersion::default(),

--- a/src/utils/expansion.rs
+++ b/src/utils/expansion.rs
@@ -108,7 +108,7 @@ fn context(key: &str) -> Result<Option<String>, Error> {
         if !Path::new(file_name).exists() {
             Ok(None)
         } else {
-            Fs::read_file(file_name).map(Some)
+            Ok(Fs::read_file(file_name).map(Some)?)
         }
     } else {
         bail!("Invalid variable expansion key: {}", key)


### PR DESCRIPTION
When encountering an empty file, rover subgraph publish currently displays an unhelpful error message:

```console
$ rover subgraph publish my-federated-graph@my-variant --schema schema.graphql --name empty --routing-url http://127.0.0.1/

error: Could not read SDL from schema.graphql

Caused by:
    '' was empty
```

This PR implements a more helpful error message: 

```console
$ rover subgraph publish my-federated-graph@my-variant --schema schema.graphql --name empty --routing-url http://127.0.0.1/

error: Could not read SDL from schema.graphql

Caused by:
    "schema.graphql" is an empty file.
```