### PR TITLE
chore: store info about last error in check workflow retry loop

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -195,8 +195,11 @@ pub enum RoverClientError {
     )]
     PlanError { msg: String },
 
-    #[error("Your check took too long to run")]
-    ChecksTimeoutError { url: Option<String> },
+    #[error("Your check took too long to run.{}", check_timeout_caused_by(.last_error))]
+    ChecksTimeoutError {
+        url: Option<String>,
+        last_error: Option<String>,
+    },
 
     #[error("You cannot publish a new subgraph without specifying a routing URL.")]
     MissingRoutingUrlError {
@@ -285,6 +288,16 @@ fn check_workflow_error_msg(check_response: &CheckWorkflowResponse) -> String {
                 all_but_last, last[0]
             )
         }
+    }
+}
+
+fn check_timeout_caused_by(last_error: &Option<String>) -> String {
+    if let Some(error) = last_error {
+        format!(
+            "\nThe latest error that occurred while polling for the check response was: {error}."
+        )
+    } else {
+        String::new()
     }
 }
 

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -43,23 +43,26 @@ pub fn run(
 ) -> Result<CheckWorkflowResponse, RoverClientError> {
     let graph_ref = input.graph_ref.clone();
     let mut url: Option<String> = None;
+    let mut last_error = None;
     let now = Instant::now();
     loop {
         let result = client.post::<GraphCheckWorkflowQuery>(input.clone().into());
         match result {
-          Ok(data) => {
-            let graph = data.clone().graph.ok_or(RoverClientError::GraphNotFound {
-                graph_ref: graph_ref.clone(),
-            })?;
-            if let Some(check_workflow) = graph.check_workflow {
-                if !matches!(check_workflow.status, CheckWorkflowStatus::PENDING) {
-                    return get_check_response_from_data(data, graph_ref);
+            Ok(data) => {
+                let graph = data.clone().graph.ok_or(RoverClientError::GraphNotFound {
+                    graph_ref: graph_ref.clone(),
+                })?;
+                if let Some(check_workflow) = graph.check_workflow {
+                    if !matches!(check_workflow.status, CheckWorkflowStatus::PENDING) {
+                        return get_check_response_from_data(data, graph_ref);
+                    }
                 }
+                url = get_target_url_from_data(data);
             }
-            url = get_target_url_from_data(data);
+            Err(e) => last_error = Some(e.to_string()),
         }
         if now.elapsed() > Duration::from_secs(input.checks_timeout_seconds) {
-            return Err(RoverClientError::ChecksTimeoutError { url });
+            return Err(RoverClientError::ChecksTimeoutError { url, last_error });
         }
         std::thread::sleep(Duration::from_secs(5));
     }
@@ -144,6 +147,8 @@ fn get_check_response_from_data(
         }),
         _ => Err(RoverClientError::ChecksTimeoutError {
             url: Some(default_target_url),
+
+            last_error: None,
         }),
     }
 }

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -252,7 +252,7 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                     Some(RoverErrorSuggestion::UpgradePlan),
                     Some(RoverErrorCode::E034),
                 ),
-                RoverClientError::ChecksTimeoutError { url } => (
+                RoverClientError::ChecksTimeoutError { url, .. } => (
                     Some(RoverErrorSuggestion::IncreaseChecksTimeout { url: url.clone() }),
                     None,
                 ),


### PR DESCRIPTION
extends pr #1740 to report the last error that occurred during a check workflow retry loop to surface the most recent error that occurred in that window.