### PR TITLE
fix: don't output color when writing to files via --output or via unix pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,17 +504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +581,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_fs",
- "atty",
  "camino",
  "cc",
  "directories-next",
@@ -2099,15 +2087,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -2487,7 +2466,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2531,7 +2510,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.13",
  "windows-sys 0.48.0",
 ]
@@ -3157,7 +3136,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3925,7 +3904,6 @@ dependencies = [
  "assert-json-diff",
  "assert_cmd",
  "assert_fs",
- "atty",
  "billboard",
  "binstall",
  "calm_io",
@@ -4011,7 +3989,6 @@ name = "rover-std"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "camino",
  "console",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ ariadne = "0.3"
 assert_fs = "1"
 assert_cmd = "2"
 assert-json-diff = "2"
-atty = "0.2"
 anyhow = "1"
 backtrace = "0.3"
 backoff = "0.4"
@@ -143,7 +142,6 @@ anyhow = { workspace = true }
 assert_fs = { workspace = true }
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
-atty = { workspace = true }
 billboard = { workspace = true }
 binstall = { workspace = true }
 calm_io = { workspace = true }

--- a/crates/rover-client/src/shared/lint_response.rs
+++ b/crates/rover-client/src/shared/lint_response.rs
@@ -7,7 +7,7 @@ use ariadne::{Color, ColorGenerator, Label, Report, ReportKind, Source};
 use serde::Serialize;
 use serde_json::{json, Value};
 
-use rover_std::should_disable_color;
+use rover_std::is_no_color_set;
 
 #[derive(Debug, Clone, Serialize, Eq, PartialEq)]
 pub struct LintResponse {
@@ -37,7 +37,7 @@ impl LintResponse {
                     start: diagnostic.start_byte_offset,
                     end: diagnostic.end_byte_offset,
                 };
-                let color = if should_disable_color() {
+                let color = if is_no_color_set() {
                     Color::Default
                 } else {
                     match diagnostic.level.as_str() {
@@ -47,7 +47,7 @@ impl LintResponse {
                         &_ => Color::Default,
                     }
                 };
-                let report_kind = if should_disable_color() {
+                let report_kind = if is_no_color_set() {
                     ReportKind::Custom(diagnostic.level.as_str(), Color::Default)
                 } else {
                     match diagnostic.level.as_str() {

--- a/crates/rover-std/Cargo.toml
+++ b/crates/rover-std/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-atty = { workspace = true }
 anyhow = { workspace = true }
 camino = { workspace = true }
 console = { workspace = true }

--- a/crates/rover-std/src/lib.rs
+++ b/crates/rover-std/src/lib.rs
@@ -7,5 +7,5 @@ pub mod prompt;
 pub use emoji::Emoji;
 pub use error::RoverStdError;
 pub use fs::Fs;
-pub use style::should_disable_color;
+pub use style::is_no_color_set;
 pub use style::Style;

--- a/crates/rover-std/src/output.rs
+++ b/crates/rover-std/src/output.rs
@@ -1,0 +1,7 @@
+use camino::Utf8PathBuf;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RoverOutputDestination {
+    File(Utf8PathBuf),
+    Stdout,
+}

--- a/crates/rover-std/src/style.rs
+++ b/crates/rover-std/src/style.rs
@@ -24,7 +24,7 @@ impl Style {
     pub fn paint<S: AsRef<str>>(&self, message: S) -> String {
         let message_ref = message.as_ref();
 
-        if should_disable_color() {
+        if is_no_color_set() {
             return message_ref.to_string();
         }
 
@@ -46,11 +46,8 @@ impl Style {
     }
 }
 
-pub fn should_disable_color() -> bool {
-    is_bool_env_var_set("NO_COLOR")
-        || is_bool_env_var_set("APOLLO_NO_COLOR")
-        || !atty::is(atty::Stream::Stdout)
-        || !atty::is(atty::Stream::Stderr)
+pub fn is_no_color_set() -> bool {
+    is_bool_env_var_set("NO_COLOR") || is_bool_env_var_set("APOLLO_NO_COLOR")
 }
 
 fn is_bool_env_var_set(key: &str) -> bool {

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-atty = { workspace = true }
 camino = { workspace = true }
 directories-next = { workspace = true }
 flate2 = { workspace = true }

--- a/installers/binstall/src/install.rs
+++ b/installers/binstall/src/install.rs
@@ -2,9 +2,8 @@ use crate::InstallerError;
 
 use rover_std::Fs;
 use std::env;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 
-use atty::{self, Stream};
 use camino::Utf8PathBuf;
 use url::Url;
 
@@ -210,7 +209,7 @@ impl Installer {
 
         // If we're not attached to a TTY then we can't get user input, so there's
         // nothing to do except inform the user about the `-f` flag.
-        if !atty::is(Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(InstallerError::NoTty);
         }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::io;
+use std::io::{self, IsTerminal};
 
 use crate::command::supergraph::compose::CompositionOutput;
 use crate::options::JsonVersion;
@@ -8,7 +8,6 @@ use crate::RoverError;
 
 use crate::command::template::queries::list_templates_for_language::ListTemplatesForLanguageTemplates;
 use crate::options::ProjectLanguage;
-use atty::Stream;
 use calm_io::{stderr, stderrln};
 use camino::Utf8PathBuf;
 use rover_client::operations::contract::describe::ContractDescribeResponse;
@@ -588,7 +587,7 @@ impl RoverOutput {
     }
 
     pub(crate) fn print_descriptor(&self) -> io::Result<()> {
-        if atty::is(Stream::Stdout) {
+        if std::io::stdout().is_terminal() {
             if let Some(descriptor) = self.descriptor() {
                 stderrln!("{}: \n", Style::Heading.paint(descriptor))?;
             }
@@ -596,7 +595,7 @@ impl RoverOutput {
         Ok(())
     }
     pub(crate) fn print_one_line_descriptor(&self) -> io::Result<()> {
-        if atty::is(Stream::Stdout) {
+        if std::io::stdout().is_terminal() {
             if let Some(descriptor) = self.descriptor() {
                 stderr!("{}: ", Style::Heading.paint(descriptor))?;
             }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -1,3 +1,5 @@
+use std::io::{self, IsTerminal};
+
 use anyhow::anyhow;
 use clap::Parser;
 use reqwest::Url;
@@ -57,9 +59,9 @@ impl Publish {
         if !self.allow_invalid_routing_url {
             Self::handle_maybe_invalid_routing_url(
                 &self.routing_url,
-                &mut std::io::stderr(),
-                &mut std::io::stdin(),
-                atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdin),
+                &mut io::stderr(),
+                &mut io::stdin(),
+                io::stderr().is_terminal() && io::stdin().is_terminal(),
             )?;
         }
 
@@ -76,9 +78,9 @@ impl Publish {
 
             Self::handle_maybe_invalid_routing_url(
                 &Some(fetch_response),
-                &mut std::io::stderr(),
-                &mut std::io::stdin(),
-                atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdin),
+                &mut io::stderr(),
+                &mut io::stdin(),
+                io::stderr().is_terminal() && io::stdin().is_terminal(),
             )?;
         }
 
@@ -118,8 +120,8 @@ impl Publish {
         maybe_invalid_routing_url: &Option<String>,
         // For testing purposes, we pass in stub `Write`er and `Read`ers to
         // simulate input and verify output.
-        writer: &mut impl std::io::Write,
-        reader: &mut impl std::io::Read,
+        writer: &mut impl io::Write,
+        reader: &mut impl io::Read,
         // Simulate a CI environment (non-TTY) for testing
         is_atty: bool,
     ) -> RoverResult<()> {
@@ -178,8 +180,8 @@ impl Publish {
 
     pub fn prompt_for_publish(
         message: &str,
-        reader: &mut impl std::io::Read,
-        writer: &mut impl std::io::Write,
+        reader: &mut impl io::Read,
+        writer: &mut impl io::Write,
     ) -> RoverResult<Option<bool>> {
         write!(writer, "{} [y/N] ", message)?;
         let mut response = [0];
@@ -198,7 +200,7 @@ impl Publish {
 
     pub fn non_tty_warn_about_local_url(
         reason: &str,
-        writer: &mut dyn std::io::Write,
+        writer: &mut dyn io::Write,
     ) -> RoverResult<()> {
         writeln!(writer, "{} {reason}", Style::WarningPrefix.paint("WARN:"),)?;
         Ok(())

--- a/src/command/template/use.rs
+++ b/src/command/template/use.rs
@@ -1,4 +1,7 @@
-use std::fs::read_dir;
+use std::{
+    fs::read_dir,
+    io::{self, IsTerminal},
+};
 
 use anyhow::{anyhow, Context};
 use camino::Utf8PathBuf;
@@ -65,7 +68,7 @@ impl Use {
     pub(crate) fn get_or_prompt_path(&self) -> RoverResult<Utf8PathBuf> {
         let path: Utf8PathBuf = if let Some(path) = &self.path {
             Ok::<Utf8PathBuf, RoverError>(path.clone())
-        } else if atty::is(atty::Stream::Stderr) {
+        } else if io::stderr().is_terminal() {
             let mut input = Input::new();
             input.with_prompt("What path would you like to extract the template to?");
             let path: Utf8PathBuf = input.interact_text()?;

--- a/src/options/license.rs
+++ b/src/options/license.rs
@@ -1,5 +1,6 @@
+use std::io::IsTerminal;
+
 use anyhow::anyhow;
-use atty::Stream;
 use clap::Parser;
 use serde::Serialize;
 
@@ -45,7 +46,7 @@ impl LicenseAccepter {
     fn prompt_accept(&self, client_config: &StudioClientConfig) -> RoverResult<bool> {
         // If we're not attached to a TTY then we can't get user input, so there's
         // nothing to do except inform the user about the `--elv2-license` flag.
-        if !atty::is(Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             let mut err = RoverError::new(anyhow!(
                 "This command requires that you accept the terms of the ELv2 license."
             ));

--- a/src/options/output.rs
+++ b/src/options/output.rs
@@ -1,4 +1,8 @@
-use std::{fmt, io, str::FromStr};
+use std::{
+    fmt,
+    io::{self, IsTerminal},
+    str::FromStr,
+};
 
 use anyhow::Result;
 use calm_io::{stderrln, stdoutln};
@@ -144,6 +148,14 @@ impl OutputOpts {
             }
             // there are default options, so if nothing is passed, print no errors or warnings
             _ => (),
+        }
+
+        let (_, destination) = self.get_format_and_strategy();
+
+        if !std::io::stdout().is_terminal()
+            || matches!(destination, RoverOutputDestination::File(_))
+        {
+            std::env::set_var("NO_COLOR", "true");
         }
     }
 

--- a/src/options/subgraph.rs
+++ b/src/options/subgraph.rs
@@ -1,3 +1,5 @@
+use std::io::{self, IsTerminal};
+
 use camino::Utf8PathBuf;
 use clap::{self, Parser};
 use serde::{Deserialize, Serialize};
@@ -70,7 +72,7 @@ impl OptionalSubgraphOpts {
     pub fn prompt_for_name(&self) -> Result<String> {
         if let Some(name) = &self.subgraph_name {
             Ok(name.to_string())
-        } else if atty::is(atty::Stream::Stderr) {
+        } else if io::stderr().is_terminal() {
             let mut input = Input::new();
             input.with_prompt(format!(
                 "{}what is the name of this subgraph?",
@@ -97,7 +99,7 @@ impl OptionalSubgraphOpts {
             Ok(subgraph_url
                 .parse()
                 .with_context(|| url_context(subgraph_url))?)
-        } else if atty::is(atty::Stream::Stderr) {
+        } else if io::stderr().is_terminal() {
             let input: String = Input::new()
                 .with_prompt(format!(
                     "{}what URL is your subgraph running on?",


### PR DESCRIPTION
Rover no longer prints ANSI color codes when writing to files or via unix pipes.

Additionally this PR removes the `atty` crate and uses the newly stabilized `std::io::IsTerminal` trait.