### PR TITLE
persisted-queries: remove "preview" from help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -392,7 +392,7 @@ pub enum Command {
     /// Commands related to updating rover
     Update(command::Update),
 
-    /// Preview feature: Commands for persisted queries
+    /// Commands for persisted queries
     #[command(visible_alias = "pq")]
     PersistedQueries(command::PersistedQueries),
 

--- a/src/command/persisted_queries/mod.rs
+++ b/src/command/persisted_queries/mod.rs
@@ -17,7 +17,7 @@ pub struct PersistedQueries {
 
 #[derive(Debug, Serialize, Parser)]
 pub enum Command {
-    /// Preview feature: Persist a list of queries (or mutations) to a graph in Apollo Studio
+    /// Persist a list of queries (or mutations) to a graph in Apollo Studio
     Publish(persisted_queries::Publish),
 }
 


### PR DESCRIPTION
(To be merged and released when the feature enters General Availability.)