### PR TITLE
feat: set default value for the `Date` http header

### DIFF
--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -4,8 +4,9 @@ use std::{io, str::FromStr, time::Duration};
 use crate::{options::ProfileOpt, PKG_NAME, PKG_VERSION};
 use anyhow::Result;
 
+use chrono::Utc;
 use houston as config;
-use reqwest::blocking::Client;
+use reqwest::{header, blocking::Client};
 use rover_client::blocking::StudioClient;
 
 use serde::Serialize;
@@ -57,6 +58,9 @@ impl ClientBuilder {
     }
 
     pub(crate) fn build(self) -> Result<Client> {
+        let mut headers = header::HeaderMap::new();
+        let now = Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        headers.insert("Date", header::HeaderValue::from_str(&now).unwrap());
         let client = Client::builder()
             .gzip(true)
             .brotli(true)
@@ -64,6 +68,7 @@ impl ClientBuilder {
             .danger_accept_invalid_hostnames(self.accept_invalid_hostnames)
             .timeout(self.timeout)
             .user_agent(format!("{}/{}", PKG_NAME, PKG_VERSION))
+            .default_headers(headers)
             .build()?;
 
         Ok(client)

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use chrono::Utc;
 use houston as config;
-use reqwest::{header, blocking::Client};
+use reqwest::{blocking::Client, header};
 use rover_client::blocking::StudioClient;
 
 use serde::Serialize;


### PR DESCRIPTION
Hello rover!

This PR is to add and set default value for the `Date` http header.
(I'm sorry for opening a PR before having an enough discussion in an issue.)

While I was using `rover` client to build a Apollo Federation supergraph, I found that one of my services rejects the `rover supergraph compose` request due to the absence of the `Date` header.

https://github.com/lablup/backend.ai/blob/0552b2c4b9bb493094393dbcc4399b5ebbbe8195/src/ai/backend/manager/api/auth.py#L324-L329

So I suggest to include the `Date` header for each request.

Refs
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date

p.s. This is my first experience of using the Rust programming language. I've searched a lot and tried my best, but it can be not good enough. Waiting for your advices! Thank you in advance.
