### PR TITLE
docs: use shared content component for GH action instructions

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -33,7 +33,7 @@ As you can see, there is a brief description, followed by the author's GitHub ha
 1. Make sure you have both `npm` and `cargo` installed on your machine and in your `PATH`.
 1. Create a new branch "#.#.#" where "#.#.#" is this release's version (release) or "#.#.#-rc.#" (release candidate)
 1. Update the version in [`./Cargo.toml`](./Cargo.toml), workspace crates like `rover-client` should remain untouched.
-1. Update the installer versions in [`docs/source/getting-started.md`](./docs/source/getting-started.md) and [`docs/source/ci-cd.md`](./docs/source/ci-cd.md). (eventually this should be automated).
+1. Update the installer versions in [`docs/source/getting-started.md`](./docs/source/getting-started.md) and [`docs/source/ci-cd.mdx`](./docs/source/ci-cd.mdx). (eventually this should be automated).
 1. Run `cargo run -- help` and copy the output to the "Command-line Options" section in [`README.md`](./README.md#command-line-options).
 1. Run `cargo xtask prep` (this will require `npm` to be installed).
 1. Push up all of your local changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"

--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -12,7 +12,6 @@ Rover's installation is similar to many other CLI tools, but the recommended met
 * [Jenkins](#jenkins)
 * [Gitlab CI/CD](#gitlab-cicd)
 
-
 > If you're using Rover with a CI/CD provider not listed here, we'd love for you to share the steps by opening an [issue](https://github.com/apollographql/rover/issues/new/choose) or [pull request](https://github.com/apollographql/rover/compare)!
 
 ## CircleCI
@@ -64,12 +63,7 @@ If you use GitHub Actions to automatically run [schema checks](/graphos/delivery
 
 <img class="screenshot" src="./assets/checks-result.jpg" width="550"/>
 
-For these entries to display correctly, you need to make sure Rover associates the schema check execution with the pull request's `HEAD` commit, as opposed to the _merge_ commit that GitHub adds. To guarantee this, set the `APOLLO_VCS_COMMIT` environment variable in your action's configuration, like so:
-
-```yaml
-env:
-  APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
-```
+<SetApolloVCSCommit />
 
 ### Linux/MacOS jobs using the `curl` installer
 


### PR DESCRIPTION
This PR replaces some text with a [new shared content component](https://github.com/apollographql/docs/pull/596/files) containing that text.