### PR TITLE
First trial use of a generator (Scaffolding code for creating a new verb for an existing noun/command)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,7 +114,7 @@ A minimal command in Rover would be laid out exactly like this:
 
 ```rust
 use serde::{Deserialize, Serialize};
-use clap::Parser
+use clap::Parser;
 use crate::{RoverResult, RoverOutput};
 
 #[derive(Debug, Serialize, Parser)]

--- a/plop-templates/new-verb/{{snakeCase verb}}.rs.hbs
+++ b/plop-templates/new-verb/{{snakeCase verb}}.rs.hbs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+use clap::Parser;
+use crate::{RoverResult, RoverOutput};
+
+#[derive(Debug, Serialize, Parser)]
+pub struct {{pascalCase verb}} { }
+
+impl {{pascalCase verb}} {
+  pub fn run(&self) -> RoverResult<RoverOutput> {
+    Ok(RoverOutput::EmptySuccess)
+  }
+}

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,0 +1,31 @@
+module.exports = function(plop) {
+  plop.setGenerator("new-verb", {
+    description: "Create a new verb for an existing noun",
+    prompts: [
+      {
+        type: "input",
+        name: "noun",
+        message: "Existing noun: ",
+      },
+      {
+        type: "input",
+        name: "verb",
+        message: "New verb: ",
+      },
+    ],
+    actions: [
+      {
+        type: "addMany",
+        destination: "src/command/{{snakeCase noun}}",
+        templateFiles: "plop-templates/new-verb/*.hbs",
+        base: "plop-templates/new-verb",
+      },
+      {
+        path: "src/command/{{snakeCase noun}}/mod.rs",
+        pattern: /(.*)/,
+        template: "$1\nmod {{snakeCase verb}};",
+        type: "modify",
+      },
+    ],
+  });
+};


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
First try at taking the instructions from the readme on how to scaffold a new verb on an existing command and added plop tooling to be able to generate the scaffolding automatically.

`npx plop`

This is an initial exploratory PR. Later PRs will build this into the dev tooling and expand on the functionality (if we don't decide to remove it)
