### PR TITLE
feat: subgraph publish --no-url shorthand

### DIFF
--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -2,7 +2,7 @@
 title: Rover subgraph commands
 ---
 
-import AuthNotice from '../../shared/auth-notice.mdx';
+import AuthNotice from "../../shared/auth-notice.mdx";
 
 A **subgraph** is a graph that contributes to the composition of a federated **supergraph**:
 
@@ -180,9 +180,9 @@ Alternatively, you can provide `-`, in which case the command uses an SDL string
 
 Every subgraph name **must**:
 
-* Begin with a letter (capital or lowercase)
-* Include only letters, numbers, underscores (`_`), and hyphens (`-`)
-* Have a maximum of 64 characters
+- Begin with a letter (capital or lowercase)
+- Include only letters, numbers, underscores (`_`), and hyphens (`-`)
+- Have a maximum of 64 characters
 
 </td>
 </tr>
@@ -234,6 +234,19 @@ By default, `rover subgraph publish` will fail if an unparsable routing URL is a
 
 </td>
 </tr>
+<tr>
+<td>
+
+###### `--no-url`
+
+</td>
+
+<td>
+
+This is shorthand for `--routing-url "" --allow-invalid-routing-url`. **It will override any existing routing URL for the subgraph.**
+
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -246,7 +259,6 @@ By default, `rover subgraph publish` will fail if an unparsable routing URL is a
 Before you [publish subgraph schema changes to GraphOS](#publishing-a-subgraph-schema-to-graphos), you can [check those changes](/graphos/delivery/schema-checks/) to confirm that you aren't introducing breaking changes to your application clients.
 
 To do so, you can run the `subgraph check` command:
-
 
 ```shell
 # using a schema file
@@ -316,7 +328,7 @@ Alternatively, you can provide `-`, in which case the command uses an SDL string
 
 <td>
 
-**Required.**  The name of the published subgraph to compare schema changes against.
+**Required.** The name of the published subgraph to compare schema changes against.
 
 </td>
 </tr>

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -67,7 +67,7 @@ impl Publish {
         // if --allow-invalid-routing-url is not provided, we need to inspect
         // the URL and possibly prompt the user to publish. this does nothing
         // if the routing url is not provided.
-        if !self.allow_invalid_routing_url {
+        if !self.no_url && !self.allow_invalid_routing_url {
             Self::handle_maybe_invalid_routing_url(
                 &self.routing_url,
                 &mut io::stderr(),

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -58,44 +58,25 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
     ) -> RoverResult<RoverOutput> {
-        if self.no_url && self.routing_url.is_some() {
-            return Err(RoverError::new(anyhow!(
-                "You cannot use --no-url and --routing-url at the same time."
-            )));
-        }
-
-        // if --allow-invalid-routing-url is not provided, we need to inspect
-        // the URL and possibly prompt the user to publish. this does nothing
-        // if the routing url is not provided.
-        if !self.no_url && !self.allow_invalid_routing_url {
-            Self::handle_maybe_invalid_routing_url(
-                &self.routing_url,
-                &mut io::stderr(),
-                &mut io::stdin(),
-                io::stderr().is_terminal() && io::stdin().is_terminal(),
-            )?;
-        }
-
         let client = client_config.get_authenticated_client(&self.profile)?;
 
-        // don't bother fetching and validating an existing routing url if
-        // --no-url is set
-        if !self.no_url && self.routing_url.is_none() {
-            let fetch_response = routing_url::run(
-                SubgraphRoutingUrlInput {
-                    graph_ref: self.graph.graph_ref.clone(),
-                    subgraph_name: self.subgraph.subgraph_name.clone(),
-                },
-                &client,
-            )?;
-
-            Self::handle_maybe_invalid_routing_url(
-                &Some(fetch_response),
-                &mut io::stderr(),
-                &mut io::stdin(),
-                io::stderr().is_terminal() && io::stdin().is_terminal(),
-            )?;
-        }
+        let url = Self::determine_routing_url(
+            self.no_url,
+            &self.routing_url,
+            self.allow_invalid_routing_url,
+            || {
+                Ok(routing_url::run(
+                    SubgraphRoutingUrlInput {
+                        graph_ref: self.graph.graph_ref.clone(),
+                        subgraph_name: self.subgraph.subgraph_name.clone(),
+                    },
+                    &client,
+                )?)
+            },
+            &mut io::stderr(),
+            &mut io::stdin(),
+            io::stderr().is_terminal() && io::stdin().is_terminal(),
+        )?;
 
         eprintln!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
@@ -109,15 +90,6 @@ impl Publish {
             .read_file_descriptor("SDL", &mut std::io::stdin())?;
 
         tracing::debug!("Publishing \n{}", &schema);
-
-        let url = if let Some(routing_url) = &self.routing_url {
-            Some(routing_url.clone())
-        } else if self.no_url {
-            // --no-url is shorthand for --routing-url ""
-            Some("".to_string())
-        } else {
-            None
-        };
 
         let publish_response = publish::run(
             SubgraphPublishInput {
@@ -136,6 +108,61 @@ impl Publish {
             subgraph: self.subgraph.subgraph_name.clone(),
             publish_response,
         })
+    }
+
+    fn determine_routing_url<F>(
+        no_url: bool,
+        routing_url: &Option<String>,
+        allow_invalid_routing_url: bool,
+
+        // For testing purposes, we pass in a closure for fetching the
+        // routing url from GraphOS
+        fetch: F,
+        // For testing purposes, we pass in stub `Write`er and `Read`ers to
+        // simulate input and verify output.
+        writer: &mut impl io::Write,
+        reader: &mut impl io::Read,
+        // Simulate a CI environment (non-TTY) for testing
+        is_atty: bool,
+    ) -> RoverResult<Option<String>>
+    where
+        F: Fn() -> RoverResult<String>,
+    {
+        if no_url && routing_url.is_some() {
+            return Err(RoverError::new(anyhow!(
+                "You cannot use --no-url and --routing-url at the same time."
+            )));
+        }
+
+        // if --allow-invalid-routing-url is not provided, we need to inspect
+        // the URL and possibly prompt the user to publish. this does nothing
+        // if the routing url is not provided.
+        if !no_url && !allow_invalid_routing_url {
+            Self::handle_maybe_invalid_routing_url(routing_url, writer, reader, is_atty)?;
+        }
+
+        // don't bother fetching and validating an existing routing url if
+        // --no-url is set
+        let mut routing_url = routing_url.clone();
+        if !no_url && routing_url.is_none() {
+            let fetch_response = fetch()?;
+            Self::handle_maybe_invalid_routing_url(
+                &Some(fetch_response.clone()),
+                writer,
+                reader,
+                is_atty,
+            )?;
+            routing_url = Some(fetch_response)
+        }
+
+        if let Some(routing_url) = routing_url {
+            Ok(Some(routing_url))
+        } else if no_url {
+            // --no-url is shorthand for --routing-url ""
+            Ok(Some("".to_string()))
+        } else {
+            Ok(None)
+        }
     }
 
     fn handle_maybe_invalid_routing_url(
@@ -232,6 +259,118 @@ impl Publish {
 #[cfg(test)]
 mod tests {
     use crate::command::subgraph::Publish;
+
+    #[test]
+    fn test_no_url() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = Vec::new();
+        let result = Publish::determine_routing_url(
+            true,
+            &None,
+            false,
+            || Ok("".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result, Some("".to_string()));
+    }
+
+    #[test]
+    fn test_routing_url_provided() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = Vec::new();
+        let result = Publish::determine_routing_url(
+            false,
+            &Some("https://provided".to_string()),
+            false,
+            || Ok("".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result, Some("https://provided".to_string()));
+    }
+
+    #[test]
+    fn test_no_url_and_routing_url_provided() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = Vec::new();
+        let result = Publish::determine_routing_url(
+            true,
+            &Some("https://provided".to_string()),
+            false,
+            || Ok("".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(
+            result.message(),
+            "You cannot use --no-url and --routing-url at the same time."
+        );
+    }
+
+    #[test]
+    fn test_routing_url_not_provided_already_exists() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = Vec::new();
+        let result = Publish::determine_routing_url(
+            false,
+            &None,
+            false,
+            || Ok("https://fromstudio".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result, Some("https://fromstudio".to_string()));
+    }
+
+    #[test]
+    fn test_routing_url_invalid_provided() {
+        let mut input = "y".as_bytes();
+        let mut output: Vec<u8> = Vec::new();
+
+        let result = Publish::determine_routing_url(
+            false,
+            &Some("invalid".to_string()),
+            false,
+            || Ok("".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result, Some("invalid".to_string()));
+        assert!(std::str::from_utf8(&output).unwrap().contains("is not a valid routing URL. Continuing the publish will make this subgraph unreachable by your supergraph. Would you still like to publish?"));
+    }
+
+    #[test]
+    fn test_not_url_invalid_from_studio() {
+        let mut input = "y".as_bytes();
+        let mut output: Vec<u8> = Vec::new();
+
+        let result = Publish::determine_routing_url(
+            true,
+            &None,
+            false,
+            || Ok("invalid".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result, Some("".to_string()));
+        assert!(std::str::from_utf8(&output).unwrap().is_empty());
+    }
 
     #[test]
     fn test_confirm_invalid_url_publish() {


### PR DESCRIPTION
This is slightly more convenient and less awkward than `--routing-url "" --allow-invalid-routing-url`

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
