### PR TITLE
fix(deps): bump binary-install 1.1.0

### DIFF
--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "axios-proxy-builder": "^0.1.1",
-        "binary-install": "^1.0.6",
+        "binary-install": "^1.1.0",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.0"
       },

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
     "axios-proxy-builder": "^0.1.1",
-    "binary-install": "^1.0.6",
+    "binary-install": "^1.1.0",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.0"
   },


### PR DESCRIPTION
`binary-install` 1.0.6 contains a [bug](https://github.com/EverlastingBugstopper/binary-install/issues/27) that would cause `rover` command to crash when it downloads the binary for the first time.

The issue is then [fixed](https://github.com/EverlastingBugstopper/binary-install/pull/28) and released in 1.1.0.