### PR TITLE
Let rover download aarch binaries on OSX.

### DIFF
--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -9,7 +9,7 @@
   "router": {
     "repository": "https://github.com/apollographql/router",
     "versions": {
-      "latest-1": "v1.37.0"
+      "latest-1": "v1.38.0"
     }
   }
 }

--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -9,7 +9,7 @@
   "router": {
     "repository": "https://github.com/apollographql/router",
     "versions": {
-      "latest-1": "v1.38.0"
+      "latest-1": "v1.37.0"
     }
   }
 }

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -5,14 +5,14 @@ use apollo_federation_types::config::{FederationVersion, PluginVersion, RouterVe
 use binstall::Installer;
 use camino::Utf8PathBuf;
 use rover_std::{sanitize_url, Fs};
-use semver::{BuildMetadata, Prerelease, Version};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use crate::{utils::client::StudioClientConfig, RoverError, RoverErrorSuggestion, RoverResult};
 
 // The first version of the router
 // That was compiled for aarch64 only
-const AARCH_OSX_FIRST_ROUTER_VERSION: Version = Version::new(1, 38, 0);;
+const AARCH_OSX_FIRST_ROUTER_VERSION: Version = Version::new(1, 38, 0);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Plugin {

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -12,13 +12,7 @@ use crate::{utils::client::StudioClientConfig, RoverError, RoverErrorSuggestion,
 
 // The first version of the router
 // That was compiled for aarch64 only
-const AARCH_OSX_FIRST_ROUTER_VERSION: Version = Version {
-    major: 1,
-    minor: 38,
-    patch: 0,
-    pre: Prerelease::EMPTY,
-    build: BuildMetadata::EMPTY,
-};
+const AARCH_OSX_FIRST_ROUTER_VERSION: Version = Version::new(1, 38, 0);;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Plugin {
@@ -65,7 +59,7 @@ impl Plugin {
             ("windows", _) => Ok("x86_64-pc-windows-msvc"),
             ("macos", _) => {
                 match self {
-                    Self::Router(RouterVersion::Exact(v)) if v.lt(&AARCH_OSX_FIRST_ROUTER_VERSION) => {
+                    Self::Router(RouterVersion::Exact(v)) if v < &AARCH_OSX_FIRST_ROUTER_VERSION => {
                         Ok("x86_64-apple-darwin")
                     },
                     // Router version 1.38 or above are built for aarch64

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -440,7 +440,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(not(target = "musl"))]
+    #[cfg(not(target = "x86_64-unknown-linux-musl"))]
     fn test_osx_plugin_versions() {
         let router_latest = Plugin::Router(RouterVersion::Latest);
         let router_exact_recent = Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0)));
@@ -464,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target = "musl")]
+    #[cfg(target = "x86_64-unknown-linux-musl")]
     fn test_plugin_version_should_fail() {
         Plugin::Router(RouterVersion::Latest)
             .get_arch_for_env("", "")

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -5,10 +5,20 @@ use apollo_federation_types::config::{FederationVersion, PluginVersion, RouterVe
 use binstall::Installer;
 use camino::Utf8PathBuf;
 use rover_std::{sanitize_url, Fs};
-use semver::Version;
+use semver::{BuildMetadata, Prerelease, Version};
 use serde::{Deserialize, Serialize};
 
 use crate::{utils::client::StudioClientConfig, RoverError, RoverErrorSuggestion, RoverResult};
+
+// The first version of the router
+// That was compiled for aarch64 only
+const AARCH_OSX_FIRST_ROUTER_VERSION: Version = Version {
+    major: 1,
+    minor: 38,
+    patch: 0,
+    pre: Prerelease::EMPTY,
+    build: BuildMetadata::EMPTY,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Plugin {
@@ -39,6 +49,10 @@ impl Plugin {
     }
 
     pub fn get_target_arch(&self) -> RoverResult<String> {
+        self.get_arch_for_env(consts::OS, consts::ARCH)
+    }
+
+    fn get_arch_for_env(&self, os: &str, arch: &str) -> RoverResult<String> {
         let mut no_prebuilt_binaries = RoverError::new(anyhow!(
             "Your current architecture does not support installation of this plugin."
         ));
@@ -47,10 +61,18 @@ impl Plugin {
             no_prebuilt_binaries.set_suggestion(RoverErrorSuggestion::CheckGnuVersion);
             return Err(no_prebuilt_binaries);
         }
-
-        match (consts::OS, consts::ARCH) {
+        match (os, arch) {
             ("windows", _) => Ok("x86_64-pc-windows-msvc"),
-            ("macos", _) => Ok("x86_64-apple-darwin"),
+            ("macos", _) => {
+                match self {
+                    Self::Router(RouterVersion::Exact(v)) if v.lt(&AARCH_OSX_FIRST_ROUTER_VERSION) => {
+                        Ok("x86_64-apple-darwin")
+                    },
+                    // Router version 1.38 or above are built for aarch64
+                    Self::Router(_) => Ok("aarch64-apple-darwin"),
+                    _ => Ok("x86_64-apple-darwin")
+                }
+            } ,
             ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
             ("linux", "aarch64") => {
                 match self {
@@ -416,5 +438,33 @@ fn find_installed_plugin(
             ));
         }
         Err(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_osx_plugin_versions() {
+        let router_latest = Plugin::Router(RouterVersion::Latest);
+        let router_exact_recent = Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0)));
+        let router_exact_older = Plugin::Router(RouterVersion::Exact(Version::new(1, 37, 0)));
+
+        let supergraph = Plugin::Supergraph(FederationVersion::LatestFedTwo);
+
+        for p in [router_latest, router_exact_recent] {
+            assert_eq!(
+                "aarch64-apple-darwin",
+                p.get_arch_for_env("macos", "").unwrap()
+            );
+        }
+
+        for p in [supergraph, router_exact_older] {
+            assert_eq!(
+                "x86_64-apple-darwin",
+                p.get_arch_for_env("macos", "").unwrap()
+            );
+        }
     }
 }

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -440,7 +440,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(not(target = "x86_64-unknown-linux-musl"))]
+    #[cfg(not(target_env = "musl"))]
     fn test_osx_plugin_versions() {
         let router_latest = Plugin::Router(RouterVersion::Latest);
         let router_exact_recent = Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0)));
@@ -464,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target = "x86_64-unknown-linux-musl")]
+    #[cfg(target_env = "musl")]
     fn test_plugin_version_should_fail() {
         Plugin::Router(RouterVersion::Latest)
             .get_arch_for_env("", "")

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -440,6 +440,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(not(target = "musl"))]
     fn test_osx_plugin_versions() {
         let router_latest = Plugin::Router(RouterVersion::Latest);
         let router_exact_recent = Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0)));
@@ -460,5 +461,13 @@ mod tests {
                 p.get_arch_for_env("macos", "").unwrap()
             );
         }
+    }
+
+    #[test]
+    #[cfg(target = "musl")]
+    fn test_plugin_version_should_fail() {
+        Plugin::Router(RouterVersion::Latest)
+            .get_arch_for_env("", "")
+            .unwrap_err();
     }
 }

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -139,7 +139,7 @@ fn latest_plugins_are_valid_versions() {
     let router_arch = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "aarch64" | "arm") => "aarch64-unknown-linux-gnu",
         ("linux", _) => "x86_64-unknown-linux-gnu",
-        ("macos", _) => "aarch64-apple-darwin",
+        ("macos", _) => "x86_64-apple-darwin", // TODO: use "aarch64-apple-darwin" once the latest router version of router is 1.38
         ("windows", _) => "x86_64-pc-windows-msvc",
         _ => panic!("not linux, macos, or windows OS for this test runner"),
     };

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -128,25 +128,33 @@ fn latest_plugins_are_valid_versions() {
     // after validating the fields, make sure we can download the binaries from GitHub
     let supergraph_release_url = format!("{}/releases/download/", &supergraph_repository);
     let router_release_url = format!("{}/releases/download/", &router_repository);
-    let arch = match (std::env::consts::OS, std::env::consts::ARCH) {
+    let federation_arch = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "aarch64" | "arm") => "aarch64-unknown-linux-gnu",
         ("linux", _) => "x86_64-unknown-linux-gnu",
         ("macos", _) => "x86_64-apple-darwin",
         ("windows", _) => "x86_64-pc-windows-msvc",
         _ => panic!("not linux, macos, or windows OS for this test runner"),
     };
+
+    let router_arch = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "aarch64" | "arm") => "aarch64-unknown-linux-gnu",
+        ("linux", _) => "x86_64-unknown-linux-gnu",
+        ("macos", _) => "aarch64-apple-darwin",
+        ("windows", _) => "x86_64-pc-windows-msvc",
+        _ => panic!("not linux, macos, or windows OS for this test runner"),
+    };
     let latest_federation_one = format!(
-        "{url}supergraph@{version}/supergraph-{version}-{arch}.tar.gz",
+        "{url}supergraph@{version}/supergraph-{version}-{federation_arch}.tar.gz",
         url = &supergraph_release_url,
         version = &latest_federation_one
     );
     let latest_federation_two = format!(
-        "{url}supergraph@{version}/supergraph-{version}-{arch}.tar.gz",
+        "{url}supergraph@{version}/supergraph-{version}-{federation_arch}.tar.gz",
         url = &supergraph_release_url,
         version = &latest_federation_two
     );
     let latest_router = format!(
-        "{url}{version}/router-{version}-{arch}.tar.gz",
+        "{url}{version}/router-{version}-{router_arch}.tar.gz",
         url = &router_release_url,
         version = &latest_router
     );


### PR DESCRIPTION
This PR updates the way the router binary name is retrieved, since the router is now compiled for the aarch target on OSX platforms.

Closes https://github.com/apollographql/rover/pull/1821
