### PR TITLE
test(ci): Pin to 2022.08.1 CircleCI Windows image, rather than "stable"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,7 @@ commands:
                 name: Install volta
                 command: |
                   choco install volta -y
+                  refreshenv
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,11 +387,16 @@ commands:
                 name: Install volta
                 command: |
                   choco install volta -y
+                  echo $env:path -split ";"
                   Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+                  echo $env:path -split ";"
+                  volta install node@16
+                  volta install npm@7
 
       - unless:
           condition:
             equal: [*arm_ubuntu_executor, << parameters.platform >>]
+            equal: [*amd_windows_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install default versions of npm and node
@@ -448,6 +453,13 @@ commands:
                   [net]
                   git-fetch-with-cli = true
                   "@
+            - run:
+                name: Install gcc
+                command: |
+                  choco install mingw --version=13.2.0 -y
+                  echo $env:path -split ";"
+                  refreshenv
+                  echo $env:path -split ";"
 
 
   exec_xtask:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,8 +395,9 @@ commands:
 
       - unless:
           condition:
-            equal: [*arm_ubuntu_executor, << parameters.platform >>]
-            equal: [*amd_windows_executor, << parameters.platform >>]
+            or:
+              - equal: [*arm_ubuntu_executor, << parameters.platform >>]
+              - equal: [*amd_windows_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install default versions of npm and node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,6 @@ commands:
                   git-fetch-with-cli = true
                   "@
 
-
   exec_xtask:
     parameters:
       command:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,11 +448,7 @@ commands:
                   [net]
                   git-fetch-with-cli = true
                   "@
-            - run:
-                name: Install gcc
-                command: |
-                  choco install mingw --version=13.2.0 -y
-                  refreshenv
+
 
   exec_xtask:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ commands:
                 name: Install volta
                 command: |
                   choco install volta -y
-                  refreshenv
+                  Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,9 +390,7 @@ commands:
 
       - unless:
           condition:
-            or:
-              - equal: [*arm_ubuntu_executor, << parameters.platform >>]
-              - equal: [*amd_windows_executor, << parameters.platform >>]
+            equal: [*arm_ubuntu_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install default versions of npm and node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,6 +447,11 @@ commands:
                   [net]
                   git-fetch-with-cli = true
                   "@
+            - run:
+                name: Install gcc
+                command: |
+                  choco install mingw --version=13.2.0 -y
+                  refreshenv
 
   exec_xtask:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ executors:
 
   amd_windows: &amd_windows_executor
     machine:
-      image: "windows-server-2019-vs2019:stable"
+      image: "windows-server-2019-vs2019:2022.08.1"
     resource_class: windows.xlarge
     shell: powershell.exe -ExecutionPolicy Bypass
     environment:
@@ -387,11 +387,6 @@ commands:
                 name: Install volta
                 command: |
                   choco install volta -y
-                  echo $env:path -split ";"
-                  Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-                  echo $env:path -split ";"
-                  volta install node@16
-                  volta install npm@7
 
       - unless:
           condition:
@@ -454,13 +449,6 @@ commands:
                   [net]
                   git-fetch-with-cli = true
                   "@
-            - run:
-                name: Install gcc
-                command: |
-                  choco install mingw --version=13.2.0 -y
-                  echo $env:path -split ";"
-                  refreshenv
-                  echo $env:path -split ";"
 
 
   exec_xtask:


### PR DESCRIPTION
Same spirit as https://github.com/apollographql/router/pull/4637

---

CircleCI updated their `current` (also known as `stable`) label to a new version that was published around the time that our Windows CI tests started [mysteriously and consistently failing](https://app.circleci.com/pipelines/github/apollographql/rover/3649/workflows/6c3eb0a4-3805-45ab-af93-22a174db13b3) on February 8th at approximately 15:00 UTC — much like we observed on the `router` repository at the same time.

Through logs and conversations with support, we understand this to be true.  To mitigate this and get our builds passing again, we are hardcoding the builds to the version that we now are able to know with certainty _was_ working, `windows-server-2019-vs2019:2022.08.1`.  The version which appears to be failing is **at the very least** `windows-server-2019-vs2019:2023.01.1`, but possibly earlier.

This PR changes the unpinned `stable` tag in our configuration to use the known-good release and we will then release and iterate _up_ from there, as much as possible.