### PR TITLE
Let rover download aarch and x86_64 binaries on OSX.

### DIFF
--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -443,15 +443,15 @@ mod tests {
     fn test_osx_plugin_versions() {
         let router_latest = Plugin::Router(RouterVersion::Latest);
         let router_exact_recent = Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 1)));
-        let router_exact_one_tirty_eight =
+        let router_exact_one_thirty_eight =
             Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0)));
-        let router_exact_one_tirty_nine =
+        let router_exact_one_thirty_nine =
             Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 0)));
         let router_exact_older = Plugin::Router(RouterVersion::Exact(Version::new(1, 37, 0)));
 
         let supergraph = Plugin::Supergraph(FederationVersion::LatestFedTwo);
 
-        for p in [router_exact_one_tirty_eight, router_exact_one_tirty_nine] {
+        for p in [router_exact_one_thirty_eight, router_exact_one_thirty_nine] {
             assert_eq!(
                 "aarch64-apple-darwin",
                 p.get_arch_for_env("macos", "").unwrap()

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -128,7 +128,7 @@ fn latest_plugins_are_valid_versions() {
     // after validating the fields, make sure we can download the binaries from GitHub
     let supergraph_release_url = format!("{}/releases/download/", &supergraph_repository);
     let router_release_url = format!("{}/releases/download/", &router_repository);
-    let federation_arch = match (std::env::consts::OS, std::env::consts::ARCH) {
+    let arch = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "aarch64" | "arm") => "aarch64-unknown-linux-gnu",
         ("linux", _) => "x86_64-unknown-linux-gnu",
         ("macos", _) => "x86_64-apple-darwin",
@@ -136,25 +136,18 @@ fn latest_plugins_are_valid_versions() {
         _ => panic!("not linux, macos, or windows OS for this test runner"),
     };
 
-    let router_arch = match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "aarch64" | "arm") => "aarch64-unknown-linux-gnu",
-        ("linux", _) => "x86_64-unknown-linux-gnu",
-        ("macos", _) => "x86_64-apple-darwin", // TODO: use "aarch64-apple-darwin" once the latest router version of router is 1.38
-        ("windows", _) => "x86_64-pc-windows-msvc",
-        _ => panic!("not linux, macos, or windows OS for this test runner"),
-    };
     let latest_federation_one = format!(
-        "{url}supergraph@{version}/supergraph-{version}-{federation_arch}.tar.gz",
+        "{url}supergraph@{version}/supergraph-{version}-{arch}.tar.gz",
         url = &supergraph_release_url,
         version = &latest_federation_one
     );
     let latest_federation_two = format!(
-        "{url}supergraph@{version}/supergraph-{version}-{federation_arch}.tar.gz",
+        "{url}supergraph@{version}/supergraph-{version}-{arch}.tar.gz",
         url = &supergraph_release_url,
         version = &latest_federation_two
     );
     let latest_router = format!(
-        "{url}{version}/router-{version}-{router_arch}.tar.gz",
+        "{url}{version}/router-{version}-{arch}.tar.gz",
         url = &router_release_url,
         version = &latest_router
     );


### PR DESCRIPTION
This PR updates the way the router binary name is retrieved, since the router version 1.39.1 and above is compiled for both aarch and x86_64 targets on OSX platforms.

Followup to https://github.com/apollographql/rover/pull/1821
