### PR TITLE
Update supergraph and router binary urls for osx

### DIFF
--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -77,7 +77,7 @@ impl Plugin {
                     Self::Router(_) => {
                        Ok("aarch64-apple-darwin")
                    },
-                   _ =>  Ok("x86_64-apple-darwin")
+                   Self::Supergraph(_) =>  Ok("x86_64-apple-darwin")
                 }
             } ,
             ("macos", _) => {

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -57,6 +57,26 @@ impl Plugin {
         }
         match (os, arch) {
             ("windows", _) => Ok("x86_64-pc-windows-msvc"),
+            ("macos", "x86_64") => {
+                match self {
+                    Self::Router(RouterVersion::Exact(v)) if AARCH_OSX_ONLY_ROUTER_VERSIONS.contains(v) => {
+                        // OSX router version 1.38.0 and 1.39.0 were only released on aarch64
+                        Err(RoverError::new(anyhow!(
+                            "Router versions {} are only available for aarch64, please use verssion 1.39.1 or above.", AARCH_OSX_ONLY_ROUTER_VERSIONS.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" and ")
+                        )))
+                    },
+                    _ => Ok("x86_64-apple-darwin")
+                }
+            } ,
+            ("macos", "aarch64") => {
+                match self {
+                    // OSX router version starting from 1.38.0 are released for aarch64
+                    Self::Router(RouterVersion::Exact(v)) if v.lt(&AARCH_OSX_ONLY_ROUTER_VERSIONS[0]) => {
+                         Ok("x86_64-apple-darwin")
+                    },
+                    _ => Ok("aarch64-apple-darwin")
+                }
+            } ,
             ("macos", _) => {
                 match self {
                     Self::Router(RouterVersion::Exact(v)) if AARCH_OSX_ONLY_ROUTER_VERSIONS.contains(v) => {

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -440,6 +440,65 @@ mod tests {
 
     #[test]
     #[cfg(not(target_env = "musl"))]
+    fn test_osx_plugin_versions_x64() {
+        // Router versions lower than 1.38.0 or greater than or equal to 1.39.1 are available
+        let available_versions = [
+            Plugin::Router(RouterVersion::Latest),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 1))),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 37, 0))),
+        ];
+
+        // Router version 1.38.0 and 1.39.0 are not available
+        let unavailable_versions = [
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0))),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 0))),
+        ];
+
+        for p in available_versions {
+            assert_eq!(
+                "x86_64-apple-darwin",
+                p.get_arch_for_env("macos", "x86_64").unwrap()
+            );
+        }
+
+        for p in unavailable_versions {
+            p.get_arch_for_env("macos", "x86_64").unwrap_err();
+        }
+    }
+
+    #[test]
+    #[cfg(not(target_env = "musl"))]
+    fn test_osx_plugin_versions_aarch64() {
+        // Router versions lower than 1.38.0 are available under the x64 alias
+        let x64_versions = [
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 37, 0))),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 36, 0))),
+        ];
+        // Router version 1.38.0 and above are available on their own
+        let aarch_versions = [
+            Plugin::Router(RouterVersion::Latest),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 1))),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 0))),
+            Plugin::Router(RouterVersion::Exact(Version::new(1, 38, 0))),
+        ];
+
+        for p in x64_versions {
+            assert_eq!(
+                "x86_64-apple-darwin",
+                p.get_arch_for_env("macos", "aarch64").unwrap()
+            );
+        }
+
+        for p in aarch_versions {
+            assert_eq!(
+                "aarch64-apple-darwin",
+                p.get_arch_for_env("macos", "aarch64").unwrap()
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(not(target_env = "musl"))]
     fn test_osx_plugin_versions() {
         let router_latest = Plugin::Router(RouterVersion::Latest);
         let router_exact_recent = Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 1)));

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -74,7 +74,10 @@ impl Plugin {
                     Self::Router(RouterVersion::Exact(v)) if v.lt(&AARCH_OSX_ONLY_ROUTER_VERSIONS[0]) => {
                          Ok("x86_64-apple-darwin")
                     },
-                    _ => Ok("aarch64-apple-darwin")
+                    Self::Router(_) => {
+                       Ok("aarch64-apple-darwin")
+                   },
+                   _ =>  Ok("x86_64-apple-darwin")
                 }
             } ,
             ("macos", _) => {
@@ -466,6 +469,9 @@ mod tests {
             Plugin::Router(RouterVersion::Latest),
             Plugin::Router(RouterVersion::Exact(Version::new(1, 39, 1))),
             Plugin::Router(RouterVersion::Exact(Version::new(1, 37, 0))),
+            // Supergraph versions remain available
+            Plugin::Supergraph(FederationVersion::ExactFedTwo(Version::new(2, 7, 1))),
+            Plugin::Supergraph(FederationVersion::LatestFedTwo),
         ];
 
         // Router version 1.38.0 and 1.39.0 are not available
@@ -493,6 +499,9 @@ mod tests {
         let x64_versions = [
             Plugin::Router(RouterVersion::Exact(Version::new(1, 37, 0))),
             Plugin::Router(RouterVersion::Exact(Version::new(1, 36, 0))),
+            // Supergraph versions remain only x64
+            Plugin::Supergraph(FederationVersion::ExactFedTwo(Version::new(2, 7, 1))),
+            Plugin::Supergraph(FederationVersion::LatestFedTwo),
         ];
         // Router version 1.38.0 and above are available on their own
         let aarch_versions = [


### PR DESCRIPTION
Latest changes in the way the router is deployed now allow us to run native aarch64 binaries on OSX.

This PR updates the url retrieval mechanism to highlight that, for `OSX`:
  - router versions 1.38.0 and 1.39.0 are not available on `x64`
  - router versions up to 1.37.0 are available for both `aarch64` and `x64` via the `x64` tarball (using rosetta).
  - router versions 1.38.0 and above are available natively for `aarch64`
  - router versions 1.39.1 and above are available natively for `x64`

No changes have been made to the supergraph binary.
