### PR TITLE
prevent an infinite loop when killing the router

### DIFF
--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -183,7 +183,9 @@ impl RouterRunner {
             rayon::spawn(move || loop {
                 let log = match router_log_receiver.recv() {
                     Ok(log) => log,
-                    Err(_) => continue,
+                    Err(_) => {
+                        break;
+                    }
                 };
                 match log {
                     BackgroundTaskLog::Stdout(stdout) => {


### PR DESCRIPTION
Sometimes, this happens:
* one subgraph is briefley unavailable while rover introspects it for composition
* composition fails due to missing types
* the composition part of rover kills the router by removing the supergraph schema file (instead of killing it via the rover side task managing it)
* the `BackgroundTask` that manages the router, and sends logs over a channel, closes
* the `Runner` that waits for logs on the channel goes into an infinite loop trying to get messages from the channel and ignoring errors, which causes the CPU usage to raise

If the `Receiver` starts returning errors, that means we won't get new data, so we should stop the runner here, and wait for a restart of the tasks

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
