### PR TITLE
Update the rust toolchain to 1.75

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.75.0"
 components = [ "rustfmt", "clippy" ]

--- a/src/command/contract/mod.rs
+++ b/src/command/contract/mod.rs
@@ -1,9 +1,6 @@
 mod describe;
 mod publish;
 
-pub use describe::Describe;
-pub use publish::Publish;
-
 use clap::Parser;
 use serde::Serialize;
 

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -5,14 +5,8 @@ mod introspect;
 mod lint;
 mod publish;
 
-pub use check::Check;
-pub use delete::Delete;
-pub use fetch::Fetch;
-pub use introspect::Introspect;
-pub use lint::Lint;
-pub use publish::Publish;
-
 use clap::Parser;
+pub use introspect::Introspect;
 use serde::Serialize;
 
 use crate::options::OutputOpts;

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -6,13 +6,7 @@ mod lint;
 mod list;
 mod publish;
 
-pub use check::Check;
-pub use delete::Delete;
-pub use fetch::Fetch;
 pub use introspect::Introspect;
-pub use lint::Lint;
-pub use list::List;
-pub use publish::Publish;
 
 use clap::Parser;
 use serde::Serialize;

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -258,7 +258,7 @@ impl Publish {
 
 #[cfg(test)]
 mod tests {
-    use crate::command::subgraph::Publish;
+    use crate::command::subgraph::publish::Publish;
 
     #[test]
     fn test_no_url() {

--- a/xtask/src/commands/prep/docs.rs
+++ b/xtask/src/commands/prep/docs.rs
@@ -2,8 +2,6 @@ use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
 use rover_std::Fs;
 
-use std::convert::TryFrom;
-
 use crate::utils::PKG_PROJECT_ROOT;
 
 pub(crate) struct DocsRunner {
@@ -51,7 +49,7 @@ impl DocsRunner {
         // and add it as a header. Then push the header and description to the
         // all_descriptions string
         for code in code_files {
-            let path = Utf8PathBuf::try_from(code.path())?;
+            let path = Utf8PathBuf::from(code.path());
 
             let contents = Fs::read_file(&path)?;
             let code_name = path

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,9 +1,9 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
 use cargo_metadata::{Metadata, MetadataCommand};
 use lazy_static::lazy_static;
 
-use std::{convert::TryFrom, env, str};
+use std::{env, str};
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 #[allow(dead_code)]
@@ -37,8 +37,7 @@ fn rover_version() -> Result<String> {
 }
 
 fn project_root() -> Result<Utf8PathBuf> {
-    let manifest_dir = Utf8PathBuf::try_from(MANIFEST_DIR)
-        .with_context(|| "Could not find the root directory.")?;
+    let manifest_dir = Utf8PathBuf::from(MANIFEST_DIR);
     let root_dir = manifest_dir
         .ancestors()
         .nth(1)


### PR DESCRIPTION
A recent MSRV bump in `clap` and `normpath` requires us to use rustc 1.74 or above.