### PR TITLE
Use task specific `rayon` threadpools and not the global threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,25 +2636,12 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
 dependencies = [
- "blocking",
  "cfg-if 1.0.0",
- "futures-core",
- "futures-io",
- "intmap",
  "libc",
- "once_cell",
  "rustc_version",
- "spinning",
- "thiserror",
  "to_method",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "io-lifetimes"
@@ -4826,15 +4813,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ heck = "0.4"
 humantime = "2.1.0"
 httpmock = "0.6"
 hyper = "0.14"
-interprocess = "1"
+interprocess = { version = "1", default-features = false }
 indoc = "2"
 lazycell = "1"
 lazy_static = "1.4"

--- a/crates/rover-std/src/fs.rs
+++ b/crates/rover-std/src/fs.rs
@@ -205,7 +205,13 @@ impl Fs {
         P: AsRef<Utf8Path>,
     {
         let path = path.as_ref().to_string();
-        rayon::spawn(move || {
+        // Build a Rayon Thread pool
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .thread_name(|idx| format!("file-watcher-{idx}"))
+            .build()
+            .expect("thread pool built successfully");
+        tp.spawn(move || {
             eprintln!("{}watching {} for changes", Emoji::Watch, &path);
 
             let (fs_tx, fs_rx) = channel();

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -1,4 +1,3 @@
-// Build a Rayon Thread pool
 use anyhow::{anyhow, Context};
 use camino::Utf8PathBuf;
 use rover_std::Emoji;

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -1,3 +1,4 @@
+// Build a Rayon Thread pool
 use anyhow::{anyhow, Context};
 use camino::Utf8PathBuf;
 use rover_std::Emoji;
@@ -33,12 +34,13 @@ impl Dev {
         let leader_channel = LeaderChannel::new();
         let follower_channel = FollowerChannel::new();
 
+        // Build a Rayon Thread pool
         let tp = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
-            .thread_name(|idx| format!("router-dev-{idx}"))
+            .thread_name(|idx| format!("router-do-dev-{idx}"))
             .build()
             .map_err(|err| {
-                RoverError::new(anyhow!("could not create router dev thread pool: {err}",))
+                RoverError::new(anyhow!("could not create router do dev thread pool: {err}",))
             })?;
         if let Some(mut leader_session) = LeaderSession::new(
             override_install_path,

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -173,7 +173,14 @@ impl LeaderSession {
 
         let follower_message_sender = self.follower_channel.sender.clone();
         let leader_message_receiver = self.leader_channel.receiver.clone();
-        rayon::spawn(move || {
+        let tp = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .thread_name(|idx| format!("router-leader-{idx}"))
+            .build()
+            .map_err(|err| {
+                RoverError::new(anyhow!("could not create router leader thread pool: {err}",))
+            })?;
+        tp.spawn(move || {
             listener
                 .incoming()
                 .filter_map(handle_socket_error)

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -173,6 +173,7 @@ impl LeaderSession {
 
         let follower_message_sender = self.follower_channel.sender.clone();
         let leader_message_receiver = self.leader_channel.receiver.clone();
+        // Build a Rayon Thread pool
         let tp = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
             .thread_name(|idx| format!("router-leader-{idx}"))

--- a/src/command/dev/router/command.rs
+++ b/src/command/dev/router/command.rs
@@ -82,6 +82,7 @@ impl BackgroundTask {
             .spawn()
             .with_context(|| "could not spawn child process")?;
 
+        // Build a Rayon Thread pool
         let tp = rayon::ThreadPoolBuilder::new()
             .num_threads(2)
             .thread_name(|idx| format!("router-command-{idx}"))

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -80,6 +80,7 @@ impl RouterConfigHandler {
         // if a router config was passed, start watching it in the background for changes
 
         if let Some(state_receiver) = self.config_reader.watch() {
+            // Build a Rayon Thread pool
             let tp = rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
                 .thread_name(|idx| format!("router-config-{idx}"))
@@ -278,6 +279,7 @@ impl RouterConfigReader {
             let (raw_tx, raw_rx) = unbounded();
             let (state_tx, state_rx) = unbounded();
             Fs::watch_file(input_config_path, raw_tx);
+            // Build a Rayon Thread pool
             let tp = rayon::ThreadPoolBuilder::new()
                 .num_threads(1)
                 .thread_name(|idx| format!("router-config-reader-{idx}"))

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -80,7 +80,14 @@ impl RouterConfigHandler {
         // if a router config was passed, start watching it in the background for changes
 
         if let Some(state_receiver) = self.config_reader.watch() {
-            rayon::spawn(move || loop {
+            let tp = rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .thread_name(|idx| format!("router-config-{idx}"))
+                .build()
+                .map_err(|err| {
+                    RoverError::new(anyhow!("could not create router config thread pool: {err}",))
+                })?;
+            tp.spawn(move || loop {
                 let config_state = state_receiver
                     .recv()
                     .expect("could not watch router config");
@@ -271,7 +278,12 @@ impl RouterConfigReader {
             let (raw_tx, raw_rx) = unbounded();
             let (state_tx, state_rx) = unbounded();
             Fs::watch_file(input_config_path, raw_tx);
-            rayon::spawn(move || loop {
+            let tp = rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .thread_name(|idx| format!("router-config-reader-{idx}"))
+                .build()
+                .ok()?;
+            tp.spawn(move || loop {
                 raw_rx
                     .recv()
                     .expect("could not watch router configuration file");

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -180,7 +180,15 @@ impl RouterRunner {
             let warn_prefix = Style::WarningPrefix.paint("WARN:");
             let error_prefix = Style::ErrorPrefix.paint("ERROR:");
             let unknown_prefix = Style::ErrorPrefix.paint("UNKNOWN:");
-            rayon::spawn(move || loop {
+            // Build a Rayon Thread pool
+            let tp = rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .thread_name(|idx| format!("router-runner-{idx}"))
+                .build()
+                .map_err(|err| {
+                    RoverError::new(anyhow!("could not create router runner thread pool: {err}",))
+                })?;
+            tp.spawn(move || loop {
                 while let Ok(log) = router_log_receiver.recv() {
                     match log {
                         BackgroundTaskLog::Stdout(stdout) => {


### PR DESCRIPTION
The global `rayon` threadpool has a variable number of threads:

 - An environment variable can be used to specify the number: RAYON_NUM_THREADS
 - If not set, The number of CPUs on the executing system is used

Relying on using the global pool may lead to a situation where the global threadpool does not have enough threads for `rover dev` to execute correctly. It's not realistic to expect customers to know how to set this environment variable and a better option is available.

At each point in `rover` where we use `rayon`, create a thread pool which is task specific and explicitly sets the number of threads available to the pool.

For example:

```
    let tp = rayon::ThreadPoolBuilder::new()
        .num_threads(1)
        .thread_name(|idx| format!("router-runner-{idx}"))
        .build()
        .map_err(|err| {
            RoverError::new(anyhow!("could not create router runner thread pool: {err}",))
        })?;
```
This has the added advantage of allowing us to provide a name for all the threads created by the pool which is helpful debugging information.

Note: It might be that a more comprehensive answer to this problem is to not use `rayon` at all, but that's a bigger change than I want to consider for fixing this specific issue.

also:
 - change the configuration of the `interprocess` crate so that non-blocking isn't available (it's broken)
 - close `stdin` on our spawned router to reduce risk of bad input
 - handle errors if we can't take `stdout` || `stderr` from our spawned router

I've tested these changes manually on my laptop by setting RAYON_NUM_THREADS=2 and using `rover dev` without observing any hangs. Without these changes, `rover dev` hangs immediately.

fixes: #1871