### PR TITLE
support unix socket URLS

### DIFF
--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -181,7 +181,7 @@ impl Publish {
                 Ok(parsed_url) => {
                     tracing::debug!("Parsed URL: {}", parsed_url.to_string());
                     let reason = format!("`{}` is not a valid routing URL. The `{}` protocol is not supported by the router. Valid protocols are `http` and `https`.", Style::Link.paint(routing_url), &parsed_url.scheme());
-                    if !["http", "https"].contains(&parsed_url.scheme()) {
+                    if !["http", "https", "unix"].contains(&parsed_url.scheme()) {
                         if is_atty {
                             Self::prompt_for_publish(
                                 format!("{reason} Continuing the publish will make this subgraph unreachable by your supergraph. Would you still like to publish?").as_str(),
@@ -330,6 +330,24 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, Some("https://fromstudio".to_string()));
+    }
+
+    #[test]
+    fn test_routing_url_unix_socket() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = Vec::new();
+        let result = Publish::determine_routing_url(
+            false,
+            &None,
+            false,
+            || Ok("unix:///path/to/subgraph.sock".to_string()),
+            &mut output,
+            &mut input,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result, Some("unix:///path/to/subgraph.sock".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
in its 1.43.0 release, the Router now supports URLs of the format `unix:///path/to/subgraph.sock`. This updates routing URL validation to accept the `unix` scheme

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
