### PR TITLE
Enable Supergraph Output using the --output flag in rover dev

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,9 +181,11 @@ impl Rover {
         match &self.command {
             Command::Config(command) => command.run(self.get_client_config()?),
             Command::Contract(command) => command.run(self.get_client_config()?),
-            Command::Dev(command) => {
-                command.run(self.get_install_override_path()?, self.get_client_config()?)
-            }
+            Command::Dev(command) => command.run(
+                self.get_install_override_path()?,
+                self.get_client_config()?,
+                &self.output_opts,
+            ),
             Command::Fed2(command) => command.run(self.get_client_config()?),
             Command::Supergraph(command) => {
                 command.run(self.get_install_override_path()?, self.get_client_config()?)

--- a/src/command/dev/compose.rs
+++ b/src/command/dev/compose.rs
@@ -4,6 +4,7 @@ use std::io::prelude::*;
 use anyhow::{Context, Error};
 use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
 use camino::Utf8PathBuf;
+
 use rover_std::{Emoji, Fs};
 
 use crate::command::dev::do_dev::log_err_and_continue;

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -7,6 +7,7 @@ use super::router::RouterConfigHandler;
 use super::Dev;
 
 use crate::command::dev::protocol::FollowerMessage;
+use crate::options::OutputOpts;
 use crate::utils::client::StudioClientConfig;
 use crate::{RoverError, RoverOutput, RoverResult};
 
@@ -22,6 +23,7 @@ impl Dev {
         &self,
         override_install_path: Option<Utf8PathBuf>,
         client_config: StudioClientConfig,
+        output_opts: &OutputOpts,
     ) -> RoverResult<RoverOutput> {
         self.opts
             .plugin_opts
@@ -48,6 +50,7 @@ impl Dev {
             follower_channel.clone(),
             self.opts.plugin_opts.clone(),
             router_config_handler,
+            output_opts,
         )? {
             eprintln!("{0}Do not run this command in production! {0}It is intended for local development.", Emoji::Warn);
             let (ready_sender, ready_receiver) = sync_channel(1);

--- a/src/command/dev/no_dev.rs
+++ b/src/command/dev/no_dev.rs
@@ -1,4 +1,5 @@
 use super::Dev;
+use crate::options::OutputOpts;
 use crate::{utils::client::StudioClientConfig, RoverError, RoverOutput, RoverResult};
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
@@ -8,6 +9,7 @@ impl Dev {
         &self,
         _override_install_path: Option<Utf8PathBuf>,
         _client_config: StudioClientConfig,
+        _output_opts: &OutputOpts,
     ) -> RoverResult<RoverOutput> {
         Err(RoverError::new(anyhow!(
             "rover dev is not supported on this platform"

--- a/src/command/dev/no_dev.rs
+++ b/src/command/dev/no_dev.rs
@@ -2,12 +2,14 @@ use super::Dev;
 use crate::{utils::client::StudioClientConfig, RoverError, RoverOutput, RoverResult};
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
+use crate::options::OutputOpts;
 
 impl Dev {
     pub fn run(
         &self,
         _override_install_path: Option<Utf8PathBuf>,
         _client_config: StudioClientConfig,
+        _output_opts: &OutputOpts,
     ) -> RoverResult<RoverOutput> {
         Err(RoverError::new(anyhow!(
             "rover dev is not supported on this platform"

--- a/src/command/dev/no_dev.rs
+++ b/src/command/dev/no_dev.rs
@@ -1,8 +1,8 @@
 use super::Dev;
+use crate::options::OutputOpts;
 use crate::{utils::client::StudioClientConfig, RoverError, RoverOutput, RoverResult};
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
-use crate::options::OutputOpts;
 
 impl Dev {
     pub fn run(

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -98,7 +98,7 @@ impl LeaderSession {
 
         // create a [`RouterRunner`] that we will use to spawn the router when we have a successful composition
         let mut router_runner = RouterRunner::new(
-            router_config_handler.get_supergraph_schema_path(output_opts.get_output_file()),
+            router_config_handler.get_supergraph_schema_path(output_opts.get_output_path()),
             router_config_handler.get_router_config_path(),
             plugin_opts,
             router_socket_addr,

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -5,10 +5,11 @@ use crate::{
         router::{RouterConfigHandler, RouterRunner},
         OVERRIDE_DEV_COMPOSITION_VERSION,
     },
-    options::PluginOpts,
+    options::{OutputOpts, PluginOpts},
     utils::client::StudioClientConfig,
     RoverError, RoverErrorSuggestion, RoverResult, PKG_VERSION,
 };
+
 use anyhow::{anyhow, Context};
 use apollo_federation_types::{
     build::SubgraphDefinition,
@@ -57,6 +58,7 @@ impl LeaderSession {
         follower_channel: FollowerChannel,
         plugin_opts: PluginOpts,
         router_config_handler: RouterConfigHandler,
+        output_opts: &OutputOpts,
     ) -> RoverResult<Option<Self>> {
         let ipc_socket_addr = router_config_handler.get_ipc_address()?;
         let router_socket_addr = router_config_handler.get_router_address();
@@ -91,12 +93,12 @@ impl LeaderSession {
             plugin_opts.clone(),
             override_install_path.clone(),
             client_config.clone(),
-            router_config_handler.get_supergraph_schema_path(),
+            router_config_handler.get_supergraph_schema_path(output_opts.get_output_path()),
         );
 
         // create a [`RouterRunner`] that we will use to spawn the router when we have a successful composition
         let mut router_runner = RouterRunner::new(
-            router_config_handler.get_supergraph_schema_path(),
+            router_config_handler.get_supergraph_schema_path(output_opts.get_output_path()),
             router_config_handler.get_router_config_path(),
             plugin_opts,
             router_socket_addr,

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -5,10 +5,11 @@ use crate::{
         router::{RouterConfigHandler, RouterRunner},
         OVERRIDE_DEV_COMPOSITION_VERSION,
     },
-    options::PluginOpts,
+    options::{OutputOpts, PluginOpts},
     utils::client::StudioClientConfig,
     RoverError, RoverErrorSuggestion, RoverResult, PKG_VERSION,
 };
+
 use anyhow::{anyhow, Context};
 use apollo_federation_types::{
     build::SubgraphDefinition,
@@ -57,6 +58,7 @@ impl LeaderSession {
         follower_channel: FollowerChannel,
         plugin_opts: PluginOpts,
         router_config_handler: RouterConfigHandler,
+        output_opts: &OutputOpts,
     ) -> RoverResult<Option<Self>> {
         let ipc_socket_addr = router_config_handler.get_ipc_address()?;
         let router_socket_addr = router_config_handler.get_router_address();
@@ -91,12 +93,12 @@ impl LeaderSession {
             plugin_opts.clone(),
             override_install_path.clone(),
             client_config.clone(),
-            router_config_handler.get_supergraph_schema_path(),
+            router_config_handler.get_supergraph_schema_path(output_opts.get_output_path()),
         );
 
         // create a [`RouterRunner`] that we will use to spawn the router when we have a successful composition
         let mut router_runner = RouterRunner::new(
-            router_config_handler.get_supergraph_schema_path(),
+            router_config_handler.get_supergraph_schema_path(output_opts.get_output_file()),
             router_config_handler.get_router_config_path(),
             plugin_opts,
             router_socket_addr,

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -137,8 +137,11 @@ impl RouterConfigHandler {
     }
 
     /// The path to the composed supergraph schema
-    pub fn get_supergraph_schema_path(&self) -> Utf8PathBuf {
-        self.tmp_supergraph_schema_path.clone()
+    pub fn get_supergraph_schema_path(&self, output_path: Option<String>) -> Utf8PathBuf {
+        return match output_path {
+            Some(path) => Utf8PathBuf::try_from(path).unwrap(),
+            _ => self.tmp_supergraph_schema_path.clone(),
+        };
     }
 
     /// The path to the patched router config YAML

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -137,8 +137,11 @@ impl RouterConfigHandler {
     }
 
     /// The path to the composed supergraph schema
-    pub fn get_supergraph_schema_path(&self) -> Utf8PathBuf {
-        self.tmp_supergraph_schema_path.clone()
+    pub fn get_supergraph_schema_path(&self, output_path: Option<String>) -> Utf8PathBuf {
+        match output_path {
+            Some(path) => Utf8PathBuf::from(path),
+            _ => self.tmp_supergraph_schema_path.clone(),
+        }
     }
 
     /// The path to the patched router config YAML

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -138,10 +138,10 @@ impl RouterConfigHandler {
 
     /// The path to the composed supergraph schema
     pub fn get_supergraph_schema_path(&self, output_path: Option<String>) -> Utf8PathBuf {
-        return match output_path {
-            Some(path) => Utf8PathBuf::try_from(path).unwrap(),
+        match output_path {
+            Some(path) => Utf8PathBuf::from(path),
             _ => self.tmp_supergraph_schema_path.clone(),
-        };
+        }
     }
 
     /// The path to the patched router config YAML

--- a/xtask/src/tools/lychee.rs
+++ b/xtask/src/tools/lychee.rs
@@ -39,7 +39,7 @@ impl LycheeRunner {
     pub(crate) fn lint(&self) -> Result<()> {
         crate::info!("Checking HTTP links in repository");
 
-        let semaphore = Arc::new(Semaphore::new(50));
+        let semaphore = Arc::new(Semaphore::new(10));
 
         let inputs: Vec<Input> = get_md_files()
             .iter()

--- a/xtask/src/tools/lychee.rs
+++ b/xtask/src/tools/lychee.rs
@@ -39,7 +39,7 @@ impl LycheeRunner {
     pub(crate) fn lint(&self) -> Result<()> {
         crate::info!("Checking HTTP links in repository");
 
-        let semaphore = Arc::new(Semaphore::new(10));
+        let semaphore = Arc::new(Semaphore::new(5));
 
         let inputs: Vec<Input> = get_md_files()
             .iter()


### PR DESCRIPTION
Re-opening the pull request related to enabling `rover dev` to write to a custom super graph file instead of always writing to a temp folder.

I am unsure as to why the lint check is unable to validate links 

