### PR TITLE
fix: Don't panic if telemetry client cannot be initialized.

### DIFF
--- a/crates/sputnik/src/report.rs
+++ b/crates/sputnik/src/report.rs
@@ -46,7 +46,7 @@ pub trait Report {
     }
 
     /// returns the Client to use when sending telemetry data
-    fn client(&self) -> Client;
+    fn client(&self) -> Result<Client, SputnikError>;
 }
 
 fn get_or_write_machine_id(path: &Utf8PathBuf) -> Result<Uuid, SputnikError> {

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -88,7 +88,7 @@ impl Session {
     pub fn new<T: Report>(app: &T) -> Result<Session, SputnikError> {
         let machine_id = app.machine_id()?;
         let command = app.serialize_command()?;
-        let client = app.client();
+        let client = app.client()?;
         let reporting_info = ReportingInfo {
             is_telemetry_enabled: app.is_telemetry_enabled()?,
             endpoint: app.endpoint()?,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -237,7 +237,7 @@ impl Rover {
             override_endpoint,
             config,
             is_sudo,
-            self.get_reqwest_client_builder()?,
+            self.get_reqwest_client_builder(),
         ))
     }
 
@@ -261,21 +261,21 @@ impl Rover {
         Ok(git_context)
     }
 
-    pub(crate) fn get_reqwest_client(&self) -> RoverResult<Client> {
+    pub(crate) fn get_reqwest_client(&self) -> reqwest::Result<Client> {
         if let Some(client) = self.client.borrow() {
             Ok(client.clone())
         } else {
             self.client
-                .fill(self.get_reqwest_client_builder()?.build()?)
-                .expect("Could not overwrite existing request client");
+                .fill(self.get_reqwest_client_builder().build()?)
+                .ok();
             self.get_reqwest_client()
         }
     }
 
-    pub(crate) fn get_reqwest_client_builder(&self) -> RoverResult<ClientBuilder> {
+    pub(crate) fn get_reqwest_client_builder(&self) -> ClientBuilder {
         // return a copy of the underlying client builder if it's already been populated
         if let Some(client_builder) = self.client_builder.borrow() {
-            Ok(*client_builder)
+            *client_builder
         } else {
             // if a request hasn't been made yet, this cell won't be populated yet
             self.client_builder
@@ -285,7 +285,7 @@ impl Rover {
                         .accept_invalid_hostnames(self.accept_invalid_hostnames)
                         .with_timeout(self.client_timeout.get_duration()),
                 )
-                .expect("Could not overwrite existing request client builder");
+                .ok();
             self.get_reqwest_client_builder()
         }
     }

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -56,7 +56,7 @@ impl ClientBuilder {
         }
     }
 
-    pub(crate) fn build(self) -> Result<Client> {
+    pub(crate) fn build(self) -> reqwest::Result<Client> {
         let client = Client::builder()
             .gzip(true)
             .brotli(true)
@@ -141,7 +141,7 @@ impl StudioClientConfig {
         }
     }
 
-    pub(crate) fn get_reqwest_client(&self) -> Result<Client> {
+    pub(crate) fn get_reqwest_client(&self) -> reqwest::Result<Client> {
         if let Some(client) = &self.client {
             Ok(client.clone())
         } else {

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -116,9 +116,8 @@ impl Report for Rover {
         Ok(config.home.join("machine.txt"))
     }
 
-    fn client(&self) -> Client {
-        self.get_reqwest_client()
-            .expect("could not get request client")
+    fn client(&self) -> Result<Client, SputnikError> {
+        self.get_reqwest_client().map_err(SputnikError::from)
     }
 }
 


### PR DESCRIPTION
Fixes #1893

Also removes a couple of expects that seemed unnecessary.