### PR TITLE
Inherit stderr of to subprocesses for debugging

### DIFF
--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -148,6 +148,7 @@ impl Compose {
 
         let output = Command::new(&exe)
             .args(["compose", yaml_path.as_ref()])
+            .stderr(std::process::Stdio::inherit())
             .output()
             .context("Failed to execute command")?;
         let stdout = str::from_utf8(&output.stdout)

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -30,6 +30,7 @@ fn it_has_windows_installer() {
 fn get_binstall_scripts_root() -> Utf8PathBuf {
     let cargo_locate_project_output = Command::new("cargo")
         .arg("locate-project")
+        .stderr(std::process::Stdio::inherit())
         .output()
         .expect("Could not run `cargo locate-project`");
 


### PR DESCRIPTION
By default `Command::output()` causes *both* stdout and stderr to be redirected to separate pipe. If following code does not print stderr this can cause error to be swallowed, making debugging harder.

This changes to inherit stderr instead, so error messages go to Rover’s own stderr.

Example before:

```
⌛ resolving SDL for subgraphs defined in /tmp/a/rover.yaml
🎶 composing supergraph with Federation v2.7.5
error: Output from `/Users/simon/.rover/bin/supergraph-v2.7.5 compose` was malformed.

Caused by:
    0: /Users/simon/.rover/bin/supergraph-v2.7.5 compose output: 
    1: EOF while parsing a value at line 1 column 0
        This error was unexpected! Please submit an issue with any relevant details about what you were trying to do: https://github.com/apollographql/rover/issues/new/choose
```

We see that stdout of the subprocess is empty, but we don’t see why.

After, with `RUST_BACKTRACE=1` added:
```
 resolving SDL for subgraphs defined in /tmp/a/rover.yaml
🎶 composing supergraph with Federation v2.7.5
thread 'main' panicked at /Users/distiller/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde_v8-0.111.0/de.rs:628:53:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: core::option::unwrap_failed
   4: <serde_v8::de::SeqAccess as serde::de::SeqAccess>::next_element_seed
   5: <serde_v8::de::MapObjectAccess as serde::de::MapAccess>::next_key_seed
   6: <serde_json::value::de::<impl serde::de::Deserialize for serde_json::value::Value>::deserialize::ValueVisitor as serde::de::Visitor>::visit_map
   7: <&mut serde_v8::de::Deserializer as serde::de::Deserializer>::deserialize_any
   8: harmonizer::op_composition_result::v8_func
   9: harmonizer::op_composition_result::v8_fn_ptr
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5
error: Output from `/Users/simon/.rover/bin/supergraph-v2.7.5 compose` was malformed.

Caused by:
    0: /Users/simon/.rover/bin/supergraph-v2.7.5 compose output: 
    1: EOF while parsing a value at line 1 column 0

[…]
```

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
