### PR TITLE
Add tests and provide status codes as part of linter errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2110,12 @@ name = "futures-task"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3373,6 +3389,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6e023aa5bdf392aa06c78e4a4e6d498baab5138d0c993503350ebbc37bf1e"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "futures-core",
+ "hyper 0.14.28",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,13 +3516,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "num"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "autocfg",
+ "num-bigint",
+ "num-complex",
  "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3507,10 +3564,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.18"
+name = "num-iter"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -4258,6 +4337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,12 +4526,14 @@ dependencies = [
  "robot-panic",
  "rover-client",
  "rover-std",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
  "serde_yaml 0.9.32",
  "serial_test",
  "shellexpand",
+ "speculoos",
  "sputnik",
  "strsim 0.10.0",
  "strum 0.25.0",
@@ -4521,6 +4608,35 @@ dependencies = [
  "memoffset",
  "rustc-hash",
  "text-size",
+]
+
+[[package]]
+name = "rstest"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
+dependencies = [
+ "cfg-if 1.0.0",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.50",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5112,6 +5228,15 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "speculoos"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65881c9270d6157f30a09233305da51bed97eef9192d0ea21e57b1c8f05c3620"
+dependencies = [
+ "num",
 ]
 
 [[package]]
@@ -6439,15 +6564,18 @@ dependencies = [
  "http 1.1.0",
  "lazy_static",
  "lychee-lib",
+ "mockito",
  "regex",
  "reqwest 0.11.24",
  "rover-client",
  "rover-std",
+ "rstest",
  "semver",
  "serde_json",
  "serde_json_traversal",
  "serde_yaml 0.9.32",
  "shell-candy",
+ "speculoos",
  "tar",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ prettytable-rs = "0.10"
 rayon = "1"
 regex = "1"
 reqwest = { version = "0.11", default-features = false }
+rstest = "0.19.0"
 semver = "1"
 serial_test = "2"
 serde = "1.0"
@@ -113,6 +114,7 @@ serde_json = "1.0"
 serde_json_traversal = "0.2"
 serde_yaml = "0.9"
 shell-candy = "0.4"
+speculoos = "0.11.0"
 strip-ansi-escapes = "0.2"
 strsim = "0.10"
 strum = "0.25"
@@ -194,4 +196,6 @@ assert_fs = { workspace = true }
 assert-json-diff = { workspace = true }
 predicates = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
+rstest = { workspace = true }
 serial_test = { workspace = true }
+speculoos = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -37,3 +37,8 @@ zip = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
 lychee-lib = { version = "0.15", features = ["vendored-openssl"] }
+
+[dev-dependencies]
+mockito = "1.4.0"
+rstest = { workspace = true }
+speculoos = { workspace = true }

--- a/xtask/src/tools/lychee.rs
+++ b/xtask/src/tools/lychee.rs
@@ -70,7 +70,14 @@ impl LycheeRunner {
 
             if !failed_checks.is_empty() {
                 for failed_check in failed_checks {
-                    crate::info!("❌ {}", failed_check.as_str());
+                    crate::info!(
+                        "❌ [Status Code: {}] {}",
+                        failed_check
+                            .1
+                            .map(|status_code| status_code.to_string())
+                            .unwrap_or("unknown".to_string()),
+                        failed_check.0.as_str()
+                    );
                 }
 
                 Err(anyhow!("Some links in markdown documentation are down."))
@@ -83,13 +90,17 @@ impl LycheeRunner {
     }
 }
 
-async fn get_failed_request(lychee_client: Client, link: Request) -> Option<Uri> {
+async fn get_failed_request(
+    lychee_client: Client,
+    link: Request,
+) -> Option<(Uri, Option<StatusCode>)> {
     let response = lychee_client
         .check(link)
         .await
         .expect("could not execute lychee request");
     if response.status().is_error() {
-        Some(response.1.uri)
+        let status_code = response.status().code();
+        Some((response.1.uri, status_code))
     } else {
         crate::info!("✅ {}", response.1.uri.as_str());
         None
@@ -135,5 +146,96 @@ fn walk_dir(base_dir: &str, md_files: &mut Vec<Utf8PathBuf>) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, time::Duration};
+
+    use anyhow::Result;
+    use http::StatusCode;
+    use lychee_lib::{ClientBuilder, InputSource, Request, Result as LycheeResult, Uri};
+    use rstest::{fixture, rstest};
+    use speculoos::prelude::*;
+    use tokio::runtime::Runtime;
+
+    use super::get_failed_request;
+
+    #[fixture]
+    fn lychee_client() -> LycheeResult<lychee_lib::Client> {
+        let accepted = Some(HashSet::from_iter(vec![
+            StatusCode::OK,
+            StatusCode::TOO_MANY_REQUESTS,
+        ]));
+        ClientBuilder::builder()
+            .exclude_all_private(false)
+            .retry_wait_time(Duration::from_secs(30))
+            .max_retries(5u8)
+            .accepted(accepted)
+            .build()
+            .client()
+    }
+
+    #[rstest]
+    #[case::success(200)]
+    fn test_get_failed_request_success(
+        lychee_client: LycheeResult<lychee_lib::Client>,
+        #[case] response_status_int: usize,
+    ) -> Result<()> {
+        let lychee_client = lychee_client?;
+        let mut server = mockito::Server::new();
+        let url = server.url();
+        let _mock = server
+            .mock("GET", "/success")
+            .with_status(response_status_int)
+            .create();
+        let request = Request::new(
+            Uri::try_from(&format!("{}/{}", url, "success") as &str)?,
+            InputSource::String("test".to_string()),
+            None,
+            None,
+            None,
+        );
+        let rt = Runtime::new()?;
+        let result = rt.block_on(get_failed_request(lychee_client, request));
+        assert_that!(result).is_none();
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::internal_server_error(400, StatusCode::BAD_REQUEST)]
+    #[case::internal_server_error(401, StatusCode::UNAUTHORIZED)]
+    #[case::internal_server_error(403, StatusCode::FORBIDDEN)]
+    #[case::internal_server_error(404, StatusCode::NOT_FOUND)]
+    #[case::internal_server_error(500, StatusCode::INTERNAL_SERVER_ERROR)]
+    fn test_get_failed_request_failure(
+        lychee_client: LycheeResult<lychee_lib::Client>,
+        #[case] response_status_int: usize,
+        #[case] response_status_code: StatusCode,
+    ) -> Result<()> {
+        let lychee_client = lychee_client?;
+        let mut server = mockito::Server::new();
+        let url = server.url();
+        let _mock = server
+            .mock("GET", "/success")
+            .with_status(response_status_int)
+            .create();
+        let uri = Uri::try_from(&format!("{}/{}", url, "success") as &str)?;
+        let request = Request::new(
+            uri.clone(),
+            InputSource::String("test".to_string()),
+            None,
+            None,
+            None,
+        );
+        let rt = Runtime::new()?;
+        let result = rt.block_on(get_failed_request(lychee_client, request));
+        assert_that!(result)
+            .is_some()
+            .is_equal_to((uri, Some(response_status_code)));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Returns the status code with the offending link when lychee lint checks fail.