### PR TITLE
Add linting rule that is violated to linting response

### DIFF
--- a/crates/rover-client/src/operations/graph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/graph/check_workflow/check_workflow_query.graphql
@@ -22,6 +22,7 @@ query GraphCheckWorkflowQuery($graph_id: ID!, $workflow_id: ID!) {
               level
               message
               coordinate
+              rule
               sourceLocations {
                 start {
                   byteOffset

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -1,5 +1,7 @@
 use std::time::{Duration, Instant};
 
+use graphql_client::*;
+
 use crate::blocking::StudioClient;
 use crate::operations::graph::check_workflow::types::{CheckWorkflowInput, QueryResponseData};
 use crate::shared::{
@@ -8,12 +10,9 @@ use crate::shared::{
 };
 use crate::RoverClientError;
 
-use graphql_client::*;
-
 use self::graph_check_workflow_query::GraphCheckWorkflowQueryGraphCheckWorkflowTasksOn::{
     LintCheckTask, OperationsCheckTask,
 };
-
 use self::graph_check_workflow_query::{
     CheckWorkflowStatus, CheckWorkflowTaskStatus,
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnLintCheckTaskResult,
@@ -218,6 +217,7 @@ fn get_lint_response_from_result(
                     level: diagnostic.level.to_string(),
                     message: diagnostic.message,
                     coordinate: diagnostic.coordinate,
+                    rule: diagnostic.rule.to_string(),
                     start_line,
                     start_byte_offset: start_byte_offset.unsigned_abs() as usize,
                     end_byte_offset: end_byte_offset.unsigned_abs() as usize,

--- a/crates/rover-client/src/operations/graph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/types.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter, Result};
 
 use crate::operations::graph::check_workflow::runner::graph_check_workflow_query;
 use crate::shared::{ChangeSeverity, CheckTaskStatus, GraphRef};
@@ -74,8 +74,8 @@ impl fmt::Display for graph_check_workflow_query::LintDiagnosticLevel {
     }
 }
 
-impl fmt::Display for graph_check_workflow_query::LintRule {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl Display for graph_check_workflow_query::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/graph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/types.rs
@@ -1,11 +1,13 @@
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
 use crate::operations::graph::check_workflow::runner::graph_check_workflow_query;
 use crate::shared::{ChangeSeverity, CheckTaskStatus, GraphRef};
-use std::fmt;
+
+use self::graph_check_workflow_query::CheckWorkflowTaskStatus;
 
 type QueryVariables = graph_check_workflow_query::Variables;
 pub(crate) type QueryResponseData = graph_check_workflow_query::ResponseData;
-
-use self::graph_check_workflow_query::CheckWorkflowTaskStatus;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CheckWorkflowInput {
@@ -69,5 +71,11 @@ impl fmt::Display for graph_check_workflow_query::LintDiagnosticLevel {
             graph_check_workflow_query::LintDiagnosticLevel::Other(_) => "UNKNOWN",
         };
         write!(f, "{}", printable)
+    }
+}
+
+impl fmt::Display for graph_check_workflow_query::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/graph/lint/lint_graph_mutation.graphql
+++ b/crates/rover-client/src/operations/graph/lint/lint_graph_mutation.graphql
@@ -5,6 +5,7 @@ mutation LintGraphMutation($sdl: String!, $graphId: ID!, $baseSdl: String) {
         coordinate
         level
         message
+        rule
         sourceLocations {
           start {
             byteOffset

--- a/crates/rover-client/src/operations/graph/lint/runner.rs
+++ b/crates/rover-client/src/operations/graph/lint/runner.rs
@@ -1,3 +1,7 @@
+use std::fmt;
+
+use graphql_client::*;
+
 use crate::blocking::StudioClient;
 use crate::operations::graph::fetch;
 use crate::operations::graph::fetch::GraphFetchInput;
@@ -6,9 +10,6 @@ use crate::operations::graph::lint::types::{
 };
 use crate::shared::{Diagnostic, GraphRef, LintResponse};
 use crate::RoverClientError;
-use std::fmt;
-
-use graphql_client::*;
 
 #[derive(GraphQLQuery)]
 // The paths are relative to the directory where your `Cargo.toml` is located.
@@ -82,6 +83,7 @@ fn get_lint_response_from_result(
                 level: diagnostic.level.to_string(),
                 message: diagnostic.message,
                 coordinate: diagnostic.coordinate,
+                rule: diagnostic.rule.to_string(),
                 start_line,
                 start_byte_offset: start_byte_offset.unsigned_abs() as usize,
                 end_byte_offset: end_byte_offset.unsigned_abs() as usize,

--- a/crates/rover-client/src/operations/graph/lint/types.rs
+++ b/crates/rover-client/src/operations/graph/lint/types.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter, Result};
 
 use crate::shared::GraphRef;
 
@@ -33,8 +32,8 @@ impl From<LintGraphMutationInput> for LintQueryVariables {
     }
 }
 
-impl fmt::Display for lint_graph_mutation::LintRule {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl Display for lint_graph_mutation::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/graph/lint/types.rs
+++ b/crates/rover-client/src/operations/graph/lint/types.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
 use crate::shared::GraphRef;
 
 use super::runner::lint_graph_mutation;
@@ -27,5 +30,11 @@ impl From<LintGraphMutationInput> for LintQueryVariables {
             sdl: input.proposed_schema,
             base_sdl: input.base_schema,
         }
+    }
+}
+
+impl fmt::Display for lint_graph_mutation::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
@@ -39,6 +39,7 @@ query SubgraphCheckWorkflowQuery($workflowId: ID!, $graphId: ID!) {
               level
               message
               coordinate
+              rule
               sourceLocations {
                 start {
                   byteOffset

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -1,6 +1,8 @@
 use std::time::{Duration, Instant};
 
-use super::types::*;
+use apollo_federation_types::build::BuildError;
+use graphql_client::*;
+
 use crate::blocking::StudioClient;
 use crate::operations::subgraph::check_workflow::types::QueryResponseData;
 use crate::shared::{
@@ -10,21 +12,18 @@ use crate::shared::{
 };
 use crate::RoverClientError;
 
-use apollo_federation_types::build::BuildError;
+use super::types::*;
 
 use self::subgraph_check_workflow_query::SubgraphCheckWorkflowQueryGraphCheckWorkflowTasksOn::{
     CompositionCheckTask, DownstreamCheckTask, LintCheckTask, OperationsCheckTask,
     ProposalsCheckTask,
 };
-
 use self::subgraph_check_workflow_query::{
     CheckWorkflowStatus, CheckWorkflowTaskStatus, ProposalStatus,
     SubgraphCheckWorkflowQueryGraphCheckWorkflowTasksOnDownstreamCheckTaskResults,
     SubgraphCheckWorkflowQueryGraphCheckWorkflowTasksOnLintCheckTaskResult,
     SubgraphCheckWorkflowQueryGraphCheckWorkflowTasksOnOperationsCheckTaskResult,
 };
-
-use graphql_client::*;
 
 #[derive(GraphQLQuery)]
 // The paths are relative to the directory where your `Cargo.toml` is located.
@@ -305,6 +304,7 @@ fn get_lint_response_from_result(
                     level: diagnostic.level.to_string(),
                     message: diagnostic.message,
                     coordinate: diagnostic.coordinate,
+                    rule: diagnostic.rule.to_string(),
                     start_line,
                     start_byte_offset: start_byte_offset.unsigned_abs() as usize,
                     end_byte_offset: end_byte_offset.unsigned_abs() as usize,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
@@ -1,14 +1,16 @@
-use crate::operations::subgraph::check_workflow::runner::subgraph_check_workflow_query;
-use crate::shared::{ChangeSeverity, GraphRef};
 use core::fmt;
+use std::fmt::{Debug, Formatter};
+
+use crate::operations::subgraph::check_workflow::runner::subgraph_check_workflow_query;
+use crate::shared::CheckTaskStatus;
+use crate::shared::{ChangeSeverity, GraphRef};
+
+use self::subgraph_check_workflow_query::CheckWorkflowTaskStatus;
 
 type QueryVariables = subgraph_check_workflow_query::Variables;
 pub(crate) type QueryResponseData = subgraph_check_workflow_query::ResponseData;
 
 pub type ProposalsCheckTaskUnion = self::subgraph_check_workflow_query::SubgraphCheckWorkflowQueryGraphCheckWorkflowTasksOnProposalsCheckTask;
-
-use self::subgraph_check_workflow_query::CheckWorkflowTaskStatus;
-use crate::shared::CheckTaskStatus;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CheckWorkflowInput {
@@ -72,5 +74,11 @@ impl fmt::Display for subgraph_check_workflow_query::LintDiagnosticLevel {
             subgraph_check_workflow_query::LintDiagnosticLevel::Other(_) => "UNKNOWN",
         };
         write!(f, "{}", printable)
+    }
+}
+
+impl fmt::Display for subgraph_check_workflow_query::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter, Result};
 
 use crate::operations::subgraph::check_workflow::runner::subgraph_check_workflow_query;
 use crate::shared::CheckTaskStatus;
@@ -77,8 +77,8 @@ impl fmt::Display for subgraph_check_workflow_query::LintDiagnosticLevel {
     }
 }
 
-impl fmt::Display for subgraph_check_workflow_query::LintRule {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl Display for subgraph_check_workflow_query::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/subgraph/lint/lint_subgraph_mutation.graphql
+++ b/crates/rover-client/src/operations/subgraph/lint/lint_subgraph_mutation.graphql
@@ -5,6 +5,7 @@ mutation LintSubgraphMutation($sdl: String!, $graphId: ID!, $baseSdl: String) {
         coordinate
         level
         message
+        rule
         sourceLocations {
           start {
             byteOffset

--- a/crates/rover-client/src/operations/subgraph/lint/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/lint/runner.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use graphql_client::*;
+
 use crate::blocking::StudioClient;
 use crate::operations::config::is_federated::{self, IsFederatedInput};
 use crate::operations::subgraph::fetch;
@@ -9,8 +11,6 @@ use crate::operations::subgraph::lint::types::{
 };
 use crate::shared::{Diagnostic, GraphRef, LintResponse};
 use crate::RoverClientError;
-
-use graphql_client::*;
 
 #[derive(GraphQLQuery)]
 // The paths are relative to the directory where your `Cargo.toml` is located.
@@ -101,6 +101,7 @@ fn get_lint_response_from_result(
                 level: diagnostic.level.to_string(),
                 message: diagnostic.message,
                 coordinate: diagnostic.coordinate,
+                rule: diagnostic.rule.to_string(),
                 start_line,
                 start_byte_offset: start_byte_offset.unsigned_abs() as usize,
                 end_byte_offset: end_byte_offset.unsigned_abs() as usize,

--- a/crates/rover-client/src/operations/subgraph/lint/types.rs
+++ b/crates/rover-client/src/operations/subgraph/lint/types.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter, Result};
 
 use crate::shared::GraphRef;
 
@@ -34,8 +33,8 @@ impl From<LintSubgraphMutationInput> for LintQueryVariables {
     }
 }
 
-impl fmt::Display for lint_subgraph_mutation::LintRule {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl Display for lint_subgraph_mutation::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/operations/subgraph/lint/types.rs
+++ b/crates/rover-client/src/operations/subgraph/lint/types.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
 use crate::shared::GraphRef;
 
 use super::runner::lint_subgraph_mutation;
@@ -28,5 +31,11 @@ impl From<LintSubgraphMutationInput> for LintQueryVariables {
             sdl: input.proposed_schema,
             base_sdl: input.base_schema,
         }
+    }
+}
+
+impl fmt::Display for lint_subgraph_mutation::LintRule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
     }
 }

--- a/crates/rover-client/src/shared/lint_response.rs
+++ b/crates/rover-client/src/shared/lint_response.rs
@@ -114,6 +114,7 @@ pub struct Diagnostic {
     pub start_line: i64,
     pub start_byte_offset: usize,
     pub end_byte_offset: usize,
+    pub rule: String,
 }
 
 #[cfg(test)]
@@ -136,6 +137,7 @@ type Query {
                 level: "WARNING".to_string(),
                 coordinate: "Query.key".to_string(),
                 message: "Schema element Query.key is missing a description.".to_string(),
+                rule: "DESCRIPTION_MISSING".to_string(),
                 start_line: 3,
                 start_byte_offset: 50,
                 end_byte_offset: 53,

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1038,6 +1038,7 @@ mod tests {
                                 "start_line": 1,
                                 "start_byte_offset": 4,
                                 "end_byte_offset": 2,
+                                "rule": "FIELD_NAMES_SHOULD_BE_CAMEL_CASE"
                             }
                         ],
                         "errors_count": 0,
@@ -1172,6 +1173,7 @@ mod tests {
                                 "start_line": 2,
                                 "start_byte_offset": 8,
                                 "end_byte_offset": 0,
+                                "rule": "FIELD_NAMES_SHOULD_BE_CAMEL_CASE"
                             },
                             {
                                 "level": "ERROR",
@@ -1180,6 +1182,7 @@ mod tests {
                                 "start_line": 3,
                                 "start_byte_offset": 5,
                                 "end_byte_offset": 0,
+                                "rule": "TYPE_NAMES_SHOULD_BE_PASCAL_CASE"
                             }
                         ],
                         "errors_count": 1,
@@ -1597,6 +1600,7 @@ mod tests {
                       "start_line": 0,
                       "start_byte_offset": 13,
                       "end_byte_offset": 18,
+                      "rule": "FIELD_NAMES_SHOULD_BE_CAMEL_CASE"
                     }
                   ],
                   "file_name": "/tmp/schema.graphql",

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -4,15 +4,11 @@ use std::{
     io::{self, IsTerminal},
 };
 
-use crate::command::supergraph::compose::CompositionOutput;
-use crate::options::JsonVersion;
-use crate::utils::table::{self, row};
-use crate::RoverError;
-
-use crate::command::template::queries::list_templates_for_language::ListTemplatesForLanguageTemplates;
-use crate::options::ProjectLanguage;
 use calm_io::{stderr, stderrln};
 use camino::Utf8PathBuf;
+use serde_json::{json, Value};
+use termimad::{crossterm::style::Attribute::Underlined, MadSkin};
+
 use rover_client::operations::contract::describe::ContractDescribeResponse;
 use rover_client::operations::contract::publish::ContractPublishResponse;
 use rover_client::operations::graph::publish::GraphPublishResponse;
@@ -26,8 +22,13 @@ use rover_client::shared::{
 };
 use rover_client::RoverClientError;
 use rover_std::Style;
-use serde_json::{json, Value};
-use termimad::{crossterm::style::Attribute::Underlined, MadSkin};
+
+use crate::command::supergraph::compose::CompositionOutput;
+use crate::command::template::queries::list_templates_for_language::ListTemplatesForLanguageTemplates;
+use crate::options::JsonVersion;
+use crate::options::ProjectLanguage;
+use crate::utils::table::{self, row};
+use crate::RoverError;
 
 /// RoverOutput defines all of the different types of data that are printed
 /// to `stdout`. Every one of Rover's commands should return `saucer::Result<RoverOutput>`
@@ -650,8 +651,11 @@ impl RoverOutput {
 mod tests {
     use std::collections::BTreeMap;
 
+    use anyhow::anyhow;
+    use apollo_federation_types::build::{BuildError, BuildErrors};
     use assert_json_diff::assert_json_eq;
     use chrono::{DateTime, Local, Utc};
+
     use rover_client::{
         operations::{
             graph::publish::{ChangeSummary, FieldChanges, TypeChanges},
@@ -667,10 +671,6 @@ mod tests {
             ProposalsCoverage, RelatedProposal, SchemaChange, Sdl, SdlType,
         },
     };
-
-    use apollo_federation_types::build::{BuildError, BuildErrors};
-
-    use anyhow::anyhow;
 
     use crate::options::JsonOutput;
 
@@ -975,6 +975,7 @@ mod tests {
                 target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/lint/1".to_string()),
                 diagnostics: vec![
                     Diagnostic {
+                        rule: "FIELD_NAMES_SHOULD_BE_CAMEL_CASE".to_string(),
                         level: "WARNING".to_string(),
                         message: "Field must be camelCase.".to_string(),
                         coordinate: "Query.all_users".to_string(),
@@ -1096,6 +1097,7 @@ mod tests {
                 ),
                 diagnostics: vec![
                     Diagnostic {
+                        rule: "FIELD_NAMES_SHOULD_BE_CAMEL_CASE".to_string(),
                         level: "WARNING".to_string(),
                         message: "Field must be camelCase.".to_string(),
                         coordinate: "Query.all_users".to_string(),
@@ -1104,6 +1106,7 @@ mod tests {
                         end_byte_offset: 0
                     },
                     Diagnostic {
+                        rule: "TYPE_NAMES_SHOULD_BE_PASCAL_CASE".to_string(),
                         level: "ERROR".to_string(),
                         message: "Type name must be PascalCase.".to_string(),
                         coordinate: "userContext".to_string(),
@@ -1568,6 +1571,7 @@ mod tests {
         let actual_json: JsonOutput = RoverError::new(RoverClientError::LintFailures {
             lint_response: LintResponse {
                 diagnostics: [Diagnostic {
+                    rule: "FIELD_NAMES_SHOULD_BE_CAMEL_CASE".to_string(),
                     coordinate: "Query.Hello".to_string(),
                     level: "ERROR".to_string(),
                     message: "Field names should use camelCase style.".to_string(),


### PR DESCRIPTION
In the past when a JSON formatted response was requested from a `lint` command it did not include the name of the rule that was being violated, so sometimes it was a bit challenging to see exactly what was wrong.

This PR fixes that and adds the name of the rule to the JSON output in all the cases where linting is invoked.

### Testing
Running a graph lint against an existing graph with a broken schema (i.e. one that's designed to trigger the linter) 

```
rover graph lint --profile studio-staging-github --schema ~/Documents/Experiments/broken_schema.graphql --format json a4gzuibxjgh9tr3@current | jq
{
  "data": {
    "diagnostics": [
      {
        "coordinate": "product",
        "end_byte_offset": 80,
        "level": "WARNING",
        "message": "Type names should use PascalCase style.",
        "start_byte_offset": 73,
        "start_line": 5
      },
      {
        "coordinate": "Mutation",
        "end_byte_offset": 13,
        "level": "WARNING",
        "message": "Schema element Mutation is missing a description.",
        "start_byte_offset": 5,
        "start_line": 1
      },
      {
        "coordinate": "Mutation.createProduct",
        "end_byte_offset": 31,
        "level": "WARNING",
        "message": "Schema element Mutation.createProduct is missing a description.",
        "start_byte_offset": 18,
        "start_line": 2
      },
      {
        "coordinate": "Query",
        "end_byte_offset": 174,
        "level": "WARNING",
        "message": "Schema element Query is missing a description.",
        "start_byte_offset": 169,
        "start_line": 13
      },
      {
        "coordinate": "Query.topProducts",
        "end_byte_offset": 190,
        "level": "WARNING",
        "message": "Schema element Query.topProducts is missing a description.",
        "start_byte_offset": 179,
        "start_line": 14
      },
      {
        "coordinate": "product",
        "end_byte_offset": 80,
        "level": "WARNING",
        "message": "Schema element product is missing a description.",
        "start_byte_offset": 73,
        "start_line": 5
      },
      {
        "coordinate": "product.cddedaddadb",
        "end_byte_offset": 153,
        "level": "WARNING",
        "message": "Schema element product.cddedaddadb is missing a description.",
        "start_byte_offset": 142,
        "start_line": 10
      },
      {
        "coordinate": "product.name",
        "end_byte_offset": 104,
        "level": "WARNING",
        "message": "Schema element product.name is missing a description.",
        "start_byte_offset": 100,
        "start_line": 7
      },
      {
        "coordinate": "product.price",
        "end_byte_offset": 120,
        "level": "WARNING",
        "message": "Schema element product.price is missing a description.",
        "start_byte_offset": 115,
        "start_line": 8
      },
      {
        "coordinate": "product.upc",
        "end_byte_offset": 88,
        "level": "WARNING",
        "message": "Schema element product.upc is missing a description.",
        "start_byte_offset": 85,
        "start_line": 6
      },
      {
        "coordinate": "product.weight",
        "end_byte_offset": 134,
        "level": "WARNING",
        "message": "Schema element product.weight is missing a description.",
        "start_byte_offset": 128,
        "start_line": 9
      },
      {
        "coordinate": "product",
        "end_byte_offset": 80,
        "level": "WARNING",
        "message": "Schema element product is unused.",
        "start_byte_offset": 73,
        "start_line": 5
      }
    ],
    "file_name": "/Users/jonathanrainer/Documents/Experiments/broken_schema.graphql",
    "proposed_schema": "type Mutation {\n  createProduct(upc: ID!, name: String): Product\n}\n\ntype product {\n  upc: String!\n  name: String\n  price: Int\n  weight: Int\n  cddedaddadb: Float\n}\n\ntype Query {\n  topProducts(first: Int = 5): [Product]\n}",
    "success": true
  },
  "error": null,
  "json_version": "1"
}
```

And then on using the version built from the changed PR 

```
     Running `target/debug/rover graph lint --profile studio-staging-github --schema /Users/jonathanrainer/Documents/Experiments/broken_schema.graphql --format json 'a4gzuibxjgh9tr3@current'`
{
  "data": {
    "diagnostics": [
      {
        "coordinate": "product",
        "end_byte_offset": 80,
        "level": "WARNING",
        "message": "Type names should use PascalCase style.",
        "rule": "TYPE_NAMES_SHOULD_BE_PASCAL_CASE",
        "start_byte_offset": 73,
        "start_line": 5
      },
      {
        "coordinate": "Mutation",
        "end_byte_offset": 13,
        "level": "WARNING",
        "message": "Schema element Mutation is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 5,
        "start_line": 1
      },
      {
        "coordinate": "Mutation.createProduct",
        "end_byte_offset": 31,
        "level": "WARNING",
        "message": "Schema element Mutation.createProduct is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 18,
        "start_line": 2
      },
      {
        "coordinate": "Query",
        "end_byte_offset": 174,
        "level": "WARNING",
        "message": "Schema element Query is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 169,
        "start_line": 13
      },
      {
        "coordinate": "Query.topProducts",
        "end_byte_offset": 190,
        "level": "WARNING",
        "message": "Schema element Query.topProducts is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 179,
        "start_line": 14
      },
      {
        "coordinate": "product",
        "end_byte_offset": 80,
        "level": "WARNING",
        "message": "Schema element product is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 73,
        "start_line": 5
      },
      {
        "coordinate": "product.cddedaddadb",
        "end_byte_offset": 153,
        "level": "WARNING",
        "message": "Schema element product.cddedaddadb is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 142,
        "start_line": 10
      },
      {
        "coordinate": "product.name",
        "end_byte_offset": 104,
        "level": "WARNING",
        "message": "Schema element product.name is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 100,
        "start_line": 7
      },
      {
        "coordinate": "product.price",
        "end_byte_offset": 120,
        "level": "WARNING",
        "message": "Schema element product.price is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 115,
        "start_line": 8
      },
      {
        "coordinate": "product.upc",
        "end_byte_offset": 88,
        "level": "WARNING",
        "message": "Schema element product.upc is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 85,
        "start_line": 6
      },
      {
        "coordinate": "product.weight",
        "end_byte_offset": 134,
        "level": "WARNING",
        "message": "Schema element product.weight is missing a description.",
        "rule": "ALL_ELEMENTS_REQUIRE_DESCRIPTION",
        "start_byte_offset": 128,
        "start_line": 9
      },
      {
        "coordinate": "product",
        "end_byte_offset": 80,
        "level": "WARNING",
        "message": "Schema element product is unused.",
        "rule": "DEFINED_TYPES_ARE_UNUSED",
        "start_byte_offset": 73,
        "start_line": 5
      }
    ],
    "file_name": "/Users/jonathanrainer/Documents/Experiments/broken_schema.graphql",
    "proposed_schema": "type Mutation {\n  createProduct(upc: ID!, name: String): Product\n}\n\ntype product {\n  upc: String!\n  name: String\n  price: Int\n  weight: Int\n  cddedaddadb: Float\n}\n\ntype Query {\n  topProducts(first: Int = 5): [Product]\n}",
    "success": true
  },
  "error": null,
  "json_version": "1"
}
```

So as can be seen we now have rule names included as we would expect