### PR TITLE
Add a test to ensure we get the right socket name back

### DIFF
--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -318,7 +318,7 @@ mod tests {
     // run on a dev laptop
     #[cfg_attr(target_os = "windows", ignore)]
     #[case("/tmp/supergraph-127.0.0.1:4000.sock")]
-    #[cfg_attr(target_os = "unix", ignore)]
+    #[cfg_attr(target_os = "linux", ignore)]
     #[cfg_attr(target_os = "macos", ignore)]
     #[case("@supergraph-127.0.0.1:4000.sock")]
     fn test_socket_types_correctly_detected(#[case] expected_ipc_address: String) {

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -304,6 +304,7 @@ impl RouterConfigReader {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -322,7 +322,8 @@ mod tests {
     #[case("@supergraph-127.0.0.1:4000.sock")]
     fn test_socket_types_correctly_detected(#[case] expected_ipc_address: String) {
         let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        let r_config = RouterConfigHandler::new(None, Some(ip_addr), None)
+        let port_number = 4000;
+        let r_config = RouterConfigHandler::new(None, Some(ip_addr), Some(port_number))
             .expect("failed to create config handler");
         assert_eq!(
             r_config.get_ipc_address().expect("should not fail"),

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -303,3 +303,30 @@ impl RouterConfigReader {
         }
     }
 }
+
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use rstest::rstest;
+
+    use crate::command::dev::router::RouterConfigHandler;
+
+    #[rstest]
+    // This test is deliberately platform specific as it leans into how the OS handles sockets
+    // as such all these tests will run in a flavour of our CI pipeline but they may well not all
+    // run on a dev laptop
+    #[cfg_attr(target_os = "windows", ignore)]
+    #[case("/tmp/supergraph-127.0.0.1:4000.sock")]
+    #[cfg_attr(target_os = "unix", ignore)]
+    #[cfg_attr(target_os = "macos", ignore)]
+    #[case("@supergraph-127.0.0.1:4000.sock")]
+    fn test_socket_types_correctly_detected(#[case] expected_ipc_address: String) {
+        let ip_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let r_config = RouterConfigHandler::new(None, Some(ip_addr), None)
+            .expect("failed to create config handler");
+        assert_eq!(
+            r_config.get_ipc_address().expect("should not fail"),
+            format!("{}", expected_ipc_address)
+        );
+    }
+}


### PR DESCRIPTION
As per title, in some future dependency upgrades we change how we derive the socket name. We want to ensure behaviours are maintained as we upgrade. So this adds a test that checks the required behaviour so we can utilise it later when making changes.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
