### PR TITLE
Fix `pnpm` installs by moving binary download location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,12 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
+  node_js:
+    docker:
+      - image: node:lts
+    resource_class: medium
+
+
 tag_matches_prerelease: &tag_matches_prerelease
   matches:
     pattern: "^.*(beta|alpha|rc|prerelease|draft|test).*$"
@@ -143,6 +149,11 @@ workflows:
               platform: [amd_ubuntu]
               rust_channel: [stable]
               command: [integration-test]
+      - install_js:
+          name: Test installation for Javascript Package Managers (<< matrix.package_manager >>)
+          matrix:
+            parameters:
+              package_manager: [npm, npm_global, pnpm]
   release:
     jobs:
       - xtask:
@@ -163,6 +174,13 @@ workflows:
               command: [integration-test]
           <<: *run_release
 
+      - install_js:
+          name: Test installation for Javascript Package Managers (<< matrix.package_manager >>)
+          matrix:
+            parameters:
+              package_manager: [ npm, npm_global, pnpm ]
+          <<: *run_release
+
       - xtask:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
@@ -177,6 +195,9 @@ workflows:
             - "Run cargo tests + studio integration tests (stable rust on amd_macos)"
             - "Run cargo tests + studio integration tests (stable rust on amd_windows)"
             - "Run supergraph-demo tests (stable rust on amd_ubuntu)"
+            - "Test installation for Javascript Package Managers (npm)"
+            - "Test installation for Javascript Package Managers (npm_global)"
+            - "Test installation for Javascript Package Managers (pnpm)"
           <<: *run_release
 
       - publish_release:
@@ -271,6 +292,21 @@ jobs:
       - compute_checksums
       - gh_release
       - npm_publish
+
+  install_js:
+    parameters:
+      package_manager:
+        type: enum
+        enum: ["npm", "npm_global", "pnpm"]
+    executor: node_js
+    steps:
+      - checkout:
+          path: "rover"
+      - run:
+          name: "Invoke Install Scripts"
+          command: |
+            cd rover/.circleci/scripts
+            ./install_<< parameters.package_manager >>.sh
 
 # reusable command snippets can be referred to in any `steps` object
 commands:

--- a/.circleci/scripts/install_npm.sh
+++ b/.circleci/scripts/install_npm.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir /test
+cd /test
+echo "Created test directory"
+npm init -y
+echo "Initialised new npm package"
+npm install --install-links=true "$SCRIPT_DIR/../../installers/npm"
+echo "Installed rover as local npm package"
+cd node_modules/.bin/
+echo "Checking version"
+./rover --version
+echo "Checked version, all ok!"

--- a/.circleci/scripts/install_npm.sh
+++ b/.circleci/scripts/install_npm.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-mkdir /test
-cd /test
+cd "$(mktemp -d)"
 echo "Created test directory"
 npm init -y
 echo "Initialised new npm package"

--- a/.circleci/scripts/install_npm_global.sh
+++ b/.circleci/scripts/install_npm_global.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir /test
+cd /test
+echo "Created test directory"
+npm install --install-links=true -g "$SCRIPT_DIR/../../installers/npm"
+echo "Installed rover as global npm package"
+cd /usr/local/bin/
+echo "Checking version"
+./rover --version
+echo "Checked version, all ok!"

--- a/.circleci/scripts/install_npm_global.sh
+++ b/.circleci/scripts/install_npm_global.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-mkdir /test
-cd /test
+cd "$(mktemp -d)"
 echo "Created test directory"
 npm install --install-links=true -g "$SCRIPT_DIR/../../installers/npm"
 echo "Installed rover as global npm package"

--- a/.circleci/scripts/install_pnpm.sh
+++ b/.circleci/scripts/install_pnpm.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-mkdir /test
-cd /test
+cd "$(mktemp -d)"
 echo "Created test directory"
 npm install -g pnpm@v9.3.0
 echo "Installed pnpm"

--- a/.circleci/scripts/install_pnpm.sh
+++ b/.circleci/scripts/install_pnpm.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir /test
+cd /test
+echo "Created test directory"
+npm install -g pnpm@v9.3.0
+echo "Installed pnpm"
+pnpm init
+pnpm add "file:$SCRIPT_DIR/../../installers/npm"
+echo "Installed rover as pnpm package"
+cd node_modules/.bin/
+echo "Checking version"
+./rover --version
+echo "Checked version, all ok!"

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -101,7 +101,7 @@ const getPlatform = () => {
 
 /*! Copyright (c) 2019 Avery Harnish - MIT License */
 class Binary {
-  constructor(name, url, config) {
+  constructor(name, url) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -131,8 +131,9 @@ class Binary {
     }
     this.url = url;
     this.name = name;
-    this.installDirectory =
-      config?.installDirectory || join(__dirname, "node_modules", ".bin");
+    const { dirname } = require('path');
+    const appDir = dirname(require.main.filename);
+    this.installDirectory = join(appDir, "binary");
 
     if (!existsSync(this.installDirectory)) {
       mkdirSync(this.installDirectory, { recursive: true });


### PR DESCRIPTION
Fixes #1881 

# The Problem

This bug requires a little explanation. So, in the release of v0.23.0 of Rover we inlined the `binary-install` dependency to resolve a security vulnerability with `axios` (https://github.com/apollographql/rover/pull/1819). The inlining of this dependency caused the place where `rover` binaries were downloaded to change, but in such a way that it only affected installs via `pnpm`.

The reason for this is that the code that was inlined was using the `__dirname` variable to site the binary installation, and this variable always contains the path of the folder where the currently executing script is located. Normally this would not be a problem because the script ran inside the `binary-install` packages folder. As evidenced by running `console.log` against the output of trying to install the binary under Rover v0.22.0

```
root@3479114cabfc:/node_modules/.bin# ./rover
Binary {
  url: 'https://rover.apollo.dev/tar/rover/x86_64-unknown-linux-gnu/v0.22.0',
  name: 'rover',
  installDirectory: '/node_modules/.pnpm/binary-install@1.1.0/node_modules/binary-install/node_modules/.bin',
  binaryPath: '/node_modules/.pnpm/binary-install@1.1.0/node_modules/binary-install/node_modules/.bin/rover'
}
....
```

However, when the package was inlined and moved the location of the script itself changed and so therefore did the value of `__dirname` and so it tried to install the binary somewhere else, as evidenced by running the same commands as above but this time using Rover v0.23.0

```
root@44b617aea38c:/usr/local/lib/node_modules/@apollo/rover# ./run.js
Binary {
  url: 'https://rover.apollo.dev/tar/rover/aarch64-unknown-linux-gnu/v0.23.0',
  name: 'rover',
  installDirectory: '/usr/local/lib/node_modules/@apollo/rover/node_modules/.bin',
  binaryPath: '/usr/local/lib/node_modules/@apollo/rover/node_modules/.bin/rover'
}
```
We see here that it's now trying to install into the `node_modules/.bin` inside the rover package itself. This is what leads to problems because this location is already utilised by `pnpm` to store a shell script (also called `rover`) that calls out to the `run.js`. So under Rover v0.23.0 we end up with an infinite loop where `binary.js` looks for the binary, finds the one put in by `pnpm`, invokes it, which then looks for the binary, finds the one put there by `pnpm`, invokes it and so on.

<details>
<summary>Why was this not a problem when using `npm` to install?</summary>
<br>
Under `npm` the situation is different, if you install `rover` globally then the shell script that invokes run.js gets installed to `usr/local/bin/rover` which then will not conflict or form the infinite loop (as per https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin)

If you install rover as part of another `npm` project then the binary gets installed to the `node_modules` inside the rover package as it's installed as can be seen below 

```
Binary {
  url: 'https://rover.apollo.dev/tar/rover/aarch64-unknown-linux-gnu/v0.23.0',
  name: 'rover',
  installDirectory: '/node_modules/@apollo/rover/node_modules/.bin',
  binaryPath: '/node_modules/@apollo/rover/node_modules/.bin/rover'
}
```

So this will not conflict either because what's specified in the `bin` stanza in `package.json` gets installed to the top level `node_modules` so again no conflict. 
</details>

# The Solution

If we stop using the `__dirname` variable and instead use something relative to the `package.json` of Rover itself all these problems disappear. This is not a known path so will not get clobbered by another package manager (`pnpm` or otherwise) and will allow consistency across platforms. That is what this PR proposes

# Testing
Added a few more CI steps to ensure we can install in all JS domains (npm, npm (global), pnpm), as can be seen here, when run with the CI without the fix we get the following behaviour

![Screenshot 2024-06-14 at 14 23 12](https://github.com/apollographql/rover/assets/1529660/67722ad1-b76d-4394-a785-7c40ed563f73)

However when run with the fix the CI check runs green, thus in future we shouldn't have this problem/it'll be caught in CI
