### PR TITLE
Add supergraph config fetch command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,7 @@ dependencies = [
  "heck 0.5.0",
  "houston",
  "httpmock",
+ "indoc",
  "interprocess",
  "lazy_static",
  "lazycell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 assert-json-diff = { workspace = true }
 httpmock = { workspace = true }
+indoc = { workspace = true }
 predicates = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
 rstest = { workspace = true }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -446,7 +446,7 @@ impl RoverOutput {
             }
             RoverOutput::EmptySuccess => None,
             RoverOutput::SupergraphConfigFetchResponse(supergraph_config) => {
-                let remapped = serde_yaml::to_value(&supergraph_config).and_then(|value| {
+                let remapped = serde_yaml::to_value(supergraph_config).and_then(|value| {
                     let mut btm: BTreeMap<String, serde_yaml::Value> =
                         serde_yaml::from_value(value)?;
                     let subgraphs = btm.get("subgraphs").cloned();

--- a/src/command/supergraph/config.rs
+++ b/src/command/supergraph/config.rs
@@ -1,0 +1,170 @@
+use apollo_federation_types::config::{FederationVersion, SubgraphConfig, SupergraphConfig};
+use clap::{Parser, Subcommand};
+use rover_client::operations::subgraph::{self, list::SubgraphListInput};
+use rover_std::Style;
+use serde::Serialize;
+
+use crate::{
+    options::{GraphRefOpt, ProfileOpt},
+    utils::client::StudioClientConfig,
+    RoverOutput, RoverResult,
+};
+
+#[derive(Debug, Serialize, Subcommand)]
+pub enum Config {
+    Fetch(ConfigFetch),
+}
+
+impl Config {
+    pub fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        match self {
+            Config::Fetch(command) => command.run(client_config),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Parser)]
+pub struct ConfigFetch {
+    #[clap(flatten)]
+    graph: GraphRefOpt,
+
+    #[clap(flatten)]
+    profile: ProfileOpt,
+
+    #[clap(long)]
+    federation_version: Option<FederationVersion>,
+}
+
+impl ConfigFetch {
+    pub fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        let client = client_config.get_authenticated_client(&self.profile)?;
+        let graph_ref = self.graph.graph_ref.to_string();
+        eprintln!(
+            "Fetching supergraph config from {} using credentials from the {} profile.",
+            Style::Link.paint(graph_ref),
+            Style::Command.paint(&self.profile.profile_name)
+        );
+
+        let graph_ref = &self.graph.graph_ref;
+
+        let subgraph_list_response = subgraph::list::run(
+            SubgraphListInput {
+                graph_ref: graph_ref.clone(),
+            },
+            &client,
+        )?;
+
+        let subgraph_configs = subgraph_list_response
+            .subgraphs
+            .iter()
+            .map(|subgraph| {
+                let subgraph_name = &subgraph.name;
+                let config = SubgraphConfig {
+                    routing_url: subgraph.url.clone(),
+                    schema: apollo_federation_types::config::SchemaSource::Subgraph {
+                        graphref: graph_ref.to_string(),
+                        subgraph: subgraph_name.to_string(),
+                    },
+                };
+                (subgraph_name.to_string(), config)
+            })
+            .collect();
+
+        let mut supergraph_config = SupergraphConfig::new(subgraph_configs, None);
+        let federation_version = self
+            .federation_version
+            .clone()
+            .unwrap_or(FederationVersion::LatestFedTwo);
+        supergraph_config.set_federation_version(federation_version);
+
+        Ok(RoverOutput::SupergraphConfigFetchResponse(
+            supergraph_config,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use apollo_federation_types::config::{
+        FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
+    };
+    use camino::Utf8PathBuf;
+    use httpmock::{Method, MockServer};
+    use rover_client::shared::GraphRef;
+    use serde_json::json;
+    use speculoos::prelude::*;
+
+    use crate::{
+        options::{GraphRefOpt, ProfileOpt},
+        utils::client::{ClientBuilder, StudioClientConfig},
+        RoverOutput,
+    };
+
+    use super::ConfigFetch;
+
+    #[test]
+    fn test_supergraph_config_fetch() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST);
+            let response = json!({
+                "data": {
+                    "frontendUrlRoot": "https://studio.apollographql.com/",
+                    "graph": {
+                        "variant": {
+                            "subgraphs": [
+                                {
+                                    "name": "actors",
+                                    "url": "https://example.com/graphql",
+                                    "updatedAt": "2024-05-27T02:20:21.261Z"
+                                }
+                            ]
+                        }
+                    }
+                }
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(response);
+        });
+        let studio_client_config = StudioClientConfig::new(
+            Some(server.base_url()),
+            houston::Config::new(None::<&Utf8PathBuf>, None).unwrap(),
+            false,
+            ClientBuilder::default(),
+        );
+        let command = ConfigFetch {
+            graph: GraphRefOpt {
+                graph_ref: GraphRef::new("test".to_string(), Some("current".to_string())).unwrap(),
+            },
+            profile: ProfileOpt {
+                profile_name: "default".to_string(),
+            },
+            federation_version: None,
+        };
+
+        let result = command.run(studio_client_config);
+        mock.assert_hits(1);
+
+        let expected_supergraph_config = SupergraphConfig::new(
+            BTreeMap::from([(
+                "actors".to_string(),
+                SubgraphConfig {
+                    routing_url: Some("https://example.com/graphql".to_string()),
+                    schema: SchemaSource::Subgraph {
+                        graphref: "test@current".to_string(),
+                        subgraph: "actors".to_string(),
+                    },
+                },
+            )]),
+            Some(FederationVersion::LatestFedTwo),
+        );
+
+        let expected_output =
+            RoverOutput::SupergraphConfigFetchResponse(expected_supergraph_config);
+
+        assert_that!(result).is_ok().is_equal_to(expected_output);
+    }
+}

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod compose;
+mod config;
 mod fetch;
 
 #[cfg(feature = "composition-js")]
@@ -26,6 +27,10 @@ pub enum Command {
 
     /// Fetch supergraph SDL from the graph registry
     Fetch(fetch::Fetch),
+
+    /// Generate or manipulate a supergraph.yaml file
+    #[clap(subcommand)]
+    Config(config::Config),
 }
 
 impl Supergraph {
@@ -37,6 +42,7 @@ impl Supergraph {
         match &self.command {
             Command::Fetch(command) => command.run(client_config),
             Command::Compose(command) => command.run(override_install_path, client_config),
+            Command::Config(command) => command.run(client_config),
         }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod dev;
 mod schema;
+mod supergraph;
 
 use assert_cmd::Command;
 use predicates::prelude::*;

--- a/tests/supergraph/config/fetch.rs
+++ b/tests/supergraph/config/fetch.rs
@@ -1,0 +1,54 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use httpmock::{Method, MockServer};
+use indoc::indoc;
+use serde_json::json;
+
+#[test]
+fn it_produces_a_supergraph_yaml_config() -> Result<()> {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(Method::POST);
+        let response = json!({
+            "data": {
+                "frontendUrlRoot": "https://studio.apollographql.com/",
+                "graph": {
+                    "variant": {
+                        "subgraphs": [
+                            {
+                                "name": "actors",
+                                "url": "https://example.com/graphql",
+                                "updatedAt": "2024-05-27T02:20:21.261Z"
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(response);
+    });
+    let expected_yaml = indoc! {r#"
+      federation_version: '2'
+      subgraphs:
+        actors:
+          routing_url: https://example.com/graphql
+          schema:
+            graphref: mygraph@current
+            subgraph: actors
+
+      "#
+    };
+    let mut cmd = Command::cargo_bin("rover")?;
+    let result = cmd
+        .env("APOLLO_REGISTRY_URL", server.base_url())
+        .arg("supergraph")
+        .arg("config")
+        .arg("fetch")
+        .arg("mygraph@current")
+        .assert();
+    result.stdout(expected_yaml);
+
+    Ok(())
+}

--- a/tests/supergraph/config/mod.rs
+++ b/tests/supergraph/config/mod.rs
@@ -1,0 +1,1 @@
+pub mod fetch;

--- a/tests/supergraph/mod.rs
+++ b/tests/supergraph/mod.rs
@@ -1,0 +1,1 @@
+pub mod config;


### PR DESCRIPTION
Fixes https://github.com/apollographql/rover/issues/1731

Allows rover to generate a supergraph.yaml file from a graph ref.