### PR TITLE
Replace `chrono` with `time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,10 +940,8 @@ checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -3549,6 +3547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,7 +4362,6 @@ dependencies = [
  "binstall",
  "calm_io",
  "camino",
- "chrono",
  "clap",
  "console",
  "crossbeam-channel",
@@ -4395,6 +4401,7 @@ dependencies = [
  "tempfile",
  "termimad",
  "timber",
+ "time",
  "toml",
  "tracing",
  "url",
@@ -4413,7 +4420,6 @@ dependencies = [
  "ariadne",
  "backoff",
  "camino",
- "chrono",
  "git-url-parse",
  "git2",
  "graphql_client",
@@ -4432,6 +4438,7 @@ dependencies = [
  "serde_json",
  "strip-ansi-escapes",
  "thiserror",
+ "time",
  "tracing",
 ]
 
@@ -5382,7 +5389,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ cargo_metadata = "0.18"
 calm_io = "0.1"
 camino = "1"
 clap = "4"
-chrono = "0.4"
 ci_info = "0.14"
 console = "0.15"
 crossbeam-channel = "0.5"
@@ -127,6 +126,7 @@ thiserror = "1"
 tar = "0.4"
 termimad = "0.29"
 tempfile = "3.8"
+time = { version = "0.3.36", features = ["formatting"]}
 tokio = "1.32"
 tokio-stream = "0.1"
 toml = "0.8"
@@ -150,7 +150,6 @@ binstall = { workspace = true }
 calm_io = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true, features = ["color", "derive", "env"] }
-chrono = { workspace = true }
 console = { workspace = true }
 crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true }
@@ -183,6 +182,7 @@ strum_macros = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 timber = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 termimad = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
@@ -199,4 +199,5 @@ predicates = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }
+time = { workspace = true, features = ["local-offset"] }
 speculoos = { workspace = true }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -13,7 +13,6 @@ apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
 apollo-encoder = { workspace = true }
 backoff = { workspace = true }
-chrono = { workspace = true, features = ["serde"] }
 git-url-parse = { workspace = true }
 git2 = { workspace = true, features = [
     "vendored-openssl",
@@ -23,6 +22,7 @@ houston = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
 prettytable-rs = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true, features = [
     "blocking",
     "brotli",
@@ -35,9 +35,10 @@ rover-std = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+time = { workspace = true, features = ["parsing", "serde"]}
 thiserror = { workspace = true }
 tracing = { workspace = true }
-regex = { workspace = true }
+
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/rover-client/src/operations/subgraph/list/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/list/runner.rs
@@ -1,4 +1,6 @@
 use graphql_client::*;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::blocking::StudioClient;
 use crate::operations::subgraph::list::types::*;
@@ -73,8 +75,8 @@ fn format_subgraphs(subgraphs: &[QuerySubgraphInfo]) -> Vec<SubgraphInfo> {
             name: subgraph.name.clone(),
             url: subgraph.url.clone(),
             updated_at: SubgraphUpdatedAt {
-                local: subgraph.updated_at.clone().parse().ok(),
-                utc: subgraph.updated_at.clone().parse().ok(),
+                local: OffsetDateTime::parse(&subgraph.updated_at, &Rfc3339).ok(),
+                utc: OffsetDateTime::parse(&subgraph.updated_at, &Rfc3339).ok(),
             },
         })
         .collect();

--- a/crates/rover-client/src/operations/subgraph/list/types.rs
+++ b/crates/rover-client/src/operations/subgraph/list/types.rs
@@ -1,12 +1,12 @@
+use serde::Serialize;
+use time::OffsetDateTime;
+
 use crate::{operations::subgraph::list::runner::subgraph_list_query, shared::GraphRef};
 
 pub(crate) type QuerySubgraphInfo = subgraph_list_query::SubgraphListQueryGraphVariantSubgraphs;
 pub(crate) type QueryResponseData = subgraph_list_query::ResponseData;
 
 type QueryVariables = subgraph_list_query::Variables;
-
-use chrono::{DateTime, Local, Utc};
-use serde::Serialize;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SubgraphListInput {
@@ -42,6 +42,6 @@ pub struct SubgraphInfo {
 
 #[derive(Clone, Serialize, Eq, PartialEq, Debug)]
 pub struct SubgraphUpdatedAt {
-    pub local: Option<DateTime<Local>>,
-    pub utc: Option<DateTime<Utc>>,
+    pub local: Option<OffsetDateTime>,
+    pub utc: Option<OffsetDateTime>,
 }


### PR DESCRIPTION
Follows on from the amazing work done in #1021 and fixes #1044.

There appear to have been several new versions of `time` released since we last took a swing at this, and the release notes for newer versions seem to indicate the issues previously had have been resolved (though it's not clear if this is true across all OSs) so reviving this inside a new PR to have another go.