### PR TITLE
Add a check to ensure correct URL is used if a `subgraph_url` and a `routing_url` are provided in a `supergraph.yml`

### DIFF
--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, time::Duration};
 use anyhow::anyhow;
 use apollo_federation_types::config::SchemaSource;
 use reqwest::Url;
+
 use rover_client::blocking::StudioClient;
 use rover_std::Fs;
 
@@ -138,13 +139,16 @@ impl SupergraphOpts {
                     SchemaSource::SubgraphIntrospection {
                         subgraph_url,
                         introspection_headers,
-                    } => SubgraphSchemaWatcher::new_from_url(
-                        (yaml_subgraph_name, subgraph_url),
-                        client.clone(),
-                        follower_messenger.clone(),
-                        polling_interval,
-                        introspection_headers,
-                    ),
+                    } => {
+                        let url = routing_url.or(Some(subgraph_url)).unwrap();
+                        SubgraphSchemaWatcher::new_from_url(
+                            (yaml_subgraph_name, url),
+                            client.clone(),
+                            follower_messenger.clone(),
+                            polling_interval,
+                            introspection_headers,
+                        )
+                    }
                     SchemaSource::Sdl { sdl } => {
                         let routing_url = routing_url.ok_or_else(|| {
                             anyhow!("`routing_url` must be set when providing SDL directly")

--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -140,7 +140,7 @@ impl SupergraphOpts {
                         subgraph_url,
                         introspection_headers,
                     } => {
-                        let url = routing_url.or(Some(subgraph_url)).unwrap();
+                        let url = routing_url.unwrap_or(subgraph_url);
                         SubgraphSchemaWatcher::new_from_url(
                             (yaml_subgraph_name, url),
                             client.clone(),

--- a/src/command/dev/schema.rs
+++ b/src/command/dev/schema.rs
@@ -83,11 +83,12 @@ impl OptionalSubgraphOpts {
                 .with_timeout(Duration::from_secs(5))
                 .build()?;
             SubgraphSchemaWatcher::new_from_url(
-                (name, url),
+                (name, url.clone()),
                 client,
                 follower_messenger,
                 self.subgraph_polling_interval,
                 None,
+                url,
             )
         }
     }
@@ -140,13 +141,14 @@ impl SupergraphOpts {
                         subgraph_url,
                         introspection_headers,
                     } => {
-                        let url = routing_url.unwrap_or(subgraph_url);
+                        let url = routing_url.unwrap_or(subgraph_url.clone());
                         SubgraphSchemaWatcher::new_from_url(
                             (yaml_subgraph_name, url),
                             client.clone(),
                             follower_messenger.clone(),
                             polling_interval,
                             introspection_headers,
+                            subgraph_url,
                         )
                     }
                     SchemaSource::Sdl { sdl } => {

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -1,3 +1,19 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context};
+use apollo_federation_types::build::SubgraphDefinition;
+use camino::{Utf8Path, Utf8PathBuf};
+use crossbeam_channel::unbounded;
+use reqwest::blocking::Client;
+use url::Url;
+
+use rover_client::blocking::StudioClient;
+use rover_client::operations::subgraph::fetch;
+use rover_client::operations::subgraph::fetch::SubgraphFetchInput;
+use rover_client::shared::GraphRef;
+use rover_std::{Emoji, Fs};
+
 use crate::{
     command::dev::{
         introspect::{IntrospectRunnerKind, UnknownIntrospectRunner},
@@ -5,20 +21,6 @@ use crate::{
     },
     RoverError, RoverErrorSuggestion, RoverResult,
 };
-use anyhow::{anyhow, Context};
-use std::collections::HashMap;
-use std::str::FromStr;
-
-use apollo_federation_types::build::SubgraphDefinition;
-use camino::{Utf8Path, Utf8PathBuf};
-use crossbeam_channel::unbounded;
-use reqwest::blocking::Client;
-use rover_client::blocking::StudioClient;
-use rover_client::operations::subgraph::fetch;
-use rover_client::operations::subgraph::fetch::SubgraphFetchInput;
-use rover_client::shared::GraphRef;
-use rover_std::{Emoji, Fs};
-use url::Url;
 
 #[derive(Debug)]
 pub struct SubgraphSchemaWatcher {
@@ -49,11 +51,14 @@ impl SubgraphSchemaWatcher {
         message_sender: FollowerMessenger,
         polling_interval: u64,
         headers: Option<HashMap<String, String>>,
+        subgraph_url: Url,
     ) -> RoverResult<Self> {
-        let (_, url) = subgraph_key.clone();
         let headers = headers.map(|header_map| header_map.into_iter().collect());
-        let introspect_runner =
-            IntrospectRunnerKind::Unknown(UnknownIntrospectRunner::new(url, client, headers));
+        let introspect_runner = IntrospectRunnerKind::Unknown(UnknownIntrospectRunner::new(
+            subgraph_url,
+            client,
+            headers,
+        ));
         Self::new_from_introspect_runner(
             subgraph_key,
             introspect_runner,


### PR DESCRIPTION
Fixes #1782 

In the past when scanning over a `supergraph.yaml` it was always the case that the subgraph URL was used. However in the case where a user provides the subgraph_url for introspection and the routing_url to access the graph we were choosing the wrong one. This fixes that, as fortunately it's only an issue with how we extract the data from the `supergraph.yaml` not an issue with federation-rs as was originally thought.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
