### PR TITLE
fix(composition): Ensure `.exe` not printed alongside Federation Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,6 +4375,7 @@ dependencies = [
  "predicates",
  "prettytable-rs",
  "rayon",
+ "regex",
  "reqwest 0.12.4",
  "robot-panic",
  "rover-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ notify = { workspace = true }
 opener = { workspace = true }
 os_info = { workspace = true }
 rayon = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json"] }
 robot-panic = { workspace = true }
 rover-client = { workspace = true }


### PR DESCRIPTION
Fixes: #1390 

This stops `.exe` being printed after we find a plugin version on windows, while retaining the behaviour we see in other cases. Unit tests prove this works, even in cases where the SemVer is particularly complex