### PR TITLE
Reinstate GLIBC 2.17 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,24 @@ run_release: &run_release
 
 # The machines we use to run our workflows on
 executors:
+  amd_centos: &amd_manylinux_executor
+    docker:
+      # This image is used for building Python Wheels but it has what we need for Rust compilation and crucially
+      # glibc 2.17.
+      - image:  quay.io/pypa/manylinux2014_x86_64:2024.07.02-0
+    resource_class: xlarge
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-gnu"
+      CHECK_GLIBC: "true"
+
+
   arm_ubuntu: &arm_ubuntu_executor
     machine:
       image: ubuntu-2004:2022.04.1
     resource_class: arm.large
     environment:
       XTASK_TARGET: "aarch64-unknown-linux-gnu"
+      CHECK_GLIBC: "true"
 
   amd_musl: &amd_musl_executor
     docker:
@@ -70,6 +82,7 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-pc-windows-msvc"
 
+  # This is only used to run supergraph-demo since you can't run Docker from Docker
   amd_ubuntu: &amd_ubuntu_executor
     machine:
       image: ubuntu-2004:2022.04.1
@@ -128,7 +141,7 @@ workflows:
           name: Run cargo tests + studio integration tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_ubuntu, amd_musl, amd_macos, amd_windows]
+              platform: [amd_manylinux, amd_musl, amd_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
 
@@ -155,7 +168,7 @@ workflows:
           name: Run cargo tests + studio integration tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_ubuntu, amd_musl, amd_macos, amd_windows]
+              platform: [amd_manylinux, amd_musl, amd_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *run_release
@@ -180,12 +193,12 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_ubuntu, amd_musl, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_manylinux, amd_musl, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
               options: ["--rebuild"]
           requires:
-            - "Run cargo tests + studio integration tests (stable rust on amd_ubuntu)"
+            - "Run cargo tests + studio integration tests (stable rust on amd_manylinux)"
             - "Run cargo tests + studio integration tests (stable rust on amd_musl)"
             - "Run cargo tests + studio integration tests (stable rust on amd_macos)"
             - "Run cargo tests + studio integration tests (stable rust on amd_windows)"
@@ -201,7 +214,7 @@ workflows:
             parameters:
               platform: [volta]
           requires:
-            - "Build and bundle release artifacts (amd_ubuntu)"
+            - "Build and bundle release artifacts (amd_manylinux)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_musl)"
             - "Build and bundle release artifacts (amd_macos)"
@@ -338,12 +351,32 @@ commands:
                 name: Update apt repositories
                 command: sudo apt-get update
             - run:
+                name: Check glibc version
+                command: ldd --version
+            - run:
                 name: Install OpenSSL
                 command: sudo apt-get install -y libssl-dev
 
       - when:
           condition:
-            equal: [*amd_musl_executor, << parameters.platform >>]
+            equal: [*amd_manylinux_executor, << parameters.platform >>]
+          steps:
+            - run:
+                name: Update and upgrade yum packages
+                command: yum -y update && yum -y upgrade
+            - run:
+                name: Install development tools
+                command: yum groupinstall -y "Development Tools"
+            - run:
+                name: Install gcc, OpenSSL, and git
+                command: yum -y install perl-core gcc openssl-devel openssl git
+            - run:
+                name: Check glibc version
+                command: ldd --version
+
+      - when:
+          condition:
+              equal: [*amd_musl_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install musl-tools and bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ run_release: &run_release
 
 # The machines we use to run our workflows on
 executors:
-  amd_centos: &amd_manylinux_executor
+  amd_manylinux: &amd_manylinux_executor
     docker:
       # This image is used for building Python Wheels but it has what we need for Rust compilation and crucially
       # glibc 2.17.

--- a/xtask/src/commands/unit_test.rs
+++ b/xtask/src/commands/unit_test.rs
@@ -1,8 +1,13 @@
+use std::env;
+use std::str::FromStr;
+
 use anyhow::Result;
+use camino::Utf8PathBuf;
 use clap::Parser;
 
 use crate::target::Target;
-use crate::tools::CargoRunner;
+use crate::tools::{CargoRunner, Runner};
+use crate::utils::PKG_PROJECT_ROOT;
 
 #[derive(Debug, Parser)]
 pub struct UnitTest {
@@ -15,6 +20,15 @@ impl UnitTest {
     pub fn run(&self) -> Result<()> {
         let cargo_runner = CargoRunner::new()?;
         cargo_runner.test(&self.target)?;
+
+        if let Target::LinuxUnknownGnu = self.target {
+            if env::var_os("CHECK_GLIBC").is_some() {
+                let check_glibc_script = "./check_glibc.sh".to_string();
+                let runner = Runner::new(Utf8PathBuf::from_str(&check_glibc_script)?.as_str());
+                let bin_path = format!("./target/{}/debug/rover", &self.target);
+                runner.exec(&[&bin_path], &PKG_PROJECT_ROOT, None)?;
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Due to CentOS EOLing we have to move to a new image. `manylinux` is used to ensure Python image builds are successful but we can use it in this context too.

This also restores the GLIBC checking that we used to do, but does not move the Security Scanning back as that can happily execute on the Ubuntu image.