### PR TITLE
fix: various clippy warnings

### DIFF
--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -132,9 +132,9 @@ mod tests {
         let graph_identity = get_identity(Actor::GRAPH);
         let other_identity = get_identity(Actor::OTHER);
 
-        assert_eq!(WhoAmI::is_valid_actor_type(&woi, &user_identity), true);
-        assert_eq!(WhoAmI::is_valid_actor_type(&woi, &graph_identity), true);
-        assert_eq!(WhoAmI::is_valid_actor_type(&woi, &other_identity), false);
+        assert!(WhoAmI::is_valid_actor_type(&woi, &user_identity));
+        assert!(WhoAmI::is_valid_actor_type(&woi, &graph_identity));
+        assert!(!WhoAmI::is_valid_actor_type(&woi, &other_identity));
     }
 
     #[test]

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -287,7 +287,7 @@ mod tests {
                 },
                 skip_update: true,
             },
-            server.address().clone(),
+            *server.address(),
             "".to_string(),
             None,
             StudioClientConfig::new(

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -311,7 +311,7 @@ mod tests {
         .unwrap()
         .get_subgraph_definitions()
         .unwrap();
-        let film_subgraph = subgraph_definitions.get(0).unwrap();
+        let film_subgraph = subgraph_definitions.first().unwrap();
         let people_subgraph = subgraph_definitions.get(1).unwrap();
 
         assert_eq!(film_subgraph.name, "films");

--- a/src/command/supergraph/resolve_config.rs
+++ b/src/command/supergraph/resolve_config.rs
@@ -27,24 +27,6 @@ pub(crate) fn expand_supergraph_yaml(content: &str) -> RoverResult<SupergraphCon
         .and_then(|v| serde_yaml::from_value(v).map_err(RoverError::from))
 }
 
-#[cfg(test)]
-mod test_expand_supergraph_yaml {
-    use apollo_federation_types::config::FederationVersion;
-
-    #[test]
-    fn test_supergraph_yaml_int_version() {
-        let yaml = r#"
-federation_version: 1
-subgraphs: 
-"#;
-        let config = super::expand_supergraph_yaml(yaml).unwrap();
-        assert_eq!(
-            config.get_federation_version(),
-            Some(FederationVersion::LatestFedOne)
-        );
-    }
-}
-
 pub(crate) fn resolve_supergraph_yaml(
     unresolved_supergraph_yaml: &FileDescriptorType,
     client_config: StudioClientConfig,
@@ -285,4 +267,22 @@ pub(crate) fn resolve_supergraph_yaml(
     }
 
     Ok(resolved_supergraph_config)
+}
+
+#[cfg(test)]
+mod test_expand_supergraph_yaml {
+    use apollo_federation_types::config::FederationVersion;
+
+    #[test]
+    fn test_supergraph_yaml_int_version() {
+        let yaml = r#"
+federation_version: 1
+subgraphs: 
+"#;
+        let config = super::expand_supergraph_yaml(yaml).unwrap();
+        assert_eq!(
+            config.get_federation_version(),
+            Some(FederationVersion::LatestFedOne)
+        );
+    }
 }

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -120,10 +120,8 @@ mod tests {
     #[test]
     fn it_correctly_parses_stdin_flag() {
         let fd = FileDescriptorType::from_str("-").unwrap();
-
-        match fd {
-            FileDescriptorType::File(_) => panic!("parsed incorrectly as file"),
-            _ => (),
+        if let FileDescriptorType::File(_) = fd {
+            panic!("parsed incorrectly as file")
         }
     }
 

--- a/tests/installers.rs
+++ b/tests/installers.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 fn it_has_nix_installer() {
     let nix_installer_path = get_binstall_scripts_root().join("nix").join("install.sh");
     let nix_script =
-        fs::read_to_string(&nix_installer_path).expect("Could not read nix installer script");
+        fs::read_to_string(nix_installer_path).expect("Could not read nix installer script");
     assert!(!nix_script.is_empty())
 }
 
@@ -22,7 +22,7 @@ fn it_has_windows_installer() {
     let windows_installer_path = get_binstall_scripts_root()
         .join("windows")
         .join("install.ps1");
-    let windows_script = fs::read_to_string(&windows_installer_path)
+    let windows_script = fs::read_to_string(windows_installer_path)
         .expect("Could not read windows installer script");
     assert!(!windows_script.is_empty())
 }
@@ -75,7 +75,7 @@ fn latest_plugins_are_valid_versions() {
         .as_str()
         .expect("JSON malformed: `supergraph.versions.latest-0` was not a string");
 
-    assert!(latest_federation_one.starts_with("v"));
+    assert!(latest_federation_one.starts_with('v'));
     Version::parse(&latest_federation_one.to_string()[1..])
         .expect("JSON malformed: `supergraph.versions.latest-0` was not valid semver");
 
@@ -85,12 +85,12 @@ fn latest_plugins_are_valid_versions() {
         .as_str()
         .expect("JSON malformed: `supergraph.versions.latest-2` was not a string");
 
-    assert!(latest_federation_two.starts_with("v"));
+    assert!(latest_federation_two.starts_with('v'));
     Version::parse(&latest_federation_two.to_string()[1..])
         .expect("JSON malformed: `supergraph.versions.latest-2 was not valid semver");
 
     let supergraph_repository = Url::parse(
-        &supergraph
+        supergraph
             .get("repository")
             .expect("JSON malformed: `supergraph.resitory` does not exist")
             .as_str()
@@ -112,12 +112,12 @@ fn latest_plugins_are_valid_versions() {
         .as_str()
         .expect("JSON malformed: `router.versions.latest-1` was not a string");
 
-    assert!(latest_router.starts_with("v"));
+    assert!(latest_router.starts_with('v'));
     Version::parse(&latest_router.to_string()[1..])
         .expect("JSON malformed: `router.versions.latest-1 was not valid semver");
 
     let router_repository = Url::parse(
-        &router
+        router
             .get("repository")
             .expect("JSON malformed: `router.resitory` does not exist")
             .as_str()


### PR DESCRIPTION
Fixes a few clippy warnings I got via my editor's LSP when navigating the repo. Confirmed they're fixed by running:
```
$ cargo clippy --tests -- --no-deps -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.79s
```