### PR TITLE
chore(integration_tests): Allow integration_test to accept a pre-compiled binary

### DIFF
--- a/xtask/src/commands/integration_test.rs
+++ b/xtask/src/commands/integration_test.rs
@@ -25,7 +25,9 @@ pub struct IntegrationTest {
 
 impl IntegrationTest {
     pub fn run(&self) -> Result<()> {
-        if std::env::var_os("RUN_NPM_TESTS").is_some() {
+        if std::env::var_os("SKIP_NPM_TESTS").is_some() {
+            crate::info!("skipping flyby tests, to run unset SKIP_NPM_TESTS",);
+        } else {
             let npm_runner = NpmRunner::new()?;
             npm_runner.flyby()?;
         }

--- a/xtask/src/commands/integration_test.rs
+++ b/xtask/src/commands/integration_test.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use camino::Utf8PathBuf;
 use clap::Parser;
 
 use crate::target::Target;
@@ -17,19 +18,28 @@ pub struct IntegrationTest {
     // The supergraph-demo org to clone
     #[arg(long = "org", default_value = "apollographql")]
     pub(crate) org: String,
+
+    #[arg(long = "binary_path")]
+    pub(crate) binary_path: Option<Utf8PathBuf>,
 }
 
 impl IntegrationTest {
     pub fn run(&self) -> Result<()> {
-        let release = false;
-        let cargo_runner = CargoRunner::new()?;
-        let git_runner = GitRunner::tmp()?;
-
-        let npm_runner = NpmRunner::new()?;
-        npm_runner.flyby()?;
+        if std::env::var_os("RUN_NPM_TESTS").is_some() {
+            let npm_runner = NpmRunner::new()?;
+            npm_runner.flyby()?;
+        }
 
         if std::env::var_os("CAN_RUN_DOCKER").is_some() {
-            let rover_exe = cargo_runner.build(&self.target, release, None)?;
+            let release = false;
+            let cargo_runner = CargoRunner::new()?;
+            let git_runner = GitRunner::tmp()?;
+            let rover_exe = if self.binary_path.is_none() {
+                crate::info!("No binary passed, building from source...");
+                cargo_runner.build(&self.target, release, None)?
+            } else {
+                self.binary_path.clone().unwrap()
+            };
             let make_runner = MakeRunner::new(rover_exe)?;
             let repo_path = git_runner.clone_supergraph_demo(&self.org, &self.branch)?;
             make_runner.test_supergraph_demo(&repo_path)?;

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -29,6 +29,7 @@ impl Test {
             target: self.target.clone(),
             branch: self.branch.clone(),
             org: self.org.clone(),
+            binary_path: None,
         };
         integration_test_runner.run()?;
         Ok(())


### PR DESCRIPTION
This way we do not have to build it on spec every time if that's not desirable. Further allow a new environment variable `RUN_NPM_TESTS` to be used to skip execution of `npm` based tests if they are not useful.