### PR TITLE
feat: trigger Github actions from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,17 @@ workflows:
               command: [test]
 
       - xtask:
+          name: Run studio integration tests on GitHub (<< matrix.rust_channel >> rust on << matrix.platform >>)
+          matrix:
+            parameters:
+              platform: [amd_ubuntu]
+              rust_channel: [stable]
+              command: [github-actions]
+              options: 
+              - |
+                --workflow-name 'tests-mac-x86.yml' --branch "<< pipeline.git.branch >>" --commit-id "<< pipeline.git.revision >>" --inputs '{"composition-versions": "[\"2.8.2\"]"}'
+
+      - xtask:
           name: Run supergraph-demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
@@ -247,7 +258,7 @@ jobs:
         type: executor
       command:
         type: enum
-        enum: [lint, unit-test, integration-test, test, package, security-checks]
+        enum: [lint, unit-test, integration-test, test, package, security-checks, github-actions]
       options:
         type: string
         default: ""
@@ -508,14 +519,16 @@ commands:
     parameters:
       command:
         type: enum
-        enum: [lint, integration-test, unit-test, test, package, security-checks]
+        enum: [lint, integration-test, unit-test, test, package, security-checks, github-actions]
       options:
         type: string
       platform:
         type: executor
     steps:
       - run:
-          command: cargo xtask << parameters.command >> << parameters.options >>
+          command: |
+            GITHUB_TOKEN=$(echo "$GH_BOT_KEY_B64" | base64 -d)
+            cargo xtask << parameters.command >> << parameters.options >>
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ workflows:
               command: [github-actions]
               options: 
               - |
-                --workflow-name 'tests-mac-x86.yml' --branch "<< pipeline.git.branch >>" --commit-id "<< pipeline.git.revision >>" --inputs '{"composition-versions": "[\"2.8.2\"]"}'
+                --workflow-name 'tests-mac-x86.yml' --branch "<< pipeline.git.branch >>" --commit-id "<< pipeline.git.revision >>" --inputs '{"composition-versions": "[\"2.8.2\"]", "router-versions": "[\"1.50.0\"]"}'
 
       - xtask:
           name: Run supergraph-demo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,8 +527,7 @@ commands:
     steps:
       - run:
           command: |
-            GITHUB_ACTIONS_TOKEN=$(echo "$GH_BOT_KEY_B64" | base64 -d)
-            cargo xtask << parameters.command >> << parameters.options >>
+            GITHUB_ACTIONS_TOKEN=$(echo "$GH_BOT_KEY_B64" | base64 -d) cargo xtask << parameters.command >> << parameters.options >>
 
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,7 @@ commands:
     steps:
       - run:
           command: |
-            GITHUB_TOKEN=$(echo "$GH_BOT_KEY_B64" | base64 -d)
+            GITHUB_ACTIONS_TOKEN=$(echo "$GH_BOT_KEY_B64" | base64 -d)
             cargo xtask << parameters.command >> << parameters.options >>
 
       - unless:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,8 @@ workflows:
 
       - xtask:
           name: Run studio integration tests on GitHub (<< matrix.rust_channel >> rust on << matrix.platform >>)
+          context:
+            - github-orb
           matrix:
             parameters:
               platform: [amd_ubuntu]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,13 @@ commands:
     steps:
       - run:
           command: |
-            GITHUB_ACTIONS_TOKEN=$(echo "$GH_BOT_KEY_B64" | base64 -d) cargo xtask << parameters.command >> << parameters.options >>
+            export GITHUB_ACTIONS_TOKEN="$(echo "$GH_BOT_KEY_B64" | base64 -d)"
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_ACTIONS_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/user
+            cargo xtask << parameters.command >> << parameters.options >>
 
       - unless:
           condition:

--- a/.github/workflows/tests-mac-x86.yml
+++ b/.github/workflows/tests-mac-x86.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         composition-version: ${{ fromJSON(inputs.composition-versions) }}
     # x86-64 runner
-    runs-on: macos-13
+    runs-on: macos-14-large
     env:
       TEST_COMPOSITION_VERSION: "=${{ matrix.composition-version }}"
       ROVER_BINARY: ../../artifact/rover

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,6 +6307,7 @@ dependencies = [
  "lazy_static",
  "lychee-lib",
  "mockito",
+ "octocrab",
  "regex",
  "reqwest 0.12.4",
  "rover-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,12 +2492,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -36,6 +36,7 @@ tokio-stream = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 which = { workspace = true }
 zip = { workspace = true }
+octocrab = "0.38.0"
 
 [target.'cfg(not(windows))'.dependencies]
 lychee-lib = { version = "0.15", features = ["vendored-openssl"] }

--- a/xtask/src/commands/github_action.rs
+++ b/xtask/src/commands/github_action.rs
@@ -1,0 +1,106 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use octocrab::{models::RunId, Octocrab, OctocrabBuilder};
+use serde_json::json;
+
+const WORKFLOW_RUN_TIMEOUT: Duration = Duration::from_secs(600);
+
+#[derive(Debug, Parser)]
+pub struct GithubActions {
+    /// The GitHub workflow name
+    #[arg(long = "workflow-name", env = "WORKFLOW_NAME")]
+    pub(crate) workflow_name: String,
+
+    /// GitHub organization name
+    #[arg(long = "organization", default_value = "apollographql")]
+    pub(crate) organization: String,
+
+    /// GitHub repository name
+    #[arg(long = "repository", default_value = "rover")]
+    pub(crate) repository: String,
+
+    /// The repository branch to use
+    #[arg(long = "branch")]
+    pub(crate) branch: String,
+
+    /// The commit ID for this run
+    #[arg(long = "commit-id")]
+    pub(crate) commit_id: String,
+
+    /// A JSON document to use as inputs for GitHub Actions
+    #[arg(long = "inputs")]
+    pub(crate) inputs: String,
+}
+
+impl GithubActions {
+    pub async fn run(&self) -> Result<()> {
+        let github_token = std::env::var("GITHUB_TOKEN")
+            .map_err(|_err| anyhow!("$GITHUB_TOKEN is not set or is not valid UTF-8."))?;
+        let octocrab = OctocrabBuilder::new()
+            .personal_token(github_token.clone())
+            .build()?;
+
+        // Trigger GitHub workflow by sending a workflow dispatch event
+        // See <https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event>
+        let inputs: serde_json::Value = serde_json::from_str(&self.inputs)?;
+        let res = octocrab
+            ._post(
+                format!(
+                    "https://api.github.com/repos/{}/{}/actions/workflows/{}/dispatches",
+                    self.organization, self.repository, self.workflow_name
+                ),
+                Some(&json!({
+                    "ref": self.branch,
+                    "inputs": inputs,
+                })),
+            )
+            .await?;
+
+        if !res.status().is_success() {
+            return Err(anyhow!(
+                "failed to start workflow, got status code {}",
+                res.status()
+            ));
+        }
+
+        // Find the corresponding workflow run ID
+        let run_id = octocrab
+            .workflows(&self.organization, &self.repository)
+            .list_runs(&self.workflow_name)
+            .branch(&self.branch)
+            .event("workflow_dispatch")
+            .send()
+            .await?
+            .into_iter()
+            .find(|run| run.head_commit.id == self.commit_id)
+            .ok_or_else(|| anyhow!("could not find a matching run on GitHub"))?
+            .id;
+
+        self.check_run(&octocrab, run_id).await
+    }
+
+    async fn check_run(&self, octocrab: &Octocrab, run_id: RunId) -> Result<()> {
+        let fut = async {
+            loop {
+                let run = octocrab
+                    .workflows(&self.organization, &self.repository)
+                    .get(run_id)
+                    .await?;
+
+                match run.status.as_str() {
+                    "completed" => return Ok(()),
+                    "failure" => return Err(anyhow!("GitHub workflow run failed")),
+                    _ => (),
+                }
+            }
+        };
+
+        tokio::select! {
+            _ = tokio::time::sleep(WORKFLOW_RUN_TIMEOUT) => Err(anyhow!("checking workflow run timed out")),
+            res = fut => res,
+
+        }
+    }
+}

--- a/xtask/src/commands/github_action.rs
+++ b/xtask/src/commands/github_action.rs
@@ -15,10 +15,6 @@ pub struct GithubActions {
     #[arg(long = "workflow-name", env = "WORKFLOW_NAME")]
     pub(crate) workflow_name: String,
 
-    /// GitHub user name
-    #[arg(long = "username", default_value = "apollo-bot2")]
-    pub(crate) username: String,
-
     /// GitHub organization name
     #[arg(long = "organization", default_value = "apollographql")]
     pub(crate) organization: String,
@@ -42,10 +38,10 @@ pub struct GithubActions {
 
 impl GithubActions {
     pub async fn run(&self) -> Result<()> {
-        let password = std::env::var("GITHUB_ACTIONS_TOKEN")
+        let token = std::env::var("GITHUB_ACTIONS_TOKEN")
             .map_err(|_err| anyhow!("$GITHUB_ACTIONS_TOKEN is not set or is not valid UTF-8."))?;
         let octocrab = OctocrabBuilder::new()
-            .basic_auth(self.username.clone(), password.clone())
+            .personal_token(token.clone())
             .build()?;
 
         // Find information about the current user

--- a/xtask/src/commands/github_action.rs
+++ b/xtask/src/commands/github_action.rs
@@ -15,6 +15,10 @@ pub struct GithubActions {
     #[arg(long = "workflow-name", env = "WORKFLOW_NAME")]
     pub(crate) workflow_name: String,
 
+    /// GitHub user name
+    #[arg(long = "username", default_value = "apollo-bot2")]
+    pub(crate) username: String,
+
     /// GitHub organization name
     #[arg(long = "organization", default_value = "apollographql")]
     pub(crate) organization: String,
@@ -38,10 +42,10 @@ pub struct GithubActions {
 
 impl GithubActions {
     pub async fn run(&self) -> Result<()> {
-        let github_token = std::env::var("GITHUB_ACTIONS_TOKEN")
+        let password = std::env::var("GITHUB_ACTIONS_TOKEN")
             .map_err(|_err| anyhow!("$GITHUB_ACTIONS_TOKEN is not set or is not valid UTF-8."))?;
         let octocrab = OctocrabBuilder::new()
-            .personal_token(github_token.clone())
+            .basic_auth(self.username.clone(), password.clone())
             .build()?;
 
         // Find information about the current user

--- a/xtask/src/commands/github_action.rs
+++ b/xtask/src/commands/github_action.rs
@@ -126,6 +126,6 @@ impl GithubActions {
             }
         };
 
-        Ok(tokio::time::timeout(WORKFLOW_RUN_TIMEOUT, fut).await??)
+        tokio::time::timeout(WORKFLOW_RUN_TIMEOUT, fut).await?
     }
 }

--- a/xtask/src/commands/github_action.rs
+++ b/xtask/src/commands/github_action.rs
@@ -36,8 +36,8 @@ pub struct GithubActions {
 
 impl GithubActions {
     pub async fn run(&self) -> Result<()> {
-        let github_token = std::env::var("GITHUB_TOKEN")
-            .map_err(|_err| anyhow!("$GITHUB_TOKEN is not set or is not valid UTF-8."))?;
+        let github_token = std::env::var("GITHUB_ACTIONS_TOKEN")
+            .map_err(|_err| anyhow!("$GITHUB_ACTIONS_TOKEN is not set or is not valid UTF-8."))?;
         let octocrab = OctocrabBuilder::new()
             .personal_token(github_token.clone())
             .build()?;

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use dist::Dist;
 pub(crate) use docs::Docs;
+pub(crate) use github_action::GithubActions;
 pub(crate) use integration_test::IntegrationTest;
 pub(crate) use lint::Lint;
 pub(crate) use package::Package;
@@ -11,6 +12,7 @@ pub(crate) use unit_test::UnitTest;
 
 pub(crate) mod dist;
 pub(crate) mod docs;
+pub(crate) mod github_action;
 pub(crate) mod integration_test;
 pub(crate) mod lint;
 pub(crate) mod package;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,6 +51,9 @@ pub enum Command {
     /// Run supergraph-demo with a local Rover build
     IntegrationTest(commands::IntegrationTest),
 
+    /// Trigger Github actions and wait for their completion
+    GithubActions(commands::GithubActions),
+
     /// Run a basic smoke test for rover dev
     Smoke(commands::Smoke),
 }
@@ -67,6 +70,9 @@ impl Xtask {
             Command::Prep(command) => command.run(),
             Command::Package(command) => command.run(),
             Command::SecurityChecks(command) => command.run(),
+            Command::GithubActions(command) => {
+                tokio::runtime::Runtime::new()?.block_on(command.run())
+            }
             Command::Smoke(command) => tokio::runtime::Runtime::new()?.block_on(command.run()),
         }?;
         eprintln!("{}", style("Success!").green().bold());


### PR DESCRIPTION
This triggers Github Actions from CircleCi, so we can continue to use CircleCI as the workflow orchestrator, but run x86 macOS jobs on Github.