### PR TITLE
fix(docs): make example for using `-` instead of filepath clearer

### DIFF
--- a/docs/source/conventions.md
+++ b/docs/source/conventions.md
@@ -73,4 +73,4 @@ Rover commands that take a file path as an option can instead accept input from 
 rover graph introspect http://localhost:4000 | rover graph check my-graph --schema -
 ```
 
-In this example, the schema returned by `graph introspect` is then passed as the `--schema` option to `graph check`.
+Notice the `-` after `--schema`. The schema returned by `graph introspect` is being passed as the `--schema` option to `graph check`, which normally takes a file rather than input from `stdin`.

--- a/docs/source/conventions.md
+++ b/docs/source/conventions.md
@@ -70,7 +70,8 @@ In this example, the schema returned by `graph fetch` is written to the file `sc
 Rover commands that take a file path as an option can instead accept input from `stdin`. To do so, pass `-` as the argument for the file path:
 
 ```
-rover graph introspect http://localhost:4000 | rover graph check my-graph --schema -
+rover graph introspect http://localhost:4000 \
+  | rover graph check my-graph --schema -
 ```
 
 Notice the `-` after `--schema`. The schema returned by `graph introspect` is being passed as the `--schema` option to `graph check`, which normally takes a file rather than input from `stdin`.


### PR DESCRIPTION
when rendered on the docs site, the `-` is easy to miss because of the little `copy` button, making the example hard to understand (I puzzled over it for a couple minutes)

<img width="699" alt="Screenshot 2024-07-09 at 1 38 18 PM" src="https://github.com/apollographql/rover/assets/26738844/c49f1256-0f44-4d0c-a6ee-5b73b0d9aa4b">
