### PR TITLE
fix(docs): add cpu arch to what we collect per command

### DIFF
--- a/docs/source/privacy.mdx
+++ b/docs/source/privacy.mdx
@@ -18,6 +18,7 @@ Unless you opt out, Rover reports the following data each time you run a command
 - A unique, anonymized **session identifier**, which is different for every command
 - The SHA-256 hash of the directory that `rover` was executed from
 - The operating system `rover` was executed on
+- The CPU architecture `rover` was executed on
 - The CI system `rover` was executed on, if any
 
 For more information on the data Apollo collects, see [our privacy policy](https://www.apollographql.com/Apollo-Privacy-Policy.pdf).


### PR DESCRIPTION
this recently changed, but I didn't think to update the docs