### PR TITLE
Fix `package.json` to a stable version when testing NPM installers

### DIFF
--- a/.circleci/scripts/install_npm.sh
+++ b/.circleci/scripts/install_npm.sh
@@ -8,6 +8,9 @@ echo "Created test directory"
 npm init -y
 echo "Initialised new npm package"
 cd "$SCRIPT_DIR/../../installers/npm"
+# The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
+# installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
+# to the latest commit exists.
 npm version --allow-same-version 0.23.0
 cd -
 echo "Temporarily patched package.json to fixed stable binary"

--- a/.circleci/scripts/install_npm.sh
+++ b/.circleci/scripts/install_npm.sh
@@ -7,6 +7,10 @@ cd "$(mktemp -d)"
 echo "Created test directory"
 npm init -y
 echo "Initialised new npm package"
+cd "$SCRIPT_DIR/../../installers/npm"
+npm version --allow-same-version 0.23.0
+cd -
+echo "Temporarily patched package.json to fixed stable binary"
 npm install --install-links=true "$SCRIPT_DIR/../../installers/npm"
 echo "Installed rover as local npm package"
 cd node_modules/.bin/

--- a/.circleci/scripts/install_npm.sh
+++ b/.circleci/scripts/install_npm.sh
@@ -2,19 +2,18 @@
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+INSTALLERS_DIR="$SCRIPT_DIR/../../installers/npm"
 
 cd "$(mktemp -d)"
 echo "Created test directory"
 npm init -y
 echo "Initialised new npm package"
-cd "$SCRIPT_DIR/../../installers/npm"
 # The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
 # installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
 # to the latest commit exists.
-npm version --allow-same-version 0.23.0
-cd -
+npm --prefix "$INSTALLERS_DIR" version --allow-same-version 0.23.0
 echo "Temporarily patched package.json to fixed stable binary"
-npm install --install-links=true "$SCRIPT_DIR/../../installers/npm"
+npm install --install-links=true "$INSTALLERS_DIR"
 echo "Installed rover as local npm package"
 cd node_modules/.bin/
 echo "Checking version"

--- a/.circleci/scripts/install_npm_global.sh
+++ b/.circleci/scripts/install_npm_global.sh
@@ -2,16 +2,16 @@
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+INSTALLERS_DIR="$SCRIPT_DIR/../../installers/npm"
 
 cd "$(mktemp -d)"
 echo "Created test directory"
-cd "$SCRIPT_DIR/../../installers/npm"
 # The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
 # installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
 # to the latest commit exists.
-npm version --allow-same-version 0.23.0
+npm version --prefix="$INSTALLERS_DIR" --allow-same-version 0.23.0
 echo "Temporarily patched package.json to fixed stable binary"
-npm install --install-links=true -g "$SCRIPT_DIR/../../installers/npm"
+npm install --install-links=true -g "$INSTALLERS_DIR"
 echo "Installed rover as global npm package"
 cd /usr/local/bin/
 echo "Checking version"

--- a/.circleci/scripts/install_npm_global.sh
+++ b/.circleci/scripts/install_npm_global.sh
@@ -6,6 +6,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$(mktemp -d)"
 echo "Created test directory"
 cd "$SCRIPT_DIR/../../installers/npm"
+# The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
+# installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
+# to the latest commit exists.
 npm version --allow-same-version 0.23.0
 echo "Temporarily patched package.json to fixed stable binary"
 npm install --install-links=true -g

--- a/.circleci/scripts/install_npm_global.sh
+++ b/.circleci/scripts/install_npm_global.sh
@@ -5,7 +5,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd "$(mktemp -d)"
 echo "Created test directory"
-npm install --install-links=true -g "$SCRIPT_DIR/../../installers/npm"
+cd "$SCRIPT_DIR/../../installers/npm"
+npm version --allow-same-version 0.23.0
+echo "Temporarily patched package.json to fixed stable binary"
+npm install --install-links=true -g
 echo "Installed rover as global npm package"
 cd /usr/local/bin/
 echo "Checking version"

--- a/.circleci/scripts/install_npm_global.sh
+++ b/.circleci/scripts/install_npm_global.sh
@@ -11,7 +11,7 @@ cd "$SCRIPT_DIR/../../installers/npm"
 # to the latest commit exists.
 npm version --allow-same-version 0.23.0
 echo "Temporarily patched package.json to fixed stable binary"
-npm install --install-links=true -g
+npm install --install-links=true -g "$SCRIPT_DIR/../../installers/npm"
 echo "Installed rover as global npm package"
 cd /usr/local/bin/
 echo "Checking version"

--- a/.circleci/scripts/install_pnpm.sh
+++ b/.circleci/scripts/install_pnpm.sh
@@ -2,18 +2,17 @@
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+INSTALLERS_DIR="$SCRIPT_DIR/../../installers/npm"
 
 cd "$(mktemp -d)"
 echo "Created test directory"
 npm install -g pnpm@v9.3.0
 echo "Installed pnpm"
-cd "$SCRIPT_DIR/../../installers/npm"
 # The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
 # installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
 # to the latest commit exists.
-npm version --allow-same-version 0.23.0
+npm --prefix "$INSTALLERS_DIR" version --allow-same-version 0.23.0
 echo "Temporarily patched package.json to fixed stable binary"
-cd -
 pnpm init
 pnpm add "file:$SCRIPT_DIR/../../installers/npm"
 echo "Installed rover as pnpm package"

--- a/.circleci/scripts/install_pnpm.sh
+++ b/.circleci/scripts/install_pnpm.sh
@@ -7,6 +7,10 @@ cd "$(mktemp -d)"
 echo "Created test directory"
 npm install -g pnpm@v9.3.0
 echo "Installed pnpm"
+cd "$SCRIPT_DIR/../../installers/npm"
+npm version --allow-same-version 0.23.0
+echo "Temporarily patched package.json to fixed stable binary"
+cd -
 pnpm init
 pnpm add "file:$SCRIPT_DIR/../../installers/npm"
 echo "Installed rover as pnpm package"

--- a/.circleci/scripts/install_pnpm.sh
+++ b/.circleci/scripts/install_pnpm.sh
@@ -8,6 +8,9 @@ echo "Created test directory"
 npm install -g pnpm@v9.3.0
 echo "Installed pnpm"
 cd "$SCRIPT_DIR/../../installers/npm"
+# The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
+# installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
+# to the latest commit exists.
 npm version --allow-same-version 0.23.0
 echo "Temporarily patched package.json to fixed stable binary"
 cd -


### PR DESCRIPTION
This way we can test what's actually important (how the installer works). Not whether the binary exists or not.