### PR TITLE
Fix Windows Installer Bug When No Arguments Presented & Add Testing To Ensure No Regressions

### DIFF
--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -48,7 +48,11 @@ function Download($version) {
 }
 
 function Invoke-Installer($tmp, $rover_install_args) {
-  & "$exe" "install" "$rover_install_args"
+  if (![string]::IsNullOrWhiteSpace($rover_install_args)) {
+    & "$exe" "install" "$rover_install_args"
+  } else {
+    & "$exe" "install"
+  }
   Remove-Item "$tmp" -Recurse -Force
 }
 


### PR DESCRIPTION
Fixes: #1928 

It seems that in certain situations whitespace is getting passed into the script and messing up the Rover install command. This fixes that by filtering out whitespace if it gets passed in.