### PR TITLE
Revert change to v2.8.2 to get passing CI back

### DIFF
--- a/examples/flyby/supergraphs/broken.yaml
+++ b/examples/flyby/supergraphs/broken.yaml
@@ -1,4 +1,5 @@
 # This supergraph composes from the two local subgraph schemas
+federation_version: =2.8.2
 subgraphs:
   locations:
     schema:

--- a/examples/flyby/supergraphs/file.yaml
+++ b/examples/flyby/supergraphs/file.yaml
@@ -1,4 +1,5 @@
 # This supergraph composes from the two local subgraph schemas
+federation_version: =2.8.2
 subgraphs:
   locations:
     schema:

--- a/examples/flyby/supergraphs/graphref.yaml
+++ b/examples/flyby/supergraphs/graphref.yaml
@@ -1,5 +1,6 @@
 # this supergraph.yaml is possible because we previously published the schemas to Apollo Studio's graph registry
 # when resolving the SDL for this supergraph, two `rover subgraph fetch` API calls are made
+federation_version: =2.8.2
 subgraphs:
   locations:
     schema:

--- a/examples/flyby/supergraphs/introspect.yaml
+++ b/examples/flyby/supergraphs/introspect.yaml
@@ -1,5 +1,6 @@
 # this supergraph composes by introspecting deployed graphs,
 # though typically introspection is disabled in production
+federation_version: =2.8.2
 subgraphs:
   locations:
     schema:

--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -3,7 +3,7 @@
     "repository": "https://github.com/apollographql/federation-rs",
     "versions": {
       "latest-0": "v0.37.1",
-      "latest-2": "v2.8.3"
+      "latest-2": "v2.8.2"
     }
   },
   "router": {


### PR DESCRIPTION
CI appears to now be failing when using v2.8.3 so reverting back until we can investigate