### PR TITLE
Add `--graph-ref` flag to `rover dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8db61fb3171a1c0f1949a322f222af6c07d9180e9184f9ae6709a88e356e5c"
+checksum = "c878d6a65db1ed770f90800962df612af8d374a0b6132343fe7d4a003b2d8c8e"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ apollo-parser = "0.7"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.13.0"
+apollo-federation-types = "0.13.1"
 
 # crates.io dependencies
 ariadne = "0.4"

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -93,7 +93,7 @@ pub struct SupergraphOpts {
     )]
     supergraph_config_path: Option<Utf8PathBuf>,
 
-    /// A graph ref that is accessible in Apollo Studio.
+    /// A [`GraphRef`] that is accessible in Apollo Studio.
     /// This is used to initialize your supergraph with the values contained in this variant.
     ///
     /// This is analogous to providing a supergraph.yaml file with references to your graph variant in studio.

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -1,8 +1,27 @@
+use std::net::IpAddr;
+
+use apollo_federation_types::config::FederationVersion;
+use camino::Utf8PathBuf;
+use clap::Parser;
+use rover_client::shared::GraphRef;
+use serde::Serialize;
+
+use crate::options::{OptionalSubgraphOpts, PluginOpts};
+
 #[cfg(feature = "composition-js")]
 mod compose;
 
 #[cfg(feature = "composition-js")]
+mod do_dev;
+
+#[cfg(feature = "composition-js")]
 mod introspect;
+
+#[cfg(feature = "composition-js")]
+mod protocol;
+
+#[cfg(feature = "composition-js")]
+mod remote_subgraphs;
 
 #[cfg(feature = "composition-js")]
 mod router;
@@ -11,26 +30,13 @@ mod router;
 mod schema;
 
 #[cfg(feature = "composition-js")]
-mod protocol;
-
-#[cfg(feature = "composition-js")]
 mod netstat;
-
-#[cfg(feature = "composition-js")]
-mod watcher;
-
-#[cfg(feature = "composition-js")]
-mod do_dev;
 
 #[cfg(not(feature = "composition-js"))]
 mod no_dev;
 
-use crate::options::{OptionalSubgraphOpts, PluginOpts};
-use std::net::IpAddr;
-
-use camino::Utf8PathBuf;
-use clap::Parser;
-use serde::Serialize;
+#[cfg(feature = "composition-js")]
+mod watcher;
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Dev {
@@ -86,6 +92,19 @@ pub struct SupergraphOpts {
         conflicts_with_all = ["subgraph_name", "subgraph_url", "subgraph_schema_path"]
     )]
     supergraph_config_path: Option<Utf8PathBuf>,
+
+    /// A graph ref that is accessible in Apollo Studio.
+    /// This is used to initialize your supergraph with the values contained in this variant.
+    ///
+    /// This is analogous to providing a supergraph.yaml file with references to your graph variant in studio.
+    ///
+    /// If used in conjunction with `--supergraph-config`, the values presented in the supergraph.yaml will take precedence over these values.
+    #[arg(long = "graph-ref")]
+    graph_ref: Option<GraphRef>,
+
+    /// The version of Apollo Federation to use for composition
+    #[arg(long = "federation-version")]
+    federation_version: Option<FederationVersion>,
 }
 
 lazy_static::lazy_static! {

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -112,7 +112,7 @@ impl LeaderSession {
         let mut router_runner = RouterRunner::new(
             router_config_handler.get_supergraph_schema_path(),
             router_config_handler.get_router_config_path(),
-            plugin_opts,
+            plugin_opts.clone(),
             router_socket_addr,
             router_config_handler.get_router_listen_path(),
             override_install_path,
@@ -403,6 +403,7 @@ impl LeaderSession {
             .map(|((name, url), sdl)| SubgraphDefinition::new(name, url.to_string(), sdl))
             .collect::<Vec<SubgraphDefinition>>()
             .into();
+
         supergraph_config.set_federation_version(self.federation_version.clone());
         supergraph_config
     }

--- a/src/command/dev/remote_subgraphs.rs
+++ b/src/command/dev/remote_subgraphs.rs
@@ -1,0 +1,55 @@
+use apollo_federation_types::config::{
+    FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
+};
+use rover_client::{
+    blocking::StudioClient,
+    operations::subgraph::{self, list::SubgraphListInput},
+    shared::GraphRef,
+};
+
+use crate::RoverResult;
+
+/// Nominal type that captures the behavior of collecting remote subgraphs into a
+/// [`SupergraphConfig`] representation
+#[derive(Clone, Debug)]
+pub struct RemoteSubgraphs(SupergraphConfig);
+
+impl RemoteSubgraphs {
+    /// Fetches [`RemoteSubgraphs`] from Studio
+    pub fn fetch(
+        client: &StudioClient,
+        federation_version: &FederationVersion,
+        graph_ref: &GraphRef,
+    ) -> RoverResult<RemoteSubgraphs> {
+        let subgraphs = subgraph::list::run(
+            SubgraphListInput {
+                graph_ref: graph_ref.clone(),
+            },
+            client,
+        )?;
+        let subgraphs = subgraphs
+            .subgraphs
+            .iter()
+            .map(|subgraph| {
+                (
+                    subgraph.name.clone(),
+                    SubgraphConfig {
+                        routing_url: subgraph.url.clone(),
+                        schema: SchemaSource::Subgraph {
+                            graphref: graph_ref.clone().to_string(),
+                            subgraph: subgraph.name.clone(),
+                        },
+                    },
+                )
+            })
+            .collect();
+        let supergraph_config = SupergraphConfig::new(subgraphs, Some(federation_version.clone()));
+        let remote_subgraphs = RemoteSubgraphs(supergraph_config);
+        Ok(remote_subgraphs)
+    }
+
+    /// Provides a reference to the inner value of this representation
+    pub fn inner(&self) -> &SupergraphConfig {
+        &self.0
+    }
+}


### PR DESCRIPTION
Adds `--graph-ref` to `rover dev` which builds a `SupergraphConfig` from Apollo Studio and optionally overrides its values with a supplied `supergraph.yaml`

Related Issue: https://github.com/apollographql/rover/issues/1494