### PR TITLE
ROVER-68 Ensure we always use correct Federation Version when Testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
       CHECK_GLIBC: "true"
+      LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
 
   arm_ubuntu: &arm_ubuntu_executor
@@ -46,6 +47,7 @@ executors:
     environment:
       XTASK_TARGET: "aarch64-unknown-linux-gnu"
       CHECK_GLIBC: "true"
+      LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
   amd_musl: &amd_musl_executor
     docker:
@@ -53,6 +55,7 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-musl"
+      LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
   amd_macos: &amd_macos_executor
     macos:
@@ -73,6 +76,7 @@ executors:
       XTASK_TARGET: "aarch64-apple-darwin"
       APPLE_TEAM_ID: "YQK948L752"
       APPLE_USERNAME: "opensource@apollographql.com"
+      LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
   amd_windows: &amd_windows_executor
     machine:
@@ -81,6 +85,7 @@ executors:
     shell: powershell.exe -ExecutionPolicy Bypass
     environment:
       XTASK_TARGET: "x86_64-pc-windows-msvc"
+      LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
   # This is only used to run supergraph-demo since you can't run Docker from Docker
   amd_ubuntu: &amd_ubuntu_executor
@@ -141,7 +146,7 @@ workflows:
           name: Run cargo tests + studio integration tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_manylinux, amd_musl, amd_macos, amd_windows]
+              platform: [amd_manylinux, amd_musl, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
 
@@ -182,7 +187,7 @@ workflows:
           name: Run cargo tests + studio integration tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_manylinux, amd_musl, amd_macos, amd_windows]
+              platform: [amd_manylinux, amd_musl, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *run_release
@@ -235,7 +240,7 @@ workflows:
           requires:
             - "Run cargo tests + studio integration tests (stable rust on amd_manylinux)"
             - "Run cargo tests + studio integration tests (stable rust on amd_musl)"
-            - "Run cargo tests + studio integration tests (stable rust on amd_macos)"
+            - "Run cargo tests + studio integration tests (stable rust on arm_macos)"
             - "Run cargo tests + studio integration tests (stable rust on amd_windows)"
             - "Run studio integration tests in GitHub Actions (amd_macos)"
             - "Run supergraph-demo tests (stable rust on amd_ubuntu)"

--- a/.github/scripts/get_latest_x_versions.sh
+++ b/.github/scripts/get_latest_x_versions.sh
@@ -1,0 +1,49 @@
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+
+VERSION_COUNT=$(($1))
+GITHUB_ORG=$2
+GITHUB_REPO=$3
+COMPONENT=$4
+VERSION_TAG=$5
+MAJOR_VERSION=$6
+
+>&2 echo "VERSION_COUNT is $VERSION_COUNT"
+>&2 echo "GITHUB_ORG is $GITHUB_ORG"
+>&2 echo "GITHUB_REPO is $GITHUB_REPO"
+>&2 echo "COMPONENT is $COMPONENT"
+>&2 echo "VERSION_TAG is $VERSION_TAG"
+>&2 echo "MAJOR_VERSION is $MAJOR_VERSION"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+LATEST_PLUGIN_VERSIONS_PATH="$SCRIPT_DIR/../../latest_plugin_versions.json"
+MAX_VERSION=$(jq -r --arg component "$COMPONENT" --arg version_tag "$VERSION_TAG" '.[$component].versions.[$version_tag] | sub("v";"")' < "$LATEST_PLUGIN_VERSIONS_PATH")
+>&2 echo "Max Version is: $MAX_VERSION"
+
+MAX_VERSION_FOUND=0
+declare -a FINAL_VERSIONS=()
+VERSIONS_FOUND=0
+
+RELEASES_URL="https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases?per_page=100"
+>&2 echo "Getting releases from $RELEASES_URL"
+RAW_VERSIONS=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "$RELEASES_URL")
+while read -r version; do
+  >&2 echo "Scanning version $version"
+  HIGHEST_VERSION=$(semver -c "$MAX_VERSION" "$version" | tail -1)
+  if [[ $HIGHEST_VERSION == "$MAX_VERSION" ]]; then
+      >&2 echo "Latest Version Found!"
+      MAX_VERSION_FOUND=1
+  fi;
+  if [ $MAX_VERSION_FOUND -eq 1 ]; then
+    if [ $VERSIONS_FOUND -lt $VERSION_COUNT ]; then
+      CLEAN_VERSION=$(semver -c "$version")
+      >&2 echo "Adding $CLEAN_VERSION to final list"
+      FINAL_VERSIONS+=("$CLEAN_VERSION")
+      (( VERSIONS_FOUND+=1 ))
+    else
+      break
+    fi
+  fi;
+done < <(echo "$RAW_VERSIONS" | jq -rc --arg major_version "v$MAJOR_VERSION" '[.[] | select((.name | contains("-") | not ) and (.name | contains($major_version)))] | .[].name  | sub("v";"")')
+
+jq -c -n '$ARGS.positional' --args -- "${FINAL_VERSIONS[@]}"

--- a/.github/workflows/run-smokes.yml
+++ b/.github/workflows/run-smokes.yml
@@ -9,17 +9,24 @@ jobs:
       router_versions: ${{ steps.router-versions.outputs.router_versions }}
       supergraph_versions: ${{ steps.supergraph-versions.outputs.supergraph_versions }}
     steps:
+      - uses: actions/checkout@v4
+        name: "Checkout rover repo"
       - run: |
-          JSON=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/apollographql/router/releases | jq -rc '[.[] | select((.name | contains("-") | not ) and (.name | contains("v")))] | [.[:3].[].name  | sub("v";"")]')
+          npm install -g semver
+        name: "Install `semver` cli"
+      - run: |
+          ls -al
+          JSON=$(source get_latest_x_versions.sh 3 apollographql router router latest-1 1)
           echo "router_versions=$JSON" >> "$GITHUB_OUTPUT"
         id: "router-versions"
-        shell: bash
+        working-directory: ".github/scripts"
         name: "Get latest Router versions"
       - run: |
-          JSON=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/apollographql/federation-rs/releases | jq -rc '[.[] | select((.name | contains("-") | not ) and (.name | contains("supergraph")))] | [.[:3].[].name | sub("supergraph@v";"")]')
+          ls -al
+          JSON=$(source get_latest_x_versions.sh 3 apollographql federation-rs supergraph latest-2 2)
           echo "supergraph_versions=$JSON" >> "$GITHUB_OUTPUT"
         id: "supergraph-versions"
-        shell: bash
+        working-directory: ".github/scripts"
         name: "Get latest Supergraph Plugin versions"
 
   run-smokes:

--- a/examples/flyby/supergraphs/broken.yaml
+++ b/examples/flyby/supergraphs/broken.yaml
@@ -1,5 +1,5 @@
 # This supergraph composes from the two local subgraph schemas
-federation_version: =2.8.2
+federation_version: 2
 subgraphs:
   locations:
     schema:

--- a/examples/flyby/supergraphs/file.yaml
+++ b/examples/flyby/supergraphs/file.yaml
@@ -1,5 +1,5 @@
 # This supergraph composes from the two local subgraph schemas
-federation_version: =2.8.2
+federation_version: 2
 subgraphs:
   locations:
     schema:

--- a/examples/flyby/supergraphs/graphref.yaml
+++ b/examples/flyby/supergraphs/graphref.yaml
@@ -1,6 +1,6 @@
 # this supergraph.yaml is possible because we previously published the schemas to Apollo Studio's graph registry
 # when resolving the SDL for this supergraph, two `rover subgraph fetch` API calls are made
-federation_version: =2.8.2
+federation_version: 2
 subgraphs:
   locations:
     schema:

--- a/examples/flyby/supergraphs/introspect.yaml
+++ b/examples/flyby/supergraphs/introspect.yaml
@@ -1,6 +1,6 @@
 # this supergraph composes by introspecting deployed graphs,
 # though typically introspection is disabled in production
-federation_version: =2.8.2
+federation_version: 2
 subgraphs:
   locations:
     schema:

--- a/examples/supergraph-demo/supergraph.yaml
+++ b/examples/supergraph-demo/supergraph.yaml
@@ -1,4 +1,4 @@
-federation_version: =2.4.3
+federation_version: 2
 subgraphs:
   products:
     routing_url: 'http://localhost:4002'

--- a/xtask/src/tools/mod.rs
+++ b/xtask/src/tools/mod.rs
@@ -1,3 +1,14 @@
+pub(crate) use cargo::CargoRunner;
+pub(crate) use git::GitRunner;
+#[cfg(not(windows))]
+pub(crate) use lychee::LycheeRunner;
+pub(crate) use make::MakeRunner;
+pub(crate) use npm::NpmRunner;
+pub(crate) use runner::Runner;
+pub(crate) use versions::LatestPluginVersions;
+#[cfg(target_os = "macos")]
+pub(crate) use xcrun::XcrunRunner;
+
 mod cargo;
 mod git;
 mod make;
@@ -7,17 +18,6 @@ mod runner;
 #[cfg(target_os = "macos")]
 mod xcrun;
 
-pub(crate) use cargo::CargoRunner;
-pub(crate) use git::GitRunner;
-pub(crate) use make::MakeRunner;
-pub(crate) use npm::NpmRunner;
-pub(crate) use runner::Runner;
-
-#[cfg(target_os = "macos")]
-pub(crate) use xcrun::XcrunRunner;
-
 #[cfg(not(windows))]
 mod lychee;
-
-#[cfg(not(windows))]
-pub(crate) use lychee::LycheeRunner;
+mod versions;

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::process::{Child, Command};
 use std::{fs, str};
@@ -172,7 +173,9 @@ impl NpmRunner {
         supergraphs_path.push("supergraphs");
         for dir_entry in fs::read_dir(supergraphs_path)? {
             let path = dir_entry.unwrap().path();
-            if path.extension().unwrap() == "yaml" {
+            if [OsString::from("yaml"), OsString::from("yml")]
+                .contains(&path.extension().unwrap().to_ascii_lowercase())
+            {
                 // Open the file once to pull out the data
                 let file = OpenOptions::new().read(true).open(&path)?;
                 let mut value: serde_yaml::Value = serde_yaml::from_reader(&file)?;

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -136,12 +136,12 @@ impl NpmRunner {
             || Fs::assert_path_exists(PKG_PROJECT_ROOT.join("examples").join("flyby").join(".env"))
                 .is_ok()
         {
-            if let Some(val) = std::env::var_os("USE_LATEST_FED_VERSION_FROM_FILE") {
+            if let Some(val) = std::env::var_os("LATEST_FED_VERSION_JSON_KEY") {
                 let json_key = match val.to_str() {
-                    Some("0") => "latest-0",
-                    Some("2") => "latest-2",
+                    Some("latest-0") => "latest-0",
+                    Some("latest-2") => "latest-2",
                     Some(_) | None => {
-                        info!("Environment variable USE_LATEST_FED_VERSION_FROM_FILE should only contain '0' or '2', could not read or misconfigured defaulting to '2'");
+                        info!("Environment variable LATEST_FED_VERSION_TO_USE_FROM_FILE should only contain 'latest-0' or 'latest-2', could not read or misconfigured defaulting to 'latest-2'");
                         "latest-2"
                     }
                 };

--- a/xtask/src/tools/versions.rs
+++ b/xtask/src/tools/versions.rs
@@ -1,0 +1,15 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LatestPluginVersions {
+    pub(crate) supergraph: Plugin,
+    router: Plugin,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Plugin {
+    pub(crate) versions: HashMap<String, String>,
+    repository: String,
+}


### PR DESCRIPTION
After the merge and rollback of bumping to `supergraph` v.2.8.3  (#1978 and #1982), there was some confusion as to why this wasn't picked up by CI _until the bump had been merged_. Turns out this is because Orbiter uses the `main` branch of the `rover` repo to know what the 'latest' version of the plugins should be, something I had not realised.

However, this leads to problems because the integration tests pick up the latest version **from main** not from the branch, so we end up in a situation where we cannot test changes to the `latest_plugin_versions` file until we merge to `main`. This PR fixes that for both the integration tests against Studio and the Smoke Tests, so we are always operating from the perspective of the state of the world the PR proposes, not the world as it actually is.

This should lead to us catching `router` and `supergraph` issues before they hit main because the Renovate PRs will fail rather than us finding out post-facto.

As an example see: https://circleci.com/gh/apollographql/rover/31971, where we emulated the bump to v2.8.3 of supergraph which broke our CI as was intended.