### PR TITLE
Minor Smoke Test Fixes

### DIFF
--- a/.github/workflows/run-smokes-manual.yml
+++ b/.github/workflows/run-smokes-manual.yml
@@ -1,0 +1,17 @@
+on:
+  workflow_dispatch:
+    inputs:
+      composition-versions:
+        description: 'JSON list of supergraph versions'
+        required: true
+        type: string
+      router-versions:
+        description: 'JSON list of router versions'
+        required: true
+        type: string
+jobs:
+  run-smokes:
+    uses: ./.github/workflows/smoke-test.yml
+    with:
+      composition-versions: ${{ inputs.composition-versions }}
+      router-versions: ${{ inputs.router-versions }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -104,5 +104,8 @@ jobs:
           ./${{ matrix.testing_target.binary_under_test }}/xtask smoke  --binary-path ./${{ matrix.testing_target.binary_under_test }}/rover --federation-version "${{ matrix.composition-version }}" --router-version "${{ matrix.router-version }}"
       - name: Run Smoke Tests (Windows)
         if: ${{ contains(matrix.testing_target.binary_under_test, 'windows')}}
+        # There appears to be an issue with `npm@10` running under Windows, this scales us back to `npm@9` where
+        # this appears to be fixed. GitHub Issue: https://github.com/npm/cli/issues/7308
         run: |
+          npm install -g npm@9.9.3
           .\${{ matrix.testing_target.binary_under_test }}\xtask.exe smoke  --binary-path .\${{ matrix.testing_target.binary_under_test }}\rover.exe --federation-version "${{ matrix.composition-version }}" --router-version "${{ matrix.router-version }}"


### PR DESCRIPTION
Put Windows back onto `npm9` to resolve a weird issue with caches on Windows, documented here: https://github.com/npm/cli/issues/7308

Also add the ability to manually invoke the smoke tests with given sets of versions for adhoc runs if required