### PR TITLE
Make brew update again when we run it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,9 +431,6 @@ commands:
               - equal: [*arm_macos_executor, << parameters.platform >>]
           steps:
             - run:
-                name: Skip homebrew update
-                command: echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
-            - run:
                 name: Install OpenSSL@1.1
                 command: brew install openssl@1.1
             - run:


### PR DESCRIPTION
If we don't we end up in situations where formulas to install are out of sync (as happened in this case with the formula for `xz`), further as not a lot of packages are installed the time hit here should be minimal.