### PR TITLE
feat(tests): e2e for `supergraph compose`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
  "predicates",
  "prettytable-rs",
  "rayon",
+ "regex",
  "reqwest 0.12.5",
  "robot-panic",
  "rover-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ httpmock = { workspace = true }
 mime = "0.3.17"
 portpicker = "0.1.1"
 predicates = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,74 @@
+# Tests
+
+This README is a work in progress. If anything is confusing or unclear, please open an issue or pull request!
+
+## End-to-end tests
+
+Our end-to-end tests can be run either locally or in GitHub. We use an example supergraph from Apollo Solutions called [retail supergraph](https://github.com/apollosolutions/retail-supergraph) as a basis for many of the tests.
+
+### Developing new end-to-end tests
+
+#### Windows and Unix
+
+We're developing for _both_ unix-based systems (Linux, MacOS) and Windows. This leads to some surprising things (like how environment variables are handled; you can't just prepend `SOME_VAR=` in powershell), which can be checked for by running the smoke tests (detailed below). 
+
+#### `RetailSupergraph`
+
+A struct with methods for interacting with the retail supergraph (e.g., getting subgraph names or URLs) and related metadata (e.g., the working directory where the retail supergraph was git cloned).  
+
+#### Fixtures
+
+Fixtures allow us to reuse either data or functionality across tests. We use [rstest](https://docs.rs/rstest/latest/rstest)'s [fixtures](https://docs.rs/rstest/latest/rstest/attr.fixture.html) and being familiar with that crate will be useful when developing tests for Rover.
+
+Some tests need subgraphs to be running (e.g., `rover dev`), but others don't. To use running subgraphs, use the `run_subgraphs_retail_supergraph` fixture. This fixture returns `RetailSupergraph` and the methods from that struct can be used in tests. See the `e2e/dev.rs` for an example.
+
+For those that only need certain data about the supergraph config, you can use the fixture `retail_supergraph`. See `e2e/supergraph/compose.rs` for an example.
+
+
+#### Fixtureless tests
+
+Some tests (like testing subcommand or option failures) don't need to use any fixture at all. That's okay! Don't feel like you need to add fixtures when they're irrelevant to your test. And, if a fixture's use doesn't make sense, raise a ticket so that we can either make it clearer in code or the documentation.
+
+
+### Locally
+
+#### Pre-requisites
+
+You'll need to be able to use `cargo` and have some familiarity with `cargo test`, but you'll also need to install NodeJS and Git because these are used to clone and then build and run a set of subgraphs that rover commands are issued against.
+
+#### Running the tests
+
+The following command runs our end-to-end tests, which are `ignored` intentionally because we don't want to run them along with all of our tests because that would slow down our local feedback loop tremendously:
+
+`cargo test e2e -- --ignored`
+
+Note: use `--nocapture` to get print statements:
+
+`cargo test e2e -- --ignored --nocapture`
+
+Particular tests can be targeted for a faster feedback loop:
+
+`cargo test e2e::supergraph::compose::it_fails_without_a_config -- --ignored --nocapture`
+
+#### ERRADDRINUSE
+
+Sometimes you'll see an error for the target address (localhost with some port) being in use. You can safely ignore these locally. When we first start the retail subgraphs, the same port gets used. Nodemon eventually gets things up and running and it's nothing about your code that's producing those errors (unless you're adding something new that uses ports and you've selected one already in use).
+
+### GitHub
+
+#### Manual smoke tests
+
+To run against our supported architectures and operating systems, go to the [manual smoke tests in GitHub Actions](https://github.com/apollographql/rover/actions/workflows/run-smokes-manual.yml), select `run workflow`, select your branch, and then use JSON arrays to specify the federation versions and router versions. Here's an example for a single federation version and a single router version:
+
+```
+["2.8.0"]
+["1.50.0"]
+```
+
+These would be input individually, which will make sense when you see the input prompt.
+
+
+#### Automatic smoke tests
+
+TBD :: we'll likely run the smoke tests against each commit in the future, but this isn't the current state of the world. So, use manual smoke tests for now.
+

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -10,20 +10,20 @@ use reqwest::Client;
 use rstest::*;
 use serde_json::{json, Value};
 use speculoos::assert_that;
-use tempfile::TempDir;
 use tokio::time::timeout;
 use tracing::error;
 use tracing_test::traced_test;
 
-use crate::e2e::{
-    run_subgraphs_retail_supergraph, test_graphql_connection, GRAPHQL_TIMEOUT_DURATION,
+use super::{
+    run_subgraphs_retail_supergraph, test_graphql_connection, RetailSupergraph,
+    GRAPHQL_TIMEOUT_DURATION,
 };
 
 const ROVER_DEV_TIMEOUT: Duration = Duration::from_secs(45);
 
 #[fixture]
 #[once]
-fn run_rover_dev(#[from(run_subgraphs_retail_supergraph)] working_dir: &TempDir) -> String {
+fn run_rover_dev(run_subgraphs_retail_supergraph: &RetailSupergraph) -> String {
     let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
     let port = pick_unused_port().expect("No ports free");
     let router_url = format!("http://localhost:{}", port);
@@ -40,7 +40,7 @@ fn run_rover_dev(#[from(run_subgraphs_retail_supergraph)] working_dir: &TempDir)
         "--elv2-license",
         "accept",
     ]);
-    cmd.current_dir(working_dir);
+    cmd.current_dir(run_subgraphs_retail_supergraph.get_working_directory());
     if let Ok(version) = env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION") {
         cmd.env("APOLLO_ROVER_DEV_COMPOSITION_VERSION", version);
     };

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
 use anyhow::Error;
+use camino::Utf8PathBuf;
 use dircpy::CopyBuilder;
 use duct::cmd;
 use git2::Repository;
@@ -19,60 +20,82 @@ use tracing::{info, warn};
 
 mod dev;
 mod subgraph;
+mod supergraph;
 
 const GRAPHQL_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Deserialize)]
-struct ReducedSupergraphConfig {
+pub struct RetailSupergraphConfig {
     subgraphs: HashMap<String, ReducedSubgraphConfig>,
 }
+
+#[derive(Debug)]
+pub struct RetailSupergraph<'a> {
+    retail_supergraph_config: RetailSupergraphConfig,
+    working_dir: Option<&'a TempDir>,
+}
+
 #[derive(Debug, Deserialize)]
 struct ReducedSubgraphConfig {
     routing_url: String,
 }
 
-impl ReducedSupergraphConfig {
-    pub fn get_subgraph_urls(self) -> Vec<String> {
-        self.subgraphs
+impl RetailSupergraph<'_> {
+    pub fn get_subgraph_urls(&self) -> Vec<String> {
+        self.retail_supergraph_config
+            .subgraphs
             .values()
             .map(|x| x.routing_url.clone())
             .collect()
     }
-}
 
-const RETAIL_SUPERGRAPH_SCHEMA_NAME: &'static str = "supergraph-config-dev.yaml";
+    pub fn get_subgraph_names(&self) -> Vec<String> {
+        self.retail_supergraph_config
+            .subgraphs
+            .keys()
+            .map(|name| name.clone())
+            .collect()
+    }
+
+    pub fn get_working_directory(&self) -> &TempDir {
+        self.working_dir.expect("no working directory")
+    }
+}
 
 #[fixture]
 #[once]
-fn run_subgraphs_retail_supergraph() -> TempDir {
+fn clone_retail_supergraph_repo() -> TempDir {
     info!("Cloning required git repository");
     // Clone the Git Repository that's needed to a temporary folder
-    let cloned_dir = TempDir::new().expect("Could not create temporary directory");
+    let working_dir = TempDir::new().expect("Could not create temporary directory");
     Repository::clone(
         "https://github.com/apollosolutions/retail-supergraph",
-        cloned_dir.path(),
+        working_dir.path(),
     )
     .expect("Could not clone supergraph repository");
-    // Jump into that temporary folder and run npm commands to kick off subgraphs
-    info!("Installing subgraph dependencies");
-    cmd!("npm", "install")
-        .dir(cloned_dir.path())
-        .run()
-        .expect("Could not install subgraph dependencies");
-    cmd!("npm", "install", "-g", "nodemon")
-        .dir(cloned_dir.path())
-        .run()
-        .expect("Could not install nodemon");
-    info!("Kicking off subgraphs");
+
+    working_dir
+}
+
+#[fixture]
+fn run_subgraphs_retail_supergraph(
+    retail_supergraph: &'static RetailSupergraph,
+) -> &'static RetailSupergraph<'static> {
+    println!("Kicking off subgraphs");
+
+    // Although the retail supergraph package.json has a `dev:subgraphs` script, windows can't
+    // recognize the `NODE_ENV=dev` preprended variable; so, we have to remake that command in a
+    // way that windows can understand
     let mut cmd = Command::new("npx");
     cmd.env("NODE_ENV", "dev");
-    cmd.args(["nodemon", "index.js"]).current_dir(&cloned_dir);
+    cmd.args(["nodemon", "index.js"])
+        .current_dir(retail_supergraph.get_working_directory());
     cmd.spawn().expect("Could not spawn subgraph process");
-    info!("Finding subgraph URLs");
-    let subgraph_urls =
-        get_supergraph_config(cloned_dir.path().join(RETAIL_SUPERGRAPH_SCHEMA_NAME))
-            .get_subgraph_urls();
-    info!("Testing subgraph connectivity");
+
+    println!("Finding subgraph URLs");
+    let subgraph_urls = retail_supergraph.get_subgraph_urls();
+
+    println!("Testing subgraph connectivity");
     for subgraph_url in subgraph_urls {
         tokio::task::block_in_place(|| {
             let client = Client::new();
@@ -85,8 +108,36 @@ fn run_subgraphs_retail_supergraph() -> TempDir {
         })
         .expect("Could not execute connectivity check");
     }
-    // Return the folder the subgraphs are in
-    cloned_dir
+    retail_supergraph
+}
+
+#[fixture]
+#[once]
+fn retail_supergraph(clone_retail_supergraph_repo: &'static TempDir) -> RetailSupergraph<'static> {
+    // Jump into that temporary folder and run npm commands to kick off subgraphs
+    info!("Installing subgraph dependencies");
+    cmd!("npm", "install")
+        .dir(clone_retail_supergraph_repo.path())
+        .run()
+        .expect("Could not install subgraph dependencies");
+
+    let supergraph_yaml_path = Utf8PathBuf::from_path_buf(
+        clone_retail_supergraph_repo
+            .path()
+            .join("supergraph-config-dev.yaml"),
+    )
+    .expect("Could not create path to config");
+
+    let content = std::fs::read_to_string(supergraph_yaml_path)
+        .expect("Could not read supergraph schema file");
+
+    let retail_supergraph_config: RetailSupergraphConfig =
+        serde_yaml::from_str(&content).expect("Could not parse supergraph schema file");
+
+    RetailSupergraph {
+        retail_supergraph_config,
+        working_dir: Some(clone_retail_supergraph_repo),
+    }
 }
 
 #[fixture]
@@ -155,10 +206,4 @@ async fn test_graphql_connection(
     .await?;
     info!("Established connection to {}", url);
     Ok(())
-}
-
-fn get_supergraph_config(supergraph_yaml_path: PathBuf) -> ReducedSupergraphConfig {
-    let content = std::fs::read_to_string(supergraph_yaml_path)
-        .expect("Could not read supergraph schema file");
-    serde_yaml::from_str(&content).expect("Could not parse supergraph schema file")
 }

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -10,26 +10,21 @@ use speculoos::assert_that;
 use tempfile::{Builder, TempDir};
 use tracing_test::traced_test;
 
-use crate::e2e::{
-    get_supergraph_config, run_single_mutable_subgraph, run_subgraphs_retail_supergraph,
-    RETAIL_SUPERGRAPH_SCHEMA_NAME,
-};
+use crate::e2e::{run_single_mutable_subgraph, run_subgraphs_retail_supergraph, RetailSupergraph};
 
 #[rstest]
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 async fn e2e_test_rover_subgraph_introspect(
-    #[from(run_subgraphs_retail_supergraph)] supergraph_dir: &TempDir,
+    run_subgraphs_retail_supergraph: &RetailSupergraph<'_>,
 ) {
     // Extract the inventory URL from the supergraph.yaml
-    let supergraph_config_path = supergraph_dir.path().join(RETAIL_SUPERGRAPH_SCHEMA_NAME);
-    let url = get_supergraph_config(supergraph_config_path)
-        .subgraphs
-        .get("inventory")
-        .unwrap()
-        .routing_url
-        .clone();
+    let url = run_subgraphs_retail_supergraph
+        .get_subgraph_urls()
+        .into_iter()
+        .find(|url| url.contains("inventory"))
+        .expect("failed to find the inventory routing URL");
 
     // Set up the command to output
     let out_file = Builder::new()

--- a/tests/e2e/supergraph/compose.rs
+++ b/tests/e2e/supergraph/compose.rs
@@ -1,0 +1,80 @@
+use std::process::Command;
+
+use assert_cmd::prelude::CommandCargoExt;
+use camino::Utf8PathBuf;
+use regex::RegexSet;
+use rstest::*;
+
+use crate::e2e::{retail_supergraph, RetailSupergraph};
+
+#[rstest]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn run_rover_supergraph(retail_supergraph: &RetailSupergraph<'_>) {
+    // GIVEN
+    //   - a supergraph config yaml (fixture)
+    //   - retail supergraphs representing any set of subgraphs to be composed into a supergraph
+    //   (fixture)
+    let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
+    cmd.args([
+        "supergraph",
+        "compose",
+        "--config",
+        "supergraph-config-dev.yaml",
+        "--output",
+        "composition-result",
+        "--elv2-license",
+        "accept",
+    ]);
+    cmd.current_dir(retail_supergraph.get_working_directory());
+
+    let match_set: Vec<String> = retail_supergraph
+        .get_subgraph_names()
+        .into_iter()
+        .map(|n| format!(r#"@join__graph\(name: "{n}"#))
+        .collect();
+
+    let re_set = RegexSet::new(&match_set).unwrap();
+
+    // WHEN
+    //   - `rover supergraph compose` is invoked with the supergraph yaml and a flag for writing
+    //   composition to disk
+    let res = cmd.spawn().expect("Could not run rover supergraph command");
+    let output = res.wait_with_output();
+    let composition_result_path = Utf8PathBuf::from_path_buf(
+        retail_supergraph
+            .get_working_directory()
+            .path()
+            .join("composition-result"),
+    )
+    .expect("failed to get composition result path");
+    let composition_result = std::fs::read_to_string(composition_result_path)
+        .expect("Could not read composition result file");
+    let matched: Vec<_> = re_set.matches(&composition_result).into_iter().collect();
+
+    // THEN
+    //   - a success code is returned
+    //   - the composition result is saved in the tmp dir
+    //   - the composition result joins all the graphs named in the supergraph config
+    assert!(output.is_ok_and(|code| code.status.success()));
+    assert_eq!(matched.len(), retail_supergraph.get_subgraph_names().len());
+}
+
+#[rstest]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn it_fails_without_a_config() {
+    // GIVEN
+    //   - an invocation of `rover supergraph compose` without any config file
+    let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
+    cmd.args(["supergraph", "compose"]);
+
+    // WHEN
+    //   - it's invoked
+    let res = cmd.spawn().expect("Could not run rover supergraph command");
+    let output = res.wait_with_output();
+
+    // THEN
+    //   - a failure  code is returned
+    assert!(output.is_ok_and(|code| { code.status.code() == Some(2) }));
+}

--- a/tests/e2e/supergraph/mod.rs
+++ b/tests/e2e/supergraph/mod.rs
@@ -1,0 +1,1 @@
+mod compose;


### PR DESCRIPTION
### notes
  - also includes a what turned from a light refactoring of the e2e mod into something heavier; by introducing a `RetailSupergraphMetadata` struct to carry data about the supergraph being tested, we can more easily contain shared methods (like getting subgraph urls, names) but also control when subgraphs are run (when locally developing on `supergraph compose`, I don't actually need anything more than the git-cloned repo). An atomic is used and rudimentary locks are introduced into the currently existing test files, which might be painful enough _not_ to go down the route here, but in practice I found it useful and think it'll help us expand our e2e tests with minimal friction
  - initial, wippy documentation on e2e tests