### PR TITLE
Fix up CODEOWNERS to bring us inline with standard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @apollographql/betelgeuse
-docs @apollographql/docs
+docs @apollographql/docs @apollographql/betelgeuse


### PR DESCRIPTION
Both Router and other repos have a model of ownership where Docs owners are pinged but are not required to approve PRs. This brings us into line with that standard, as per message from Maria

> Hey! Hmm, interesting. On the other repos (clients, router, etc.) the docs team are a sort of optional codeowner, i.e., we get pinged on .md/mdx changes, but our approvals aren’t required for a PR to merge. This has worked well—what are your thoughts on aligning the Rover repo to that standard?