### PR TITLE
fix(clients): use the `--client-timeout` flag as the period we allow retries with exponential backoff + jitter

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -11,22 +11,25 @@ use crate::error::{EndpointKind, RoverClientError};
 
 pub(crate) const JSON_CONTENT_TYPE: &str = "application/json";
 
-const MAX_ELAPSED_TIME: Option<Duration> =
-    Some(Duration::from_secs(if cfg!(test) { 2 } else { 10 }));
-
 /// Represents a generic GraphQL client for making http requests.
 pub struct GraphQLClient {
     graphql_endpoint: String,
     client: ReqwestClient,
+    retry_period: Option<Duration>,
 }
 
 impl GraphQLClient {
     /// Construct a new [Client] from a `graphql_endpoint`.
     /// This client is used for generic GraphQL requests, such as introspection.
-    pub fn new(graphql_endpoint: &str, client: ReqwestClient) -> GraphQLClient {
+    pub fn new(
+        graphql_endpoint: &str,
+        client: ReqwestClient,
+        retry_period: Option<Duration>,
+    ) -> GraphQLClient {
         GraphQLClient {
             graphql_endpoint: graphql_endpoint.to_string(),
             client,
+            retry_period,
         }
     }
 
@@ -151,7 +154,7 @@ impl GraphQLClient {
 
         if should_retry {
             let backoff_strategy = ExponentialBackoff {
-                max_elapsed_time: MAX_ELAPSED_TIME,
+                max_elapsed_time: self.retry_period,
                 ..Default::default()
             };
 
@@ -323,7 +326,11 @@ mod tests {
         });
 
         let client = ReqwestClient::new();
-        let graphql_client = GraphQLClient::new(&server.url(success_path), client);
+        let graphql_client = GraphQLClient::new(
+            &server.url(success_path),
+            client,
+            Some(Duration::from_secs(3)),
+        );
 
         let response = graphql_client.execute(
             "{}".to_string(),
@@ -348,7 +355,11 @@ mod tests {
         });
 
         let client = ReqwestClient::new();
-        let graphql_client = GraphQLClient::new(&server.url(internal_server_error_path), client);
+        let graphql_client = GraphQLClient::new(
+            &server.url(internal_server_error_path),
+            client,
+            Some(Duration::from_secs(3)),
+        );
 
         let response = graphql_client.execute(
             "{}".to_string(),
@@ -373,7 +384,11 @@ mod tests {
         });
 
         let client = ReqwestClient::new();
-        let graphql_client = GraphQLClient::new(&server.url(not_found_path), client);
+        let graphql_client = GraphQLClient::new(
+            &server.url(not_found_path),
+            client,
+            Some(Duration::from_secs(3)),
+        );
 
         let response = graphql_client.execute(
             "{}".to_string(),
@@ -405,7 +420,11 @@ mod tests {
             .timeout(Duration::from_secs(1))
             .build()
             .unwrap();
-        let graphql_client = GraphQLClient::new(&server.url(timeout_path), client);
+        let graphql_client = GraphQLClient::new(
+            &server.url(timeout_path),
+            client,
+            Some(Duration::from_secs(3)),
+        );
 
         let response = graphql_client.execute(
             "{}".to_string(),

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use houston::{Credential, CredentialOrigin};
+use std::time::Duration;
 
 use graphql_client::GraphQLQuery;
 use reqwest::blocking::Client as ReqwestClient;
@@ -27,10 +28,11 @@ impl StudioClient {
         version: &str,
         is_sudo: bool,
         client: ReqwestClient,
+        retry_period: Option<Duration>,
     ) -> StudioClient {
         StudioClient {
             credential,
-            client: GraphQLClient::new(graphql_endpoint, client),
+            client: GraphQLClient::new(graphql_endpoint, client, retry_period),
             version: version.to_string(),
             is_sudo,
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,6 +239,7 @@ impl Rover {
             config,
             is_sudo,
             self.get_reqwest_client_builder(),
+            Some(self.client_timeout.get_duration()),
         ))
     }
 

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -125,7 +125,7 @@ impl Dev {
             subgraph_watchers.into_iter().for_each(|mut watcher| {
                 std::thread::spawn(move || {
                     let _ = watcher
-                        .watch_subgraph_for_changes()
+                        .watch_subgraph_for_changes(client_config.retry_period)
                         .map_err(log_err_and_continue);
                 });
             });
@@ -166,7 +166,7 @@ impl Dev {
 
             // watch for subgraph changes on the main thread
             // it will take care of updating the main `rover dev` session
-            subgraph_refresher.watch_subgraph_for_changes()?;
+            subgraph_refresher.watch_subgraph_for_changes(client_config.retry_period)?;
         }
 
         unreachable!("watch_subgraph_for_changes never returns")

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -295,6 +295,7 @@ mod tests {
                 houston::Config::new(None::<&Utf8PathBuf>, None).unwrap(),
                 false,
                 ClientBuilder::new(),
+                Some(Duration::from_secs(3)),
             ),
         );
 

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use reqwest::blocking::Client;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use rover_client::{
     blocking::GraphQLClient,
@@ -20,17 +20,27 @@ pub struct Introspect {
 }
 
 impl Introspect {
-    pub fn run(&self, client: Client, output_opts: &OutputOpts) -> RoverResult<RoverOutput> {
+    pub fn run(
+        &self,
+        client: Client,
+        output_opts: &OutputOpts,
+        retry_period: Option<Duration>,
+    ) -> RoverResult<RoverOutput> {
         if self.opts.watch {
-            self.exec_and_watch(&client, output_opts)
+            self.exec_and_watch(&client, output_opts, retry_period)
         } else {
-            let sdl = self.exec(&client, true)?;
+            let sdl = self.exec(&client, true, retry_period)?;
             Ok(RoverOutput::Introspection(sdl))
         }
     }
 
-    pub fn exec(&self, client: &Client, should_retry: bool) -> RoverResult<String> {
-        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone());
+    pub fn exec(
+        &self,
+        client: &Client,
+        should_retry: bool,
+        retry_period: Option<Duration>,
+    ) -> RoverResult<String> {
+        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone(), retry_period);
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();
@@ -43,8 +53,13 @@ impl Introspect {
         Ok(introspect::run(GraphIntrospectInput { headers }, &client, should_retry)?.schema_sdl)
     }
 
-    pub fn exec_and_watch(&self, client: &Client, output_opts: &OutputOpts) -> ! {
+    pub fn exec_and_watch(
+        &self,
+        client: &Client,
+        output_opts: &OutputOpts,
+        retry_period: Option<Duration>,
+    ) -> ! {
         self.opts
-            .exec_and_watch(|| self.exec(client, false), output_opts)
+            .exec_and_watch(|| self.exec(client, false, retry_period), output_opts)
     }
 }

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -59,9 +59,11 @@ impl Graph {
             Command::Fetch(command) => command.run(client_config),
             Command::Lint(command) => command.run(client_config),
             Command::Publish(command) => command.run(client_config, git_context),
-            Command::Introspect(command) => {
-                command.run(client_config.get_reqwest_client()?, output_opts)
-            }
+            Command::Introspect(command) => command.run(
+                client_config.get_reqwest_client()?,
+                output_opts,
+                client_config.retry_period,
+            ),
         }
     }
 }

--- a/src/command/subgraph/introspect.rs
+++ b/src/command/subgraph/introspect.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use reqwest::blocking::Client;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use rover_client::{
     blocking::GraphQLClient,
@@ -18,17 +18,27 @@ pub struct Introspect {
 }
 
 impl Introspect {
-    pub fn run(&self, client: Client, output_opts: &OutputOpts) -> RoverResult<RoverOutput> {
+    pub fn run(
+        &self,
+        client: Client,
+        output_opts: &OutputOpts,
+        retry_period: Option<Duration>,
+    ) -> RoverResult<RoverOutput> {
         if self.opts.watch {
-            self.exec_and_watch(&client, output_opts)
+            self.exec_and_watch(&client, output_opts, retry_period)
         } else {
-            let sdl = self.exec(&client, true)?;
+            let sdl = self.exec(&client, true, retry_period)?;
             Ok(RoverOutput::Introspection(sdl))
         }
     }
 
-    pub fn exec(&self, client: &Client, should_retry: bool) -> RoverResult<String> {
-        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone());
+    pub fn exec(
+        &self,
+        client: &Client,
+        should_retry: bool,
+        retry_period: Option<Duration>,
+    ) -> RoverResult<String> {
+        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone(), retry_period);
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();
@@ -41,8 +51,13 @@ impl Introspect {
         Ok(introspect::run(SubgraphIntrospectInput { headers }, &client, should_retry)?.result)
     }
 
-    pub fn exec_and_watch(&self, client: &Client, output_opts: &OutputOpts) -> ! {
+    pub fn exec_and_watch(
+        &self,
+        client: &Client,
+        output_opts: &OutputOpts,
+        retry_period: Option<Duration>,
+    ) -> ! {
         self.opts
-            .exec_and_watch(|| self.exec(client, false), output_opts)
+            .exec_and_watch(|| self.exec(client, false, retry_period), output_opts)
     }
 }

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -61,9 +61,11 @@ impl Subgraph {
                 command.run(client_config, git_context, checks_timeout_seconds)
             }
             Command::Delete(command) => command.run(client_config),
-            Command::Introspect(command) => {
-                command.run(client_config.get_reqwest_client()?, output_opts)
-            }
+            Command::Introspect(command) => command.run(
+                client_config.get_reqwest_client()?,
+                output_opts,
+                client_config.retry_period,
+            ),
             Command::Fetch(command) => command.run(client_config),
             Command::Lint(command) => command.run(client_config),
             Command::List(command) => command.run(client_config),

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -116,6 +116,7 @@ pub struct StudioClientConfig {
     version: String,
     is_sudo: bool,
     client: Option<Client>,
+    pub(crate) retry_period: Option<Duration>,
 }
 
 impl StudioClientConfig {
@@ -124,6 +125,7 @@ impl StudioClientConfig {
         config: config::Config,
         is_sudo: bool,
         client_builder: ClientBuilder,
+        retry_period: Option<Duration>,
     ) -> StudioClientConfig {
         let version = if cfg!(debug_assertions) {
             format!("{} (dev)", PKG_VERSION)
@@ -138,6 +140,7 @@ impl StudioClientConfig {
             client_builder,
             is_sudo,
             client: None,
+            retry_period,
         }
     }
 
@@ -163,6 +166,7 @@ impl StudioClientConfig {
             &self.version,
             self.is_sudo,
             self.get_reqwest_client()?,
+            self.retry_period,
         ))
     }
 }

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -120,6 +120,7 @@ mod test_get_supergraph_config {
     use std::io::Write;
     use std::path::PathBuf;
     use std::str::FromStr;
+    use std::time::Duration;
 
     use apollo_federation_types::config::FederationVersion;
     use camino::Utf8PathBuf;
@@ -306,6 +307,7 @@ mod test_get_supergraph_config {
             config,
             false,
             ClientBuilder::default(),
+            Some(Duration::from_secs(3)),
         );
 
         let actual_result = if let Some(name) = local_subgraph {
@@ -635,6 +637,7 @@ mod test_resolve_supergraph_yaml {
     use std::io::Write;
     use std::path::PathBuf;
     use std::string::ToString;
+    use std::time::Duration;
 
     use anyhow::Result;
     use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
@@ -687,7 +690,13 @@ mod test_resolve_supergraph_yaml {
 
     #[fixture]
     fn client_config(config: Config) -> StudioClientConfig {
-        StudioClientConfig::new(None, config, false, ClientBuilder::default())
+        StudioClientConfig::new(
+            None,
+            config,
+            false,
+            ClientBuilder::default(),
+            Some(Duration::from_secs(3)),
+        )
     }
 
     #[fixture]
@@ -1079,6 +1088,7 @@ type _Service {\n  sdl: String\n}"#;
             config,
             false,
             ClientBuilder::default(),
+            Some(Duration::from_secs(3)),
         );
 
         let mut supergraph_config_path = tempfile::NamedTempFile::new()?;

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -436,8 +436,11 @@ pub(crate) fn resolve_supergraph_yaml(
                             .get_reqwest_client()
                             .map_err(RoverError::from)
                             .and_then(|reqwest_client| {
-                                let client =
-                                    GraphQLClient::new(subgraph_url.as_ref(), reqwest_client);
+                                let client = GraphQLClient::new(
+                                    subgraph_url.as_ref(),
+                                    reqwest_client,
+                                    client_config.retry_period,
+                                );
 
                                 // given a federated introspection URL, use subgraph introspect to
                                 // obtain SDL and add it to subgraph_definition.

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 mod config;
 mod dev;
 mod graph;
+mod options;
 mod subgraph;
 mod supergraph;
 

--- a/tests/e2e/options/client_timeout.rs
+++ b/tests/e2e/options/client_timeout.rs
@@ -36,7 +36,7 @@ async fn e2e_test_rover_client_timeout_option(
         "--name",
         "perf-subgraph-00",
         "--client-timeout",
-        "3",
+        &timeout.to_string(),
         &remote_supergraph_graphref,
     ]);
     cmd.output().expect("Could not run command");

--- a/tests/e2e/options/client_timeout.rs
+++ b/tests/e2e/options/client_timeout.rs
@@ -5,7 +5,6 @@ use rstest::*;
 
 use crate::e2e::remote_supergraph_graphref;
 
-// TODO: fill out status code ranges
 #[rstest]
 #[case::retries_500s(3, 500)]
 #[case::retries_429s(3, 429)]

--- a/tests/e2e/options/client_timeout.rs
+++ b/tests/e2e/options/client_timeout.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+
+use assert_cmd::prelude::CommandCargoExt;
+use rstest::*;
+
+use crate::e2e::remote_supergraph_graphref;
+
+// TODO: fill out status code ranges
+#[rstest]
+#[case::retries_500s(3, 500)]
+#[case::retries_429s(3, 429)]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_test_rover_client_timeout_option(
+    #[case] timeout: usize,
+    #[case] status_code: u16,
+    remote_supergraph_graphref: String,
+) {
+    // GIVEN
+    //   - a server returning a status code set dynamically via test case
+    //   - the rover binary
+    let server = httpmock::MockServer::start();
+    let mocked_route = server.mock(|when, then| {
+        when.any_request();
+        then.status(status_code);
+    });
+
+    let fake_registry = format!("http://{}/graphql", server.address().to_string());
+
+    // WHEN
+    //   - a command supporting the --client-timeout option is invoked
+    let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
+    cmd.env("APOLLO_REGISTRY_URL", fake_registry);
+    cmd.args([
+        "subgraph",
+        "fetch",
+        "--name",
+        "perf-subgraph-00",
+        "--client-timeout",
+        "3",
+        &remote_supergraph_graphref,
+    ]);
+    cmd.output().expect("Could not run command");
+
+    // THEN
+    //  - the number of calls is greater than the timeout. This is because the timeout is a
+    //  Duration for how long the client will live and we use that Duration as the _same_ Duration
+    //  for how long we'll retry. There being at least as many attempted calls as the timeout means
+    //  the crate we use, backoff, is doing its job in both retrying the call but also adding
+    //  expoential backoff and jitter; this works out for smaller timeouts, but after a certain
+    //  threshold of retries, enough backoff would be added to make the calls lower than the
+    //  overall timeout (understood as a number that gets used as seconds in a Duration)
+    let calls = mocked_route.hits();
+    assert!(calls >= timeout);
+}

--- a/tests/e2e/options/mod.rs
+++ b/tests/e2e/options/mod.rs
@@ -1,0 +1,1 @@
+mod client_timeout;

--- a/xtask/src/commands/prep/templates_schema.rs
+++ b/xtask/src/commands/prep/templates_schema.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::process::Command;
+use std::{collections::HashMap, time::Duration};
 
 use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
@@ -34,7 +34,11 @@ fn introspect() -> Result<String> {
         "fetching the latest templates schema by introspecting {}...",
         &graphql_endpoint
     );
-    let graphql_client = GraphQLClient::new(graphql_endpoint, Client::new());
+    let graphql_client = GraphQLClient::new(
+        graphql_endpoint,
+        Client::new(),
+        Some(Duration::from_secs(10)),
+    );
     introspect::run(
         GraphIntrospectInput {
             headers: HashMap::new(),


### PR DESCRIPTION
- we were _always_ defaulting our retries to 10s; that might have made sense in the synchronous world, but in the coming asynchronous world we can use the full time the client is alive for retries
- I don't love this approach with its passing-of-args-everywhere, but I made a ticket for a more thorough refactor rather than start going down that route now
- ~~**still adding tests**~~ I can't think of any more valuable tests to add, but definitely open to hearing what others might find useful here