### PR TITLE
ROVER-83 Add tests for `whoami`

### DIFF
--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -1,2 +1,0 @@
-pub mod api_key;
-pub mod profile;

--- a/tests/e2e/config/auth.rs
+++ b/tests/e2e/config/auth.rs
@@ -1,8 +1,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use rstest::rstest;
 
-#[test]
-fn it_has_a_config_profile_auth_command() {
+#[rstest]
+#[ignore]
+fn e2e_test_rover_auth_help() {
     let mut cmd = Command::cargo_bin("rover").unwrap();
     cmd.arg("config")
         .arg("auth")
@@ -11,8 +13,9 @@ fn it_has_a_config_profile_auth_command() {
         .success();
 }
 
-#[test]
-fn it_errors_on_an_empty_apikey() {
+#[rstest]
+#[ignore]
+fn e2e_test_rover_auth_fail_empty_api_key() {
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd.arg("config").arg("auth").write_stdin("").assert();
     result.stderr(predicate::str::contains("empty"));

--- a/tests/e2e/config/list.rs
+++ b/tests/e2e/config/list.rs
@@ -1,19 +1,21 @@
+use std::convert::TryFrom;
+
 use assert_cmd::Command;
-use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 use predicates::prelude::*;
+use rstest::rstest;
+use tempfile::TempDir;
 
 use houston::{Config, Profile};
 use rover::utils::env::RoverEnvKey;
 
-use std::convert::TryFrom;
-
 const CUSTOM_PROFILE: &str = "custom-profile";
 const CUSTOM_API_KEY: &str = "custom-api-key";
 
-#[test]
-fn it_can_list_no_profiles() {
-    let temp_dir = get_temp_dir();
+#[rstest]
+#[ignore]
+fn e2e_test_rover_config_list_empty() {
+    let temp_dir = Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap();
     let mut cmd = Command::cargo_bin("rover").unwrap();
     let result = cmd
         .arg("config")
@@ -23,9 +25,10 @@ fn it_can_list_no_profiles() {
     result.stderr(predicate::str::contains("No profiles"));
 }
 
-#[test]
-fn it_can_list_one_profile() {
-    let temp_dir = get_temp_dir();
+#[rstest]
+#[ignore]
+fn e2e_test_rover_config_list_one_profile() {
+    let temp_dir = Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap();
     let config = Config::new(Some(temp_dir.clone()).as_ref(), None).unwrap();
     Profile::set_api_key(CUSTOM_PROFILE, &config, CUSTOM_API_KEY).unwrap();
 
@@ -36,8 +39,4 @@ fn it_can_list_one_profile() {
         .arg("list")
         .assert();
     result.stdout(predicate::str::contains(CUSTOM_PROFILE));
-}
-
-fn get_temp_dir() -> Utf8PathBuf {
-    Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap()
 }

--- a/tests/e2e/config/mod.rs
+++ b/tests/e2e/config/mod.rs
@@ -1,0 +1,4 @@
+mod auth;
+mod list;
+
+mod whoami;

--- a/tests/e2e/config/whoami.rs
+++ b/tests/e2e/config/whoami.rs
@@ -1,0 +1,49 @@
+use assert_cmd::Command;
+use rstest::rstest;
+use serde::Deserialize;
+use serde_json::Value;
+use speculoos::assert_that;
+use speculoos::prelude::BooleanAssertions;
+use tempfile::Builder;
+
+#[derive(Deserialize, Debug)]
+#[allow(dead_code)]
+struct WhoAmIResponse {
+    api_key: String,
+    graph_id: Option<String>,
+    graph_title: Option<String>,
+    key_type: String,
+    origin: String,
+    success: bool,
+    user_id: Option<String>,
+}
+
+#[rstest]
+#[ignore]
+fn e2e_test_rover_config_whoami() {
+    let out_file = Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .expect("Could not create output file");
+
+    let mut cmd = Command::cargo_bin("rover").unwrap();
+    cmd.args([
+        "config",
+        "whoami",
+        "--format",
+        "json",
+        "--output",
+        out_file.path().to_str().unwrap(),
+    ])
+    .assert()
+    .success();
+
+    let response: Value =
+        serde_json::from_reader(out_file.as_file()).expect("Cannot read JSON from response file");
+    // In deserializing the response, we're proving that sensitive details are present without
+    // actually printing them
+    let deserialised_response: WhoAmIResponse =
+        serde_json::from_value(response["data"].clone()).unwrap();
+    // However we should assert on at least one just to double check that were' getting a sensible response
+    assert_that!(deserialised_response.success).is_true();
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -18,6 +18,7 @@ use tempfile::TempDir;
 use tokio::time::timeout;
 use tracing::{info, warn};
 
+mod config;
 mod dev;
 mod graph;
 mod subgraph;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,7 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-mod config;
 mod dev;
 mod output;
 mod schema;


### PR DESCRIPTION
In this PR I've added a test for `whoami` and also consolidated some of the other 'integration-like' tests into the End-To-End test framework. This is pointing towards an eventual demarkation where we have end-to-end tests and more traditional integration tests sitting side by side but this is gradual process that we'll move towards over time.