### PR TITLE
ROVER-79 Add E2E Test for `subgraph publish`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,6 +4340,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbd599a8c757f89100e3ae559fb1ef9efa1cfd9276136862e3089dec627b31"
+dependencies = [
+ "rand",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,6 +4632,8 @@ dependencies = [
  "portpicker",
  "predicates",
  "prettytable-rs",
+ "rand",
+ "rand_regex",
  "rayon",
  "regex",
  "reqwest 0.12.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,8 @@ indoc = { workspace = true }
 mime = "0.3.17"
 portpicker = "0.1.1"
 predicates = { workspace = true }
+rand = "0.8.5"
+rand_regex = "0.17.0"
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
 rstest = { workspace = true }

--- a/tests/e2e/artifacts/subgraph/perfSubgraph01.graphql
+++ b/tests/e2e/artifacts/subgraph/perfSubgraph01.graphql
@@ -1,0 +1,55 @@
+
+
+
+
+extend type PerfSubgraph00 @key(fields: "id") {
+	"""
+	ID of the GraphQL test object
+	"""
+	id: ID! @external
+	"""
+	Random test object
+	"""
+	perfSubgraph01(latencyMs: Int, size: Int): [PerfSubgraph01!]!
+}
+
+"""
+GraphQL test object for queries
+"""
+type PerfSubgraph01 @key(fields: "id") {
+	id: ID! @shareable
+	"""
+	Random name
+	"""
+	name(length: Int): String!
+	"""
+	Random array of names
+	"""
+	nameArray(size: Int, length: Int): [String!]!
+	"""
+	Random number
+	"""
+	number: Int!
+}
+
+type Query {
+	"""
+	Random test object
+	"""
+	perfSubgraph01(latencyMs: Int, size: Int): [PerfSubgraph01!]!
+}
+
+
+type Subscription {
+	"""
+	Yield test objects at the given interval
+	"""
+	perfSubgraph01(interval: Int!, size: Int): PerfSubgraph01!
+}
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+extend schema @link(
+	url: "https://specs.apollo.dev/federation/v2.3",
+	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective", "@interfaceObject"]
+)

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -214,7 +214,12 @@ async fn test_graphql_connection(
 
 #[fixture]
 fn remote_supergraph_graphref() -> String {
-    String::from("rover-e2e-tests")
+    String::from("rover-e2e-tests@current")
+}
+
+#[fixture]
+fn remote_supergraph_publish_test_variant_graphref() -> String {
+    String::from("rover-e2e-tests@publish-test")
 }
 #[fixture]
 fn test_artifacts_directory() -> PathBuf {

--- a/tests/e2e/subgraph/mod.rs
+++ b/tests/e2e/subgraph/mod.rs
@@ -1,3 +1,4 @@
 mod fetch;
 mod introspect;
 mod lint;
+mod publish;

--- a/tests/e2e/subgraph/publish.rs
+++ b/tests/e2e/subgraph/publish.rs
@@ -1,0 +1,134 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::str::from_utf8;
+
+use assert_cmd::prelude::CommandCargoExt;
+use rand::Rng;
+use rstest::rstest;
+use serde::Deserialize;
+use speculoos::assert_that;
+use speculoos::iter::ContainingIntoIterAssertions;
+use tracing::{error, info};
+use tracing_test::traced_test;
+
+use crate::e2e::{remote_supergraph_publish_test_variant_graphref, test_artifacts_directory};
+
+#[derive(Debug, Deserialize)]
+struct SubgraphListResponse {
+    data: Data,
+}
+
+#[derive(Debug, Deserialize)]
+struct Data {
+    subgraphs: Vec<Subgraph>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Subgraph {
+    name: String,
+}
+
+impl SubgraphListResponse {
+    fn get_subgraph_names(&self) -> Vec<String> {
+        self.data.subgraphs.iter().map(|s| s.name.clone()).collect()
+    }
+}
+
+#[rstest]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+async fn e2e_test_rover_subgraph_publish(
+    remote_supergraph_publish_test_variant_graphref: String,
+    test_artifacts_directory: PathBuf,
+) {
+    // Generate an identifier, so we won't have problems with re-using names etc.
+    // I appreciate that in theory it's possible there could be a clash here, however, there are
+    // 3.2 * 10^115 possibilities for identifiers, so I think for practical purposes we can
+    // consider these as unique.
+    let mut rng = rand::thread_rng();
+    let id_regex = rand_regex::Regex::compile("[a-zA-Z][a-zA-Z0-9_-]{0,63}", 100)
+        .expect("Could not compile regex");
+    let id: String = (&mut rng).sample::<String, &rand_regex::Regex>(&id_regex);
+    let schema_path = test_artifacts_directory.join("subgraph/perfSubgraph01.graphql");
+    info!("Using name {} for subgraph", &id);
+
+    // Grab the initial list of subgraphs to check that what we want doesn't already exist
+    let mut subgraph_list_cmd =
+        Command::cargo_bin("rover").expect("Could not find necessary binary");
+    subgraph_list_cmd.args([
+        "subgraph",
+        "list",
+        &remote_supergraph_publish_test_variant_graphref,
+        "--format",
+        "json",
+    ]);
+    let list_cmd_output = subgraph_list_cmd
+        .output()
+        .expect("Could not run initial list command");
+    let resp: SubgraphListResponse = serde_json::from_slice(list_cmd_output.stdout.as_slice())
+        .expect(&format!(
+            "Could not parse response to struct - Raw: {}",
+            from_utf8(list_cmd_output.stdout.as_slice()).unwrap()
+        ));
+    let initial_subgraphs = resp.get_subgraph_names();
+    assert_that(&initial_subgraphs).does_not_contain(&id);
+
+    // Construct a command to publish a new subgraph to a variant that's specifically for this
+    // purpose
+    info!("Creating subgraph with name {}", &id);
+    let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
+    cmd.args([
+        "subgraph",
+        "publish",
+        "--name",
+        &id,
+        "--schema",
+        schema_path.canonicalize().unwrap().to_str().unwrap(),
+        "--routing-url",
+        "https://eu-west-1.performance.graphoscloud.net/perfSubgraph01/graphql",
+        &remote_supergraph_publish_test_variant_graphref,
+    ]);
+    let output = cmd.output().expect("Could not run command");
+
+    if !output.status.success() {
+        error!("{}", String::from_utf8(output.stderr).unwrap());
+        panic!("Command did not complete successfully");
+    }
+
+    // Then ask for the list again and check the subgraph is there
+    let post_creation_output = subgraph_list_cmd
+        .output()
+        .expect("Could not run list command after creating new variant");
+    let post_creation_resp: SubgraphListResponse =
+        serde_json::from_slice(post_creation_output.stdout.as_slice())
+            .expect("Could not parse response to struct");
+    let final_subgraphs = post_creation_resp.get_subgraph_names();
+    assert_that(&final_subgraphs).contains(&id);
+
+    info!("Deleting subgraph with name {}", &id);
+    // Then issue a command to delete the subgraph so the state is clean
+    //
+    // I also appreciate this is not fool-proof, as if the test fails this will mean we are
+    // left with subgraphs lying around. In the future we should move to something like
+    // test-context (https://docs.rs/test-context/latest/test_context/) so that we get cleanup
+    // for free. Until then we can manually clean up if it becomes necessary.
+    // TODO: Replace rstest fixtures with test-context
+    let mut subgraph_delete_cmd =
+        Command::cargo_bin("rover").expect("Could not find necessary binary");
+    subgraph_delete_cmd.args([
+        "subgraph",
+        "delete",
+        "--name",
+        &id,
+        "--confirm",
+        &remote_supergraph_publish_test_variant_graphref,
+    ]);
+
+    let delete_output = subgraph_delete_cmd.output().expect("Could not run command");
+
+    if !delete_output.status.success() {
+        error!("{}", String::from_utf8(delete_output.stderr).unwrap());
+        panic!("Command did not complete successfully");
+    }
+}


### PR DESCRIPTION
Adds an end-to-end test for publishing a subgraph, using a special variant within Studio. This also tests `delete` by proxy as we attempt to clean up the subgraph after the fact.

I appreciate this isn't foolproof because if the test fails the cleanup will not happen, but short of transitioning all the tests to `test_context` which is planned, there's little we can do because of the way fixtures work in `rstest`.

Run through the smokes framework and all seems fine: https://github.com/apollographql/rover/actions/runs/10246941106 and inspecting in Studio we don't end up with lots of bits and pieces left over