### PR TITLE
feat(tests): Let E2Es message if scheduled run contains failures

### DIFF
--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -37,3 +37,20 @@ jobs:
       composition-versions: '${{ needs.calculate_correct_version_ranges.outputs.supergraph_versions }}'
       router-versions: '${{ needs.calculate_correct_version_ranges.outputs.router_versions }}'
     secrets: inherit
+
+  message-slack:
+    runs-on: ubuntu-24.04
+    needs: run-smokes
+    if: ${{ needs.run-smokes.outputs.status == 'failure' }}
+    steps:
+      - name: Send custom JSON data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "run_url": ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }},
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_E2E_TEST_FAILURE_WEBHOOK_URL }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,6 +9,10 @@ on:
         description: 'JSON list of router versions'
         required: true
         type: string
+    outputs:
+      status:
+        description: A single value that determines if this run of the smoke tests was a success or contained failures
+        value: ${{ jobs.results.outputs.status }}
 
 #TODO: When GitHub Actions supports ARM based Linux images for public repos: https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/ this will need to be added
 name: Smoke Tests
@@ -127,3 +131,21 @@ jobs:
           $E2E_BINARY=Get-ChildItem -Path .\${{ matrix.testing_target.binary_under_test }}\deps -File | Where-Object { $_.Name -like 'e2e-*.exe' } | ForEach-Object { $_.FullName }
           Write-Output "Found '$E2E_BINARY'"
           & $E2E_BINARY --ignored --nocapture
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [ smoke_tests ]
+    outputs:
+      status: ${{ steps.check_matrix.outputs.status }}
+    steps:
+      - run: |
+          echo "status=failure" >> $GITHUB_OUTPUT
+          exit 1
+        id: check_matrix
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}


### PR DESCRIPTION
Now we have E2E tests that run nightly, it would be much better to let them message us in Slack if there's a failure in the run. This PR implements that, by computing an aggregated status for the matrix run, passing it out of the re-usable workflow and then acting in the calling workflow.

Testing will be a bit challenging but we can improve on it over the next few days as I don't mind this taking a bit of time to roll out.