### PR TITLE
ROVER-97 Add support for contract variants

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -1,8 +1,7 @@
+use apollo_federation_types::build::BuildErrors;
 use thiserror::Error;
 
 use crate::shared::{CheckTaskStatus, CheckWorkflowResponse, GraphRef, LintResponse};
-
-use apollo_federation_types::build::BuildErrors;
 
 /// RoverClientError represents all possible failures that can occur during a client request.
 #[derive(Error, Debug)]
@@ -139,6 +138,11 @@ pub enum RoverClientError {
     /// was supplied.
     #[error("The variant `{graph_ref}` is a non-contract variant. This operation is only possible for contract variants.")]
     ExpectedContractVariant { graph_ref: GraphRef },
+
+    /// This error occurs when a request returns data as though it was both a contract and non-contract variant.
+    /// This usually indicates an error from studio, but is very unlikely to occur in practice
+    #[error("The graph `{graph_ref}` has returned a response indicating it is both a contract and non-contract variant.")]
+    ContractAndNonContractVariant { graph_ref: GraphRef },
 
     /// The API returned an invalid ChangeSeverity value
     #[error("Invalid ChangeSeverity.")]

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -139,11 +139,6 @@ pub enum RoverClientError {
     #[error("The variant `{graph_ref}` is a non-contract variant. This operation is only possible for contract variants.")]
     ExpectedContractVariant { graph_ref: GraphRef },
 
-    /// This error occurs when a request returns data as though it was both a contract and non-contract variant.
-    /// This usually indicates an error from studio, but is very unlikely to occur in practice
-    #[error("The graph `{graph_ref}` has returned a response indicating it is both a contract and non-contract variant.")]
-    ContractAndNonContractVariant { graph_ref: GraphRef },
-
     /// The API returned an invalid ChangeSeverity value
     #[error("Invalid ChangeSeverity.")]
     InvalidSeverity,

--- a/crates/rover-client/src/operations/subgraph/fetch_all/fetch_all_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/fetch_all_query.graphql
@@ -9,6 +9,15 @@ query SubgraphFetchAllQuery($graph_ref: ID!) {
           sdl
         }
       }
+      sourceVariant {
+        subgraphs {
+          name
+          url
+          activePartialSchema {
+            sdl
+          }
+        }
+      }
     }
   }
 }

--- a/crates/rover-client/src/operations/subgraph/fetch_all/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/runner.rs
@@ -1,6 +1,7 @@
 use graphql_client::*;
 
 use crate::blocking::StudioClient;
+use crate::shared::GraphRef;
 use crate::RoverClientError;
 
 use super::types::*;
@@ -37,68 +38,138 @@ fn get_subgraphs_from_response_data(
         None => Err(RoverClientError::GraphNotFound {
             graph_ref: input.graph_ref,
         }),
-        Some(SubgraphFetchAllGraphVariant::GraphVariant(variant)) => variant.subgraphs.map_or_else(
-            || {
-                Err(RoverClientError::ExpectedFederatedGraph {
-                    graph_ref: input.graph_ref,
-                    can_operation_convert: true,
-                })
-            },
-            |subgraphs| {
-                Ok(subgraphs
-                    .into_iter()
-                    .map(|subgraph| {
-                        Subgraph::builder()
-                            .name(subgraph.name.clone())
-                            .and_url(subgraph.url)
-                            .sdl(subgraph.active_partial_schema.sdl)
-                            .build()
-                    })
-                    .collect())
-            },
-        ),
+        Some(SubgraphFetchAllGraphVariant::GraphVariant(variant)) => {
+            extract_subgraphs_from_response(variant, input.graph_ref)
+        }
         _ => Err(RoverClientError::InvalidGraphRef),
+    }
+}
+fn extract_subgraphs_from_response(
+    value: SubgraphFetchAllQueryVariantOnGraphVariant,
+    graph_ref: GraphRef,
+) -> Result<Vec<Subgraph>, RoverClientError> {
+    match (value.subgraphs, value.source_variant) {
+        (None, None) => Err(RoverClientError::ExpectedFederatedGraph {
+            graph_ref,
+            can_operation_convert: true,
+        }),
+        (
+            None,
+            Some(SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant {
+                subgraphs: Some(subgraphs),
+            }),
+        ) => Ok(subgraphs
+            .into_iter()
+            .map(|subgraph| subgraph.into())
+            .collect()),
+        (Some(subgraphs), None) => Ok(subgraphs
+            .into_iter()
+            .map(|subgraph| subgraph.into())
+            .collect()),
+        _ => Err(RoverClientError::ContractAndNonContractVariant { graph_ref }),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use rstest::{fixture, rstest};
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     use crate::shared::GraphRef;
 
     use super::*;
 
+    const SDL: &'static str =
+        "extend type User @key(fields: \"id\") {\n  id: ID! @external\n  age: Int\n}\n";
+    const URL: &'static str = "http://my.subgraph.com";
+    const SUBGRAPH_NAME: &'static str = "accounts";
+
     #[rstest]
-    fn get_services_from_response_data_works(#[from(mock_input)] input: SubgraphFetchAllInput) {
-        let sdl = "extend type User @key(fields: \"id\") {\n  id: ID! @external\n  age: Int\n}\n"
-            .to_string();
-        let url = "http://my.subgraph.com".to_string();
-        let json_response = json!({
-            "variant": {
-                "__typename": "GraphVariant",
+    #[case::subgraphs_returned_direct_from_variant(json!(
+    {
+        "variant": {
+            "__typename": "GraphVariant",
+            "subgraphs": [
+                 {
+                    "name": SUBGRAPH_NAME,
+                    "url": URL,
+                    "activePartialSchema": {
+                        "sdl": SDL
+                     }
+                },
+            ],
+            "sourceVariant": null
+        }
+    }
+    ), Some(vec![Subgraph::builder().url(URL).sdl(SDL).name(SUBGRAPH_NAME).build()]))]
+    #[case::subgraphs_returned_via_source_variant(json!(
+    {
+        "variant": {
+            "__typename": "GraphVariant",
+            "subgraphs": null,
+            "sourceVariant": {
                 "subgraphs": [
-                    {
-                        "name": "accounts",
-                        "url": &url,
-                        "activePartialSchema": {
-                            "sdl": &sdl
-                        }
-                    },
+                {
+                    "name": SUBGRAPH_NAME,
+                    "url": URL,
+                    "activePartialSchema": {
+                        "sdl": SDL
+                    }
+                }
                 ]
             }
-        });
+        }
+    }), Some(vec![Subgraph::builder().url(URL).sdl(SDL).name(SUBGRAPH_NAME).build()]))]
+    #[case::no_subgraphs_returned_in_either_case(json!(
+    {
+        "variant": {
+            "__typename": "GraphVariant",
+            "subgraphs": null,
+            "sourceVariant": {
+                "subgraphs": null
+            }
+        }
+    }), None)]
+    #[case::subgraphs_returned_from_both_sides_of_the_query(json!(
+    {
+        "variant": {
+        "__typename": "GraphVariant",
+        "subgraphs": [
+            {
+                "name": SUBGRAPH_NAME,
+                "url": URL,
+                "activePartialSchema": {
+                    "sdl": SDL
+                }
+            }
+        ],
+        "sourceVariant": {
+            "subgraphs": [
+                {
+                    "name": SUBGRAPH_NAME,
+                    "url": URL,
+                    "activePartialSchema": {
+                        "sdl": SDL
+                    }
+                 }
+             ]
+        }
+    }
+    }), None)]
+    fn get_services_from_response_data_works(
+        #[from(mock_input)] input: SubgraphFetchAllInput,
+        #[case] json_response: Value,
+        #[case] expected_subgraphs: Option<Vec<Subgraph>>,
+    ) {
         let data: SubgraphFetchAllResponseData = serde_json::from_value(json_response).unwrap();
-        let expected_subgraph = Subgraph::builder()
-            .url(url)
-            .sdl(sdl)
-            .name("accounts".to_string())
-            .build();
         let output = get_subgraphs_from_response_data(input, data);
 
-        assert!(output.is_ok());
-        assert_eq!(output.unwrap(), vec![expected_subgraph]);
+        if expected_subgraphs.is_some() {
+            assert!(output.is_ok());
+            assert_eq!(output.unwrap(), expected_subgraphs.unwrap());
+        } else {
+            assert!(output.is_err());
+        };
     }
 
     #[rstest]

--- a/crates/rover-client/src/operations/subgraph/fetch_all/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/runner.rs
@@ -79,15 +79,7 @@ fn extract_subgraphs_from_response(
         // 3. If we get subgraphs back from both 'sides' of the query, we take the results from
         // querying the **graphVariant**, as this is closest to the original behaviour, before
         // we introduced the querying of the sourceVariant.
-        (Some(subgraphs), None)
-        | (
-            Some(subgraphs),
-            Some(SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant { subgraphs: None }),
-        )
-        | (
-            Some(subgraphs),
-            Some(SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant { subgraphs: Some(_) }),
-        ) => Ok(subgraphs
+        (Some(subgraphs), _) => Ok(subgraphs
             .into_iter()
             .map(|subgraph| subgraph.into())
             .collect()),

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -11,7 +11,7 @@ pub(crate) type SubgraphFetchAllGraphVariant =
     subgraph_fetch_all_query::SubgraphFetchAllQueryVariant;
 
 pub(crate) type SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant =
-    SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant;
+    subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant;
 pub(crate) type SubgraphFetchAllQueryVariantOnGraphVariant =
     subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariant;
 pub(crate) type QueryVariables = subgraph_fetch_all_query::Variables;

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -9,6 +9,11 @@ use super::runner::subgraph_fetch_all_query;
 pub(crate) type SubgraphFetchAllResponseData = subgraph_fetch_all_query::ResponseData;
 pub(crate) type SubgraphFetchAllGraphVariant =
     subgraph_fetch_all_query::SubgraphFetchAllQueryVariant;
+
+pub(crate) type SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant =
+    SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant;
+pub(crate) type SubgraphFetchAllQueryVariantOnGraphVariant =
+    subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariant;
 pub(crate) type QueryVariables = subgraph_fetch_all_query::Variables;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -37,5 +42,34 @@ impl From<Subgraph> for SubgraphConfig {
             routing_url: value.url,
             schema: SchemaSource::Sdl { sdl: value.sdl },
         }
+    }
+}
+
+impl From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSubgraphs>
+    for Subgraph
+{
+    fn from(
+        value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSubgraphs,
+    ) -> Self {
+        Subgraph::builder()
+            .name(value.name)
+            .and_url(value.url)
+            .sdl(value.active_partial_schema.sdl)
+            .build()
+    }
+}
+
+impl
+    From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantSubgraphs>
+    for Subgraph
+{
+    fn from(
+        value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantSubgraphs,
+    ) -> Self {
+        Subgraph::builder()
+            .name(value.name)
+            .and_url(value.url)
+            .sdl(value.active_partial_schema.sdl)
+            .build()
     }
 }

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -2,6 +2,9 @@ use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
 use buildstructor::Builder;
 use derive_getters::Getters;
 
+pub(crate) use subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariant;
+pub(crate) use subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant;
+
 use crate::shared::GraphRef;
 
 use super::runner::subgraph_fetch_all_query;
@@ -10,10 +13,6 @@ pub(crate) type SubgraphFetchAllResponseData = subgraph_fetch_all_query::Respons
 pub(crate) type SubgraphFetchAllGraphVariant =
     subgraph_fetch_all_query::SubgraphFetchAllQueryVariant;
 
-pub(crate) type SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant =
-    subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariant;
-pub(crate) type SubgraphFetchAllQueryVariantOnGraphVariant =
-    subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariant;
 pub(crate) type QueryVariables = subgraph_fetch_all_query::Variables;
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -315,7 +315,6 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                 RoverClientError::OrganizationNotFound { .. } => {
                     (Some(RoverErrorSuggestion::CheckGraphNameAndAuth), None)
                 }
-                RoverClientError::ContractAndNonContractVariant { .. } => (None, None),
             };
             return RoverErrorMetadata {
                 json_version: JsonVersion::default(),

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -1,17 +1,16 @@
-mod code;
-mod suggestion;
-
-pub use code::RoverErrorCode;
-pub use suggestion::RoverErrorSuggestion;
-
-use houston::HoustonProblem;
-use rover_client::{EndpointKind, RoverClientError};
-
-use crate::{options::JsonVersion, utils::env::RoverEnvKey};
-
 use std::env;
 
 use serde::Serialize;
+
+pub use code::RoverErrorCode;
+use houston::HoustonProblem;
+use rover_client::{EndpointKind, RoverClientError};
+pub use suggestion::RoverErrorSuggestion;
+
+use crate::{options::JsonVersion, utils::env::RoverEnvKey};
+
+mod code;
+mod suggestion;
 
 /// Metadata contains extra information about specific errors
 /// Currently this includes an optional error `Code`
@@ -316,6 +315,7 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                 RoverClientError::OrganizationNotFound { .. } => {
                     (Some(RoverErrorSuggestion::CheckGraphNameAndAuth), None)
                 }
+                RoverClientError::ContractAndNonContractVariant { .. } => (None, None),
             };
             return RoverErrorMetadata {
                 json_version: JsonVersion::default(),


### PR DESCRIPTION
Extend the GraphQL query to pull back a base variant as well and then coalesce that together into a single response later on. These should be mutually exclusive but in the worrying case they're not, Rover should error so that case should be covered. 

Have tested this against a contract variant locally and it pulls back/composes a supergraph schema as you'd expect it to, so am happy, though would much appreciate some more eyes on this to think through any corner cases that might arise.