### PR TITLE
Tightening up how we do Slack messaging

### DIFF
--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -5,6 +5,7 @@ on:
 name: "Run Smokes (Automated)"
 jobs:
   calculate_correct_version_ranges:
+    name: "Calculate Correct Version Ranges"
     runs-on: ubuntu-24.04
     outputs:
       router_versions: ${{ steps.router-versions.outputs.router_versions }}
@@ -31,6 +32,7 @@ jobs:
         name: "Get latest Supergraph Plugin versions"
 
   run-smokes:
+    name: "Run Smoke Tests"
     uses: ./.github/workflows/smoke-test.yml
     needs: calculate_correct_version_ranges
     with:
@@ -41,6 +43,7 @@ jobs:
   message-slack:
     runs-on: ubuntu-24.04
     needs: run-smokes
+    name: "Message Slack On Test Failure"
     if: ${{ needs.run-smokes.result == 'failure' }}
     steps:
       - name: Send custom JSON data to Slack workflow

--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -41,7 +41,7 @@ jobs:
   message-slack:
     runs-on: ubuntu-24.04
     needs: run-smokes
-    if: ${{ needs.run-smokes.outputs.status == 'failure' }}
+    if: ${{ needs.run-smokes.result == 'failure' }}
     steps:
       - name: Send custom JSON data to Slack workflow
         id: slack

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,10 +9,6 @@ on:
         description: 'JSON list of router versions'
         required: true
         type: string
-    outputs:
-      status:
-        description: A single value that determines if this run of the smoke tests was a success or contained failures
-        value: ${{ jobs.results.outputs.status }}
 
 #TODO: When GitHub Actions supports ARM based Linux images for public repos: https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/ this will need to be added
 name: Smoke Tests
@@ -73,7 +69,7 @@ jobs:
     needs: build_binaries
     name: Run smoke tests
     strategy:
-      max-parallel: 8
+      fail-fast: false
       matrix:
         composition-version: ${{ fromJSON(inputs.composition-versions) }}
         router-version: ${{ fromJSON(inputs.router-versions) }}
@@ -94,7 +90,6 @@ jobs:
             binary_under_test: aarch64-apple-darwin
     # x86-64 runner
     runs-on: ${{ matrix.testing_target.run_test_on }}
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         name: "Checkout rover repo"
@@ -131,21 +126,3 @@ jobs:
           $E2E_BINARY=Get-ChildItem -Path .\${{ matrix.testing_target.binary_under_test }}\deps -File | Where-Object { $_.Name -like 'e2e-*.exe' } | ForEach-Object { $_.FullName }
           Write-Output "Found '$E2E_BINARY'"
           & $E2E_BINARY --ignored --nocapture
-  results:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: Final Results
-    needs: [ smoke_tests ]
-    outputs:
-      status: ${{ steps.check_matrix.outputs.status }}
-    steps:
-      - run: |
-          echo "status=failure" >> $GITHUB_OUTPUT
-          exit 1
-        id: check_matrix
-        if: >-
-          ${{
-               contains(needs.*.result, 'failure')
-            || contains(needs.*.result, 'cancelled')
-            || contains(needs.*.result, 'skipped')
-          }}


### PR DESCRIPTION
Turns out we can use GitHub Actions features to do this better. If we remove `continue-on-error`, and replace it by turning off 'fail-fast', we get all the smoke tests to run which gives us all the errors, and the re-usable workflow gets a nice status.

We can then track the status in the calling workflow, and execute the Slack message on the back of that. Which is much nicer.

We can also remove the `max-parallelism` aspect because it was an incorrect attempt to fix a different problem and just makes the test run slower.