### PR TITLE
Add step to fail workflow if matrix branch fails

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -126,3 +126,23 @@ jobs:
           $E2E_BINARY=Get-ChildItem -Path .\${{ matrix.testing_target.binary_under_test }}\deps -File | Where-Object { $_.Name -like 'e2e-*.exe' } | ForEach-Object { $_.FullName }
           Write-Output "Found '$E2E_BINARY'"
           & $E2E_BINARY --ignored --nocapture
+  # It appears as though GitHub Actions mechanisms for handling errors within matrix job runs are... less than
+  # intuitive. There's an answer here (https://github.com/orgs/community/discussions/26822) that describes the
+  # fact that if any of the jobs in the matrix succeeds then the job is marked successful as well. So we
+  # have to intervene manually to ensure this job actually fails if any of the branches of the matrix fails.
+  #
+  # It might be the case we can simplify this as future GitHub Actions changes may render this obsolete, but for
+  # now this appears to be the only solution.
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [ smoke_tests ]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}


### PR DESCRIPTION
As comment indicates, GitHub Actions handling of matrices and the overall workflow result appears to be quite janky and not at all as you'd expect. So this adds a final job that will only run if we get failures, this will then cause the workflow to fail which will bubble up into the calling workflow.