### PR TITLE
(fix) xtask: blocking -> async

### DIFF
--- a/xtask/src/commands/prep/mod.rs
+++ b/xtask/src/commands/prep/mod.rs
@@ -21,7 +21,7 @@ pub struct Prep {
 impl Prep {
     pub async fn run(&self) -> Result<()> {
         if !self.offline {
-            main_schema::update()?;
+            main_schema::update().await?;
             templates_schema::update().await?;
         }
 


### PR DESCRIPTION
## Description

We missed the removal of the blocking client in `xtask` during the [asyncification](https://github.com/apollographql/rover/pull/2035). This PR fixes that.

```
 Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s
     Running `target/debug/xtask prep`
...
thread 'main' panicked at /Users/dan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.38.1/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Testing
`cargo xtask prep` does not panic.