### PR TITLE
Allow `rover dev` to utilise watching again

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -45,6 +45,7 @@ impl Dev {
                 .unwrap_or(FederationVersion::LatestFedTwo),
             client_config.clone(),
             &self.opts.plugin_opts.profile,
+            false,
         )
         .await?;
 

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -119,6 +119,7 @@ impl Compose {
             &self.opts.federation_version.clone().unwrap_or(LatestFedTwo),
             client_config.clone(),
             &self.opts.plugin_opts.profile,
+            true,
         )
         .await?
         // WARNING: remove this unwrap

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -77,9 +77,17 @@ pub async fn get_supergraph_config(
         None => None,
     };
     let supergraph_config = if let Some(file_descriptor) = &supergraph_config_path {
+        // Depending on the context we might want two slightly different kinds of SupergraphConfig.
         if create_static_config {
+            // In this branch we get a completely resolved config, so all the references in it are
+            // resolved to a concrete SDL that could be printed out to a user. This is what
+            // `supergraph compose` uses.
             Some(resolve_supergraph_yaml(file_descriptor, client_config, profile_opt).await?)
         } else {
+            // Alternatively, we might actually want a more dynamic object so that we can
+            // set up watchers on the subgraph sources. This branch is what `rover dev` uses.
+            // So we run the `expand` function only to hydrate the YAML into a series of objects,
+            // but we don't need to completely resolve all of those objects.
             let config = file_descriptor
                 .read_file_descriptor("supergraph config", &mut std::io::stdin())
                 .and_then(|contents| expand_supergraph_yaml(&contents))?;


### PR DESCRIPTION
Fixes a regression whereby `rover dev` was creating supergraph configs that were the same as those used by `supergraph compose`. This is incorrect because `rover dev`'s interpretation requires a dynamic config it can resolve consistently whereas `supergraph compose` wants a completely static config, so it can output it.