### PR TITLE
`rover dev`: add `--license` flag

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -57,6 +57,7 @@ impl Dev {
             self.opts.plugin_opts.clone(),
             &supergraph_config,
             router_config_handler,
+            self.opts.supergraph_opts.license.clone(),
         )
         .await?
         {

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -87,7 +87,7 @@ pub struct SupergraphOpts {
     ///
     /// For information on the format of this file, please see https://www.apollographql.com/docs/rover/commands/supergraphs/#yaml-configuration-file.
     #[arg(
-        long = "supergraph-config", 
+        long = "supergraph-config",
         conflicts_with_all = ["subgraph_name", "subgraph_url", "subgraph_schema_path"]
     )]
     supergraph_config_path: Option<FileDescriptorType>,
@@ -104,6 +104,12 @@ pub struct SupergraphOpts {
     /// The version of Apollo Federation to use for composition
     #[arg(long = "federation-version")]
     federation_version: Option<FederationVersion>,
+
+    /// The path to an offline enterprise license file.
+    ///
+    /// For more information, please see https://www.apollographql.com/docs/router/enterprise-features/#offline-enterprise-license
+    #[arg(long)]
+    license: Option<Utf8PathBuf>,
 }
 
 lazy_static::lazy_static! {

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -60,6 +60,7 @@ impl LeaderSession {
     /// Ok(Some(Self)) when successfully initiated
     /// Ok(None) when a LeaderSession already exists for that address
     /// Err(RoverError) when something went wrong.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         override_install_path: Option<Utf8PathBuf>,
         client_config: &StudioClientConfig,

--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -68,6 +68,7 @@ impl LeaderSession {
         plugin_opts: PluginOpts,
         supergraph_config: &Option<SupergraphConfig>,
         router_config_handler: RouterConfigHandler,
+        license: Option<Utf8PathBuf>,
     ) -> RoverResult<Option<Self>> {
         let raw_socket_name = router_config_handler.get_raw_socket_name();
         let router_socket_addr = router_config_handler.get_router_address();
@@ -116,6 +117,7 @@ impl LeaderSession {
             router_config_handler.get_router_listen_path(),
             override_install_path,
             client_config.clone(),
+            license,
         );
 
         let config_fed_version = supergraph_config

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -36,6 +36,7 @@ pub struct RouterRunner {
 }
 
 impl RouterRunner {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         supergraph_schema_path: Utf8PathBuf,
         router_config_path: Utf8PathBuf,

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -32,6 +32,7 @@ pub struct RouterRunner {
     client_config: StudioClientConfig,
     plugin_exe: Option<Utf8PathBuf>,
     router_handle: Option<BackgroundTask>,
+    license: Option<Utf8PathBuf>,
 }
 
 impl RouterRunner {
@@ -43,6 +44,7 @@ impl RouterRunner {
         router_listen_path: String,
         override_install_path: Option<Utf8PathBuf>,
         client_config: StudioClientConfig,
+        license: Option<Utf8PathBuf>,
     ) -> Self {
         Self {
             supergraph_schema_path,
@@ -54,6 +56,7 @@ impl RouterRunner {
             client_config,
             router_handle: None,
             plugin_exe: None,
+            license,
         }
     }
 
@@ -87,12 +90,18 @@ impl RouterRunner {
     }
 
     pub async fn get_command_to_spawn(&mut self) -> RoverResult<String> {
-        Ok(format!(
+        let mut command = format!(
             "{plugin_exe} --supergraph {supergraph} --hot-reload --config {config} --log trace --dev",
             plugin_exe = self.maybe_install_router().await?,
             supergraph = self.supergraph_schema_path.as_str(),
             config = self.router_config_path.as_str(),
-        ))
+        );
+
+        if let Some(license) = &self.license {
+            command.push_str(&format!(" --license {}", license));
+        }
+
+        Ok(command)
     }
 
     pub async fn wait_for_startup(&mut self, client: Client) -> RoverResult<()> {

--- a/src/command/dev/router/runner.rs
+++ b/src/command/dev/router/runner.rs
@@ -351,6 +351,7 @@ mod tests {
                 ClientBuilder::new(),
                 Some(Duration::from_secs(3)),
             ),
+            None,
         );
 
         // WHEN waiting for router startup


### PR DESCRIPTION
## Description

As requested in https://github.com/apollographql/rover/issues/1937, this PR adds the ability to pass along an offline enterprise license to the router when running `rover dev`. 