### PR TITLE
installers: add aarch64-unknown-linux-musl check

### DIFF
--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -118,12 +118,13 @@ get_architecture() {
             if has_required_glibc; then
                 local _ostype=unknown-linux-gnu
             else
+                local _ostype=unknown-linux-musl
+
                 # We do not currently release builds for aarch64-unknown-linux-musl
                 if [ "$_cputype" = aarch64 ]; then
-                    err "Unsupported platform: aarch64-unknown-linux-musl"
+                    err "Unsupported platform: aarch64-$_ostype"
                 fi
 
-                local _ostype=unknown-linux-musl
                 say "Downloading musl binary that does not include \`rover supergraph compose\`."
             fi
             ;;

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -118,6 +118,11 @@ get_architecture() {
             if has_required_glibc; then
                 local _ostype=unknown-linux-gnu
             else
+                # We do not currently release builds for aarch64-unknown-linux-musl
+                if [ "$_cputype" = aarch64 ]; then
+                    err "Unsupported platform: aarch64-unknown-linux-musl"
+                fi
+
                 local _ostype=unknown-linux-musl
                 say "Downloading musl binary that does not include \`rover supergraph compose\`."
             fi


### PR DESCRIPTION
## Description

As we do not currently release builds for `aarch64-unknown-linux-musl`, the nix installer script will currently fail to download a binary on this platform. This is most commonly seen  when running a Linux based Docker container on macOS.

This PR adds a check that returns early to prevent a download failure.

## Testing

Tested in a Docker container on macOS:
```
$ cat Dockerfile
FROM alpine
RUN apk add bash curl
ADD ./installers/binstall/scripts/nix/install.sh /tmp/install.sh
RUN /tmp/install.sh

$ docker build .
------
 > [4/4] RUN /tmp/install.sh:
0.086 This operating system does not support dynamic linking to glibc.
0.088 ERROR: Unsupported platform: aarch64-unknown-linux-musl
------
Dockerfile:4
--------------------
   2 |     RUN apk add bash curl
   3 |     ADD ./installers/binstall/scripts/nix/install.sh /tmp/install.sh
   4 | >>> RUN /tmp/install.sh
   5 |
--------------------
ERROR: failed to solve: process "/bin/sh -c /tmp/install.sh" did not complete successfully: exit code: 1
```