### PR TITLE
Move us to later Ubuntu images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
 
   arm_ubuntu: &arm_ubuntu_executor
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2004:2024.05.1
     resource_class: arm.large
     environment:
       XTASK_TARGET: "aarch64-unknown-linux-gnu"
@@ -90,7 +90,7 @@ executors:
   # This is only used to run supergraph-demo since you can't run Docker from Docker
   amd_ubuntu: &amd_ubuntu_executor
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2004:2024.05.1
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
CircleCI are removing support for older versions of these machine images so we should bring ourselves up to date to avoid it, this shouldn't change anything w.r.t `glibc` versions etc. because we're not changing the version of Ubuntu just the actual image we use.