### PR TITLE
feat: Display the results of custom check tasks

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -306,6 +306,15 @@ fn check_workflow_error_msg(check_response: &CheckWorkflowResponse) -> String {
         } else {
             None
         },
+        if let Some(custom_response) = &check_response.maybe_custom_response {
+            if custom_response.task_status == CheckTaskStatus::FAILED {
+                Some("custom")
+            } else {
+                None
+            }
+        } else {
+            None
+        },
     ]
     .iter()
     .filter_map(|&x| x)

--- a/crates/rover-client/src/operations/graph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/graph/check_workflow/check_workflow_query.graphql
@@ -42,6 +42,29 @@ query GraphCheckWorkflowQuery($graph_id: ID!, $workflow_id: ID!) {
             }
           }
         }
+        ... on CustomCheckTask {
+          result {
+            violations {
+              coordinate
+              level
+              message
+              rule
+              sourceLocations {
+                start {
+                  byteOffset
+                  column
+                  line
+                }
+                end {
+                  byteOffset
+                  column
+                  line
+                }
+                subgraphName
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -264,8 +264,7 @@ fn get_custom_response_from_result(
 ) -> Option<CustomCheckResponse> {
     match results {
         Some(result) => {
-            let mut violations = Vec::with_capacity(result.violations.len());
-            for violation in result.violations {
+            let violations: Vec<Violation> = result.violations.iter().map(|violation| {
                 let start_line = if let Some(source_locations) = &violation.source_locations {
                     if !source_locations.is_empty() {
                         Some(source_locations[0].start.line)
@@ -275,13 +274,13 @@ fn get_custom_response_from_result(
                 } else {
                     None
                 };
-                violations.push(Violation {
+                Violation {
                     level: violation.level.to_string(),
-                    message: violation.message,
+                    message: violation.message.clone(),
                     start_line,
-                    rule: violation.rule,
-                })
-            }
+                    rule: violation.rule.clone(),
+                }
+            }).collect();
             Some(CustomCheckResponse {
                 task_status: task_status.into(),
                 target_url,

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -264,23 +264,27 @@ fn get_custom_response_from_result(
 ) -> Option<CustomCheckResponse> {
     match results {
         Some(result) => {
-            let violations: Vec<Violation> = result.violations.iter().map(|violation| {
-                let start_line = if let Some(source_locations) = &violation.source_locations {
-                    if !source_locations.is_empty() {
-                        Some(source_locations[0].start.line)
+            let violations: Vec<Violation> = result
+                .violations
+                .iter()
+                .map(|violation| {
+                    let start_line = if let Some(source_locations) = &violation.source_locations {
+                        if !source_locations.is_empty() {
+                            Some(source_locations[0].start.line)
+                        } else {
+                            None
+                        }
                     } else {
                         None
+                    };
+                    Violation {
+                        level: violation.level.to_string(),
+                        message: violation.message.clone(),
+                        start_line,
+                        rule: violation.rule.clone(),
                     }
-                } else {
-                    None
-                };
-                Violation {
-                    level: violation.level.to_string(),
-                    message: violation.message.clone(),
-                    start_line,
-                    rule: violation.rule.clone(),
-                }
-            }).collect();
+                })
+                .collect();
             Some(CustomCheckResponse {
                 task_status: task_status.into(),
                 target_url,

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -5,16 +5,17 @@ use graphql_client::*;
 use crate::blocking::StudioClient;
 use crate::operations::graph::check_workflow::types::{CheckWorkflowInput, QueryResponseData};
 use crate::shared::{
-    CheckWorkflowResponse, Diagnostic, GraphRef, LintCheckResponse, OperationCheckResponse,
-    SchemaChange,
+    CheckWorkflowResponse, CustomCheckResponse, Diagnostic, GraphRef, LintCheckResponse,
+    OperationCheckResponse, SchemaChange, Violation,
 };
 use crate::RoverClientError;
 
 use self::graph_check_workflow_query::GraphCheckWorkflowQueryGraphCheckWorkflowTasksOn::{
-    LintCheckTask, OperationsCheckTask,
+    CustomCheckTask, LintCheckTask, OperationsCheckTask,
 };
 use self::graph_check_workflow_query::{
     CheckWorkflowStatus, CheckWorkflowTaskStatus,
+    GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnCustomCheckTaskResult,
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnLintCheckTaskResult,
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnOperationsCheckTaskResult,
 };
@@ -96,6 +97,12 @@ fn get_check_response_from_data(
         GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnLintCheckTaskResult,
     > = None;
 
+    let mut custom_status = None;
+    let mut custom_target_url = None;
+    let mut custom_result: Option<
+        GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnCustomCheckTaskResult,
+    > = None;
+
     for task in check_workflow.tasks {
         match task.on {
             OperationsCheckTask(typed_task) => {
@@ -112,6 +119,13 @@ fn get_check_response_from_data(
                 lint_target_url = task.target_url;
                 if let Some(result) = typed_task.result {
                     lint_result = Some(result)
+                }
+            }
+            CustomCheckTask(typed_task) => {
+                custom_status = Some(task.status);
+                custom_target_url = task.target_url;
+                if let Some(result) = typed_task.result {
+                    custom_result = Some(result)
                 }
             }
             _ => (),
@@ -138,6 +152,11 @@ fn get_check_response_from_data(
             lint_target_url,
             lint_result,
         ),
+        maybe_custom_response: get_custom_response_from_result(
+            custom_status,
+            custom_target_url,
+            custom_result,
+        ),
         maybe_proposals_response: None,
         maybe_downstream_response: None,
     };
@@ -160,6 +179,7 @@ fn get_target_url_from_data(data: QueryResponseData) -> Option<String> {
                 match task.on {
                     OperationsCheckTask(_) => target_url = task.target_url,
                     LintCheckTask(_) => target_url = task.target_url,
+                    CustomCheckTask(_) => target_url = task.target_url,
                     _ => (),
                 }
             }
@@ -231,6 +251,41 @@ fn get_lint_response_from_result(
                 diagnostics,
                 errors_count: result.stats.errors_count.unsigned_abs(),
                 warnings_count: result.stats.warnings_count.unsigned_abs(),
+            })
+        }
+        None => None,
+    }
+}
+
+fn get_custom_response_from_result(
+    task_status: Option<CheckWorkflowTaskStatus>,
+    target_url: Option<String>,
+    results: Option<GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnCustomCheckTaskResult>,
+) -> Option<CustomCheckResponse> {
+    match results {
+        Some(result) => {
+            let mut violations = Vec::with_capacity(result.violations.len());
+            for violation in result.violations {
+                let start_line = if let Some(source_locations) = &violation.source_locations {
+                    if !source_locations.is_empty() {
+                        Some(source_locations[0].start.line)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                violations.push(Violation {
+                    level: violation.level.to_string(),
+                    message: violation.message,
+                    start_line,
+                    rule: violation.rule,
+                })
+            }
+            Some(CustomCheckResponse {
+                task_status: task_status.into(),
+                target_url,
+                violations,
             })
         }
         None => None,

--- a/crates/rover-client/src/operations/graph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/types.rs
@@ -79,3 +79,15 @@ impl Display for graph_check_workflow_query::LintRule {
         Debug::fmt(self, f)
     }
 }
+
+impl fmt::Display for graph_check_workflow_query::ViolationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match &self {
+            graph_check_workflow_query::ViolationLevel::WARNING => "WARNING",
+            graph_check_workflow_query::ViolationLevel::ERROR => "ERROR",
+            graph_check_workflow_query::ViolationLevel::INFO => "INFO",
+            graph_check_workflow_query::ViolationLevel::Other(_) => "UNKNOWN",
+        };
+        write!(f, "{}", printable)
+    }
+}

--- a/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
@@ -59,6 +59,29 @@ query SubgraphCheckWorkflowQuery($workflowId: ID!, $graphId: ID!) {
             }
           }
         }
+        ... on CustomCheckTask {
+          result {
+            violations {
+              coordinate
+              level
+              message
+              rule
+              sourceLocations {
+                start {
+                  byteOffset
+                  column
+                  line
+                }
+                end {
+                  byteOffset
+                  column
+                  line
+                }
+                subgraphName
+              }
+            }
+          }
+        }
         ... on ProposalsCheckTask {
           didOverrideProposalsCheckTask
           proposalCoverage

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -417,8 +417,7 @@ fn get_custom_response_from_result(
 ) -> Option<CustomCheckResponse> {
     match results {
         Some(result) => {
-            let mut violations = Vec::with_capacity(result.violations.len());
-            for violation in result.violations {
+            let violations: Vec<Violation> = result.violations.iter().map(|violation| {
                 let start_line = if let Some(source_locations) = &violation.source_locations {
                     if !source_locations.is_empty() {
                         Some(source_locations[0].start.line)
@@ -428,13 +427,13 @@ fn get_custom_response_from_result(
                 } else {
                     None
                 };
-                violations.push(Violation {
+                Violation {
                     level: violation.level.to_string(),
-                    message: violation.message,
+                    message: violation.message.clone(),
                     start_line,
-                    rule: violation.rule,
-                })
-            }
+                    rule: violation.rule.clone(),
+                }
+            }).collect();
             Some(CustomCheckResponse {
                 task_status: task_status.into(),
                 target_url,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
@@ -82,3 +82,15 @@ impl Display for subgraph_check_workflow_query::LintRule {
         Debug::fmt(self, f)
     }
 }
+
+impl fmt::Display for subgraph_check_workflow_query::ViolationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match &self {
+            subgraph_check_workflow_query::ViolationLevel::WARNING => "WARNING",
+            subgraph_check_workflow_query::ViolationLevel::ERROR => "ERROR",
+            subgraph_check_workflow_query::ViolationLevel::INFO => "INFO",
+            subgraph_check_workflow_query::ViolationLevel::Other(_) => "UNKNOWN",
+        };
+        write!(f, "{}", printable)
+    }
+}

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -7,9 +7,10 @@ mod lint_response;
 
 pub use async_check_response::CheckRequestSuccessResult;
 pub use check_response::{
-    ChangeSeverity, CheckConfig, CheckTaskStatus, CheckWorkflowResponse, DownstreamCheckResponse,
-    LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel,
-    ProposalsCoverage, RelatedProposal, SchemaChange, ValidationPeriod,
+    ChangeSeverity, CheckConfig, CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse,
+    DownstreamCheckResponse, LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
+    ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange,
+    ValidationPeriod, Violation,
 };
 pub use fetch_response::{FetchResponse, Sdl, SdlType};
 pub use git_context::GitContext;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -680,9 +680,10 @@ mod tests {
             },
         },
         shared::{
-            ChangeSeverity, CheckTaskStatus, CheckWorkflowResponse, Diagnostic, LintCheckResponse,
-            OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel,
-            ProposalsCoverage, RelatedProposal, SchemaChange, Sdl, SdlType,
+            ChangeSeverity, CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse,
+            Diagnostic, LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
+            ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange, Sdl,
+            SdlType, Violation,
         },
     };
 
@@ -1011,6 +1012,18 @@ mod tests {
                     display_name: "Mock Proposal".to_string(),
                 }],
             }),
+            maybe_custom_response: Some(CustomCheckResponse {
+                task_status: CheckTaskStatus::PASSED,
+                target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/custom/1".to_string()),
+                violations:  vec![
+                    Violation {
+                        rule: "NAMING_CONVENTION".to_string(),
+                        level: "WARNING".to_string(),
+                        message: "Fields must use camelCase.".to_string(),
+                        start_line: Some(1),
+                    },
+                ],
+            }),
             maybe_downstream_response: None,
         };
 
@@ -1023,6 +1036,18 @@ mod tests {
                 "success": true,
                 "core_schema_modified": true,
                 "tasks": {
+                    "custom": {
+                        "target_url": "https://studio.apollographql.com/graph/my-graph/variant/current/custom/1",
+                        "task_status": "PASSED",
+                        "violations": [
+                            {
+                                "level": "WARNING",
+                                "message": "Fields must use camelCase.",
+                                "rule": "NAMING_CONVENTION",
+                                "start_line": 1
+                            },
+                        ],
+                    },
                     "operations": {
                         "task_status": "PASSED",
                         "target_url": "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1",
@@ -1143,6 +1168,18 @@ mod tests {
                     display_name: "Mock Proposal".to_string(),
                 }],
             }),
+            maybe_custom_response: Some(CustomCheckResponse {
+                task_status: CheckTaskStatus::FAILED,
+                target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/custom/1".to_string()),
+                violations:  vec![
+                    Violation {
+                        rule: "NAMING_CONVENTION".to_string(),
+                        level: "ERROR".to_string(),
+                        message: "Fields must use camelCase.".to_string(),
+                        start_line: Some(2),
+                    },
+                ],
+            }),
             maybe_downstream_response: None,
         };
 
@@ -1158,6 +1195,18 @@ mod tests {
                 "success": false,
                 "core_schema_modified": false,
                 "tasks": {
+                    "custom": {
+                        "target_url": "https://studio.apollographql.com/graph/my-graph/variant/current/custom/1",
+                        "task_status": "FAILED",
+                        "violations": [
+                            {
+                                "level": "ERROR",
+                                "message": "Fields must use camelCase.",
+                                "rule": "NAMING_CONVENTION",
+                                "start_line": 2
+                            },
+                        ],
+                    },
                     "operations": {
                         "task_status": "FAILED",
                         "target_url": "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1",
@@ -1217,7 +1266,7 @@ mod tests {
                 },
             },
             "error": {
-                "message": "The changes in the schema you proposed caused operation, linter and proposal checks to fail.",
+                "message": "The changes in the schema you proposed caused operation, linter, proposal and custom checks to fail.",
                 "code": "E043",
             }
         });


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

### Overview

We are adding a new implementation of the [CheckWorkflowTask](https://studio.apollographql.com/graph/apollo-platform/variant/main/schema/reference/interfaces/CheckWorkflowTask) interface to the platform API called [CustomCheckTask](https://studio.apollographql.com/graph/apollo-platform/variant/main/schema/reference/objects/CustomCheckTask)

This PR pulls in the schema changes to make the rover client aware of the new type, and adds the ability to print the results out in both table format or as json.

The changes made here are largely based on the prior art of adding the ProposalsCheckTask in this pr: https://github.com/apollographql/rover/pull/1768

### Testing

Returning these fields from the backend is still gated off by a feature flag, but I have been able to run this locally and see how things get printed out as well as expanded the unit tests for `--format=json`

Using the space below to show the examples I have of the different cases that custom check results can be returned.

Has results, passes with warnings
```
Custom Check [PASSED]:
Resulted in 11 violations.
┌─────────┬─────────────────────────────────────┬──────┬────────────────────────────────────────────────────────────────────────────────┐
│  Level  │                Rule                 │ Line │                                    Message                                     │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 2    │ type "Cart" must have exactly one non-nullable unique identifier.              │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 15   │ type "CartMutations" must have exactly one non-nullable unique identifier.     │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 15   │ Description is required for type "CartMutations"                               │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 21   │ type "CheckoutResult" must have exactly one non-nullable unique identifier.    │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 21   │ Description is required for type "CheckoutResult"                              │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 26   │ Description is required for type "Mutation"                                    │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 72   │ Description is required for type "Query"                                       │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/naming-convention   │ 95   │ Field "ProductByID" should be in camelCase format                              │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 103  │ type "ResultWithMessage" must have exactly one non-nullable unique identifier. │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 103  │ Description is required for type "ResultWithMessage"                           │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 108  │ Description is required for type "User"                                        │
└─────────┴─────────────────────────────────────┴──────┴────────────────────────────────────────────────────────────────────────────────┘
View custom check details at: https://studio-staging.apollographql.com/graph/REDATED/custom/db61e8b5-a4d2-4dc1-a3b4-b9b507c471c0
```

Fails with an ERROR
```
Custom Check [FAILED]:
Resulted in 11 violations.
┌─────────┬─────────────────────────────────────┬──────┬────────────────────────────────────────────────────────────────────────────────┐
│  Level  │                Rule                 │ Line │                                    Message                                     │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 2    │ type "Cart" must have exactly one non-nullable unique identifier.              │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 15   │ type "CartMutations" must have exactly one non-nullable unique identifier.     │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 15   │ Description is required for type "CartMutations"                               │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 21   │ type "CheckoutResult" must have exactly one non-nullable unique identifier.    │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 21   │ Description is required for type "CheckoutResult"                              │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 26   │ Description is required for type "Mutation"                                    │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 72   │ Description is required for type "Query"                                       │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ ERROR   │ @graphql-eslint/naming-convention   │ 95   │ Field "ProductByID" should be in camelCase format                              │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/strict-id-in-types  │ 103  │ type "ResultWithMessage" must have exactly one non-nullable unique identifier. │
│         │                                     │      │ Accepted name: id.                                                             │
│         │                                     │      │ Accepted type: ID.                                                             │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 103  │ Description is required for type "ResultWithMessage"                           │
├─────────┼─────────────────────────────────────┼──────┼────────────────────────────────────────────────────────────────────────────────┤
│ WARNING │ @graphql-eslint/require-description │ 108  │ Description is required for type "User"                                        │
└─────────┴─────────────────────────────────────┴──────┴────────────────────────────────────────────────────────────────────────────────┘
View custom check details at: https://studio-staging.apollographql.com/graph/REDACTED/custom/555aec3b-2076-45e4-b8f3-030f38f80dd5
error[E043]: The changes in the schema you proposed caused custom checks to fail.
        See https://www.apollographql.com/docs/graphos/delivery/schema-checks for more information on resolving check errors.
```

Fail with blank line number
```
Custom Check [FAILED]:
Resulted in 1 violation.
┌───────┬───────────────────────┬──────┬─────────────────────────────────────────────────────────┐
│ Level │         Rule          │ Line │                         Message                         │
├───────┼───────────────────────┼──────┼─────────────────────────────────────────────────────────┤
│ ERROR │ PULL_REQUEST_REQUIRED │      │ All schema changes must have an associated pull request │
└───────┴───────────────────────┴──────┴─────────────────────────────────────────────────────────┘
View custom check details at: https://studio-staging.apollographql.com/graph/REDACTED/custom/6c5a8d88-cff1-45d3-8dd1-1a9cc2f8c29a
error[E043]: The changes in the schema you proposed caused custom checks to fail.
        See https://www.apollographql.com/docs/graphos/delivery/schema-checks for more information on resolving check errors.
```


Failed but with no violations,
```
Custom Check [FAILED]:
Resulted in no violations.
View custom check details at: https://studio-staging.apollographql.com/graph/custom-check-test/variant/qa/custom/40cf0f99-9dcf-44eb-8379-db67fc15b5f9
error[E043]: The changes in the schema you proposed caused custom checks to fail.
        See https://www.apollographql.com/docs/graphos/delivery/schema-checks for more information on resolving check errors.
```

For older versions of rover that do not know about the new interface implementation, the fallback error response when a check fails will continue to show,
```
error[E043]: The changes in the schema you proposed resulted in an unknown check task to fail.
        See https://www.apollographql.com/docs/graphos/delivery/schema-checks for more information on resolving check errors.
```