### PR TITLE
Smoke Tests Bug Fixes

### DIFF
--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: run-smokes
     name: "Message Slack On Test Failure"
-    if: ${{ needs.run-smokes.result == 'failure' }}
+    if: ${{ failure() }}
     steps:
       - name: Send custom JSON data to Slack workflow
         id: slack

--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -2,7 +2,7 @@ on:
   schedule:
     - cron: '0 9 * * *'
 
-name: "Run Smokes (Automated)"
+name: "Run Smoke Tests (Automated)"
 jobs:
   calculate_correct_version_ranges:
     name: "Calculate Correct Version Ranges"

--- a/tests/e2e/graph/introspect.rs
+++ b/tests/e2e/graph/introspect.rs
@@ -109,7 +109,8 @@ async fn e2e_test_rover_graph_introspect_watch(
     schema_file
         .write(new_schema.as_bytes())
         .expect("Could not update schema");
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    child.kill().unwrap();
     // Get the new result
     out_file
         .seek(SeekFrom::Start(0))
@@ -131,6 +132,4 @@ async fn e2e_test_rover_graph_introspect_watch(
     asserting(&format!("changes which was {:?}, has no elements", changes))
         .that(&changes)
         .is_empty();
-
-    child.kill().unwrap();
 }

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -110,7 +110,8 @@ async fn e2e_test_rover_subgraph_introspect_watch(
     schema_file
         .write(new_schema.as_bytes())
         .expect("Could not update schema");
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    child.kill().unwrap();
     // Get the new result
     out_file
         .seek(SeekFrom::Start(0))
@@ -132,6 +133,4 @@ async fn e2e_test_rover_subgraph_introspect_watch(
     asserting(&format!("changes which was {:?}, has no elements", changes))
         .that(&changes)
         .is_empty();
-
-    child.kill().unwrap();
 }


### PR DESCRIPTION
We've seen some spurious smoke test failures recently because of being unable to decode the schema that comes back when its being watched. My hunch is that this is because we don't quite wait long enough in the test so this increases the timeout. To try and add some extra safety we also shutdown the `watch` command post-waiting so that the state of the file should be fixed before we attempt to read it. This should make this safer

This also includes a fix for the smoke tests so that Slack should actually get messaged when the workflow fails. Beforehand because it was relying on a state of the job looked up explicitly, if a job failed elsewhere it would cancel all other jobs so the messaging job would never run. However in this version and using the special `failure()` syntax we can run the messaging job whenever any task fails without it being skipped.

Green Smoke Test Run: https://github.com/apollographql/rover/actions/runs/10665653050