### PR TITLE
fix(compose): avoid misleading warning when `--output` is not specified

### DIFF
--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -213,8 +213,8 @@ impl Compose {
 
         // When the `--output` flag is used, we need a supergraph binary version that is at least
         // v2.9.0. We ignore that flag for composition when we have anything less than that
-        if output_file.is_some() && exact_version.major < 2
-            || (exact_version.major == 2 && exact_version.minor < 9)
+        if output_file.is_some()
+            && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
         {
             eprintln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", federation_version);
             output_file = None;


### PR DESCRIPTION
In Rover v2.6.1 (#2045) we added some logic to disable the `--output` flag and print a warning when the federation version is less than 2.9.

Due to a precedence error, the warning also prints when the federation version is a 2.x version less than 2.9 and the `--output` flag is *not* provided. The only negative effect is a confusing error being printed, as `output_file = None` is a no-op in this case.
