### PR TITLE
fix(compose, dev): improve `--graph-ref` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,16 +158,16 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c878d6a65db1ed770f90800962df612af8d374a0b6132343fe7d4a003b2d8c8e"
+checksum = "bd88512dea257880f1e47d5541d14ba8a573b267fdc54af78f1b0bfdd3b73861"
 dependencies = [
  "camino",
  "log",
  "semver",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "serde_yaml 0.8.26",
  "thiserror",
  "url",
@@ -1434,16 +1434,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
@@ -1473,20 +1463,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.9.3",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1525,17 +1501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
 ]
@@ -3377,7 +3342,7 @@ dependencies = [
  "ring",
  "secrecy",
  "serde",
- "serde_with 3.9.0",
+ "serde_with",
  "shellexpand",
  "thiserror",
  "tokio",
@@ -5075,16 +5040,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
@@ -5097,20 +5052,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.9.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.13.1"
+apollo-federation-types = "0.13.2"
 
 # crates.io dependencies
 ariadne = "0.4"
@@ -72,7 +72,7 @@ assert_cmd = "2"
 assert-json-diff = "2"
 anyhow = "1"
 backtrace = "0.3"
-backoff = { version = "0.4", features = [ "tokio" ]}
+backoff = { version = "0.4", features = ["tokio"] }
 base64 = "0.22"
 billboard = "0.2"
 buildstructor = "0.5.4"
@@ -102,7 +102,9 @@ interprocess = { version = "2", default-features = false }
 indoc = "2"
 lazycell = "1"
 lazy_static = "1.4"
-notify = { version = "6", default-features = false, features = ["macos_kqueue"] }
+notify = { version = "6", default-features = false, features = [
+    "macos_kqueue",
+] }
 notify-debouncer-full = "0.3.1"
 opener = "0.7"
 os_info = "3.7"
@@ -201,7 +203,7 @@ assert_fs = { workspace = true }
 assert-json-diff = { workspace = true }
 dircpy = "0.3.19"
 duct = "0.13.7"
-git2 = { workspace = true, features = ["https"]}
+git2 = { workspace = true, features = ["https"] }
 graphql-schema-diff = "0.2.0"
 httpmock = { workspace = true }
 indoc = { workspace = true }

--- a/crates/rover-client/src/operations/subgraph/fetch_all/fetch_all_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/fetch_all_query.graphql
@@ -9,12 +9,28 @@ query SubgraphFetchAllQuery($graph_ref: ID!) {
           sdl
         }
       }
+      latestLaunch {
+        buildInput {
+          __typename
+          ... on CompositionBuildInput {
+            version
+          }
+        }
+      }
       sourceVariant {
         subgraphs {
           name
           url
           activePartialSchema {
             sdl
+          }
+        }
+        latestLaunch {
+          buildInput {
+            __typename
+            ... on CompositionBuildInput {
+              version
+            }
           }
         }
       }

--- a/crates/rover-client/src/operations/subgraph/fetch_all/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/mod.rs
@@ -2,4 +2,4 @@ mod runner;
 mod types;
 
 pub use runner::run;
-pub use types::SubgraphFetchAllInput;
+pub use types::{SubgraphFetchAllInput, SubgraphFetchAllResponse};

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -93,7 +93,10 @@ impl From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLa
         value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunch,
     ) -> Self {
         if let OuterCompositionBuildInput(composition_build_input) = value.build_input {
-            composition_build_input.version.as_ref().and_then(|v| FederationVersion::from_str(&("=".to_owned() + v)).ok())
+            composition_build_input
+                .version
+                .as_ref()
+                .and_then(|v| FederationVersion::from_str(&("=".to_owned() + v)).ok())
         } else {
             None
         }

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -11,6 +11,11 @@ use crate::shared::GraphRef;
 
 use super::runner::subgraph_fetch_all_query;
 
+use subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunchBuildInput::CompositionBuildInput
+  as OuterCompositionBuildInput;
+use subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantLatestLaunchBuildInput::CompositionBuildInput
+  as InnerCompositionBuildInput;
+
 pub(crate) type SubgraphFetchAllResponseData = subgraph_fetch_all_query::ResponseData;
 pub(crate) type SubgraphFetchAllGraphVariant =
     subgraph_fetch_all_query::SubgraphFetchAllQueryVariant;
@@ -87,7 +92,7 @@ impl From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLa
     fn from(
         value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunch,
     ) -> Self {
-        if let subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunchBuildInput::CompositionBuildInput(composition_build_input) = value.build_input {
+        if let OuterCompositionBuildInput(composition_build_input) = value.build_input {
             composition_build_input.version.as_ref().and_then(|v| FederationVersion::from_str(&("=".to_owned() + v)).ok())
         } else {
             None
@@ -101,7 +106,7 @@ impl From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSo
     fn from(
         value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantLatestLaunch,
     ) -> Self {
-        if let subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantLatestLaunchBuildInput::CompositionBuildInput(composition_build_input) = value.build_input {
+        if let InnerCompositionBuildInput(composition_build_input) = value.build_input {
             composition_build_input.version.as_ref().and_then(|v| FederationVersion::from_str(&("=".to_owned() + v)).ok())
         } else {
             None

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -1,4 +1,6 @@
-use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
+use std::str::FromStr;
+
+use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
 use buildstructor::Builder;
 use derive_getters::Getters;
 
@@ -26,6 +28,12 @@ impl From<SubgraphFetchAllInput> for QueryVariables {
             graph_ref: input.graph_ref.to_string(),
         }
     }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SubgraphFetchAllResponse {
+    pub subgraphs: Vec<Subgraph>,
+    pub federation_version: Option<FederationVersion>,
 }
 
 #[derive(Clone, Builder, Debug, Eq, Getters, PartialEq)]
@@ -70,5 +78,33 @@ impl
             .and_url(value.url)
             .sdl(value.active_partial_schema.sdl)
             .build()
+    }
+}
+
+impl From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunch>
+    for Option<FederationVersion>
+{
+    fn from(
+        value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunch,
+    ) -> Self {
+        if let subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantLatestLaunchBuildInput::CompositionBuildInput(composition_build_input) = value.build_input {
+            composition_build_input.version.as_ref().and_then(|v| FederationVersion::from_str(&("=".to_owned() + v)).ok())
+        } else {
+            None
+        }
+    }
+}
+
+impl From<subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantLatestLaunch>
+    for Option<FederationVersion>
+{
+    fn from(
+        value: subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantLatestLaunch,
+    ) -> Self {
+        if let subgraph_fetch_all_query::SubgraphFetchAllQueryVariantOnGraphVariantSourceVariantLatestLaunchBuildInput::CompositionBuildInput(composition_build_input) = value.build_input {
+            composition_build_input.version.as_ref().and_then(|v| FederationVersion::from_str(&("=".to_owned() + v)).ok())
+        } else {
+            None
+        }
     }
 }

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -62,7 +62,7 @@ cat ./supergraph.yaml | rover supergraph compose --config -
 You can optionally pass a variant's graph ref to download each subgraph's SDL and compose the supergraph SDL like so:
 
 ```bash
-rover supergraph config --graph-ref platform@staging
+rover supergraph compose --graph-ref platform@staging
 ```
 
 You can optionally pass a [YAML configuration file](#yaml-configuration-file) to override specific subgraphs or add a new one.
@@ -81,9 +81,9 @@ subgraphs:
 You can override a variant's published `products` subgraph like so:
 
 ```bash showLineNumbers=false
-rover dev \
+rover supergraph compose \
   --graph-ref docs-example-graph@current \
-  --supergraph-config path/to/supergraph_override.yaml
+  --config path/to/supergraph_override.yaml
 
 ```
 

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -87,6 +87,8 @@ rover supergraph compose \
 
 ```
 
+Note that you only need to set `routing_url` if you want to change it from the routing URL registered for the subgraph in GraphOS.
+
 ### YAML configuration file
 
 The supergraph configuration file (often referred to as `supergraph.yaml`) includes configuration options for each of your [subgraphs](/federation/building-supergraphs/subgraphs-overview/). The following example file configures a supergraph with two subgraphs (`films` and `people`):

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -38,7 +38,7 @@ pub struct Compose {
 pub struct SupergraphConfigSource {
     /// The relative path to the supergraph configuration file. You can pass `-` to use stdin instead of a file.
     #[serde(skip_serializing)]
-    #[arg(long = "config", conflicts_with = "graph_ref")]
+    #[arg(long = "config")]
     supergraph_yaml: Option<FileDescriptorType>,
 
     /// A [`GraphRef`] that is accessible in Apollo Studio.
@@ -47,7 +47,7 @@ pub struct SupergraphConfigSource {
     /// This is analogous to providing a supergraph.yaml file with references to your graph variant in studio.
     ///
     /// If used in conjunction with `--config`, the values presented in the supergraph.yaml will take precedence over these values.
-    #[arg(long = "graph-ref", conflicts_with = "supergraph_yaml")]
+    #[arg(long = "graph-ref")]
     graph_ref: Option<GraphRef>,
 }
 

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -124,12 +124,16 @@ fn merge_supergraph_configs(
     // file; otherwise the version fetched from Studio; otherwise LatestFedTwo.
     let resolved_federation_version = target_federation_version
         .cloned()
-        .or_else(|| local_config
-            .as_ref()
-            .and_then(|it| it.get_federation_version()))
-        .or_else(|| remote_config
-            .as_ref()
-            .and_then(|it| it.get_federation_version()))
+        .or_else(|| {
+            local_config
+                .as_ref()
+                .and_then(|it| it.get_federation_version())
+        })
+        .or_else(|| {
+            remote_config
+                .as_ref()
+                .and_then(|it| it.get_federation_version())
+        })
         .unwrap_or(FederationVersion::LatestFedTwo);
 
     match (remote_config, local_config) {

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -121,13 +121,13 @@ fn merge_supergraph_configs(
 ) -> Option<SupergraphConfig> {
     // We use the federation version explicitly given at the command line as top
     // priority; otherwise the version explicitly given in the local config
-    // file; otherwise the version fetched from Studio.
+    // file; otherwise the version fetched from Studio; otherwise LatestFedTwo.
     let resolved_federation_version = target_federation_version
         .cloned()
-        .or(local_config
+        .or_else(|| local_config
             .as_ref()
             .and_then(|it| it.get_federation_version()))
-        .or(remote_config
+        .or_else(|| remote_config
             .as_ref()
             .and_then(|it| it.get_federation_version()))
         .unwrap_or(FederationVersion::LatestFedTwo);


### PR DESCRIPTION
Make `rover supergraph compose --graph-ref REF --config CONFIG` work as documented (and don't remove `routing_url`s fetched from GraphOS if they're missing from the local file).

Make `rover supergraph compose --graph-ref REF` and `rover dev --graph-ref REF` use the graph ref's federation version.

Fix docs.

(Individual commits have more detailed messages.)