### PR TITLE
fix(dev): run router without leadersession

### DIFF
--- a/src/command/dev/compose.rs
+++ b/src/command/dev/compose.rs
@@ -59,6 +59,29 @@ impl ComposeRunner {
         }
     }
 
+    /// Run composition and report back the on the state of composition, potentially updating the
+    /// supergraph schema representation or removing it altogether
+    ///
+    /// States:
+    ///
+    /// - No previous composition, but successful new composition
+    /// - Previous composition had an error and the current composition had an error
+    /// - Previous successful composition; current composition is successful
+    /// - No composition (should be unreachable)
+    /// - Error composing
+    ///
+    ///
+    /// Development notes:
+    ///
+    /// Future work:
+    ///
+    /// - We should work towward stronger typing because we return an optional CompositionOutput or a
+    /// string. We should codify errors and return an enum of states to make it easier to work with
+    /// and understand
+    ///
+    /// SIDE EFFECTS (WARNING)
+    ///
+    /// - This function can update or remove the supergraph schema!
     pub async fn run(
         &mut self,
         supergraph_config: &mut SupergraphConfig,


### PR DESCRIPTION
- router running
- no need for ctrlc handler now that we're not using leader/followers; this was for the follower to ack and send along a message to kill the leader; but, we'll just use the drop impl on the router runner instead to do the dirt
- removes the `compose` fn in favor of doing it in the `run` fn--primarily for clarity and to capture _what_, exactly, is happening: we do composition, but only as a check that we'll have something for the router to run; separating out that check and the router spawning is a bit nicer

have tested locally (e2e won't pass until subgraphs are watched; see #2102) and the router spins up on localhost:4000 and is queryable when you add something like `tokio::sync::sleep()` after starting the router (when we watch subgraphs, this chunk of code goes away, but it's useful to see a running router)