### PR TITLE
Revert "feat(dev): remove multi-terminal use (#2088)"

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -9,7 +9,7 @@ use rover_std::warnln;
 use crate::command::dev::protocol::FollowerMessage;
 use crate::utils::client::StudioClientConfig;
 use crate::utils::supergraph_config::get_supergraph_config;
-use crate::{RoverError, RoverErrorCode, RoverErrorSuggestion, RoverOutput, RoverResult};
+use crate::{RoverError, RoverOutput, RoverResult};
 
 use super::protocol::{FollowerChannel, FollowerMessenger, LeaderChannel, LeaderSession};
 use super::router::RouterConfigHandler;
@@ -32,6 +32,7 @@ impl Dev {
 
         let router_config_handler = RouterConfigHandler::try_from(&self.opts.supergraph_opts)?;
         let router_address = router_config_handler.get_router_address();
+        let raw_socket_name = router_config_handler.get_raw_socket_name();
         let leader_channel = LeaderChannel::new();
         let follower_channel = FollowerChannel::new();
 
@@ -45,7 +46,7 @@ impl Dev {
         )
         .await?;
 
-        let mut leader_session = LeaderSession::new(
+        if let Some(mut leader_session) = LeaderSession::new(
             override_install_path,
             &client_config,
             leader_channel.clone(),
@@ -56,74 +57,111 @@ impl Dev {
             self.opts.supergraph_opts.license.clone(),
         )
         .await?
-        .ok_or(
-            RoverError::new(anyhow!("failed to start a LeaderSession"))
-                .with_code(Some(RoverErrorCode::E005))
-                .with_suggestion(RoverErrorSuggestion::SubmitIssue),
-        )?;
+        {
+            warnln!(
+                "Do not run this command in production! It is intended for local development only."
+            );
+            let (ready_sender, mut ready_receiver) = channel(1);
+            let follower_messenger = FollowerMessenger::from_main_session(
+                follower_channel.clone().sender,
+                leader_channel.receiver,
+            );
 
-        warnln!("Do not run this command in production! It is intended for local development.");
-        let (ready_sender, mut ready_receiver) = channel(1);
-        let follower_messenger = FollowerMessenger::from_main_session(
-            follower_channel.clone().sender,
-            leader_channel.receiver,
-        );
+            tokio::task::spawn_blocking(move || {
+                ctrlc::set_handler(move || {
+                    eprintln!(
+                        "\nshutting down the `rover dev` session and all attached processes..."
+                    );
+                    let _ = follower_channel
+                        .sender
+                        .send(FollowerMessage::shutdown(true))
+                        .map_err(|e| {
+                            let e =
+                                RoverError::new(anyhow!("could not shut down router").context(e));
+                            log_err_and_continue(e)
+                        });
+                })
+                .context("could not set ctrl-c handler for main `rover dev` process")
+                .unwrap();
+            });
 
-        tokio::task::spawn_blocking(move || {
-            ctrlc::set_handler(move || {
-                eprintln!("\nshutting down the `rover dev` session and all attached processes...");
-                let _ = follower_channel
-                    .sender
-                    .send(FollowerMessage::shutdown(true))
-                    .map_err(|e| {
-                        let e = RoverError::new(anyhow!("could not shut down router").context(e));
-                        log_err_and_continue(e)
-                    });
-            })
-            .context("could not set ctrl-c handler for main `rover dev` process")
-            .unwrap();
-        });
+            let subgraph_watcher_handle = tokio::task::spawn(async move {
+                let _ = leader_session
+                    .listen_for_all_subgraph_updates(ready_sender)
+                    .await
+                    .map_err(log_err_and_continue);
+            });
 
-        let subgraph_watcher_handle = tokio::task::spawn(async move {
-            let _ = leader_session
-                .listen_for_all_subgraph_updates(ready_sender)
+            ready_receiver.next().await.unwrap();
+
+            let subgraph_watchers = self
+                .opts
+                .supergraph_opts
+                .get_subgraph_watchers(
+                    &client_config,
+                    supergraph_config,
+                    follower_messenger.clone(),
+                    self.opts.subgraph_opts.subgraph_polling_interval,
+                    &self.opts.plugin_opts.profile,
+                    self.opts.subgraph_opts.subgraph_retries,
+                )
                 .await
-                .map_err(log_err_and_continue);
-        });
+                .transpose()
+                .unwrap_or_else(|| {
+                    self.opts
+                        .subgraph_opts
+                        .get_subgraph_watcher(
+                            router_address,
+                            &client_config,
+                            follower_messenger.clone(),
+                        )
+                        .map(|watcher| vec![watcher])
+                })?;
 
-        ready_receiver.next().await.unwrap();
-
-        let subgraph_watchers = self
-            .opts
-            .supergraph_opts
-            .get_subgraph_watchers(
+            let futs = subgraph_watchers.into_iter().map(|mut watcher| async move {
+                let _ = watcher
+                    .watch_subgraph_for_changes(client_config.retry_period)
+                    .await
+                    .map_err(log_err_and_continue);
+            });
+            tokio::join!(join_all(futs), subgraph_watcher_handle.map(|_| ()));
+        } else {
+            let follower_messenger = FollowerMessenger::from_attached_session(&raw_socket_name);
+            let mut subgraph_refresher = self.opts.subgraph_opts.get_subgraph_watcher(
+                router_address,
                 &client_config,
-                supergraph_config,
                 follower_messenger.clone(),
-                self.opts.subgraph_opts.subgraph_polling_interval,
-                &self.opts.plugin_opts.profile,
-                self.opts.subgraph_opts.subgraph_retries,
-            )
-            .await
-            .transpose()
-            .unwrap_or_else(|| {
-                self.opts
-                    .subgraph_opts
-                    .get_subgraph_watcher(
-                        router_address,
-                        &client_config,
-                        follower_messenger.clone(),
-                    )
-                    .map(|watcher| vec![watcher])
-            })?;
+            )?;
+            tracing::info!(
+                "connecting to existing `rover dev` process by communicating via the interprocess socket located at {raw_socket_name}",
+            );
 
-        let futs = subgraph_watchers.into_iter().map(|mut watcher| async move {
-            let _ = watcher
+            // start the interprocess socket health check in the background
+            let health_messenger = follower_messenger.clone();
+            tokio::task::spawn_blocking(move || {
+                let _ = health_messenger.health_check().map_err(|_| {
+                    eprintln!("shutting down...");
+                    std::process::exit(1);
+                });
+            });
+
+            // set up the ctrl+c handler to notify the main session to remove the killed subgraph
+            let kill_name = subgraph_refresher.get_name();
+            ctrlc::set_handler(move || {
+                eprintln!("\nshutting down...");
+                let _ = follower_messenger
+                    .remove_subgraph(&kill_name)
+                    .map_err(log_err_and_continue);
+                std::process::exit(1);
+            })
+            .context("could not set ctrl-c handler")?;
+
+            // watch for subgraph changes on the main thread
+            // it will take care of updating the main `rover dev` session
+            subgraph_refresher
                 .watch_subgraph_for_changes(client_config.retry_period)
-                .await
-                .map_err(log_err_and_continue);
-        });
-        tokio::join!(join_all(futs), subgraph_watcher_handle.map(|_| ()));
+                .await?;
+        }
 
         unreachable!("watch_subgraph_for_changes never returns")
     }

--- a/src/command/dev/protocol/follower/messenger.rs
+++ b/src/command/dev/protocol/follower/messenger.rs
@@ -1,11 +1,13 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, io::BufReader, time::Duration};
 
 use anyhow::anyhow;
 use apollo_federation_types::build::SubgraphDefinition;
 use crossbeam_channel::{Receiver, Sender};
+use interprocess::local_socket::traits::Stream;
 
 use crate::command::dev::protocol::{
-    FollowerMessage, LeaderMessageKind, SubgraphKeys, SubgraphName,
+    create_socket_name, socket_read, socket_write, FollowerMessage, LeaderMessageKind,
+    SubgraphKeys, SubgraphName,
 };
 use crate::{RoverError, RoverErrorSuggestion, RoverResult, PKG_VERSION};
 
@@ -25,6 +27,27 @@ impl FollowerMessenger {
                 follower_message_sender,
                 leader_message_receiver,
             ),
+        }
+    }
+
+    /// Create a [`FollowerMessenger`] for an attached session that can talk to the main session via a socket.
+    pub fn from_attached_session(raw_socket_name: &str) -> Self {
+        Self {
+            kind: FollowerMessengerKind::from_attached_session(raw_socket_name.to_string()),
+        }
+    }
+
+    /// Send a health check to the main session once every second to make sure it is alive.
+    ///
+    /// This is function will block indefinitely and should be run from a separate thread.
+    pub fn health_check(&self) -> RoverResult<()> {
+        loop {
+            if let Err(e) =
+                self.message_leader(FollowerMessage::health_check(self.is_from_main_session())?)
+            {
+                break Err(e);
+            }
+            std::thread::sleep(Duration::from_secs(1));
         }
     }
 
@@ -85,6 +108,9 @@ enum FollowerMessengerKind {
         follower_message_sender: Sender<FollowerMessage>,
         leader_message_receiver: Receiver<LeaderMessageKind>,
     },
+    FromAttachedSession {
+        raw_socket_name: String,
+    },
 }
 
 impl FollowerMessengerKind {
@@ -96,6 +122,10 @@ impl FollowerMessengerKind {
             follower_message_sender,
             leader_message_receiver,
         }
+    }
+
+    fn from_attached_session(raw_socket_name: String) -> Self {
+        Self::FromAttachedSession { raw_socket_name }
     }
 
     fn message_leader(
@@ -119,6 +149,35 @@ impl FollowerMessengerKind {
                 tracing::trace!("main session received leader message from channel");
 
                 leader_message
+            }
+            FromAttachedSession { raw_socket_name } => {
+                let socket_name = create_socket_name(raw_socket_name)?;
+                let stream = Stream::connect(socket_name).map_err(|_| {
+                    let mut err = RoverError::new(anyhow!(
+                        "there is not a main `rover dev` process to report updates to"
+                    ));
+                    err.set_suggestion(RoverErrorSuggestion::SubmitIssue);
+                    err
+                })?;
+
+                let mut stream = BufReader::new(stream);
+
+                tracing::trace!("attached session sending follower message on socket");
+                // send our message over the socket
+                socket_write(&follower_message, &mut stream)?;
+
+                tracing::trace!("attached session reading leader message from socket");
+                // wait for our message to be read by the other socket handler
+                // then read the response that was written back to the socket
+                socket_read(&mut stream).map_err(|e| {
+                    RoverError::new(
+                        anyhow!(
+                            "this process did not receive a message from the main process after sending {:?}",
+                            &follower_message
+                        )
+                        .context(e),
+                    )
+                })
             }
         }?;
 

--- a/src/command/dev/protocol/mod.rs
+++ b/src/command/dev/protocol/mod.rs
@@ -2,6 +2,7 @@ use interprocess::local_socket::{GenericFilePath, Name, ToFsName};
 
 pub use follower::*;
 pub use leader::*;
+pub(crate) use socket::*;
 pub use types::*;
 
 mod follower;

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -325,6 +325,10 @@ impl SubgraphSchemaWatcher {
     pub fn set_schema_refresher(&mut self, new_refresher: SubgraphSchemaWatcherKind) {
         self.schema_watcher_kind = new_refresher;
     }
+
+    pub fn get_name(&self) -> String {
+        self.subgraph_key.0.to_string()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/error/metadata/code.rs
+++ b/src/error/metadata/code.rs
@@ -10,9 +10,7 @@ pub enum RoverErrorCode {
     E002,
     E003,
     E004,
-    /// Unexpected behavior. Programming mistake made in Rover or its dependent crates
     E005,
-    /// Unexpected behavior. Programming mistake made in the Registry
     E006,
     E007,
     E008,

--- a/src/error/metadata/codes/E005.md
+++ b/src/error/metadata/codes/E005.md
@@ -1,4 +1,4 @@
-This error is unexpected behavior and is likely the result of a programming mistake made in Rover.
+This error is unexpected behavior, and likely the result of a programming mistake made in the graph registry. 
 
 
 This error shouldn't be reachable under normal circumstances, but if it does occur, please [open an issue](https://github.com/apollographql/rover/issues/new?body=Error%20E005%0A%0ADescribe%20your%20issue%20or%20question%20here&labels=triage) and let us know.

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -66,15 +66,6 @@ impl RoverError {
         Self { error, metadata }
     }
 
-    pub fn set_code(&mut self, code: Option<RoverErrorCode>) {
-        self.metadata.code = code;
-    }
-
-    pub fn with_code(mut self, code: Option<RoverErrorCode>) -> Self {
-        self.metadata.code = code;
-        self
-    }
-
     pub fn set_suggestion(&mut self, suggestion: RoverErrorSuggestion) {
         self.metadata.suggestions.push(suggestion);
     }


### PR DESCRIPTION
This is phase 1 in the release of v0.26.2, we're temporarily removing this from `main` such that the refactoring of `rover dev` does not get released before it is complete and functioning.