### PR TITLE
ROVER-135 Make paths in supergraph.yaml resolve relative to the location of the file, not the current working directory of Rover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,8 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd88512dea257880f1e47d5541d14ba8a573b267fdc54af78f1b0bfdd3b73861"
+version = "0.13.1"
+source = "git+https://github.com/apollographql/federation-rs?branch=jr/ROVER-135#a198f474da4126707520f86c2fe4b7645d9b103c"
 dependencies = [
  "camino",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.13.2"
+apollo-federation-types = { git = "https://github.com/apollographql/federation-rs", branch = "jr/ROVER-135" }
 
 # crates.io dependencies
 ariadne = "0.4"

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -1,10 +1,9 @@
-use std::cmp::Ordering;
-use std::fmt::{self, Display, Write as _};
-
+use crate::utils::env::RoverEnvKey;
+use camino::Utf8PathBuf;
 use rover_client::shared::GraphRef;
 use rover_std::Style;
-
-use crate::utils::env::RoverEnvKey;
+use std::cmp::Ordering;
+use std::fmt::{self, Display, Write as _};
 
 use serde::Serialize;
 
@@ -79,6 +78,10 @@ pub enum RoverErrorSuggestion {
         frontend_url_root: String,
     },
     AddRoutingUrlToSupergraphYaml,
+    InvalidSupergraphYamlSubgraphSchemaPath {
+        subgraph_name: String,
+        supergraph_yaml_path: Utf8PathBuf,
+    },
     PublishSubgraphWithRoutingUrl {
         subgraph_name: String,
         graph_ref: String,
@@ -256,8 +259,11 @@ UpgradePlan => "Rover has likely reached rate limits while running graph or subg
                 format!("Try publishing the subgraph with a routing URL like so `rover subgraph publish {graph_ref} --name {subgraph_name} --routing-url <url>`")
             },
             AllowInvalidRoutingUrlOrSpecifyValidUrl => format!("Try publishing the subgraph with a valid routing URL. If you are sure you want to publish an invalid routing URL, re-run this command with the {} option.", Style::Command.paint("`--allow-invalid-routing-url`")),
-            ContactApolloAccountManager => {"Discuss your requirements with your Apollo point of contact.".to_string()}
-            TryAgainLater => {"Please try again later.".to_string()}
+            ContactApolloAccountManager => {"Discuss your requirements with your Apollo point of contact.".to_string()},
+            TryAgainLater => {"Please try again later.".to_string()},
+            InvalidSupergraphYamlSubgraphSchemaPath {
+                subgraph_name, supergraph_yaml_path
+            } => format!("Make sure the specified path for subgraph '{}' is relative to the location of the supergraph schema file ({})", subgraph_name, Style::Path.paint(supergraph_yaml_path))
         };
         write!(formatter, "{}", &suggestion)
     }

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -207,7 +207,7 @@ mod test_get_supergraph_config {
     use crate::options::ProfileOpt;
     use crate::utils::client::{ClientBuilder, StudioClientConfig};
     use crate::utils::parsers::FileDescriptorType;
-    use crate::utils::supergraph_config::get_supergraph_config;
+    use crate::utils::supergraph_config::{get_supergraph_config, resolve_federation_version};
 
     #[fixture]
     #[once]
@@ -1277,6 +1277,7 @@ subgraphs:
             &FileDescriptorType::File(config_path),
             client_config,
             &profile_opt,
+            false,
         )
         .await
         .unwrap()

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -277,11 +277,6 @@ mod test_get_supergraph_config {
         Some(String::from("pandas")),
         Some(vec![(String::from("pandas"), String::from("local"))]),
     )]
-    #[case::local_takes_precedence(
-        Some(String::from("pandas")),
-        Some(String::from("pandas")),
-        Some(vec![(String::from("pandas"), String::from("local"))]),
-    )]
     #[tokio::test]
     async fn test_get_supergraph_config(
         config: Config,
@@ -329,6 +324,15 @@ mod test_get_supergraph_config {
                                 url
                                 activePartialSchema {
                                   sdl
+                                }
+                              }
+                              sourceVariant {
+                                subgraphs {
+                                  name
+                                  url
+                                  activePartialSchema {
+                                    sdl
+                                  }
                                 }
                               }
                             }

--- a/src/utils/telemetry.rs
+++ b/src/utils/telemetry.rs
@@ -151,15 +151,15 @@ mod tests {
 
     #[test]
     fn it_can_serialize_commands_with_arguments() {
-        let args = vec![PKG_NAME, "config", "list", "--help"];
+        let args = vec![PKG_NAME, "explain", "E002"];
         let rover = Rover::parse_from(args);
         let actual_serialized_command = rover
             .serialize_command()
             .expect("could not serialize command");
         let mut expected_arguments = HashMap::new();
-        expected_arguments.insert("help".to_string(), json!(true));
+        expected_arguments.insert("code".to_string(), json!("E002"));
         let expected_serialized_command = Command {
-            name: "config whoami".to_string(),
+            name: "explain".to_string(),
             arguments: expected_arguments,
         };
         assert_eq!(actual_serialized_command, expected_serialized_command);


### PR DESCRIPTION
As per the title, to support integration with the Language Server we need to remove a 'quirk' of Rover whereby if you specify a file in the supergraph.yaml with a relative path, that path is resolved relative to the location that rover is running in at the time. This doesn't work in that context so instead we are changing it to resolve relative to the location of the supergraph.yaml file itself.

I've added a unit test for this and run my own tests and it all seems to work ok.

In addition I've fixed a test that has been broken for a long time, a more detailed write up on this test will follow

Successful smoke test run: https://github.com/apollographql/rover/actions/runs/10795662532/job/29943305762