### PR TITLE
feat: show linter and custom check states even if diagnostics do not exist

### DIFF
--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -52,14 +52,12 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(lint_response) = &self.maybe_lint_response {
-            if !lint_response.diagnostics.is_empty() {
-                msg.push('\n');
-                msg.push_str(&Self::task_title(
-                    "Linter Check",
-                    lint_response.task_status.clone(),
-                ));
-                msg.push_str(lint_response.get_output().as_str());
-            }
+            msg.push('\n');
+            msg.push_str(&Self::task_title(
+                "Linter Check",
+                lint_response.task_status.clone(),
+            ));
+            msg.push_str(lint_response.get_output().as_str());
         }
 
         if let Some(proposals_response) = &self.maybe_proposals_response {
@@ -72,16 +70,12 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(custom_response) = &self.maybe_custom_response {
-            if !custom_response.violations.is_empty()
-                || custom_response.task_status == CheckTaskStatus::FAILED
-            {
-                msg.push('\n');
-                msg.push_str(&Self::task_title(
-                    "Custom Check",
-                    custom_response.task_status.clone(),
-                ));
-                msg.push_str(custom_response.get_output().as_str());
-            }
+            msg.push('\n');
+            msg.push_str(&Self::task_title(
+                "Custom Check",
+                custom_response.task_status.clone(),
+            ));
+            msg.push_str(custom_response.get_output().as_str());
         }
 
         if let Some(downstream_response) = &self.maybe_downstream_response {
@@ -273,12 +267,15 @@ impl LintCheckResponse {
             _ => format!("{} and {}", error_msg, warning_msg),
         };
 
-        msg.push_str(&format!("Resulted in {}.", plural_errors));
-
-        msg.push('\n');
-
-        msg.push_str(&self.get_table());
-
+        if !self.diagnostics.is_empty() {
+            msg.push_str(&format!("Resulted in {}.", plural_errors));
+            msg.push('\n');
+            msg.push_str(&self.get_table());
+        } else {
+            msg.push_str("No linting errors or warnings found.");
+            msg.push('\n');
+        }
+        
         if let Some(url) = &self.target_url {
             msg.push_str("View linter check details at: ");
             msg.push_str(&Style::Link.paint(url));
@@ -426,12 +423,13 @@ impl CustomCheckResponse {
             _ => format!("{} violations", self.violations.len()),
         };
 
-        msg.push_str(&format!("Resulted in {}.", violation_msg));
-
-        msg.push('\n');
-
         if !self.violations.is_empty() {
+            msg.push_str(&format!("Resulted in {}.", violation_msg));
+            msg.push('\n');
             msg.push_str(&self.get_table());
+        } else {
+            msg.push_str("No custom check violations found.");
+            msg.push('\n');
         }
 
         if let Some(url) = &self.target_url {

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -275,7 +275,6 @@ impl LintCheckResponse {
             msg.push_str("No linting errors or warnings found.");
             msg.push('\n');
         }
-        
         if let Some(url) = &self.target_url {
             msg.push_str("View linter check details at: ");
             msg.push_str(&Style::Link.paint(url));

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1140,13 +1140,13 @@ mod tests {
         let expected_text = "
 There were no changes detected in the composed API schema, but the core schema was modified.
 
-\u{1b}[1mLinter Check\u{1b}[0m [\u{1b}[32mPASSED\u{1b}[0m]:
+Linter Check [PASSED]:
 No linting errors or warnings found.
-View linter check details at: \u{1b}[36mhttps://studio.apollographql.com/graph/my-graph/variant/current/lint/1\u{1b}[0m
+View linter check details at: https://studio.apollographql.com/graph/my-graph/variant/current/lint/1
 
-\u{1b}[1mCustom Check\u{1b}[0m [\u{1b}[32mPASSED\u{1b}[0m]:
+Custom Check [PASSED]:
 No custom check violations found.
-View custom check details at: \u{1b}[36mhttps://studio.apollographql.com/graph/my-graph/variant/current/custom/1\u{1b}[0m";
+View custom check details at: https://studio.apollographql.com/graph/my-graph/variant/current/custom/1";
 
         assert_eq!(actual_text, expected_text);
     }

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1105,12 +1105,17 @@ mod tests {
     #[test]
     fn check_success_response_with_empty_lint_and_custom_violations_text() {
         let mock_check_response = CheckWorkflowResponse {
-            default_target_url: "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1".to_string(),
+            default_target_url:
+                "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1"
+                    .to_string(),
             maybe_core_schema_modified: Some(true),
             maybe_operations_response: None,
             maybe_lint_response: Some(LintCheckResponse {
                 task_status: CheckTaskStatus::PASSED,
-                target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/lint/1".to_string()),
+                target_url: Some(
+                    "https://studio.apollographql.com/graph/my-graph/variant/current/lint/1"
+                        .to_string(),
+                ),
                 diagnostics: vec![],
                 errors_count: 0,
                 warnings_count: 0,
@@ -1118,14 +1123,19 @@ mod tests {
             maybe_proposals_response: None,
             maybe_custom_response: Some(CustomCheckResponse {
                 task_status: CheckTaskStatus::PASSED,
-                target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/custom/1".to_string()),
-                violations:  vec![],
+                target_url: Some(
+                    "https://studio.apollographql.com/graph/my-graph/variant/current/custom/1"
+                        .to_string(),
+                ),
+                violations: vec![],
             }),
             maybe_downstream_response: None,
         };
 
-        let actual_text =
-            RoverOutput::CheckWorkflowResponse(mock_check_response).get_stdout().expect("Expected response to be Ok").expect("Expected response to exist");
+        let actual_text = RoverOutput::CheckWorkflowResponse(mock_check_response)
+            .get_stdout()
+            .expect("Expected response to be Ok")
+            .expect("Expected response to exist");
 
         let expected_text = "
 There were no changes detected in the composed API schema, but the core schema was modified.

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1103,6 +1103,45 @@ mod tests {
     }
 
     #[test]
+    fn check_success_response_with_empty_lint_and_custom_violations_text() {
+        let mock_check_response = CheckWorkflowResponse {
+            default_target_url: "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1".to_string(),
+            maybe_core_schema_modified: Some(true),
+            maybe_operations_response: None,
+            maybe_lint_response: Some(LintCheckResponse {
+                task_status: CheckTaskStatus::PASSED,
+                target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/lint/1".to_string()),
+                diagnostics: vec![],
+                errors_count: 0,
+                warnings_count: 0,
+            }),
+            maybe_proposals_response: None,
+            maybe_custom_response: Some(CustomCheckResponse {
+                task_status: CheckTaskStatus::PASSED,
+                target_url: Some("https://studio.apollographql.com/graph/my-graph/variant/current/custom/1".to_string()),
+                violations:  vec![],
+            }),
+            maybe_downstream_response: None,
+        };
+
+        let actual_text =
+            RoverOutput::CheckWorkflowResponse(mock_check_response).get_stdout().expect("Expected response to be Ok").expect("Expected response to exist");
+
+        let expected_text = "
+There were no changes detected in the composed API schema, but the core schema was modified.
+
+\u{1b}[1mLinter Check\u{1b}[0m [\u{1b}[32mPASSED\u{1b}[0m]:
+No linting errors or warnings found.
+View linter check details at: \u{1b}[36mhttps://studio.apollographql.com/graph/my-graph/variant/current/lint/1\u{1b}[0m
+
+\u{1b}[1mCustom Check\u{1b}[0m [\u{1b}[32mPASSED\u{1b}[0m]:
+No custom check violations found.
+View custom check details at: \u{1b}[36mhttps://studio.apollographql.com/graph/my-graph/variant/current/custom/1\u{1b}[0m";
+
+        assert_eq!(actual_text, expected_text);
+    }
+
+    #[test]
     fn check_failure_response_json() {
         let graph_ref = GraphRef {
             name: "name".to_string(),


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
## Overview

We have been displaying check results for Linter and Custom checks as a table with diagnostics when they fail, but when they pass and the diagnostic list is empty their status is not displayed which can be confusing for users who are expecting to see a success state for these check tasks. See this [slack thread](https://apollograph.slack.com/archives/C025ENJA19Q/p1727113824239119) for an example.

## Changes

Instead of skipping the empty state, we should display these and include text to surface that there are no diagnostics to show in the result as well as a link to the result if it does exist (it will lead them to a success state but it is helpful nonetheless).
