### PR TITLE
Test SubgraphWatchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,6 +4546,7 @@ dependencies = [
  "timber",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tower 0.5.1",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,9 +4653,11 @@ dependencies = [
  "notify-debouncer-full",
  "rstest",
  "speculoos",
+ "tap",
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ tempfile = "3.8"
 tokio = "1.38"
 tokio-stream = "0.1"
 tokio-test = "0.4.4"
+tokio-util = "0.7.12"
 toml = "0.8"
 tower = { version = "0.5.0", features = ["make", "retry", "timeout"] }
 tower-http = "0.5.2"
@@ -156,6 +157,7 @@ tower-test = "0.4.0"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.3"
+tracing-test = "0.2.5"
 which = "6"
 wsl = "0.1"
 uuid = "1"
@@ -215,6 +217,7 @@ termimad = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "process", "sync"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
@@ -243,4 +246,4 @@ reqwest = { workspace = true, features = ["native-tls-vendored"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 speculoos = { workspace = true }
-tracing-test = "0.2.5"
+tracing-test = { workspace = true }

--- a/crates/rover-std/Cargo.toml
+++ b/crates/rover-std/Cargo.toml
@@ -12,7 +12,9 @@ camino = { workspace = true }
 console = { workspace = true }
 notify = { workspace = true }
 notify-debouncer-full = { workspace = true }
-tokio = { workspace = true }
+tap = { workspace = true }
+tokio = { workspace = true, features = [ "macros", "rt", "rt-multi-thread" ] }
+tokio-util = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/src/command/dev/introspect.rs
+++ b/src/command/dev/introspect.rs
@@ -124,7 +124,7 @@ impl SubgraphIntrospectRunner {
                 watch: false,
             },
         }
-        .exec(&self.client, true, self.retry_period)
+        .exec(self.client.clone(), true, self.retry_period)
         .await
     }
 }
@@ -150,7 +150,7 @@ impl GraphIntrospectRunner {
                 watch: false,
             },
         }
-        .exec(&self.client, true, self.retry_period)
+        .exec(self.client.clone(), true, self.retry_period)
         .await
     }
 }

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -59,7 +59,7 @@ impl Introspect {
         )
     }
 
-    pub async fn exec_and_watch(
+    pub fn exec_and_watch(
         &self,
         client: Client,
         output_opts: &OutputOpts,
@@ -69,7 +69,6 @@ impl Introspect {
         self.opts.exec_and_watch(
             {
                 move || {
-                    let retry_period = retry_period.clone();
                     let introspect = introspect.clone();
                     let client = client.clone();
                     async move { introspect.exec(client, false, retry_period).await }

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use reqwest::Client;
 use serde::Serialize;
 use std::{collections::HashMap, time::Duration};
+use tokio_util::sync::CancellationToken;
 
 use rover_client::{
     blocking::GraphQLClient,
@@ -13,7 +14,7 @@ use crate::{
     RoverOutput, RoverResult,
 };
 
-#[derive(Debug, Serialize, Parser)]
+#[derive(Clone, Debug, Serialize, Parser)]
 pub struct Introspect {
     #[clap(flatten)]
     pub opts: IntrospectOpts,
@@ -27,21 +28,21 @@ impl Introspect {
         retry_period: Option<Duration>,
     ) -> RoverResult<RoverOutput> {
         if self.opts.watch {
-            self.exec_and_watch(&client, output_opts, retry_period)
-                .await
+            let _ = self.exec_and_watch(client, output_opts, retry_period);
+            Ok(RoverOutput::EmptySuccess)
         } else {
-            let sdl = self.exec(&client, true, retry_period).await?;
+            let sdl = self.exec(client, true, retry_period).await?;
             Ok(RoverOutput::Introspection(sdl))
         }
     }
 
     pub async fn exec(
         &self,
-        client: &Client,
+        client: Client,
         should_retry: bool,
         retry_period: Option<Duration>,
     ) -> RoverResult<String> {
-        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone(), retry_period);
+        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client, retry_period);
 
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();
@@ -60,13 +61,21 @@ impl Introspect {
 
     pub async fn exec_and_watch(
         &self,
-        client: &Client,
+        client: Client,
         output_opts: &OutputOpts,
-
         retry_period: Option<Duration>,
-    ) -> ! {
-        self.opts
-            .exec_and_watch(|| self.exec(client, false, retry_period), output_opts)
-            .await
+    ) -> CancellationToken {
+        let introspect = self.clone();
+        self.opts.exec_and_watch(
+            {
+                move || {
+                    let retry_period = retry_period.clone();
+                    let introspect = introspect.clone();
+                    let client = client.clone();
+                    async move { introspect.exec(client, false, retry_period).await }
+                }
+            },
+            output_opts,
+        )
     }
 }

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -1,5 +1,4 @@
 use std::{
-    env::current_dir,
     fs::File,
     io::{Read, Write},
     process::Command,
@@ -18,21 +17,11 @@ use rover_client::{shared::GraphRef, RoverClientError};
 use rover_std::warnln;
 use semver::Version;
 use serde::Serialize;
-use tokio::join;
-use tokio_stream::StreamExt;
 
 use crate::{
     command::{
         install::{Install, Plugin},
         supergraph::compose::CompositionOutput,
-    },
-    composition::{
-        runner::Runner,
-        supergraph::{
-            binary::{OutputTarget, SupergraphBinary},
-            config::SupergraphConfigResolver,
-            version::SupergraphVersion,
-        },
     },
     options::PluginOpts,
     utils::{
@@ -77,10 +66,6 @@ pub struct SupergraphComposeOpts {
     /// The version of Apollo Federation to use for composition
     #[arg(long = "federation-version")]
     federation_version: Option<FederationVersion>,
-
-    #[cfg_attr(debug_assertions, arg(long, default_value_t = false))]
-    #[cfg(debug_assertions)]
-    watch: bool,
 }
 
 impl Compose {
@@ -93,8 +78,6 @@ impl Compose {
                     supergraph_yaml: Some(FileDescriptorType::File("RAM".into())),
                     graph_ref: None,
                 },
-                #[cfg(debug_assertions)]
-                watch: false,
             },
         }
     }
@@ -137,107 +120,6 @@ impl Compose {
         client_config: StudioClientConfig,
         output_file: Option<Utf8PathBuf>,
     ) -> RoverResult<RoverOutput> {
-        #[cfg(debug_assertions)]
-        if self.opts.watch {
-            // Get the current supergraph config path if the supergraph file is passed directly.
-            // Otherwise, use the current directory. E.g., when piping from stdin.
-            let supergraph_config_root = if let Some(FileDescriptorType::File(file_path)) =
-                &self.opts.supergraph_config_source.supergraph_yaml
-            {
-                file_path
-                    .parent()
-                    .ok_or_else(|| {
-                        anyhow!("could not get the parent directory of the provided supergraph config: {file_path}")
-                    })?
-                    .to_path_buf()
-            } else {
-                warnln!("watching supergraph config is only supported when passing a file directly, stdin is not supported.");
-                Utf8PathBuf::try_from(current_dir()?)?
-            };
-
-            let studio_client =
-                client_config.get_authenticated_client(&self.opts.plugin_opts.profile)?;
-
-            // Create a new temp file used to write supergraph config to while watching for
-            // changes to the original source config.
-            let target_supergraph_config_path: Utf8PathBuf = tempfile::Builder::new()
-                .prefix("supergraph")
-                .tempdir()
-                .map_err(|err| {
-                    anyhow!(
-                        "unable to construct temporary supergraph directory. Error: {:?}",
-                        err
-                    )
-                })
-                .and_then(|target_dir| {
-                    Utf8PathBuf::try_from(target_dir.into_path()).map_err(|err| {
-                        anyhow!(
-                            "unable to construct temporary supergraph config path: {:?}",
-                            err
-                        )
-                    })
-                })
-                .map(|target_dir| target_dir.join("supergraph.graphql"))?;
-
-            // Load supergraph config from the given yaml source, attempting to load and resolve
-            // subgraph definitions.
-            let supergraph_config = SupergraphConfigResolver::new()
-                .load_from_file_descriptor(
-                    self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
-                )?
-                .load_remote_subgraphs(
-                    &studio_client,
-                    self.opts.supergraph_config_source.graph_ref.as_ref(),
-                )
-                .await?
-                .lazily_resolve_subgraphs(&supergraph_config_root)
-                .await?
-                .with_target(target_supergraph_config_path);
-
-            supergraph_config.write().await.map_err(|err| {
-                anyhow!("Unable to write supergraph config to temporary file: {err}")
-            })?;
-
-            // Attempt to extract the federation version from the supergraph config.
-            let federation_version = supergraph_config.federation_version();
-            let install_path = self
-                .maybe_install_supergraph(override_install_path, client_config, federation_version)
-                .await?;
-            let exact_federation_version = match Self::extract_federation_version(&install_path)? {
-                FederationVersion::ExactFedTwo(exact_version) => exact_version,
-                FederationVersion::ExactFedOne(exact_version) => exact_version,
-                _ => {
-                    return Err(anyhow!(
-                        "unable to extract the exact federation version from the supergraph binary located at: {install_path}"
-                    )
-                    .into());
-                }
-            };
-
-            // Create a new supergraph binary installer.
-            let supergraph_binary = SupergraphBinary::new(
-                install_path,
-                SupergraphVersion::new(exact_federation_version),
-                output_file
-                    .map(OutputTarget::File)
-                    .unwrap_or_else(|| OutputTarget::Stdout),
-            );
-
-            // Run the supergraph binary and wait for composition messages to arrive.
-            let mut messages = Runner::new(supergraph_config, supergraph_binary)
-                .run()
-                .await?;
-            let join_handle = tokio::task::spawn(async move {
-                while let Some(message) = messages.next().await {
-                    eprintln!("{:?}", message);
-                }
-            });
-
-            join!(join_handle).0?;
-
-            return Ok(RoverOutput::EmptySuccess);
-        }
-
         let mut supergraph_config = get_supergraph_config(
             &self.opts.supergraph_config_source.graph_ref,
             &self.opts.supergraph_config_source.supergraph_yaml.clone(),

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -1,4 +1,5 @@
 use std::{
+    env::current_dir,
     fs::File,
     io::{Read, Write},
     process::Command,
@@ -17,11 +18,21 @@ use rover_client::{shared::GraphRef, RoverClientError};
 use rover_std::warnln;
 use semver::Version;
 use serde::Serialize;
+use tokio::join;
+use tokio_stream::StreamExt;
 
 use crate::{
     command::{
         install::{Install, Plugin},
         supergraph::compose::CompositionOutput,
+    },
+    composition::{
+        runner::Runner,
+        supergraph::{
+            binary::{OutputTarget, SupergraphBinary},
+            config::SupergraphConfigResolver,
+            version::SupergraphVersion,
+        },
     },
     options::PluginOpts,
     utils::{
@@ -66,6 +77,10 @@ pub struct SupergraphComposeOpts {
     /// The version of Apollo Federation to use for composition
     #[arg(long = "federation-version")]
     federation_version: Option<FederationVersion>,
+
+    #[cfg_attr(debug_assertions, arg(long, default_value_t = false))]
+    #[cfg(debug_assertions)]
+    watch: bool,
 }
 
 impl Compose {
@@ -78,6 +93,8 @@ impl Compose {
                     supergraph_yaml: Some(FileDescriptorType::File("RAM".into())),
                     graph_ref: None,
                 },
+                #[cfg(debug_assertions)]
+                watch: false,
             },
         }
     }
@@ -120,6 +137,107 @@ impl Compose {
         client_config: StudioClientConfig,
         output_file: Option<Utf8PathBuf>,
     ) -> RoverResult<RoverOutput> {
+        #[cfg(debug_assertions)]
+        if self.opts.watch {
+            // Get the current supergraph config path if the supergraph file is passed directly.
+            // Otherwise, use the current directory. E.g., when piping from stdin.
+            let supergraph_config_root = if let Some(FileDescriptorType::File(file_path)) =
+                &self.opts.supergraph_config_source.supergraph_yaml
+            {
+                file_path
+                    .parent()
+                    .ok_or_else(|| {
+                        anyhow!("could not get the parent directory of the provided supergraph config: {file_path}")
+                    })?
+                    .to_path_buf()
+            } else {
+                warnln!("watching supergraph config is only supported when passing a file directly, stdin is not supported.");
+                Utf8PathBuf::try_from(current_dir()?)?
+            };
+
+            let studio_client =
+                client_config.get_authenticated_client(&self.opts.plugin_opts.profile)?;
+
+            // Create a new temp file used to write supergraph config to while watching for
+            // changes to the original source config.
+            let target_supergraph_config_path: Utf8PathBuf = tempfile::Builder::new()
+                .prefix("supergraph")
+                .tempdir()
+                .map_err(|err| {
+                    anyhow!(
+                        "unable to construct temporary supergraph directory. Error: {:?}",
+                        err
+                    )
+                })
+                .and_then(|target_dir| {
+                    Utf8PathBuf::try_from(target_dir.into_path()).map_err(|err| {
+                        anyhow!(
+                            "unable to construct temporary supergraph config path: {:?}",
+                            err
+                        )
+                    })
+                })
+                .map(|target_dir| target_dir.join("supergraph.graphql"))?;
+
+            // Load supergraph config from the given yaml source, attempting to load and resolve
+            // subgraph definitions.
+            let supergraph_config = SupergraphConfigResolver::new()
+                .load_from_file_descriptor(
+                    self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
+                )?
+                .load_remote_subgraphs(
+                    &studio_client,
+                    self.opts.supergraph_config_source.graph_ref.as_ref(),
+                )
+                .await?
+                .lazily_resolve_subgraphs(&supergraph_config_root)
+                .await?
+                .with_target(target_supergraph_config_path);
+
+            supergraph_config.write().await.map_err(|err| {
+                anyhow!("Unable to write supergraph config to temporary file: {err}")
+            })?;
+
+            // Attempt to extract the federation version from the supergraph config.
+            let federation_version = supergraph_config.federation_version();
+            let install_path = self
+                .maybe_install_supergraph(override_install_path, client_config, federation_version)
+                .await?;
+            let exact_federation_version = match Self::extract_federation_version(&install_path)? {
+                FederationVersion::ExactFedTwo(exact_version) => exact_version,
+                FederationVersion::ExactFedOne(exact_version) => exact_version,
+                _ => {
+                    return Err(anyhow!(
+                        "unable to extract the exact federation version from the supergraph binary located at: {install_path}"
+                    )
+                    .into());
+                }
+            };
+
+            // Create a new supergraph binary installer.
+            let supergraph_binary = SupergraphBinary::new(
+                install_path,
+                SupergraphVersion::new(exact_federation_version),
+                output_file
+                    .map(OutputTarget::File)
+                    .unwrap_or_else(|| OutputTarget::Stdout),
+            );
+
+            // Run the supergraph binary and wait for composition messages to arrive.
+            let mut messages = Runner::new(supergraph_config, supergraph_binary)
+                .run()
+                .await?;
+            let join_handle = tokio::task::spawn(async move {
+                while let Some(message) = messages.next().await {
+                    eprintln!("{:?}", message);
+                }
+            });
+
+            join!(join_handle).0?;
+
+            return Ok(RoverOutput::EmptySuccess);
+        }
+
         let mut supergraph_config = get_supergraph_config(
             &self.opts.supergraph_config_source.graph_ref,
             &self.opts.supergraph_config_source.supergraph_yaml.clone(),

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -10,12 +10,11 @@ use derive_getters::Getters;
 pub mod events;
 pub mod run_composition;
 pub mod runner;
-pub mod subgraph_watchers;
 pub mod supergraph;
 pub mod types;
 
 #[cfg(feature = "composition-js")]
-pub mod watchers;
+mod watchers;
 
 #[derive(Getters, Debug, Clone, Eq, PartialEq)]
 pub struct CompositionSuccess {
@@ -35,12 +34,10 @@ pub enum CompositionError {
     #[error("Failed to read the file at: {path}")]
     ReadFile { path: Utf8PathBuf, error: String },
     #[error("Encountered {} while trying to build a supergraph.", .source.length_string())]
-    Build {
-        source: BuildErrors,
-        // NB: in do_compose (rover_client/src/error -> BuildErrors) this includes num_subgraphs,
-        // but this is only important if we end up with a RoverError (it uses a singular or plural
-        // error message); so, leaving TBD if we go that route because it'll require figuring out
-        // from something like the supergraph_config how many subgraphs we attempted to compose
-        // (alternatively, we could just reword the error message to allow for either)
-    },
+    Build { source: BuildErrors },
+}
+
+#[cfg(test)]
+pub fn compose_output() -> String {
+    "{\"Ok\":{\"supergraphSdl\":\"schema\\n  @link(url: \\\"https://specs.apollo.dev/link/v1.0\\\")\\n  @link(url: \\\"https://specs.apollo.dev/join/v0.3\\\", for: EXECUTION)\\n  @link(url: \\\"https://specs.apollo.dev/tag/v0.3\\\", import: [\\\"@tag\\\"])\\n  @link(url: \\\"https://specs.apollo.dev/inaccessible/v0.2\\\", import: [\\\"@inaccessible\\\"], for: SECURITY)\\n{\\n  query: Query\\n}\\n\\ndirective @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION\\n\\ndirective @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE\\n\\ndirective @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION\\n\\ndirective @join__graph(name: String!, url: String!) on ENUM_VALUE\\n\\ndirective @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE\\n\\ndirective @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR\\n\\ndirective @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION\\n\\ndirective @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA\\n\\ndirective @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA\\n\\nscalar join__FieldSet\\n\\nenum join__Graph {\\n  PANDAS @join__graph(name: \\\"pandas\\\", url: \\\"http://localhost:4003\\\")\\n  PRODUCTS @join__graph(name: \\\"products\\\", url: \\\"http://localhost:4002\\\")\\n  USERS @join__graph(name: \\\"users\\\", url: \\\"http://localhost:4001\\\")\\n}\\n\\nscalar link__Import \\n\\nenum link__Purpose {\\n  \\\"\\\"\\\"\\n  `SECURITY` features provide metadata necessary to securely resolve fields.\\n  \\\"\\\"\\\"\\n  SECURITY\\n\\n  \\\"\\\"\\\"\\n  `EXECUTION` features provide metadata necessary for operation execution.\\n  \\\"\\\"\\\"\\n  EXECUTION\\n}\\n\\ntype Panda\\n @join__type(graph: PANDAS)\\n{\\n  name: ID!\\n  favoriteFood: String @tag(name: \\\"nom-nom-nom\\\")\\n}\\n\\ntype Product implements ProductItf & SkuItf\\n  @join__implements(graph: PRODUCTS, interface: \\\"ProductItf\\\")\\n  @join__implements(graph: PRODUCTS, interface: \\\"SkuItf\\\")\\n  @join__type(graph: PRODUCTS, key: \\\"id\\\")\\n  @join__type(graph: PRODUCTS, key: \\\"sku package\\\")\\n @join__type(graph: PRODUCTS, key: \\\"sku variation { id }\\\")\\n{\\n  id: ID! @tag(name: \\\"hi-from-products\\\")\\n  sku: String\\n  package: String\\n  variation: ProductVariation\\n  dimensions: ProductDimension\\n  createdBy: User\\n  hidden: String\\n}\\n\\ntype ProductDimension\\n  @join__type(graph: PRODUCTS)\\n{\\n  size: String\\n  weight: Float\\n}\\n\\ninterface ProductItf implements SkuItf\\n  @join__implements(graph: PRODUCTS, interface: \\\"SkuItf\\\")\\n  @join__type(graph: PRODUCTS)\\n{\\n  id: ID!\\n  sku: String\\n  package: String\\n  variation: ProductVariation\\n  dimensions: ProductDimension\\n  createdBy: User\\n  hidden: String @inaccessible\\n}\\n\\ntype ProductVariation\\n  @join__type(graph: PRODUCTS)\\n{\\n  id: ID!\\n}\\n\\ntype Query\\n  @join__type(graph: PANDAS)\\n  @join__type(graph: PRODUCTS)\\n  @join__type(graph: USERS)\\n{\\n  allPandas: [Panda] @join__field(graph: PANDAS)\\n  panda(name: ID!): Panda @join__field(graph: PANDAS)\\n  allProducts: [ProductItf] @join__field(graph: PRODUCTS)\\n  product(id: ID!): ProductItf @join__field(graph: PRODUCTS)\\n}\\n\\nenum ShippingClass\\n  @join__type(graph: PRODUCTS)\\n{\\n  STANDARD @join__enumValue(graph: PRODUCTS)\\n  EXPRESS @join__enumValue(graph: PRODUCTS)\\n}\\n\\ninterface SkuItf\\n  @join__type(graph: PRODUCTS)\\n{\\n  sku: String\\n}\\n\\ntype User\\n  @join__type(graph: PRODUCTS, key: \\\"email\\\")\\n  @join__type(graph: USERS, key: \\\"email\\\")\\n{\\n  email: ID! @tag(name: \\\"test-from-users\\\")\\n  totalProductsCreated: Int\\n  name: String @join__field(graph: USERS)\\n}\",\"hints\":[{\"message\":\"[UNUSED_ENUM_TYPE]: Enum type \\\"ShippingClass\\\" is defined but unused. It will be included in the supergraph with all the values appearing in any subgraph (\\\"as if\\\" it was only used as an output type).\",\"code\":\"UNUSED_ENUM_TYPE\",\"nodes\":[],\"omittedNodesCount\":0}]}}".to_string()
 }

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -10,11 +10,12 @@ use derive_getters::Getters;
 pub mod events;
 pub mod run_composition;
 pub mod runner;
+pub mod subgraph_watchers;
 pub mod supergraph;
 pub mod types;
 
 #[cfg(feature = "composition-js")]
-mod watchers;
+pub mod watchers;
 
 #[derive(Getters, Debug, Clone, Eq, PartialEq)]
 pub struct CompositionSuccess {

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -10,11 +10,12 @@ use derive_getters::Getters;
 pub mod events;
 pub mod run_composition;
 pub mod runner;
+pub mod subgraph_watchers;
 pub mod supergraph;
 pub mod types;
 
 #[cfg(feature = "composition-js")]
-mod watchers;
+pub mod watchers;
 
 #[derive(Getters, Debug, Clone, Eq, PartialEq)]
 pub struct CompositionSuccess {
@@ -34,10 +35,12 @@ pub enum CompositionError {
     #[error("Failed to read the file at: {path}")]
     ReadFile { path: Utf8PathBuf, error: String },
     #[error("Encountered {} while trying to build a supergraph.", .source.length_string())]
-    Build { source: BuildErrors },
-}
-
-#[cfg(test)]
-pub fn compose_output() -> String {
-    "{\"Ok\":{\"supergraphSdl\":\"schema\\n  @link(url: \\\"https://specs.apollo.dev/link/v1.0\\\")\\n  @link(url: \\\"https://specs.apollo.dev/join/v0.3\\\", for: EXECUTION)\\n  @link(url: \\\"https://specs.apollo.dev/tag/v0.3\\\", import: [\\\"@tag\\\"])\\n  @link(url: \\\"https://specs.apollo.dev/inaccessible/v0.2\\\", import: [\\\"@inaccessible\\\"], for: SECURITY)\\n{\\n  query: Query\\n}\\n\\ndirective @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION\\n\\ndirective @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE\\n\\ndirective @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION\\n\\ndirective @join__graph(name: String!, url: String!) on ENUM_VALUE\\n\\ndirective @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE\\n\\ndirective @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR\\n\\ndirective @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION\\n\\ndirective @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA\\n\\ndirective @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA\\n\\nscalar join__FieldSet\\n\\nenum join__Graph {\\n  PANDAS @join__graph(name: \\\"pandas\\\", url: \\\"http://localhost:4003\\\")\\n  PRODUCTS @join__graph(name: \\\"products\\\", url: \\\"http://localhost:4002\\\")\\n  USERS @join__graph(name: \\\"users\\\", url: \\\"http://localhost:4001\\\")\\n}\\n\\nscalar link__Import \\n\\nenum link__Purpose {\\n  \\\"\\\"\\\"\\n  `SECURITY` features provide metadata necessary to securely resolve fields.\\n  \\\"\\\"\\\"\\n  SECURITY\\n\\n  \\\"\\\"\\\"\\n  `EXECUTION` features provide metadata necessary for operation execution.\\n  \\\"\\\"\\\"\\n  EXECUTION\\n}\\n\\ntype Panda\\n @join__type(graph: PANDAS)\\n{\\n  name: ID!\\n  favoriteFood: String @tag(name: \\\"nom-nom-nom\\\")\\n}\\n\\ntype Product implements ProductItf & SkuItf\\n  @join__implements(graph: PRODUCTS, interface: \\\"ProductItf\\\")\\n  @join__implements(graph: PRODUCTS, interface: \\\"SkuItf\\\")\\n  @join__type(graph: PRODUCTS, key: \\\"id\\\")\\n  @join__type(graph: PRODUCTS, key: \\\"sku package\\\")\\n @join__type(graph: PRODUCTS, key: \\\"sku variation { id }\\\")\\n{\\n  id: ID! @tag(name: \\\"hi-from-products\\\")\\n  sku: String\\n  package: String\\n  variation: ProductVariation\\n  dimensions: ProductDimension\\n  createdBy: User\\n  hidden: String\\n}\\n\\ntype ProductDimension\\n  @join__type(graph: PRODUCTS)\\n{\\n  size: String\\n  weight: Float\\n}\\n\\ninterface ProductItf implements SkuItf\\n  @join__implements(graph: PRODUCTS, interface: \\\"SkuItf\\\")\\n  @join__type(graph: PRODUCTS)\\n{\\n  id: ID!\\n  sku: String\\n  package: String\\n  variation: ProductVariation\\n  dimensions: ProductDimension\\n  createdBy: User\\n  hidden: String @inaccessible\\n}\\n\\ntype ProductVariation\\n  @join__type(graph: PRODUCTS)\\n{\\n  id: ID!\\n}\\n\\ntype Query\\n  @join__type(graph: PANDAS)\\n  @join__type(graph: PRODUCTS)\\n  @join__type(graph: USERS)\\n{\\n  allPandas: [Panda] @join__field(graph: PANDAS)\\n  panda(name: ID!): Panda @join__field(graph: PANDAS)\\n  allProducts: [ProductItf] @join__field(graph: PRODUCTS)\\n  product(id: ID!): ProductItf @join__field(graph: PRODUCTS)\\n}\\n\\nenum ShippingClass\\n  @join__type(graph: PRODUCTS)\\n{\\n  STANDARD @join__enumValue(graph: PRODUCTS)\\n  EXPRESS @join__enumValue(graph: PRODUCTS)\\n}\\n\\ninterface SkuItf\\n  @join__type(graph: PRODUCTS)\\n{\\n  sku: String\\n}\\n\\ntype User\\n  @join__type(graph: PRODUCTS, key: \\\"email\\\")\\n  @join__type(graph: USERS, key: \\\"email\\\")\\n{\\n  email: ID! @tag(name: \\\"test-from-users\\\")\\n  totalProductsCreated: Int\\n  name: String @join__field(graph: USERS)\\n}\",\"hints\":[{\"message\":\"[UNUSED_ENUM_TYPE]: Enum type \\\"ShippingClass\\\" is defined but unused. It will be included in the supergraph with all the values appearing in any subgraph (\\\"as if\\\" it was only used as an output type).\",\"code\":\"UNUSED_ENUM_TYPE\",\"nodes\":[],\"omittedNodesCount\":0}]}}".to_string()
+    Build {
+        source: BuildErrors,
+        // NB: in do_compose (rover_client/src/error -> BuildErrors) this includes num_subgraphs,
+        // but this is only important if we end up with a RoverError (it uses a singular or plural
+        // error message); so, leaving TBD if we go that route because it'll require figuring out
+        // from something like the supergraph_config how many subgraphs we attempted to compose
+        // (alternatively, we could just reword the error message to allow for either)
+    },
 }

--- a/src/composition/run_composition.rs
+++ b/src/composition/run_composition.rs
@@ -21,8 +21,8 @@ pub struct RunComposition<ReadF, ExecC> {
 
 impl<ReadF, ExecC> SubtaskHandleStream for RunComposition<ReadF, ExecC>
 where
-    ReadF: ReadFile + Clone + Send + Sync + 'static,
-    ExecC: ExecCommand + Clone + Send + Sync + 'static,
+    ReadF: ReadFile + Send + Sync + 'static,
+    ExecC: ExecCommand + Send + Sync + 'static,
 {
     type Input = SubgraphChanged;
     type Output = CompositionEvent;
@@ -71,5 +71,113 @@ where
             }
         });
         cancellation_token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        process::{ExitStatus, Output},
+        str::FromStr,
+    };
+
+    use anyhow::Result;
+    use apollo_federation_types::config::SupergraphConfig;
+    use camino::Utf8PathBuf;
+    use futures::{
+        stream::{once, BoxStream},
+        StreamExt,
+    };
+    use rstest::rstest;
+    use semver::Version;
+
+    use crate::{
+        composition::{
+            compose_output,
+            events::CompositionEvent,
+            supergraph::{
+                binary::{OutputTarget, SupergraphBinary},
+                config::FinalSupergraphConfig,
+                version::SupergraphVersion,
+            },
+            watchers::{
+                subtask::{Subtask, SubtaskRunStream},
+                watcher::subgraph::SubgraphChanged,
+            },
+        },
+        utils::effect::{exec::MockExecCommand, read_file::MockReadFile},
+    };
+
+    use super::RunComposition;
+
+    #[rstest]
+    #[case::success(false, compose_output())]
+    #[case::error(true, "invalid".to_string())]
+    #[tokio::test]
+    async fn test_runcomposition_handle(
+        #[case] composition_error: bool,
+        #[case] composition_output: String,
+    ) -> Result<()> {
+        let supergraph_config = FinalSupergraphConfig::new(
+            Some(Utf8PathBuf::from_str("/tmp/supergraph_config.yaml")?),
+            Utf8PathBuf::from_str("/tmp/target/supergraph_config.yaml")?,
+            SupergraphConfig::new(BTreeMap::new(), None),
+        );
+
+        let supergraph_binary = SupergraphBinary::new(
+            Utf8PathBuf::from_str("/tmp/supergraph")?,
+            SupergraphVersion::new(Version::from_str("2.8.0")?),
+            OutputTarget::Stdout,
+        );
+
+        let mut mock_exec = MockExecCommand::new();
+        mock_exec
+            .expect_exec_command()
+            .times(1)
+            .returning(move |_, _| {
+                Ok(Output {
+                    status: ExitStatus::default(),
+                    stdout: composition_output.as_bytes().into(),
+                    stderr: Vec::default(),
+                })
+            });
+
+        let mut mock_read_file = MockReadFile::new();
+        mock_read_file.expect_read_file().times(0);
+
+        let composition_handler = RunComposition::builder()
+            .supergraph_config(supergraph_config)
+            .supergraph_binary(supergraph_binary)
+            .exec_command(mock_exec)
+            .read_file(mock_read_file)
+            .build();
+
+        let subgraph_change_events: BoxStream<SubgraphChanged> =
+            once(async { SubgraphChanged::from("subgraph-name") }).boxed();
+        let (mut composition_messages, composition_subtask) = Subtask::new(composition_handler);
+        let abort_handle = composition_subtask.run(subgraph_change_events);
+
+        // Assert we always get a composition started event.
+        assert!(matches!(
+            composition_messages.next().await.unwrap(),
+            CompositionEvent::Started
+        ));
+
+        // Assert we get the expected final composition event.
+        if !composition_error {
+            assert!(matches!(
+                composition_messages.next().await.unwrap(),
+                CompositionEvent::Success(..)
+            ));
+        } else {
+            assert!(matches!(
+                composition_messages.next().await.unwrap(),
+                CompositionEvent::Error(..)
+            ));
+        }
+
+        abort_handle.cancel();
+        Ok(())
     }
 }

--- a/src/composition/run_composition.rs
+++ b/src/composition/run_composition.rs
@@ -48,9 +48,8 @@ where
                                         .send(CompositionEvent::Started)
                                         .tap_err(|err| tracing::error!("{:?}", err));
 
-                                    let result = self.supergraph_binary
-                                        .compose(&self.exec_command, &self.read_file, &path).await;
-                                    result
+                                    self.supergraph_binary
+                                        .compose(&self.exec_command, &self.read_file, &path).await
                                 };
                                 match output {
                                     Ok(success) => {

--- a/src/composition/run_composition.rs
+++ b/src/composition/run_composition.rs
@@ -1,8 +1,7 @@
 use buildstructor::Builder;
-use futures::stream::BoxStream;
 use tap::TapFallible;
-use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 
 use crate::utils::effect::{exec::ExecCommand, read_file::ReadFile};
 
@@ -22,153 +21,55 @@ pub struct RunComposition<ReadF, ExecC> {
 
 impl<ReadF, ExecC> SubtaskHandleStream for RunComposition<ReadF, ExecC>
 where
-    ReadF: ReadFile + Send + Sync + 'static,
-    ExecC: ExecCommand + Send + Sync + 'static,
+    ReadF: ReadFile + Clone + Send + Sync + 'static,
+    ExecC: ExecCommand + Clone + Send + Sync + 'static,
 {
     type Input = SubgraphChanged;
     type Output = CompositionEvent;
-
     fn handle(
         self,
-        sender: UnboundedSender<Self::Output>,
-        mut input: BoxStream<'static, Self::Input>,
-    ) -> AbortHandle {
-        let supergraph_config = self.supergraph_config.clone();
-        tokio::task::spawn(async move {
-            while (input.next().await).is_some() {
-                // NOTE: holding the read lock makes this blocking, we should
-                // ensure it is dropped asap.
-                let output = {
-                    let path = supergraph_config.read_lock().await;
-                    let _ = sender
-                        .send(CompositionEvent::Started)
-                        .tap_err(|err| tracing::error!("{:?}", err));
-                    self.supergraph_binary
-                        .compose(&self.exec_command, &self.read_file, &path)
-                        .await
-                };
-                match output {
-                    Ok(success) => {
-                        let _ = sender
-                            .send(CompositionEvent::Success(success))
-                            .tap_err(|err| tracing::error!("{:?}", err));
-                    }
-                    Err(err) => {
-                        let _ = sender
-                            .send(CompositionEvent::Error(err))
-                            .tap_err(|err| tracing::error!("{:?}", err));
-                    }
+        sender: tokio::sync::mpsc::UnboundedSender<Self::Output>,
+        mut input: futures::stream::BoxStream<'static, Self::Input>,
+    ) -> CancellationToken {
+        let cancellation_token = CancellationToken::new();
+        tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {}
+                    _ = {
+                        let supergraph_config = self.supergraph_config.clone();
+                        async move {
+                            while (input.next().await).is_some() {
+                                // this block makes sure that the read lock is dropped asap
+                                let output = {
+                                    let path = supergraph_config.read_lock().await;
+                                    let _ = sender
+                                        .send(CompositionEvent::Started)
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+
+                                    let result = self.supergraph_binary
+                                        .compose(&self.exec_command, &self.read_file, &path).await;
+                                    result
+                                };
+                                match output {
+                                    Ok(success) => {
+                                        let _ = sender
+                                            .send(CompositionEvent::Success(success))
+                                            .tap_err(|err| tracing::error!("{:?}", err));
+                                    }
+                                    Err(err) => {
+                                        let _ = sender
+                                            .send(CompositionEvent::Error(err))
+                                            .tap_err(|err| tracing::error!("{:?}", err));
+                                    }
+                                }
+                            }
+                        }
+                    } => {}
                 }
             }
-        })
-        .abort_handle()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        collections::BTreeMap,
-        process::{ExitStatus, Output},
-        str::FromStr,
-    };
-
-    use anyhow::Result;
-    use apollo_federation_types::config::SupergraphConfig;
-    use camino::Utf8PathBuf;
-    use futures::{
-        stream::{once, BoxStream},
-        StreamExt,
-    };
-    use rstest::rstest;
-    use semver::Version;
-
-    use crate::{
-        composition::{
-            compose_output,
-            events::CompositionEvent,
-            supergraph::{
-                binary::{OutputTarget, SupergraphBinary},
-                config::FinalSupergraphConfig,
-                version::SupergraphVersion,
-            },
-            watchers::{
-                subtask::{Subtask, SubtaskRunStream},
-                watcher::subgraph::SubgraphChanged,
-            },
-        },
-        utils::effect::{exec::MockExecCommand, read_file::MockReadFile},
-    };
-
-    use super::RunComposition;
-
-    #[rstest]
-    #[case::success(false, compose_output())]
-    #[case::error(true, "invalid".to_string())]
-    #[tokio::test]
-    async fn test_runcomposition_handle(
-        #[case] composition_error: bool,
-        #[case] composition_output: String,
-    ) -> Result<()> {
-        let supergraph_config = FinalSupergraphConfig::new(
-            Some(Utf8PathBuf::from_str("/tmp/supergraph_config.yaml")?),
-            Utf8PathBuf::from_str("/tmp/target/supergraph_config.yaml")?,
-            SupergraphConfig::new(BTreeMap::new(), None),
-        );
-
-        let supergraph_binary = SupergraphBinary::new(
-            Utf8PathBuf::from_str("/tmp/supergraph")?,
-            SupergraphVersion::new(Version::from_str("2.8.0")?),
-            OutputTarget::Stdout,
-        );
-
-        let mut mock_exec = MockExecCommand::new();
-        mock_exec
-            .expect_exec_command()
-            .times(1)
-            .returning(move |_, _| {
-                Ok(Output {
-                    status: ExitStatus::default(),
-                    stdout: composition_output.as_bytes().into(),
-                    stderr: Vec::default(),
-                })
-            });
-
-        let mut mock_read_file = MockReadFile::new();
-        mock_read_file.expect_read_file().times(0);
-
-        let composition_handler = RunComposition::builder()
-            .supergraph_config(supergraph_config)
-            .supergraph_binary(supergraph_binary)
-            .exec_command(mock_exec)
-            .read_file(mock_read_file)
-            .build();
-
-        let subgraph_change_events: BoxStream<SubgraphChanged> =
-            once(async { SubgraphChanged }).boxed();
-        let (mut composition_messages, composition_subtask) = Subtask::new(composition_handler);
-        let abort_handle = composition_subtask.run(subgraph_change_events);
-
-        // Assert we always get a composition started event.
-        assert!(matches!(
-            composition_messages.next().await.unwrap(),
-            CompositionEvent::Started
-        ));
-
-        // Assert we get the expected final composition event.
-        if !composition_error {
-            assert!(matches!(
-                composition_messages.next().await.unwrap(),
-                CompositionEvent::Success(..)
-            ));
-        } else {
-            assert!(matches!(
-                composition_messages.next().await.unwrap(),
-                CompositionEvent::Error(..)
-            ));
-        }
-
-        abort_handle.abort();
-        Ok(())
+        });
+        cancellation_token
     }
 }

--- a/src/composition/runner.rs
+++ b/src/composition/runner.rs
@@ -1,18 +1,11 @@
-use std::collections::HashMap;
-
 use apollo_federation_types::config::SupergraphConfig;
 use futures::stream::{empty, StreamExt};
-use tap::TapFallible;
-use tokio::task::AbortHandle;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::{
     composition::watchers::{
         subtask::{Subtask, SubtaskRunUnit},
-        watcher::{
-            file::FileWatcher, subgraph::SubgraphWatcher,
-            supergraph_config::SupergraphConfigWatcher,
-        },
+        watcher::{file::FileWatcher, supergraph_config::SupergraphConfigWatcher},
     },
     utils::effect::{exec::TokioCommand, read_file::FsReadFile},
     RoverResult,
@@ -21,11 +14,9 @@ use crate::{
 use super::{
     events::CompositionEvent,
     run_composition::RunComposition,
+    subgraph_watchers::SubgraphWatchers,
     supergraph::{binary::SupergraphBinary, config::FinalSupergraphConfig},
-    watchers::{
-        subtask::{SubtaskHandleStream, SubtaskRunStream},
-        watcher::{subgraph::SubgraphChanged, supergraph_config::SupergraphConfigDiff},
-    },
+    watchers::{subtask::SubtaskRunStream, watcher::supergraph_config::SupergraphConfigDiff},
 };
 
 // TODO: handle retry flag for subgraphs (see rover dev help)
@@ -91,99 +82,5 @@ impl Runner {
         } else {
             None
         }
-    }
-}
-
-struct SubgraphWatchers {
-    watchers: HashMap<
-        String,
-        (
-            UnboundedReceiverStream<SubgraphChanged>,
-            Subtask<SubgraphWatcher, SubgraphChanged>,
-        ),
-    >,
-}
-
-impl SubgraphWatchers {
-    pub fn new(supergraph_config: SupergraphConfig) -> SubgraphWatchers {
-        let watchers = supergraph_config
-            .into_iter()
-            .filter_map(|(name, subgraph_config)| {
-                SubgraphWatcher::try_from(subgraph_config.schema)
-                    .tap_err(|err| tracing::warn!("Skipping subgraph {}: {:?}", name, err))
-                    .ok()
-                    .map(|value| (name, Subtask::new(value)))
-            })
-            .collect();
-        SubgraphWatchers { watchers }
-    }
-}
-
-impl SubtaskHandleStream for SubgraphWatchers {
-    type Input = SupergraphConfigDiff;
-    type Output = SubgraphChanged;
-    fn handle(
-        self,
-        sender: tokio::sync::mpsc::UnboundedSender<Self::Output>,
-        mut input: futures::stream::BoxStream<'static, Self::Input>,
-    ) -> tokio::task::AbortHandle {
-        tokio::task::spawn(async move {
-            let mut abort_handles: HashMap<String, (AbortHandle, AbortHandle)> = HashMap::new();
-            for (subgraph_name, (mut messages, subtask)) in self.watchers.into_iter() {
-                let sender = sender.clone();
-                let messages_abort_handle = tokio::task::spawn(async move {
-                    while let Some(event) = messages.next().await {
-                        let _ = sender
-                            .send(event)
-                            .tap_err(|err| tracing::error!("{:?}", err));
-                    }
-                })
-                .abort_handle();
-                let subtask_abort_handle = subtask.run();
-                abort_handles.insert(subgraph_name, (messages_abort_handle, subtask_abort_handle));
-            }
-
-            // for supergraph diff events
-            while let Some(diff) = input.next().await {
-                // for new subgraphs added to the session
-                for (name, subgraph_config) in diff.added() {
-                    if let Ok((mut messages, subtask)) =
-                        SubgraphWatcher::try_from(subgraph_config.schema.clone())
-                            .map(Subtask::new)
-                            .tap_err(|err| {
-                                tracing::warn!(
-                                    "Cannot configure new subgraph for {name}: {:?}",
-                                    err
-                                )
-                            })
-                    {
-                        let sender = sender.clone();
-                        let messages_abort_handle = tokio::spawn(async move {
-                            while let Some(event) = messages.next().await {
-                                let _ = sender
-                                    .send(event)
-                                    .tap_err(|err| tracing::error!("{:?}", err));
-                            }
-                        })
-                        .abort_handle();
-                        let subtask_abort_handle = subtask.run();
-                        abort_handles.insert(
-                            name.to_string(),
-                            (messages_abort_handle, subtask_abort_handle),
-                        );
-                    }
-                }
-                for name in diff.removed() {
-                    if let Some((messages_abort_handle, subtask_abort_handle)) =
-                        abort_handles.get(name)
-                    {
-                        messages_abort_handle.abort();
-                        subtask_abort_handle.abort();
-                        abort_handles.remove(name);
-                    }
-                }
-            }
-        })
-        .abort_handle()
     }
 }

--- a/src/composition/subgraph_watchers.rs
+++ b/src/composition/subgraph_watchers.rs
@@ -1,0 +1,163 @@
+use std::{
+    collections::HashMap,
+    ops::DerefMut,
+    sync::{Arc, OnceLock},
+};
+
+use apollo_federation_types::config::SupergraphConfig;
+use rover_std::infoln;
+use tap::TapFallible;
+use tokio::sync::Mutex;
+use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
+use tokio_util::sync::CancellationToken;
+
+use super::watchers::{
+    subtask::{Subtask, SubtaskHandleStream, SubtaskRunUnit},
+    watcher::{
+        subgraph::{SubgraphChanged, SubgraphWatcher},
+        supergraph_config::SupergraphConfigDiff,
+    },
+};
+
+pub struct SubgraphWatchers {
+    watchers: HashMap<
+        String,
+        (
+            UnboundedReceiverStream<SubgraphChanged>,
+            Subtask<SubgraphWatcher, SubgraphChanged>,
+        ),
+    >,
+}
+
+impl SubgraphWatchers {
+    pub fn new(supergraph_config: SupergraphConfig) -> SubgraphWatchers {
+        let watchers = supergraph_config
+            .into_iter()
+            .filter_map(|(name, subgraph_config)| {
+                SubgraphWatcher::try_from((name.to_string(), subgraph_config.schema))
+                    .tap_err(|err| tracing::warn!("Skipping subgraph {}: {:?}", name, err))
+                    .ok()
+                    .map(|value| (name, Subtask::new(value)))
+            })
+            .collect();
+        SubgraphWatchers { watchers }
+    }
+
+    fn spawn_subgraph_subtask(
+        sender: tokio::sync::mpsc::UnboundedSender<SubgraphChanged>,
+        mut messages: UnboundedReceiverStream<SubgraphChanged>,
+        subtask: Subtask<SubgraphWatcher, SubgraphChanged>,
+    ) -> CancellationToken {
+        let cancellation_token = CancellationToken::new();
+        tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                let messages_abort_handle = Arc::new(OnceLock::new());
+                let subtask_cancellation_token = Arc::new(OnceLock::new());
+                tokio::select! {
+                    _ = {
+                        cancellation_token.cancelled()
+                    } => {
+                        if let Some(messages_abort_handle) = messages_abort_handle.get() {
+                            messages_abort_handle.abort();
+                        }
+                        if let Some(subtask_cancellation_token) = subtask_cancellation_token.get() {
+                            subtask_cancellation_token.cancel();
+                        }
+                    }
+                    _ = {
+                        let messages_abort_handle = messages_abort_handle.clone();
+                        let subtask_cancellation_token = subtask_cancellation_token.clone();
+                        async move {
+                            let abort_handle = tokio::task::spawn(async move {
+                                while let Some(event) = messages.next().await {
+                                    let _ = sender
+                                        .send(event)
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                }
+                            }).abort_handle();
+                            let _ = messages_abort_handle.set(abort_handle).tap_err(|err| tracing::error!("{:?}", err));
+                            let _ = subtask_cancellation_token.set(subtask.run()).tap_err(|err| tracing::error!("{:?}", err));
+                        }
+                    } => {}
+                }
+            }
+        });
+        cancellation_token
+    }
+}
+
+impl SubtaskHandleStream for SubgraphWatchers {
+    type Input = SupergraphConfigDiff;
+    type Output = SubgraphChanged;
+    fn handle(
+        self,
+        sender: tokio::sync::mpsc::UnboundedSender<Self::Output>,
+        mut input: futures::stream::BoxStream<'static, Self::Input>,
+    ) -> CancellationToken {
+        let cancellation_token = CancellationToken::new();
+        tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                let abort_handles: Arc<Mutex<HashMap<String, CancellationToken>>> =
+                    Arc::new(Mutex::new(HashMap::new()));
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        let abort_handles = abort_handles.clone();
+                        let mut abort_handles = abort_handles.lock().await;
+                        let abort_handles = abort_handles.deref_mut();
+                        for (subgraph_name, abort_handle) in abort_handles.into_iter() {
+                            infoln!("Shutting down subgraph: {}", subgraph_name);
+                            abort_handle.cancel();
+                        }
+                        abort_handles.clear();
+                    }
+                    _ = {
+                        let abort_handles = abort_handles.clone();
+                        async move {
+
+                            for (subgraph_name, (messages, subtask)) in self.watchers.into_iter() {
+                                let sender = sender.clone();
+                                let cancellation_token = Self::spawn_subgraph_subtask(sender, messages, subtask);
+                                let mut abort_handles = abort_handles.lock().await;
+                                let abort_handles = abort_handles.deref_mut();
+                                abort_handles.insert(subgraph_name, cancellation_token);
+                            }
+
+                            // for supergraph diff events
+                            while let Some(diff) = input.next().await {
+                                // for new subgraphs added to the session
+                                for (name, subgraph_config) in diff.added() {
+                                    if let Ok((messages, subtask)) = SubgraphWatcher::try_from((
+                                        name.to_string(),
+                                        subgraph_config.schema.clone(),
+                                    ))
+                                        .map(Subtask::new)
+                                        .tap_err(|err| {
+                                            tracing::warn!("Cannot configure new subgraph for {name}: {:?}", err)
+                                        }) {
+                                            let sender = sender.clone();
+                                            let cancellation_token = Self::spawn_subgraph_subtask(sender, messages, subtask);
+                                            let mut abort_handles = abort_handles.lock().await;
+                                            let abort_handles = abort_handles.deref_mut();
+                                            abort_handles.insert(name.to_string(), cancellation_token);
+                                        }
+                                }
+                                for name in diff.removed() {
+                                    let mut abort_handles = abort_handles.lock().await;
+                                    let abort_handles = abort_handles.deref_mut();
+                                    if let Some(cancellation_token) = abort_handles.get(name)
+                                    {
+                                        cancellation_token.cancel();
+                                        abort_handles.remove(name);
+                                    }
+                                }
+                            }
+                        }
+                    } => {}
+                }
+            }
+        });
+        cancellation_token
+    }
+}

--- a/src/composition/subgraph_watchers.rs
+++ b/src/composition/subgraph_watchers.rs
@@ -106,7 +106,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                         let abort_handles = abort_handles.clone();
                         let mut abort_handles = abort_handles.lock().await;
                         let abort_handles = abort_handles.deref_mut();
-                        for (subgraph_name, abort_handle) in abort_handles.into_iter() {
+                        for (subgraph_name, abort_handle) in abort_handles.iter_mut() {
                             infoln!("Shutting down subgraph: {}", subgraph_name);
                             abort_handle.cancel();
                         }

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -176,10 +176,7 @@ mod tests {
     use speculoos::prelude::*;
 
     use crate::{
-        composition::{
-            compose_output,
-            supergraph::{config::FinalSupergraphConfig, version::SupergraphVersion},
-        },
+        composition::supergraph::{config::FinalSupergraphConfig, version::SupergraphVersion},
         utils::effect::{exec::MockExecCommand, read_file::MockReadFile},
     };
 
@@ -203,8 +200,13 @@ mod tests {
     }
 
     #[fixture]
+    fn build_output() -> String {
+        "{\"Ok\":{\"supergraphSdl\":\"schema\\n  @link(url: \\\"https://specs.apollo.dev/link/v1.0\\\")\\n  @link(url: \\\"https://specs.apollo.dev/join/v0.3\\\", for: EXECUTION)\\n  @link(url: \\\"https://specs.apollo.dev/tag/v0.3\\\", import: [\\\"@tag\\\"])\\n  @link(url: \\\"https://specs.apollo.dev/inaccessible/v0.2\\\", import: [\\\"@inaccessible\\\"], for: SECURITY)\\n{\\n  query: Query\\n}\\n\\ndirective @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION\\n\\ndirective @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE\\n\\ndirective @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION\\n\\ndirective @join__graph(name: String!, url: String!) on ENUM_VALUE\\n\\ndirective @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE\\n\\ndirective @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR\\n\\ndirective @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION\\n\\ndirective @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA\\n\\ndirective @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA\\n\\nscalar join__FieldSet\\n\\nenum join__Graph {\\n  PANDAS @join__graph(name: \\\"pandas\\\", url: \\\"http://localhost:4003\\\")\\n  PRODUCTS @join__graph(name: \\\"products\\\", url: \\\"http://localhost:4002\\\")\\n  USERS @join__graph(name: \\\"users\\\", url: \\\"http://localhost:4001\\\")\\n}\\n\\nscalar link__Import \\n\\nenum link__Purpose {\\n  \\\"\\\"\\\"\\n  `SECURITY` features provide metadata necessary to securely resolve fields.\\n  \\\"\\\"\\\"\\n  SECURITY\\n\\n  \\\"\\\"\\\"\\n  `EXECUTION` features provide metadata necessary for operation execution.\\n  \\\"\\\"\\\"\\n  EXECUTION\\n}\\n\\ntype Panda\\n @join__type(graph: PANDAS)\\n{\\n  name: ID!\\n  favoriteFood: String @tag(name: \\\"nom-nom-nom\\\")\\n}\\n\\ntype Product implements ProductItf & SkuItf\\n  @join__implements(graph: PRODUCTS, interface: \\\"ProductItf\\\")\\n  @join__implements(graph: PRODUCTS, interface: \\\"SkuItf\\\")\\n  @join__type(graph: PRODUCTS, key: \\\"id\\\")\\n  @join__type(graph: PRODUCTS, key: \\\"sku package\\\")\\n @join__type(graph: PRODUCTS, key: \\\"sku variation { id }\\\")\\n{\\n  id: ID! @tag(name: \\\"hi-from-products\\\")\\n  sku: String\\n  package: String\\n  variation: ProductVariation\\n  dimensions: ProductDimension\\n  createdBy: User\\n  hidden: String\\n}\\n\\ntype ProductDimension\\n  @join__type(graph: PRODUCTS)\\n{\\n  size: String\\n  weight: Float\\n}\\n\\ninterface ProductItf implements SkuItf\\n  @join__implements(graph: PRODUCTS, interface: \\\"SkuItf\\\")\\n  @join__type(graph: PRODUCTS)\\n{\\n  id: ID!\\n  sku: String\\n  package: String\\n  variation: ProductVariation\\n  dimensions: ProductDimension\\n  createdBy: User\\n  hidden: String @inaccessible\\n}\\n\\ntype ProductVariation\\n  @join__type(graph: PRODUCTS)\\n{\\n  id: ID!\\n}\\n\\ntype Query\\n  @join__type(graph: PANDAS)\\n  @join__type(graph: PRODUCTS)\\n  @join__type(graph: USERS)\\n{\\n  allPandas: [Panda] @join__field(graph: PANDAS)\\n  panda(name: ID!): Panda @join__field(graph: PANDAS)\\n  allProducts: [ProductItf] @join__field(graph: PRODUCTS)\\n  product(id: ID!): ProductItf @join__field(graph: PRODUCTS)\\n}\\n\\nenum ShippingClass\\n  @join__type(graph: PRODUCTS)\\n{\\n  STANDARD @join__enumValue(graph: PRODUCTS)\\n  EXPRESS @join__enumValue(graph: PRODUCTS)\\n}\\n\\ninterface SkuItf\\n  @join__type(graph: PRODUCTS)\\n{\\n  sku: String\\n}\\n\\ntype User\\n  @join__type(graph: PRODUCTS, key: \\\"email\\\")\\n  @join__type(graph: USERS, key: \\\"email\\\")\\n{\\n  email: ID! @tag(name: \\\"test-from-users\\\")\\n  totalProductsCreated: Int\\n  name: String @join__field(graph: USERS)\\n}\",\"hints\":[{\"message\":\"[UNUSED_ENUM_TYPE]: Enum type \\\"ShippingClass\\\" is defined but unused. It will be included in the supergraph with all the values appearing in any subgraph (\\\"as if\\\" it was only used as an output type).\",\"code\":\"UNUSED_ENUM_TYPE\",\"nodes\":[],\"omittedNodesCount\":0}]}}".to_string()
+    }
+
+    #[fixture]
     fn build_result() -> BuildResult {
-        serde_json::from_str::<BuildResult>(&compose_output()).unwrap()
+        serde_json::from_str::<BuildResult>(&build_output()).unwrap()
     }
 
     #[fixture]
@@ -271,7 +273,10 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_compose_success(composition_output: CompositionSuccess) -> Result<()> {
+    async fn test_compose_success(
+        build_output: String,
+        composition_output: CompositionSuccess,
+    ) -> Result<()> {
         let supergraph_version = SupergraphVersion::new(fed_two_eight());
         let binary_path = Utf8PathBuf::from_str("/tmp/supergraph")?;
         let output_target = OutputTarget::Stdout;
@@ -295,6 +300,7 @@ mod tests {
         let mut mock_read_file = MockReadFile::new();
         mock_read_file.expect_read_file().times(0);
         let mut mock_exec = MockExecCommand::new();
+        let build_output = build_output.clone();
 
         mock_exec
             .expect_exec_command()
@@ -306,7 +312,7 @@ mod tests {
             .returning(move |_, _| {
                 Ok(Output {
                     status: ExitStatus::default(),
-                    stdout: compose_output().as_bytes().into(),
+                    stdout: build_output.clone().as_bytes().into(),
                     stderr: Vec::default(),
                 })
             });

--- a/src/composition/supergraph/config/resolve/subgraph.rs
+++ b/src/composition/supergraph/config/resolve/subgraph.rs
@@ -659,7 +659,7 @@ mod tests {
 
         // THEN we should receive an error that the path was unable to be resolved
         let subject = assert_that!(result).is_err().subject;
-        let _ = if let ResolveSubgraphError::FileNotFound {
+        if let ResolveSubgraphError::FileNotFound {
             subgraph_name: actual_subgraph_name,
             supergraph_yaml_path,
             path,

--- a/src/composition/watchers/mod.rs
+++ b/src/composition/watchers/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod subtask;
+pub mod subtask;
 pub mod watcher;

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -1,9 +1,12 @@
+use std::sync::{Arc, OnceLock};
+
 use camino::Utf8PathBuf;
-use futures::{stream::BoxStream, StreamExt};
-use rover_std::{errln, Fs};
+use rover_std::{errln, Fs, RoverStdError};
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
+
+use crate::composition::watchers::subtask::SubtaskHandleUnit;
 
 #[derive(Clone, Debug)]
 pub struct FileWatcher {
@@ -15,25 +18,75 @@ impl FileWatcher {
         Self { path }
     }
 
-    pub fn watch(self) -> BoxStream<'static, String> {
-        let path = self.path;
-        let (file_tx, file_rx) = unbounded_channel();
-        let output = UnboundedReceiverStream::new(file_rx);
-        Fs::watch_file(path.clone(), file_tx);
-        output
-            .filter_map(move |result| {
-                let path = path.clone();
-                async move {
-                    result
-                        .and_then(|_| {
-                            Fs::read_file(path).tap_err(|err| {
-                                tracing::error!("Could not read file: {:?}", err);
-                                errln!("error reading file: {:?}", err);
-                            })
-                        })
-                        .ok()
+    fn read_file(&self) -> Result<String, RoverStdError> {
+        Fs::read_file(&self.path).tap_err(|err| {
+            tracing::error!("Could not read file: {:?}", err);
+            errln!("error reading file: {:?}", err);
+        })
+    }
+}
+
+impl SubtaskHandleUnit for FileWatcher {
+    type Output = String;
+
+    fn handle(self, sender: tokio::sync::mpsc::UnboundedSender<Self::Output>) -> CancellationToken {
+        let cancellation_token = CancellationToken::new();
+        match self.read_file() {
+            Ok(contents) => {
+                let _ = sender.send(contents).tap_err(|err| {
+                    tracing::error!(
+                        "Could not push initial file watch message. Error: {:?}",
+                        err
+                    );
+                });
+            }
+            Err(err) => {
+                tracing::error!(
+                    "Could not push initial file watch message. Error: {:?}",
+                    err
+                );
+            }
+        }
+        tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            let abort_handle = Arc::new(OnceLock::new());
+            async move {
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        let abort_handle = abort_handle.clone();
+                        if let Some(abort_handle) = abort_handle.get() {
+                            abort_handle.abort();
+                        }
+                    }
+                    _ = {
+                        let abort_handle = abort_handle.clone();
+                        async move {
+                            tracing::debug!("!!!!!");
+                            let (file_tx, mut file_rx) = unbounded_channel();
+                            let join_handle = Fs::watch_file(self.path.clone(), file_tx);
+                            let _ = abort_handle.set(join_handle).tap_err(|err| tracing::error!("{:?}", err));
+                            while file_rx.recv().await.is_some() {
+                                match Fs::read_file(self.path.clone()) {
+                                    Ok(contents) => {
+                                        let _ = sender.send(contents).tap_err(|err| {
+                                            tracing::error!(
+                                                "Could not send new file contents for file ({}). Error: {:?}",
+                                                self.path,
+                                                err
+                                            )
+                                        });
+                                    }
+                                    Err(err) => {
+                                        tracing::error!("Could not read file: {:?}", err);
+                                        errln!("error reading file: {:?}", err);
+                                    }
+                                }
+                            }
+                        }
+                    } => {}
                 }
-            })
-            .boxed()
+            }
+        });
+        cancellation_token
     }
 }

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -1,18 +1,26 @@
-use std::{marker::Send, pin::Pin};
+use std::{
+    fmt::Display,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use apollo_federation_types::config::SchemaSource;
-use futures::{Stream, StreamExt};
+use derive_getters::Getters;
+use futures::StreamExt;
 use tap::TapFallible;
 use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedSender},
     task::AbortHandle,
 };
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     cli::RoverOutputFormatKind,
     command::subgraph::introspect::Introspect as SubgraphIntrospect,
-    composition::{types::SubgraphUrl, watchers::subtask::SubtaskHandleUnit},
+    composition::{
+        types::SubgraphUrl,
+        watchers::subtask::{Subtask, SubtaskHandleUnit, SubtaskRunUnit},
+    },
     options::{IntrospectOpts, OutputChannelKind, OutputOpts},
 };
 
@@ -26,6 +34,8 @@ pub struct UnsupportedSchemaSource(SchemaSource);
 /// changes because it informs any listeners that they may need to react (eg, by recomposing when
 /// the listener is composition)
 pub struct SubgraphWatcher {
+    /// The name of the subgraph being watched
+    name: String,
     /// The kind of watcher used (eg, file, introspection)
     watcher: SubgraphWatcherKind,
 }
@@ -42,26 +52,26 @@ pub enum SubgraphWatcherKind {
     /// Don't ever update, schema is only pulled once.
     // TODO: figure out what to do with this; is it ever used? can we remove it?
     _Once(String),
-
-    /// Event specifically used for testing watch handlers.
-    #[cfg(test)]
-    TestWatcher,
 }
 
-impl TryFrom<SchemaSource> for SubgraphWatcher {
+impl TryFrom<(String, SchemaSource)> for SubgraphWatcher {
     type Error = UnsupportedSchemaSource;
 
     // SchemaSource comes from Apollo Federation types. Importantly, it strips comments and
     // directives from introspection (but not when the source is a file)
-    fn try_from(schema_source: SchemaSource) -> Result<Self, Self::Error> {
+    fn try_from(
+        (subgraph_name, schema_source): (String, SchemaSource),
+    ) -> Result<Self, Self::Error> {
         match schema_source {
             SchemaSource::File { file } => Ok(Self {
+                name: subgraph_name,
                 watcher: SubgraphWatcherKind::File(FileWatcher::new(file)),
             }),
             SchemaSource::SubgraphIntrospection {
                 subgraph_url,
                 introspection_headers,
             } => Ok(Self {
+                name: subgraph_name,
                 watcher: SubgraphWatcherKind::Introspect(SubgraphIntrospection::new(
                     subgraph_url,
                     introspection_headers.map(|header_map| header_map.into_iter().collect()),
@@ -73,28 +83,13 @@ impl TryFrom<SchemaSource> for SubgraphWatcher {
     }
 }
 
-impl SubgraphWatcherKind {
-    /// Watch a subgraph for changes based on the kind of watcher attached.
-    ///
-    /// Development note: this is a stream of Strings, but in the future we might want something
-    /// more flexible to get type safety.
-    async fn watch(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
+impl SubtaskHandleUnit for SubgraphWatcherKind {
+    type Output = String;
+    fn handle(self, sender: UnboundedSender<Self::Output>) -> CancellationToken {
         match self {
-            Self::File(file_watcher) => file_watcher.clone().watch(),
-            Self::Introspect(introspection) => introspection.watch(),
-            // TODO: figure out what this is; sdl? stdin one-off? either way, probs not watching
-            Self::_Once(_) => unimplemented!(),
-
-            // Create a new single buffered channel for testing watch events.
-            #[cfg(test)]
-            Self::TestWatcher => {
-                use tokio::sync::mpsc::channel;
-                use tokio_stream::wrappers::ReceiverStream;
-
-                let (tx, rx) = channel(1);
-                tx.send("watch event".to_string()).await.unwrap();
-                ReceiverStream::new(rx).boxed()
-            }
+            Self::File(file_watcher) => file_watcher.handle(sender),
+            Self::Introspect(introspection) => introspection.handle(sender),
+            _ => unimplemented!(),
         }
     }
 }
@@ -112,95 +107,133 @@ impl SubgraphIntrospection {
     fn new(endpoint: SubgraphUrl, headers: Option<Vec<(String, String)>>) -> Self {
         Self { endpoint, headers }
     }
+}
 
-    // TODO: better typing so that it's over some impl, not string; makes all watch() fns require
-    // returning a string
-    fn watch(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
-        let client = reqwest::Client::new();
+impl SubtaskHandleUnit for SubgraphIntrospection {
+    type Output = String;
+
+    fn handle(self, sender: UnboundedSender<Self::Output>) -> CancellationToken {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
         let endpoint = self.endpoint.clone();
         let headers = self.headers.clone();
 
-        let (tx, rx) = unbounded_channel();
-        let rx_stream = UnboundedReceiverStream::new(rx);
+        let cancellation_token = CancellationToken::new();
+        let introspect_cancellation_token: Arc<OnceLock<CancellationToken>> =
+            Arc::new(OnceLock::new());
+        let receiver_abort_handle: Arc<OnceLock<AbortHandle>> = Arc::new(OnceLock::new());
 
         // Spawn a tokio task in the background to watch for subgraph changes
-        tokio::spawn(async move {
-            // TODO: handle errors?
-            let _ = SubgraphIntrospect {
-                opts: IntrospectOpts {
-                    endpoint,
-                    headers,
-                    watch: true,
-                },
-            }
-            .run(
-                client,
-                &OutputOpts {
-                    format_kind: RoverOutputFormatKind::default(),
-                    output_file: None,
-                    // Attach a transmitter to stream back any subgraph changes
-                    channel: Some(tx),
-                },
-                // TODO: impl retries (at least for dev from cli flag)
-                None,
-            )
-            .await;
-        });
-
-        // Stream any subgraph changes, filtering out empty responses (None) while passing along
-        // the sdl changes
-        rx_stream
-            .filter_map(|change| async move {
-                match change {
-                    OutputChannelKind::Sdl(sdl) => Some(sdl),
+        tokio::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        let introspect_cancellation_token = introspect_cancellation_token.clone();
+                        let receiver_abort_handle = receiver_abort_handle.clone();
+                        if let Some(introspect_cancellation_token) = introspect_cancellation_token.get() {
+                            introspect_cancellation_token.cancel();
+                        }
+                        if let Some(receiver_abort_handle) = receiver_abort_handle.get() {
+                            receiver_abort_handle.abort();
+                        }
+                    }
+                    _ = {
+                        let introspect_cancellation_token = introspect_cancellation_token.clone();
+                        let receiver_abort_handle = receiver_abort_handle.clone();
+                        async move {
+                            let (tx, mut rx) = unbounded_channel();
+                            let _ = receiver_abort_handle.set(tokio::task::spawn(async move {
+                                while let Some(change) = rx.recv().await {
+                                    match change {
+                                        OutputChannelKind::Sdl(sdl) => {
+                                            let _ = sender.send(sdl).tap_err(|err| tracing::error!("{:?}", err));
+                                        }
+                                    }
+                                }
+                            }).abort_handle()).tap_err(|err| tracing::error!("{:?}", err));
+                            let _ = introspect_cancellation_token.set({
+                                // TODO: handle errors?
+                                SubgraphIntrospect {
+                                    opts: IntrospectOpts {
+                                        endpoint,
+                                        headers,
+                                        watch: true,
+                                    },
+                                }
+                                .exec_and_watch(
+                                    client,
+                                    &OutputOpts {
+                                        format_kind: RoverOutputFormatKind::default(),
+                                        output_file: None,
+                                        // Attach a transmitter to stream back any subgraph changes
+                                        channel: Some(tx),
+                                    },
+                                    // TODO: impl retries (at least for dev from cli flag)
+                                    None,
+                                )
+                            }).tap_err(|err| tracing::error!("{:?}", err));
+                        }
+                    } => {}
                 }
-            })
-            .boxed()
+            }
+        });
+        cancellation_token
     }
 }
 
-/// A unit struct denoting a change to a subgraph, used by composition to know whether to
-/// recompose.
-pub struct SubgraphChanged;
+/// A unit struct denoting a change to a subgraph, used by composition to know whether to recompose
+#[derive(Clone, Debug, Eq, PartialEq, Getters)]
+pub struct SubgraphChanged {
+    name: String,
+}
+
+impl<T: Display> From<T> for SubgraphChanged {
+    fn from(value: T) -> Self {
+        SubgraphChanged {
+            name: value.to_string(),
+        }
+    }
+}
 
 impl SubtaskHandleUnit for SubgraphWatcher {
     type Output = SubgraphChanged;
 
-    fn handle(self, sender: UnboundedSender<Self::Output>) -> AbortHandle {
-        tokio::spawn(async move {
-            let mut watcher = self.watcher.watch().await;
-            while watcher.next().await.is_some() {
-                let _ = sender
-                    .send(SubgraphChanged)
-                    .tap_err(|err| tracing::error!("{:?}", err));
+    fn handle(self, sender: UnboundedSender<Self::Output>) -> CancellationToken {
+        let cancellation_token = CancellationToken::new();
+        tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                let subtask_cancellation_token = Arc::new(OnceLock::new());
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        let subtask_cancellation_token = subtask_cancellation_token.clone();
+                        if let Some(subtask_cancellation_token) = subtask_cancellation_token.get() {
+                            subtask_cancellation_token.cancel();
+                        }
+                    }
+                    _ = {
+                        let subtask_cancellation_token = subtask_cancellation_token.clone();
+                        async move {
+                            let (mut watcher_messages, watcher_subtask) =
+                                <Subtask<_, String>>::new(self.watcher);
+                            tokio::task::spawn(async move {
+                                while watcher_messages.next().await.is_some() {
+                                    let _ = sender
+                                        .send(SubgraphChanged {
+                                            name: self.name.to_string(),
+                                        })
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                }
+                            });
+                            let _ = subtask_cancellation_token.set(watcher_subtask.run()).tap_err(|err| tracing::error!("{:?}", err));
+                        }
+                    } => {}
+                }
             }
-        })
-        .abort_handle()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use futures::StreamExt;
-
-    use crate::composition::watchers::subtask::{Subtask, SubtaskRunUnit};
-
-    use super::{SubgraphChanged, SubgraphWatcher, SubgraphWatcherKind};
-
-    #[tokio::test]
-    async fn test_subgraphwatcher_handle() {
-        let watch_handler = SubgraphWatcher {
-            watcher: SubgraphWatcherKind::TestWatcher,
-        };
-
-        let (mut watch_messages, watch_subtask) = Subtask::new(watch_handler);
-        let abort_handle = watch_subtask.run();
-
-        assert!(matches!(
-            watch_messages.next().await.unwrap(),
-            SubgraphChanged
-        ));
-
-        abort_handle.abort();
+        });
+        cancellation_token
     }
 }

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -1,13 +1,16 @@
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::{Arc, OnceLock},
+};
 
 use apollo_federation_types::config::{ConfigError, SubgraphConfig, SupergraphConfig};
 use derive_getters::Getters;
-use futures::StreamExt;
-use rover_std::errln;
 use tap::TapFallible;
-use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 
-use crate::composition::watchers::subtask::SubtaskHandleUnit;
+use crate::composition::watchers::subtask::{Subtask, SubtaskHandleUnit, SubtaskRunUnit};
 
 use super::file::FileWatcher;
 
@@ -30,31 +33,52 @@ impl SupergraphConfigWatcher {
 
 impl SubtaskHandleUnit for SupergraphConfigWatcher {
     type Output = SupergraphConfigDiff;
-
-    fn handle(self, sender: UnboundedSender<Self::Output>) -> AbortHandle {
-        tokio::spawn(async move {
-            let mut latest_supergraph_config = self.supergraph_config.clone();
-            while let Some(contents) = self.file_watcher.clone().watch().next().await {
-                match SupergraphConfig::new_from_yaml(&contents) {
-                    Ok(supergraph_config) => {
-                        if let Ok(supergraph_config_diff) = SupergraphConfigDiff::new(
-                            &latest_supergraph_config,
-                            supergraph_config.clone(),
-                        ) {
-                            let _ = sender
-                                .send(supergraph_config_diff)
-                                .tap_err(|err| tracing::error!("{:?}", err));
+    fn handle(self, sender: UnboundedSender<Self::Output>) -> CancellationToken {
+        let cancellation_token = CancellationToken::new();
+        tokio::spawn({
+            let cancellation_token = cancellation_token.clone();
+            async move {
+                let subtask_cancellation_token = Arc::new(OnceLock::new());
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        let subtask_cancellation_token = subtask_cancellation_token.clone();
+                        if let Some(subtask_cancellation_token) = subtask_cancellation_token.get() {
+                            subtask_cancellation_token.cancel();
                         }
-                        latest_supergraph_config = supergraph_config;
                     }
-                    Err(err) => {
-                        tracing::error!("could not parse supergraph config file: {:?}", err);
-                        errln!("could not parse supergraph config file: {:?}", err);
-                    }
+                    _ = {
+                        let subtask_cancellation_token = subtask_cancellation_token.clone();
+                        async move {
+                            let mut latest_supergraph_config = self.supergraph_config.clone();
+                            let (mut messages, subtask) = <Subtask<_, String>>::new(self.file_watcher.clone());
+                            tokio::spawn(async move {
+                                while let Some(contents) = messages.next().await {
+                                    match SupergraphConfig::new_from_yaml(&contents) {
+                                        Ok(supergraph_config) => {
+                                            if let Ok(supergraph_config_diff) = SupergraphConfigDiff::new(
+                                                &latest_supergraph_config,
+                                                supergraph_config.clone(),
+                                            ) {
+                                                let _ = sender
+                                                    .send(supergraph_config_diff)
+                                                    .tap_err(|err| tracing::error!("{:?}", err));
+                                            }
+                                            latest_supergraph_config = supergraph_config;
+                                        }
+                                        Err(err) => {
+                                            tracing::error!("Could not parse supergraph config file. {:?}", err);
+                                            eprintln!("Could not parse supergraph config file");
+                                        }
+                                    }
+                                }
+                            });
+                            let _ = subtask_cancellation_token.set(subtask.run()).tap_err(|err| tracing::error!("{:?}", err));
+                        }
+                    } => {}
                 }
             }
-        })
-        .abort_handle()
+        });
+        cancellation_token
     }
 }
 
@@ -65,86 +89,29 @@ pub struct SupergraphConfigDiff {
 }
 
 impl SupergraphConfigDiff {
-    /// Compares the differences between two supergraph configs,
-    /// returning the added and removed subgraphs.
     pub fn new(
         old: &SupergraphConfig,
         new: SupergraphConfig,
     ) -> Result<SupergraphConfigDiff, ConfigError> {
         let old_subgraph_defs = old.get_subgraph_definitions().tap_err(|err| {
-            // TODO: why do we print here instead of just defering to the caller?
-            errln!(
-                "error getting subgraph definitions from the current supergraph config: {:?}",
+            eprintln!(
+                "Error getting subgraph definitions from the current supergraph config: {:?}",
                 err
             )
         })?;
-
-        // Collect the subgraph definitions from the new supergraph config.
         let new_subgraphs: BTreeMap<String, SubgraphConfig> = new.into_iter().collect();
-
-        // Collect the old and new subgraph names.
         let old_subgraph_names: HashSet<String> =
             HashSet::from_iter(old_subgraph_defs.iter().map(|def| def.name.to_string()));
-        let new_subgraph_names: HashSet<String> =
+        let new_subgraph_names =
             HashSet::from_iter(new_subgraphs.keys().map(|name| name.to_string()));
-
-        // Compare the old and new subgraph names to find additions.
         let added_names: HashSet<String> =
             HashSet::from_iter(new_subgraph_names.difference(&old_subgraph_names).cloned());
-
-        // Compare the old and new subgraph names to find removals.
         let removed_names = old_subgraph_names.difference(&new_subgraph_names);
-
-        // Filter the added and removed subgraphs from the new supergraph config.
         let added = new_subgraphs
             .into_iter()
             .filter(|(name, _)| added_names.contains(name))
             .collect::<Vec<_>>();
         let removed = removed_names.into_iter().cloned().collect::<Vec<_>>();
-
         Ok(SupergraphConfigDiff { added, removed })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
-    use apollo_federation_types::config::{SchemaSource, SubgraphConfig, SupergraphConfig};
-
-    use super::SupergraphConfigDiff;
-
-    #[test]
-    fn test_supergraph_config_diff() {
-        // Construct a generic subgraph definition.
-        let subgraph_def = SubgraphConfig {
-            routing_url: Some("url".to_string()),
-            schema: SchemaSource::Sdl {
-                sdl: "sdl".to_string(),
-            },
-        };
-
-        // Create an old supergraph config with subgraph definitions.
-        let old_subgraph_defs: BTreeMap<String, SubgraphConfig> = BTreeMap::from([
-            ("subgraph_a".to_string(), subgraph_def.clone()),
-            ("subgraph_b".to_string(), subgraph_def.clone()),
-        ]);
-        let old = SupergraphConfig::new(old_subgraph_defs, None);
-
-        // Create a new supergraph config with 1 new and 1 old subgraph definitions.
-        let new_subgraph_defs: BTreeMap<String, SubgraphConfig> = BTreeMap::from([
-            ("subgraph_a".to_string(), subgraph_def.clone()),
-            ("subgraph_c".to_string(), subgraph_def.clone()),
-        ]);
-        let new = SupergraphConfig::new(new_subgraph_defs, None);
-
-        // Assert diff contain correct additions and removals.
-        let diff = SupergraphConfigDiff::new(&old, new).unwrap();
-        assert_eq!(1, diff.added().len());
-        assert_eq!(1, diff.removed().len());
-        assert!(diff
-            .added()
-            .contains(&("subgraph_c".to_string(), subgraph_def.clone())));
-        assert!(diff.removed().contains(&"subgraph_b".to_string()));
     }
 }

--- a/src/options/introspect.rs
+++ b/src/options/introspect.rs
@@ -1,7 +1,11 @@
+use std::sync::{Arc, OnceLock};
+
 use clap::Parser;
 use futures::Future;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use tap::TapFallible;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     options::{OutputOpts, RoverPrinter},
@@ -11,7 +15,7 @@ use crate::{
 
 use super::OutputChannelKind;
 
-#[derive(Debug, Serialize, Deserialize, Parser)]
+#[derive(Clone, Debug, Serialize, Deserialize, Parser)]
 pub struct IntrospectOpts {
     /// The endpoint of the subgraph to introspect
     #[serde(skip_serializing)]
@@ -33,52 +37,73 @@ pub struct IntrospectOpts {
 }
 
 impl IntrospectOpts {
-    pub async fn exec_and_watch<F, G>(&self, exec_fn: F, output_opts: &OutputOpts) -> !
+    pub fn exec_and_watch<F, G>(&self, exec_fn: F, output_opts: &OutputOpts) -> CancellationToken
     where
-        F: Fn() -> G,
-        G: Future<Output = RoverResult<String>>,
+        F: Fn() -> G + Send + 'static,
+        G: Future<Output = RoverResult<String>> + Send,
     {
+        let cancellation_token = CancellationToken::new();
+        let should_quit = Arc::new(OnceLock::new());
         let mut last_result = None;
-        loop {
-            match exec_fn().await {
-                Ok(sdl) => {
-                    let mut was_updated = true;
-                    if let Some(last) = last_result {
-                        if last == sdl {
-                            was_updated = false
-                        }
+        tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            let output_opts = output_opts.clone();
+            async move {
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        let should_quit = should_quit.clone();
+                        let _ = should_quit.set(true).tap_err(|err| tracing::error!("{:?}", err));
                     }
+                    _ = {
+                        let should_quit = should_quit.clone();
+                        let output_opts = output_opts.clone();
+                        async move {
+                            while should_quit.get().is_none() {
+                                match exec_fn().await {
+                                    Ok(sdl) => {
+                                        let mut was_updated = true;
+                                        if let Some(last) = last_result {
+                                            if last == sdl {
+                                                was_updated = false
+                                            }
+                                        }
 
-                    if was_updated {
-                        let sdl = sdl.to_string();
-                        let output = RoverOutput::Introspection(sdl.clone());
-                        let _ = output.write_or_print(output_opts).map_err(|e| e.print());
-                        if let Some(channel) = &output_opts.channel {
-                            // TODO: error handling
-                            let _ = channel.send(OutputChannelKind::Sdl(sdl));
+                                        if was_updated {
+                                            let sdl = sdl.to_string();
+                                            let output = RoverOutput::Introspection(sdl.clone());
+                                            let _ = output.write_or_print(&output_opts).map_err(|e| e.print());
+                                            if let Some(channel) = &output_opts.channel {
+                                                // TODO: error handling
+                                                let _ = channel.send(OutputChannelKind::Sdl(sdl));
+                                            }
+                                        }
+                                        last_result = Some(sdl);
+                                    }
+                                    Err(error) => {
+                                        let mut was_updated = true;
+                                        let e = error.to_string();
+                                        if let Some(last) = last_result {
+                                            if last == e {
+                                                was_updated = false;
+                                            }
+                                        }
+                                        if was_updated {
+                                            let _ = error.write_or_print(&output_opts).map_err(|e| e.print());
+                                            if let Some(channel) = &output_opts.channel {
+                                                // TODO: error handling
+                                                let _ = channel.send(OutputChannelKind::Sdl(e.clone()));
+                                            }
+                                        }
+                                        last_result = Some(e);
+                                    }
+                                }
+                                tokio::time::sleep(std::time::Duration::from_secs(1)).await
+                            }
                         }
-                    }
-                    last_result = Some(sdl);
-                }
-                Err(error) => {
-                    let mut was_updated = true;
-                    let e = error.to_string();
-                    if let Some(last) = last_result {
-                        if last == e {
-                            was_updated = false;
-                        }
-                    }
-                    if was_updated {
-                        let _ = error.write_or_print(output_opts).map_err(|e| e.print());
-                        if let Some(channel) = &output_opts.channel {
-                            // TODO: error handling
-                            let _ = channel.send(OutputChannelKind::Sdl(e.clone()));
-                        }
-                    }
-                    last_result = Some(e);
+                    } => {}
                 }
             }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await
-        }
+        });
+        cancellation_token
     }
 }

--- a/src/options/output.rs
+++ b/src/options/output.rs
@@ -84,7 +84,7 @@ pub enum OutputChannelKind {
     Sdl(String),
 }
 
-#[derive(Debug, Parser, Serialize, Default)]
+#[derive(Clone, Debug, Parser, Serialize, Default)]
 pub struct OutputOpts {
     /// Specify Rover's format type
     #[arg(long = "format", global = true, default_value_t)]

--- a/src/utils/effect/exec.rs
+++ b/src/utils/effect/exec.rs
@@ -1,15 +1,12 @@
 use std::process::Output;
 
+#[cfg(test)]
+use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
 use camino::Utf8PathBuf;
 use tokio::process::Command;
 
-#[cfg_attr(test, derive(thiserror::Error, Debug))]
-#[cfg(test)]
-#[cfg_attr(test, error("MockExecError"))]
-pub struct MockExecError {}
-
-#[cfg_attr(test, mockall::automock(type Error = MockExecError;))]
+#[cfg_attr(test, mockall::automock(type Error = AnyhowError;))]
 #[async_trait]
 pub trait ExecCommand {
     type Error: std::fmt::Debug + 'static;

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -476,7 +476,7 @@ mod test_get_supergraph_config {
         let supergraph_config_path = third_level_folder.path().join("supergraph.yaml");
         fs::write(
             supergraph_config_path.clone(),
-            &supergraph_config.into_bytes(),
+            supergraph_config.into_bytes(),
         )
         .expect("Could not write supergraph.yaml");
 
@@ -1165,7 +1165,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
       file: ./people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let mut config_path = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1205,7 +1205,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1259,7 +1259,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();

--- a/tests/composition/mod.rs
+++ b/tests/composition/mod.rs
@@ -1,0 +1,1 @@
+mod subgraph_watchers;

--- a/tests/composition/subgraph_watchers.rs
+++ b/tests/composition/subgraph_watchers.rs
@@ -1,0 +1,196 @@
+use std::{collections::BTreeMap, io::Write, str::FromStr, sync::Arc, time::Duration};
+
+use anyhow::Result;
+use apollo_federation_types::config::{SchemaSource, SubgraphConfig, SupergraphConfig};
+use camino::Utf8PathBuf;
+use futures::{lock::Mutex, StreamExt};
+use httpmock::{Mock, MockServer};
+use rover::composition::{
+    subgraph_watchers::SubgraphWatchers,
+    watchers::{subtask::SubtaskHandleStream, watcher::subgraph::SubgraphChanged},
+};
+use rstest::{fixture, rstest};
+use serde_json::json;
+use speculoos::prelude::*;
+use tempfile::NamedTempFile;
+use tokio::sync::mpsc::unbounded_channel;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use crate::graphql::SUBGRAPH_INTROSPECTION_QUERY;
+
+#[fixture]
+#[once]
+fn mock_server() -> httpmock::MockServer {
+    MockServer::start()
+}
+
+#[fixture]
+fn sdl() -> String {
+    format!(
+        "type Query {{ test_{}: String! }}",
+        Uuid::new_v4().as_simple()
+    )
+}
+
+#[fixture]
+fn subgraph_name() -> String {
+    Uuid::new_v4().as_simple().to_string()
+}
+
+#[fixture]
+fn introspection_subgraph<'a>(
+    mock_server: &'a MockServer,
+    sdl: String,
+    subgraph_name: String,
+) -> (String, SubgraphConfig, Mock<'a>) {
+    let mock_server_address = mock_server.address();
+    let root = format!(
+        "http://{}:{}",
+        mock_server_address.ip(),
+        mock_server_address.port()
+    );
+    let routing_url = format!("{}/{}", root, subgraph_name);
+    let mock = mock_server.mock(|when, then| {
+        let expected_body = json!({
+            "query": SUBGRAPH_INTROSPECTION_QUERY,
+            "variables": null,
+            "operationName": "SubgraphIntrospectQuery"
+        });
+        when.path(format!("/{}", subgraph_name))
+            .method(httpmock::Method::POST)
+            .json_body_obj(&expected_body);
+        then.status(200).json_body(json!({
+            "data": {
+                "_service": {
+                    "sdl": sdl
+                }
+            }
+        }));
+    });
+    let subgraph_config = SubgraphConfig {
+        routing_url: Some(routing_url.clone()),
+        schema: SchemaSource::SubgraphIntrospection {
+            subgraph_url: url::Url::from_str(&routing_url).expect("Invalid Url"),
+            introspection_headers: None,
+        },
+    };
+    (subgraph_name, subgraph_config, mock)
+}
+
+#[fixture]
+fn file_subgraph(sdl: String, subgraph_name: String) -> (String, SubgraphConfig, NamedTempFile) {
+    let mut file = NamedTempFile::new().expect("Could not create temp file");
+    file.write_all(sdl.as_bytes())
+        .expect("Could not write SDL to temp file");
+    let file_path = Utf8PathBuf::from_path_buf(file.path().to_path_buf())
+        .expect("Could not convert file path to Utf8PathBuf");
+    let subgraph_config = SubgraphConfig {
+        routing_url: Some("http://example.com".to_string()),
+        schema: SchemaSource::File { file: file_path },
+    };
+    (subgraph_name, subgraph_config, file)
+}
+
+#[rstest]
+#[timeout(std::time::Duration::from_secs(5))]
+#[traced_test]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_setup_subgraph_watchers(
+    mock_server: &'_ MockServer,
+    introspection_subgraph: (String, SubgraphConfig, Mock<'_>),
+    file_subgraph: (String, SubgraphConfig, NamedTempFile),
+) -> Result<()> {
+    let (
+        introspection_subgraph_name,
+        introspection_subgraph_config,
+        mut introspection_subgraph_mock,
+    ) = introspection_subgraph;
+    let (file_subgraph_name, file_subgraph_config, _file) = file_subgraph;
+    let subgraphs = BTreeMap::from_iter([
+        (
+            introspection_subgraph_name.to_string(),
+            introspection_subgraph_config,
+        ),
+        (file_subgraph_name.to_string(), file_subgraph_config),
+    ]);
+    let supergraph_config = SupergraphConfig::new(subgraphs, None);
+    let subgraph_watchers = SubgraphWatchers::new(supergraph_config);
+    let (tx, rx) = unbounded_channel();
+    let rx = Arc::new(Mutex::new(rx));
+    let input_stream = futures::stream::empty().boxed();
+    let _ = subgraph_watchers.handle(tx, input_stream);
+
+    let timeout = tokio::time::timeout(Duration::from_millis(500), {
+        let rx = rx.clone();
+        async move {
+            let mut output = None;
+            if let Some(change) = rx.lock().await.recv().await {
+                output = Some(change);
+            }
+            output
+        }
+    })
+    .await;
+    assert_that!(timeout)
+        .is_ok()
+        .is_some()
+        .is_equal_to(SubgraphChanged::from(file_subgraph_name.to_string()));
+
+    let timeout = tokio::time::timeout(Duration::from_millis(500), {
+        let rx = rx.clone();
+        async move {
+            let mut output = None;
+            if let Some(change) = rx.lock().await.recv().await {
+                output = Some(change);
+            }
+            output
+        }
+    })
+    .await;
+    assert_that!(timeout)
+        .is_ok()
+        .is_some()
+        .is_equal_to(SubgraphChanged::from(
+            introspection_subgraph_name.to_string(),
+        ));
+
+    introspection_subgraph_mock.delete();
+
+    mock_server.mock(|when, then| {
+        let expected_body = json!({
+            "query": SUBGRAPH_INTROSPECTION_QUERY,
+            "variables": null,
+            "operationName": "SubgraphIntrospectQuery"
+        });
+        when.path(format!("/{}", introspection_subgraph_name))
+            .method(httpmock::Method::POST)
+            .json_body_obj(&expected_body);
+        then.status(200).json_body(json!({
+            "data": {
+                "_service": {
+                    "sdl": sdl()
+                }
+            }
+        }));
+    });
+
+    let timeout = tokio::time::timeout(Duration::from_millis(1500), {
+        let rx = rx.clone();
+        async move {
+            let mut output = None;
+            if let Some(change) = rx.lock().await.recv().await {
+                output = Some(change);
+            }
+            output
+        }
+    })
+    .await;
+
+    assert_that!(timeout)
+        .is_ok()
+        .is_some()
+        .is_equal_to(SubgraphChanged::from(introspection_subgraph_name));
+
+    Ok(())
+}

--- a/tests/e2e/graph/introspect.rs
+++ b/tests/e2e/graph/introspect.rs
@@ -107,7 +107,7 @@ async fn e2e_test_rover_graph_introspect_watch(
         .open(schema_path)
         .expect("Cannot open schema file");
     schema_file
-        .write(new_schema.as_bytes())
+        .write_all(new_schema.as_bytes())
         .expect("Could not update schema");
     tokio::time::sleep(Duration::from_secs(5)).await;
     child.kill().unwrap();

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -44,7 +44,6 @@ async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_n
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()
@@ -101,7 +100,6 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()
@@ -122,7 +120,6 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()
@@ -189,7 +186,6 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -57,7 +57,7 @@ impl RetailSupergraph<'_> {
         self.retail_supergraph_config
             .subgraphs
             .keys()
-            .map(|name| name.clone())
+            .cloned()
             .collect()
     }
 
@@ -161,11 +161,11 @@ async fn run_single_mutable_subgraph() -> (String, TempDir, String) {
 
     info!("Installing subgraph dependencies");
     cmd!("npm", "run", "clean")
-        .dir(&target.path())
+        .dir(target.path())
         .run()
         .expect("Could not clean directory");
     cmd!("npm", "install")
-        .dir(&target.path())
+        .dir(target.path())
         .run()
         .expect("Could not install subgraph dependencies");
     info!("Kicking off subgraphs");
@@ -173,7 +173,7 @@ async fn run_single_mutable_subgraph() -> (String, TempDir, String) {
     let port = pick_unused_port().expect("No free ports");
     let url = format!("http://localhost:{}", port);
     cmd.args(["run", "start", "--", &port.to_string()])
-        .current_dir(&target.path());
+        .current_dir(target.path());
     cmd.spawn().expect("Could not spawn subgraph process");
     info!("Testing subgraph connectivity");
     let client = Client::new();

--- a/tests/e2e/options/client_timeout.rs
+++ b/tests/e2e/options/client_timeout.rs
@@ -24,7 +24,7 @@ async fn e2e_test_rover_client_timeout_option(
         then.status(status_code);
     });
 
-    let fake_registry = format!("http://{}/graphql", server.address().to_string());
+    let fake_registry = format!("http://{}/graphql", server.address());
 
     // WHEN
     //   - a command supporting the --client-timeout option is invoked

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -108,7 +108,7 @@ async fn e2e_test_rover_subgraph_introspect_watch(
         .open(schema_path)
         .expect("Cannot open schema file");
     schema_file
-        .write(new_schema.as_bytes())
+        .write_all(new_schema.as_bytes())
         .expect("Could not update schema");
     tokio::time::sleep(Duration::from_secs(5)).await;
     child.kill().unwrap();

--- a/tests/e2e/subgraph/publish.rs
+++ b/tests/e2e/subgraph/publish.rs
@@ -49,7 +49,7 @@ async fn e2e_test_rover_subgraph_publish(
     let mut rng = rand::thread_rng();
     let id_regex = rand_regex::Regex::compile("[a-zA-Z][a-zA-Z0-9_-]{0,63}", 100)
         .expect("Could not compile regex");
-    let id: String = (&mut rng).sample::<String, &rand_regex::Regex>(&id_regex);
+    let id: String = rng.sample::<String, &rand_regex::Regex>(&id_regex);
     let schema_path = test_artifacts_directory.join("subgraph/perfSubgraph01.graphql");
     info!("Using name {} for subgraph", &id);
 
@@ -67,10 +67,12 @@ async fn e2e_test_rover_subgraph_publish(
         .output()
         .expect("Could not run initial list command");
     let resp: SubgraphListResponse = serde_json::from_slice(list_cmd_output.stdout.as_slice())
-        .expect(&format!(
-            "Could not parse response to struct - Raw: {}",
-            from_utf8(list_cmd_output.stdout.as_slice()).unwrap()
-        ));
+        .unwrap_or_else(|_| {
+            panic!(
+                "Could not parse response to struct - Raw: {}",
+                from_utf8(list_cmd_output.stdout.as_slice()).unwrap()
+            )
+        });
     let initial_subgraphs = resp.get_subgraph_names();
     assert_that(&initial_subgraphs).does_not_contain(&id);
 

--- a/tests/graphql/mod.rs
+++ b/tests/graphql/mod.rs
@@ -1,0 +1,2 @@
+pub const SUBGRAPH_INTROSPECTION_QUERY: &str =
+    include_str!("./subgraph_introspection_query.graphql");

--- a/tests/graphql/subgraph_introspection_query.graphql
+++ b/tests/graphql/subgraph_introspection_query.graphql
@@ -1,0 +1,6 @@
+query SubgraphIntrospectQuery {
+    # eslint-disable-next-line
+    _service {
+        sdl
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,7 +1,9 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+mod composition;
 mod dev;
+mod graphql;
 mod output;
 mod schema;
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+#[cfg(feature = "composition-js")]
 mod composition;
 mod dev;
 mod graphql;


### PR DESCRIPTION
### Changes

`Fs::watch_file` is turned into an asynchronous implementation via an example found [here](https://stackoverflow.com/a/76889673). This seems to fix an issue where tests won't exit when using file watchers. This behavior is possibly due to the original blocking nature of `Fs::watch_file` in conjunction with the async rewrite.

This also modifies the file subgraph watcher to be consistent with the introspection watcher, where introspection will emit a changed event when it starts running.

The order of operations in `FileWatcher` is also changed so that end-users have a chance to subscribe to its implementation before it starts running. This necessitates converting FileWatcher to a `SubtaskHandleUnit` and calling it as a `Subtask` in order to provide the two-step (subscribe, _then_ start producing events) order that this pattern provides.

As a result of using `Subtask`s within other `Handle`, there are cases where two subtasks are spawned in a handle: one to run the inner subtask, and one to watch its messages. This means that we can't return a single `AbortHandle` any more, which leads us to trying to find a slightly more robust shutdown pattern. The pattern chosen was found [here](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html). It provides a pattern where the desired task will race against a cancellation future, using `tokio::select!`. When the cancellation token is called, we can call any necessary cleanup procedures (such as calling multiple `AbortHandle`s)