### PR TITLE
fix(openssl): downgrade `openssl-src`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3967,9 +3967,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
```
 aaronarinder@Aarons-MBP  ~/apollo/rover   dylan/language-server+dev  cargo update openssl-src -
-precise 300.3.1+3.3.1
    Updating crates.io index
 Downgrading openssl-src v300.3.2+3.3.2 -> v300.3.1+3.3.1
```