### PR TITLE
Fix integration tests against the [supergraph-demo

### DIFF
--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -659,7 +659,7 @@ mod test_merge_supergraph_configs {
         TestCase::RemoteNoFedVersionLocalNoFedVersion,
         None,
         // Expected because latest
-        FederationVersion::LatestFedTwo
+        FederationVersion::LatestFedOne
     )]
     #[case::remote_no_fed_local_has_version_no_target(
         TestCase::RemoteNoFedVersionLocalHasVersionNoTarget,
@@ -671,7 +671,7 @@ mod test_merge_supergraph_configs {
         TestCase::RemoteFedVersionLocalNoFedVersionNoTarget,
         None,
         // Expected because remote
-        FederationVersion::LatestFedTwo
+        FederationVersion::LatestFedOne
     )]
     fn it_merges_local_and_remote_supergraphs(
         #[case] test_case: TestCase,

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -410,7 +410,7 @@ mod test_get_supergraph_config {
     }
 
     #[rstest]
-    #[case::no_supplied_fed_version(None, None, FederationVersion::LatestFedTwo)]
+    #[case::no_supplied_fed_version(None, None, FederationVersion::LatestFedOne)]
     #[case::using_supergraph_yaml_version(
         None,
         Some(FederationVersion::LatestFedOne),
@@ -749,7 +749,7 @@ fn resolve_federation_version(
     requested_federation_version.unwrap_or_else(|| {
         supergraph_config
             .get_federation_version()
-            .unwrap_or_else(|| FederationVersion::LatestFedTwo)
+            .unwrap_or_default()
     })
 }
 


### PR DESCRIPTION
Fixes tests against the [supergraph demo repo](https://github.com/apollographql/supergraph-demo). In the previous iteration, the federation version resolver defaulted to the `FederationVersion::LatestFedTwo` when it should have been `FederationVersion::LatestFedOne`