### PR TITLE
composition: check env var when getting fed version

### DIFF
--- a/src/command/dev/protocol/leader.rs
+++ b/src/command/dev/protocol/leader.rs
@@ -1,9 +1,9 @@
-use std::str::FromStr;
 use std::{
     collections::{hash_map::Entry::Vacant, HashMap},
     fmt::Debug,
     io::BufReader,
     net::TcpListener,
+    str::FromStr,
 };
 
 use anyhow::{anyhow, Context};

--- a/src/composition/supergraph/config/mod.rs
+++ b/src/composition/supergraph/config/mod.rs
@@ -359,13 +359,13 @@ mod tests {
     )]
     fn test_final_supergraph_config_federation_version(
         #[case] env_var: Option<String>,
-        #[case] fed_version: Option<FederationVersion>,
-        #[case] expected: FederationVersion,
+        #[case] conf_fed_version: Option<FederationVersion>,
+        #[case] expected_fed_version: FederationVersion,
     ) {
-        let supergraph_config = SupergraphConfig::new(BTreeMap::new(), fed_version.clone());
+        let supergraph_config = SupergraphConfig::new(BTreeMap::new(), conf_fed_version);
         let final_config =
             FinalSupergraphConfig::new(None, "/path/to/file".into(), supergraph_config);
-        let fed_version = final_config.federation_version(env_var);
-        assert_eq!(expected, fed_version);
+        let actual_fed_version = final_config.federation_version(env_var);
+        assert_eq!(expected_fed_version, actual_fed_version);
     }
 }

--- a/src/composition/supergraph/config/mod.rs
+++ b/src/composition/supergraph/config/mod.rs
@@ -345,6 +345,7 @@ mod tests {
 
     #[rstest]
     #[case::env_var_set(Some("2.9".to_string()), None, FederationVersion::LatestFedTwo)]
+    #[case::env_var_set_invalid(Some("invalid".to_string()), None, FederationVersion::LatestFedTwo)]
     #[case::env_var_unset_config_set(
         None,
         Some(FederationVersion::LatestFedTwo),

--- a/src/composition/supergraph/config/mod.rs
+++ b/src/composition/supergraph/config/mod.rs
@@ -299,10 +299,10 @@ impl FinalSupergraphConfig {
     }
 
     /// Calculates what the correct version of Federation should be, based on the
-    /// value on the given environment variable or the supergraph config.
+    /// value of the given environment variable, or the supergraph config.
     ///
     /// The order of precedence is:
-    /// Environment Variable -> Supergraph Schema -> Default (Latest)
+    /// Environment Variable -> Supergraph Config -> Default (Latest)
     pub fn federation_version(&self, env_var: Option<String>) -> FederationVersion {
         let env_var_version = if let Some(version) = env_var {
             match FederationVersion::from_str(&version) {
@@ -363,11 +363,9 @@ mod tests {
         #[case] expected: FederationVersion,
     ) {
         let supergraph_config = SupergraphConfig::new(BTreeMap::new(), fed_version.clone());
-
         let final_config =
             FinalSupergraphConfig::new(None, "/path/to/file".into(), supergraph_config);
         let fed_version = final_config.federation_version(env_var);
-
         assert_eq!(expected, fed_version);
     }
 }


### PR DESCRIPTION
This PR adds the ability to use an env var when checking the federation version of a `FinalSupergraphConfig`.