### PR TITLE
Use notify macos_fsevent feature over macos_kqueue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ itertools = "0.13.0"
 lazycell = "1"
 lazy_static = "1.4"
 notify = { version = "6", default-features = false, features = [
-    "macos_kqueue",
+    "macos_fsevent",
 ] }
 notify-debouncer-full = "0.3.1"
 opener = "0.7"


### PR DESCRIPTION
Solves for a bug in main where switching git branches ends up
locking/blocking/breaking file watcher events