### PR TITLE
feat(file watching): use poll-based watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1196,45 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "console-api"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1887,15 +1973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "file-id"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,6 +2426,19 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -3355,6 +3445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,20 +3659,6 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "notify-debouncer-full"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
-dependencies = [
- "crossbeam-channel",
- "file-id",
- "log",
- "notify",
- "parking_lot",
- "walkdir",
 ]
 
 [[package]]
@@ -4215,6 +4297,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,14 +4842,15 @@ dependencies = [
  "anyhow",
  "camino",
  "console",
+ "console-subscriber",
  "notify",
- "notify-debouncer-full",
  "rstest",
  "speculoos",
  "tap",
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "url",
@@ -5798,6 +5913,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -5928,6 +6044,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5935,8 +6081,11 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
  "tokio-util",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,7 @@ indoc = "2"
 itertools = "0.13.0"
 lazycell = "1"
 lazy_static = "1.4"
-notify = { version = "6", default-features = false, features = [
-    "macos_kqueue",
-] }
-notify-debouncer-full = "0.3.1"
+notify = { version = "6" }
 opener = "0.7"
 os_info = "3.7"
 os_type = "2.6"

--- a/crates/rover-std/Cargo.toml
+++ b/crates/rover-std/Cargo.toml
@@ -11,17 +11,17 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 console = { workspace = true }
 notify = { workspace = true }
-notify-debouncer-full = { workspace = true }
 tap = { workspace = true }
 tokio = { workspace = true, features = [ "macros", "rt", "rt-multi-thread", "time" ] }
 tokio-util = { workspace = true}
+tokio-stream = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+console-subscriber = "0.4.0"
 
 [dev-dependencies]
 notify = { workspace = true }
-notify-debouncer-full = { workspace = true }
 rstest = { workspace = true }
 speculoos = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rover-std/src/error.rs
+++ b/crates/rover-std/src/error.rs
@@ -5,15 +5,19 @@ pub enum RoverStdError {
     /// AdhocError comes from the anyhow crate
     #[error(transparent)]
     AdhocError(#[from] anyhow::Error),
-
     /// This error is thrown when there is an error watching a file
     #[error("an unexpected error occured while watching for changes")]
     Notify(#[from] notify::Error),
-
     /// This error is thrown when there is an empty file
     #[error("\"{empty_file}\" is an empty file.")]
     EmptyFile {
         /// The empty file path
         empty_file: String,
+    },
+    /// This error is thrown when a watched file is removed
+    #[error("\"{file}\" has been removed.")]
+    FileRemoved {
+        /// The empty file path
+        file: String,
     },
 }

--- a/src/command/dev/router/config.rs
+++ b/src/command/dev/router/config.rs
@@ -1,5 +1,6 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
@@ -267,6 +268,7 @@ impl RouterConfigReader {
         if let Some(input_config_path) = &self.input_config_path {
             let (raw_tx, mut raw_rx) = tokio::sync::mpsc::unbounded_channel();
             let (state_tx, state_rx) = unbounded();
+            let input_config_path: PathBuf = input_config_path.as_path().into();
             Fs::watch_file(input_config_path, raw_tx);
             tokio::spawn(async move {
                 while let Some(res) = raw_rx.recv().await {

--- a/src/command/dev/watcher.rs
+++ b/src/command/dev/watcher.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::{collections::HashMap, time::Duration};
 
@@ -305,7 +306,7 @@ impl SubgraphSchemaWatcher {
 
                 let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
-                let watch_path = path.clone();
+                let watch_path: PathBuf = path.as_path().into();
 
                 Fs::watch_file(watch_path, tx);
 

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -1,32 +1,54 @@
 use camino::Utf8PathBuf;
 use futures::{stream::BoxStream, StreamExt};
-use rover_std::{errln, Fs};
+use rover_std::{errln, Fs, RoverStdError};
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
+/// File watcher specifically for files related to composition
 #[derive(Clone, Debug)]
 pub struct FileWatcher {
+    /// The filepath to watch
     path: Utf8PathBuf,
 }
 
 impl FileWatcher {
+    /// Create a new filewatcher
     pub fn new(path: Utf8PathBuf) -> Self {
         Self { path }
     }
 
+    /// Watch a file
+    ///
+    /// When a file is removed, the internal rover-std::fs filewatcher will be cancelled. The
+    /// composition filewatcher's stream will still be active, however
+    ///
+    /// Development note: in the future, we might consider a way to kill the watcher when the
+    /// rover-std::fs filewatcher dies. Right now, the stream remains active and we can
+    /// indefinitely loop on a close filewatcher
     pub fn watch(self) -> BoxStream<'static, String> {
         let path = self.path;
         let (file_tx, file_rx) = unbounded_channel();
         let output = UnboundedReceiverStream::new(file_rx);
-        Fs::watch_file(path.clone(), file_tx);
+        let cancellation_token = Fs::watch_file(path.as_path().into(), file_tx);
+
         output
             .filter_map(move |result| {
                 let path = path.clone();
+                let cancellation_token = cancellation_token.clone();
                 async move {
+                    // We cancel the filewatching when the file has been removed because it
+                    // can no longer be watched
+                    if let Err(RoverStdError::FileRemoved { file }) = &result {
+                        println!("in file removed");
+                        tracing::error!("Closing file watcher for {file}");
+                        errln!("Closing file watcher for {file:?}");
+                        cancellation_token.cancel();
+                    }
+
                     result
                         .and_then(|_| {
-                            Fs::read_file(path).tap_err(|err| {
+                            Fs::read_file(path.clone()).tap_err(|err| {
                                 tracing::error!("Could not read file: {:?}", err);
                                 errln!("error reading file: {:?}", err);
                             })
@@ -35,5 +57,49 @@ impl FileWatcher {
                 }
             })
             .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use speculoos::assert_that;
+    use speculoos::option::OptionAssertions;
+    use speculoos::result::ResultAssertions;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_watches() {
+        let some_file = tempfile::Builder::new().tempfile().unwrap();
+        let path = some_file.path().to_path_buf();
+        let watcher = FileWatcher::new(Utf8PathBuf::from_path_buf(path.clone()).unwrap());
+        let mut watching = watcher.watch();
+        let _ = tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let mut writeable_file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .expect("Cannot open file");
+
+        writeable_file
+            .write("some change".as_bytes())
+            .expect("couldn't write to file");
+
+        let mut output = None;
+        while let None = output {
+            let _ = tokio::time::sleep(Duration::from_secs(1)).await;
+            output = watching.next().await;
+        }
+
+        assert_that(&output)
+            .is_some()
+            .matches(|actual| actual == "some change");
+
+        let _ = some_file.close();
     }
 }

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -100,7 +100,7 @@ impl CargoRunner {
     pub(crate) fn test(&self, target: &Target) -> Result<()> {
         let command_output = self.cargo_exec(
             vec!["test", "--workspace", "--locked"],
-            vec![],
+            vec!["--nocapture"],
             Some(target),
         )?;
 


### PR DESCRIPTION
poll-based watching is nice for a few reasons:

- handles a good chunk of [known problems](https://docs.rs/notify/6.1.1/notify/#known-problems) (eg, pseudo-filesystems, editor quirks, network-mounted filesystems, and so on)
- better platform support (windows quirks)
- fewer deps (no debouncer needed; polling is itself debounced)
- no backend wonkiness (ie, not needing to choose between kqueue or fsevents)
- simpler conceptual model (polling is easier to understand than notify's debouncer-wrapped watcher, at least for me; notify can be difficult to read through because it has a lot of indirection and odd patterns--eg, results that never return an Err, etc, and adding another layer of debouncing only makes that all harder to follow)

poll-based watching _isn't_ nice for these reasons:
- for pseudo filesystems, we have to compare the contents; there's a performance cost to this and we might have to tune it over time