### PR TITLE
Fixing up payload to be valid JSON & adding a timeout

### DIFF
--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -32,6 +32,7 @@ jobs:
         name: "Get latest Supergraph Plugin versions"
 
   run-smokes:
+    timeout-minutes: 45
     name: "Run Smoke Tests"
     uses: ./.github/workflows/smoke-test.yml
     needs: calculate_correct_version_ranges

--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -53,7 +53,7 @@ jobs:
           # This data can be any valid JSON from a previous step in the GitHub Action
           payload: |
             {
-              "run_url": ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }},
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_E2E_TEST_FAILURE_WEBHOOK_URL }}


### PR DESCRIPTION
The Slack Messaging for the failing smoke tests has been failing because the `payload` object is not valid JSON. This _should_ resolve that issue by adding quotes to the value portion.

Further, sometimes errors in the smokes can lead to them not timing out properly and running for hours, this is not a good approach and the smoke tests should **never** take more than 45 minutes, so I've added that as a timeout to the step that will actually execute the smokes.