### PR TITLE
Switch to a timeout of 15 minutes per matrix job for Smoke Tests

### DIFF
--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -32,7 +32,6 @@ jobs:
         name: "Get latest Supergraph Plugin versions"
 
   run-smokes:
-    timeout-minutes: 45
     name: "Run Smoke Tests"
     uses: ./.github/workflows/smoke-test.yml
     needs: calculate_correct_version_ranges

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -66,6 +66,7 @@ jobs:
           if-no-files-found: error
           retention-days: 5
   smoke_tests:
+    timeout-minutes: 15
     needs: build_binaries
     name: Run smoke tests
     strategy:


### PR DESCRIPTION
It turns out that GitHub Actions doesn't support `timeout-minutes` when you're calling a re-usable workflow 😠 

So instead we're pushing the timeout down into each of the spawned matrix jobs, this will still solve our existing problems because it's generally a single branch that causes the issue.