### PR TITLE
Add ability to skip lint checks where no .md files changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,6 @@ workflows:
           app-dir: "~/project/installers/npm"
           test-results-for: jest
           override-ci-command: npm install --ignore-scripts
-
   release:
     jobs:
       - xtask:
@@ -292,6 +291,25 @@ workflows:
             - secops-oidc
             - github-orb
           git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+  nightly-lint:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - xtask:
+          name: Lint (Nightly)
+          matrix:
+            parameters:
+              platform: [ volta ]
+              rust_channel: [ stable ]
+              command: [ lint ]
+              options:
+                - |
+                  --force
 jobs:
   xtask:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ workflows:
               command: [lint]
               options:
                 - | 
-                  --branch-name << pipeline.git.branch >>
+                  --current-sha << pipeline.git.revision >>
   security_checks:
     jobs:
       - xtask:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,9 @@ workflows:
               platform: [volta]
               rust_channel: [stable]
               command: [lint]
+              options:
+                - | 
+                  --branch-name << pipeline.git.branch >>
   security_checks:
     jobs:
       - xtask:

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -8,8 +8,8 @@ use crate::tools::{CargoRunner, GitRunner, NpmRunner};
 #[derive(Debug, Parser)]
 pub struct Lint {
     /// The current (most recent SHA) to use for comparison
-    #[arg(long = "branch-name", default_value = "main")]
-    pub(crate) branch_name: String,
+    #[arg(long = "current-sha", default_value = "main")]
+    pub(crate) current_sha: String,
 
     #[arg(long, short, action)]
     pub(crate) force: bool,
@@ -19,15 +19,15 @@ impl Lint {
     pub async fn run(&self) -> Result<()> {
         CargoRunner::new()?.lint()?;
         NpmRunner::new()?.lint()?;
-        lint_links(&self.branch_name, self.force).await
+        lint_links(&self.current_sha, self.force).await
     }
 }
 
 #[cfg(not(windows))]
-async fn lint_links(branch_name: &str, force: bool) -> Result<()> {
+async fn lint_links(current_sha: &str, force: bool) -> Result<()> {
     if force
         || GitRunner::tmp()?
-            .get_changed_files(branch_name)?
+            .get_changed_files(current_sha)?
             .iter()
             .any(|path| path.extension().unwrap_or_default() == "md")
     {

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -4,26 +4,39 @@ use clap::Parser;
 #[cfg(not(windows))]
 use crate::tools::LycheeRunner;
 
-use crate::tools::{CargoRunner, NpmRunner};
+use crate::tools::{CargoRunner, GitRunner, NpmRunner};
 
 #[derive(Debug, Parser)]
-pub struct Lint {}
+pub struct Lint {
+    /// The current (most recent SHA) to use for comparison
+    #[arg(long = "branch-name")]
+    pub(crate) branch_name: String,
+}
 
 impl Lint {
     pub async fn run(&self) -> Result<()> {
         CargoRunner::new()?.lint()?;
         NpmRunner::new()?.lint()?;
-        lint_links().await
+        lint_links(&self.branch_name).await
     }
 }
 
 #[cfg(not(windows))]
-async fn lint_links() -> Result<()> {
-    LycheeRunner::new()?.lint().await
+async fn lint_links(branch_name: &str) -> Result<()> {
+    let changed_files = GitRunner::tmp()?.get_changed_files(branch_name)?;
+    if changed_files
+        .iter()
+        .any(|path| path.extension().unwrap_or_default() == "md")
+    {
+        LycheeRunner::new()?.lint().await
+    } else {
+        eprintln!("Skipping the lint checker for '.md' files as no '.md' files have changed.");
+        Ok(())
+    }
 }
 
 #[cfg(windows)]
-async fn lint_links() -> Result<()> {
+async fn lint_links(branch_name: &str) -> Result<()> {
     eprintln!("Skipping the lint checker.");
 
     Ok(())


### PR DESCRIPTION
As per title, checking all our links are still functioning is good but it's a waste of time where nothing has changed those links. This will skip the checks where there are no changes (which will mostly be PRs) and add a nightly check so we still get warning if links are broken.