### PR TITLE
Move Smoke Tests Away from macOS 12

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -77,17 +77,19 @@ jobs:
         testing_target:
           - run_test_on: windows-2022
             binary_under_test: x86_64-pc-windows-msvc
-          - run_test_on: macos-12
-            binary_under_test: x86_64-apple-darwin
           - run_test_on: macos-13
             binary_under_test: x86_64-apple-darwin
           - run_test_on: macos-14-large
+            binary_under_test: x86_64-apple-darwin
+          - run_test_on: macos-15-large
             binary_under_test: x86_64-apple-darwin
           - run_test_on: ubuntu-22.04
             binary_under_test: x86_64-unknown-linux-gnu
           - run_test_on: macos-13-xlarge
             binary_under_test: aarch64-apple-darwin
           - run_test_on: macos-14
+            binary_under_test: aarch64-apple-darwin
+          - run_test_on: macos-15
             binary_under_test: aarch64-apple-darwin
     # x86-64 runner
     runs-on: ${{ matrix.testing_target.run_test_on }}


### PR DESCRIPTION
At present we test on macOS 12 - 14, now that 12 is being deprecated by Github Actions - [Announcement](https://github.com/actions/runner-images/issues/10721) - we should move this range forward from 13 - 15. 

Tested via running the smoke tests here: https://github.com/apollographql/rover/actions/runs/11212715621