### PR TITLE
feat(subgraph watching): proper events emitted

### DIFF
--- a/src/composition/run_composition.rs
+++ b/src/composition/run_composition.rs
@@ -8,8 +8,9 @@ use crate::utils::effect::{exec::ExecCommand, read_file::ReadFile};
 
 use super::{
     events::CompositionEvent,
+    runner::SubgraphChanged,
     supergraph::{binary::SupergraphBinary, config::FinalSupergraphConfig},
-    watchers::{subtask::SubtaskHandleStream, watcher::subgraph::SubgraphChanged},
+    watchers::subtask::SubtaskHandleStream,
 };
 
 #[derive(Builder)]
@@ -87,15 +88,13 @@ mod tests {
         composition::{
             compose_output,
             events::CompositionEvent,
+            runner::SubgraphChanged,
             supergraph::{
                 binary::{OutputTarget, SupergraphBinary},
                 config::FinalSupergraphConfig,
                 version::SupergraphVersion,
             },
-            watchers::{
-                subtask::{Subtask, SubtaskRunStream},
-                watcher::subgraph::SubgraphChanged,
-            },
+            watchers::subtask::{Subtask, SubtaskRunStream},
         },
         utils::effect::{exec::MockExecCommand, read_file::MockReadFile},
     };
@@ -145,7 +144,7 @@ mod tests {
             .build();
 
         let subgraph_change_events: BoxStream<SubgraphChanged> =
-            once(async { SubgraphChanged }).boxed();
+            once(async { SubgraphChanged::default() }).boxed();
         let (mut composition_messages, composition_subtask) = Subtask::new(composition_handler);
         let abort_handle = composition_subtask.run(subgraph_change_events);
 

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -65,7 +65,6 @@ mod tests {
     use futures::StreamExt;
     use speculoos::assert_that;
     use speculoos::option::OptionAssertions;
-    use speculoos::result::ResultAssertions;
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::time::Duration;

--- a/src/composition/watchers/watcher/introspection.rs
+++ b/src/composition/watchers/watcher/introspection.rs
@@ -1,0 +1,71 @@
+use std::{marker::Send, pin::Pin};
+
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc::unbounded_channel;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use crate::{
+    cli::RoverOutputFormatKind,
+    command::subgraph::introspect::Introspect as SubgraphIntrospect,
+    composition::types::SubgraphUrl,
+    options::{IntrospectOpts, OutputChannelKind, OutputOpts},
+};
+/// Subgraph introspection
+#[derive(Debug, Clone)]
+pub struct SubgraphIntrospection {
+    endpoint: SubgraphUrl,
+    // TODO: ticket using a hashmap, not a tuple, in introspect opts as eventual cleanup
+    headers: Option<Vec<(String, String)>>,
+}
+
+//TODO: impl retry (needed at least for dev)
+impl SubgraphIntrospection {
+    pub fn new(endpoint: SubgraphUrl, headers: Option<Vec<(String, String)>>) -> Self {
+        Self { endpoint, headers }
+    }
+
+    // TODO: better typing so that it's over some impl, not string; makes all watch() fns require
+    // returning a string
+    pub fn watch(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
+        let client = reqwest::Client::new();
+        let endpoint = self.endpoint.clone();
+        let headers = self.headers.clone();
+
+        let (tx, rx) = unbounded_channel();
+        let rx_stream = UnboundedReceiverStream::new(rx);
+
+        // Spawn a tokio task in the background to watch for subgraph changes
+        tokio::spawn(async move {
+            // TODO: handle errors?
+            let _ = SubgraphIntrospect {
+                opts: IntrospectOpts {
+                    endpoint,
+                    headers,
+                    watch: true,
+                },
+            }
+            .run(
+                client,
+                &OutputOpts {
+                    format_kind: RoverOutputFormatKind::default(),
+                    output_file: None,
+                    // Attach a transmitter to stream back any subgraph changes
+                    channel: Some(tx),
+                },
+                // TODO: impl retries (at least for dev from cli flag)
+                None,
+            )
+            .await;
+        });
+
+        // Stream any subgraph changes, filtering out empty responses (None) while passing along
+        // the sdl changes
+        rx_stream
+            .filter_map(|change| async move {
+                match change {
+                    OutputChannelKind::Sdl(sdl) => Some(sdl),
+                }
+            })
+            .boxed()
+    }
+}

--- a/src/composition/watchers/watcher/mod.rs
+++ b/src/composition/watchers/watcher/mod.rs
@@ -1,3 +1,4 @@
 pub mod file;
+pub mod introspection;
 pub mod subgraph;
 pub mod supergraph_config;

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -3,20 +3,11 @@ use std::{marker::Send, pin::Pin};
 use apollo_federation_types::config::SchemaSource;
 use futures::{Stream, StreamExt};
 use tap::TapFallible;
-use tokio::{
-    sync::mpsc::{unbounded_channel, UnboundedSender},
-    task::AbortHandle,
-};
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 
-use crate::{
-    cli::RoverOutputFormatKind,
-    command::subgraph::introspect::Introspect as SubgraphIntrospect,
-    composition::{types::SubgraphUrl, watchers::subtask::SubtaskHandleUnit},
-    options::{IntrospectOpts, OutputChannelKind, OutputOpts},
-};
+use crate::composition::watchers::subtask::SubtaskHandleUnit;
 
-use super::file::FileWatcher;
+use super::{file::FileWatcher, introspection::SubgraphIntrospection};
 
 #[derive(thiserror::Error, Debug)]
 #[error("Unsupported subgraph introspection source: {:?}", .0)]
@@ -42,10 +33,6 @@ pub enum SubgraphWatcherKind {
     /// Don't ever update, schema is only pulled once.
     // TODO: figure out what to do with this; is it ever used? can we remove it?
     _Once(String),
-
-    /// Event specifically used for testing watch handlers.
-    #[cfg(test)]
-    TestWatcher,
 }
 
 impl TryFrom<SchemaSource> for SubgraphWatcher {
@@ -84,123 +71,28 @@ impl SubgraphWatcherKind {
             Self::Introspect(introspection) => introspection.watch(),
             // TODO: figure out what this is; sdl? stdin one-off? either way, probs not watching
             Self::_Once(_) => unimplemented!(),
-
-            // Create a new single buffered channel for testing watch events.
-            #[cfg(test)]
-            Self::TestWatcher => {
-                use tokio::sync::mpsc::channel;
-                use tokio_stream::wrappers::ReceiverStream;
-
-                let (tx, rx) = channel(1);
-                tx.send("watch event".to_string()).await.unwrap();
-                ReceiverStream::new(rx).boxed()
-            }
         }
-    }
-}
-
-/// Subgraph introspection
-#[derive(Debug, Clone)]
-pub struct SubgraphIntrospection {
-    endpoint: SubgraphUrl,
-    // TODO: ticket using a hashmap, not a tuple, in introspect opts as eventual cleanup
-    headers: Option<Vec<(String, String)>>,
-}
-
-//TODO: impl retry (needed at least for dev)
-impl SubgraphIntrospection {
-    fn new(endpoint: SubgraphUrl, headers: Option<Vec<(String, String)>>) -> Self {
-        Self { endpoint, headers }
-    }
-
-    // TODO: better typing so that it's over some impl, not string; makes all watch() fns require
-    // returning a string
-    fn watch(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
-        let client = reqwest::Client::new();
-        let endpoint = self.endpoint.clone();
-        let headers = self.headers.clone();
-
-        let (tx, rx) = unbounded_channel();
-        let rx_stream = UnboundedReceiverStream::new(rx);
-
-        // Spawn a tokio task in the background to watch for subgraph changes
-        tokio::spawn(async move {
-            // TODO: handle errors?
-            let _ = SubgraphIntrospect {
-                opts: IntrospectOpts {
-                    endpoint,
-                    headers,
-                    watch: true,
-                },
-            }
-            .run(
-                client,
-                &OutputOpts {
-                    format_kind: RoverOutputFormatKind::default(),
-                    output_file: None,
-                    // Attach a transmitter to stream back any subgraph changes
-                    channel: Some(tx),
-                },
-                // TODO: impl retries (at least for dev from cli flag)
-                None,
-            )
-            .await;
-        });
-
-        // Stream any subgraph changes, filtering out empty responses (None) while passing along
-        // the sdl changes
-        rx_stream
-            .filter_map(|change| async move {
-                match change {
-                    OutputChannelKind::Sdl(sdl) => Some(sdl),
-                }
-            })
-            .boxed()
     }
 }
 
 /// A unit struct denoting a change to a subgraph, used by composition to know whether to
 /// recompose.
-pub struct SubgraphChanged;
+pub struct SubgraphSchemaChanged {
+    pub sdl: String,
+}
 
 impl SubtaskHandleUnit for SubgraphWatcher {
-    type Output = SubgraphChanged;
+    type Output = SubgraphSchemaChanged;
 
     fn handle(self, sender: UnboundedSender<Self::Output>) -> AbortHandle {
         tokio::spawn(async move {
             let mut watcher = self.watcher.watch().await;
-            while watcher.next().await.is_some() {
+            while let Some(sdl) = watcher.next().await {
                 let _ = sender
-                    .send(SubgraphChanged)
+                    .send(SubgraphSchemaChanged { sdl })
                     .tap_err(|err| tracing::error!("{:?}", err));
             }
         })
         .abort_handle()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use futures::StreamExt;
-
-    use crate::composition::watchers::subtask::{Subtask, SubtaskRunUnit};
-
-    use super::{SubgraphChanged, SubgraphWatcher, SubgraphWatcherKind};
-
-    #[tokio::test]
-    async fn test_subgraphwatcher_handle() {
-        let watch_handler = SubgraphWatcher {
-            watcher: SubgraphWatcherKind::TestWatcher,
-        };
-
-        let (mut watch_messages, watch_subtask) = Subtask::new(watch_handler);
-        let abort_handle = watch_subtask.run();
-
-        assert!(matches!(
-            watch_messages.next().await.unwrap(),
-            SubgraphChanged
-        ));
-
-        abort_handle.abort();
     }
 }


### PR DESCRIPTION
feature changes:
- emit SDL from subgraph changes
- emit SubgraphChanged { name, sdl } from watchers into composition pipeline

clean-up:
- moved introspection watcher to its own file akin to the file watcher for easier/better organization
- killed a test that, by my lights, doesn't add too much value (but makes us conditionally compile a bit of code for it--felt like it wasn't super clean)