### PR TITLE
feat(subgraph introspection): use polling option, use studio client

### DIFF
--- a/src/command/dev/introspect.rs
+++ b/src/command/dev/introspect.rs
@@ -122,6 +122,9 @@ impl SubgraphIntrospectRunner {
                 endpoint: self.endpoint.clone(),
                 headers: self.headers.clone(),
                 watch: false,
+                // TODO: remove after the composition rewrite; this is the de facto default of the
+                // polling interval option, here to make compilation work
+                polling_interval: Duration::from_secs(1),
             },
         }
         .exec(&self.client, true, self.retry_period)
@@ -148,6 +151,9 @@ impl GraphIntrospectRunner {
                 endpoint: self.endpoint.clone(),
                 headers: self.headers.clone(),
                 watch: false,
+                // TODO: remove after the composition rewrite; this is the de facto default of the
+                // polling interval option, here to make compilation work
+                polling_interval: Duration::from_secs(1),
             },
         }
         .exec(&self.client, true, self.retry_period)

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -78,7 +78,7 @@ impl SubgraphWatcherKind {
 /// A unit struct denoting a change to a subgraph, used by composition to know whether to
 /// recompose.
 pub struct SubgraphSchemaChanged {
-    pub sdl: String,
+    sdl: String,
 }
 
 impl SubtaskHandleUnit for SubgraphWatcher {

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -5,7 +5,7 @@ use futures::{Stream, StreamExt};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 
-use crate::composition::watchers::subtask::SubtaskHandleUnit;
+use crate::{composition::watchers::subtask::SubtaskHandleUnit, utils::client::StudioClientConfig};
 
 use super::{file::FileWatcher, introspection::SubgraphIntrospection};
 
@@ -35,12 +35,15 @@ pub enum SubgraphWatcherKind {
     _Once(String),
 }
 
-impl TryFrom<SchemaSource> for SubgraphWatcher {
-    type Error = UnsupportedSchemaSource;
-
-    // SchemaSource comes from Apollo Federation types. Importantly, it strips comments and
-    // directives from introspection (but not when the source is a file)
-    fn try_from(schema_source: SchemaSource) -> Result<Self, Self::Error> {
+impl SubgraphWatcher {
+    /// Derive the right SubgraphWatcher (ie, File, Introspection) from the federation-rs SchemaSource
+    pub fn from_schema_source(
+        schema_source: SchemaSource,
+        client_config: &StudioClientConfig,
+        introspection_polling_interval: u64,
+    ) -> Result<Self, Box<UnsupportedSchemaSource>> {
+        // SchemaSource comes from Apollo Federation types. Importantly, it strips comments and
+        // directives from introspection (but not when the source is a file)
         match schema_source {
             SchemaSource::File { file } => Ok(Self {
                 watcher: SubgraphWatcherKind::File(FileWatcher::new(file)),
@@ -52,10 +55,12 @@ impl TryFrom<SchemaSource> for SubgraphWatcher {
                 watcher: SubgraphWatcherKind::Introspect(SubgraphIntrospection::new(
                     subgraph_url,
                     introspection_headers.map(|header_map| header_map.into_iter().collect()),
+                    client_config,
+                    introspection_polling_interval,
                 )),
             }),
             // TODO: figure out if there are any other sources to worry about; SDL (stdin? not sure) / Subgraph (ie, from graph-ref)
-            unsupported_source => Err(UnsupportedSchemaSource(unsupported_source)),
+            unsupported_source => Err(Box::new(UnsupportedSchemaSource(unsupported_source))),
         }
     }
 }
@@ -77,6 +82,7 @@ impl SubgraphWatcherKind {
 
 /// A unit struct denoting a change to a subgraph, used by composition to know whether to
 /// recompose.
+#[derive(derive_getters::Getters)]
 pub struct SubgraphSchemaChanged {
     sdl: String,
 }

--- a/src/options/introspect.rs
+++ b/src/options/introspect.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use clap::Parser;
 use futures::Future;
 use reqwest::Url;
@@ -17,7 +19,7 @@ pub struct IntrospectOpts {
     #[serde(skip_serializing)]
     pub endpoint: Url,
 
-    /// headers to pass to the endpoint. Values must be key:value pairs.
+    /// Headers to pass to the endpoint. Values must be key:value pairs.
     /// If a value has a space in it, use quotes around the pair,
     /// ex. -H "Auth:some key"
 
@@ -27,9 +29,17 @@ pub struct IntrospectOpts {
     #[serde(skip_serializing)]
     pub headers: Option<Vec<(String, String)>>,
 
-    /// poll the endpoint, printing the introspection result if/when its contents change
+    /// Poll the endpoint, printing the introspection result if/when its contents change
     #[arg(long)]
     pub watch: bool,
+
+    /// The interval at which to poll the endpoint
+    #[serde(skip_serializing)]
+    // We skip this because we're already using one from the dev command
+    // TODO: eventually we should reocncile the dev option with this one and figure out which is
+    // best to use
+    #[arg(skip)]
+    pub polling_interval: Duration,
 }
 
 impl IntrospectOpts {
@@ -78,7 +88,7 @@ impl IntrospectOpts {
                     last_result = Some(e);
                 }
             }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await
+            tokio::time::sleep(self.polling_interval).await
         }
     }
 }


### PR DESCRIPTION
- use studio client from config to respect global options
- add polling interval to IntrospectionOpts to respect the polling flag from dev (this needs to be reworked after the composition rewrite; before, we were looping and using an interval/tick, but we can more easily get the polling behavior and put it in a more natural place by slotting it into the logic that actually calls out to subgraphs for introspection)