### PR TITLE
feat(subgraph watching): support SDL, SchemaSource::Subgraph changes

### DIFF
--- a/src/composition/run_composition.rs
+++ b/src/composition/run_composition.rs
@@ -88,7 +88,7 @@ mod tests {
         composition::{
             compose_output,
             events::CompositionEvent,
-            runner::{SubgraphChanged, SubgraphEvent},
+            runner::{SubgraphEvent, SubgraphSchemaChanged},
             supergraph::{
                 binary::{OutputTarget, SupergraphBinary},
                 config::FinalSupergraphConfig,
@@ -144,7 +144,8 @@ mod tests {
             .build();
 
         let subgraph_change_events: BoxStream<SubgraphEvent> =
-            once(async { SubgraphEvent::SubgraphChanged(SubgraphChanged::default()) }).boxed();
+            once(async { SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged::default()) })
+                .boxed();
         let (mut composition_messages, composition_subtask) = Subtask::new(composition_handler);
         let abort_handle = composition_subtask.run(subgraph_change_events);
 

--- a/src/composition/runner.rs
+++ b/src/composition/runner.rs
@@ -56,7 +56,7 @@ use super::{
     supergraph::{binary::SupergraphBinary, config::FinalSupergraphConfig},
     watchers::{
         subtask::{SubtaskHandleStream, SubtaskRunStream},
-        watcher::{subgraph::SubgraphSchemaChanged, supergraph_config::SupergraphConfigDiff},
+        watcher::{subgraph::WatchedSdlChange, supergraph_config::SupergraphConfigDiff},
     },
 };
 
@@ -164,8 +164,8 @@ struct SubgraphWatchers {
     watchers: HashMap<
         String,
         (
-            UnboundedReceiverStream<SubgraphSchemaChanged>,
-            Subtask<SubgraphWatcher, SubgraphSchemaChanged>,
+            UnboundedReceiverStream<WatchedSdlChange>,
+            Subtask<SubgraphWatcher, WatchedSdlChange>,
         ),
     >,
 }
@@ -207,14 +207,14 @@ impl SubgraphWatchers {
 /// name of the subgraph
 pub enum SubgraphEvent {
     /// A change to the watched subgraph
-    SubgraphChanged(SubgraphChanged),
+    SubgraphChanged(SubgraphSchemaChanged),
     /// The subgraph is no longer watched
-    SubgraphRemoved(SubgraphRemoved),
+    SubgraphRemoved(SubgraphSchemaRemoved),
 }
 /// An event denoting that the subgraph has changed, emitting its name and the SDL reflecting that
 /// change
 #[derive(derive_getters::Getters, Default)]
-pub struct SubgraphChanged {
+pub struct SubgraphSchemaChanged {
     /// Subgraph name
     name: String,
     /// SDL with changes
@@ -223,7 +223,7 @@ pub struct SubgraphChanged {
 
 /// The subgraph is no longer watched
 #[derive(derive_getters::Getters, Default)]
-pub struct SubgraphRemoved {
+pub struct SubgraphSchemaRemoved {
     /// The name of the removed subgraph
     name: String,
 }
@@ -250,7 +250,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                 let messages_abort_handle = tokio::task::spawn(async move {
                     while let Some(change) = messages.next().await {
                         let _ = sender
-                            .send(SubgraphEvent::SubgraphChanged(SubgraphChanged {
+                            .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
                                 name: subgraph_name_c.clone(),
                                 sdl: change.sdl().to_string(),
                             }))
@@ -267,39 +267,68 @@ impl SubtaskHandleStream for SubgraphWatchers {
                 // If we detect additional diffs, start a new subgraph subtask.
                 // Adding the abort handle to the currentl collection of handles.
                 for (subgraph_name, subgraph_config) in diff.added() {
-                    if let Ok((mut messages, subtask)) = SubgraphWatcher::from_schema_source(
+                    if let Ok(subgraph_watcher) = SubgraphWatcher::from_schema_source(
                         subgraph_config.schema.clone(),
                         &self.profile,
                         &self.client_config,
                         self.introspection_polling_interval,
                     )
-                    .map(|subgraph_watcher| {
-                        Subtask::<SubgraphWatcher, SubgraphSchemaChanged>::new(subgraph_watcher)
-                    })
                     .tap_err(|err| {
                         tracing::warn!(
                             "Cannot configure new subgraph for {subgraph_name}: {:?}",
                             err
                         )
                     }) {
-                        let sender = sender.clone();
-                        let subgraph_name_c = subgraph_name.clone();
-                        let messages_abort_handle = tokio::spawn(async move {
-                            while let Some(change) = messages.next().await {
-                                let _ = sender
-                                    .send(SubgraphEvent::SubgraphChanged(SubgraphChanged {
-                                        name: subgraph_name_c.to_string(),
-                                        sdl: change.sdl().to_string(),
-                                    }))
-                                    .tap_err(|err| tracing::error!("{:?}", err));
-                            }
-                        })
-                        .abort_handle();
-                        let subtask_abort_handle = subtask.run();
-                        abort_handles.insert(
-                            subgraph_name.to_string(),
-                            (messages_abort_handle, subtask_abort_handle),
-                        );
+                        // If a SchemaSource::Subgraph or SchemaSource::Sdl was added, we don't
+                        // want to spin up watchers; rather, we emit a SubgraphSchemaChanged event with
+                        // either what we fetch from Studio (for Subgraphs) or what the SupergraphConfig
+                        // has for Sdls
+                        if let SubgraphWatcherKind::Once(non_repeating_fetch) =
+                            subgraph_watcher.watcher()
+                        {
+                            let _ = non_repeating_fetch
+                                .run()
+                                .await
+                                .tap_err(|err| {
+                                    tracing::error!("failed to get {subgraph_name}'s SDL: {err:?}")
+                                })
+                                .map(|sdl| {
+                                    let _ = sender
+                                        .send(SubgraphEvent::SubgraphChanged(
+                                            SubgraphSchemaChanged {
+                                                name: subgraph_name.to_string(),
+                                                sdl,
+                                            },
+                                        ))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                });
+                        // When we have a SchemaSource that's watchable, we start a new subtask
+                        // and add it to our list of subtasks
+                        } else {
+                            let (mut messages, subtask) =
+                                Subtask::<SubgraphWatcher, WatchedSdlChange>::new(subgraph_watcher);
+
+                            let sender = sender.clone();
+                            let subgraph_name_c = subgraph_name.clone();
+                            let messages_abort_handle = tokio::spawn(async move {
+                                while let Some(change) = messages.next().await {
+                                    let _ = sender
+                                        .send(SubgraphEvent::SubgraphChanged(
+                                            SubgraphSchemaChanged {
+                                                name: subgraph_name_c.to_string(),
+                                                sdl: change.sdl().to_string(),
+                                            },
+                                        ))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                }
+                            })
+                            .abort_handle();
+                            let subtask_abort_handle = subtask.run();
+                            abort_handles.insert(
+                                subgraph_name.to_string(),
+                                (messages_abort_handle, subtask_abort_handle),
+                            );
+                        }
                     }
                 }
 
@@ -321,10 +350,12 @@ impl SubtaskHandleStream for SubgraphWatchers {
                                 })
                                 .map(|sdl| {
                                     let _ = sender
-                                        .send(SubgraphEvent::SubgraphChanged(SubgraphChanged {
-                                            name: name.to_string(),
-                                            sdl,
-                                        }))
+                                        .send(SubgraphEvent::SubgraphChanged(
+                                            SubgraphSchemaChanged {
+                                                name: name.to_string(),
+                                                sdl,
+                                            },
+                                        ))
                                         .tap_err(|err| tracing::error!("{:?}", err));
                                 });
                         }
@@ -340,7 +371,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                         subtask_abort_handle.abort();
                         abort_handles.remove(name);
                         let _ = sender
-                            .send(SubgraphEvent::SubgraphRemoved(SubgraphRemoved {
+                            .send(SubgraphEvent::SubgraphRemoved(SubgraphSchemaRemoved {
                                 name: name.to_string(),
                             }))
                             .tap_err(|err| tracing::error!("{:?}", err));

--- a/src/composition/watchers/watcher/mod.rs
+++ b/src/composition/watchers/watcher/mod.rs
@@ -1,4 +1,6 @@
 pub mod file;
 pub mod introspection;
+pub mod remote;
+pub mod sdl;
 pub mod subgraph;
 pub mod supergraph_config;

--- a/src/composition/watchers/watcher/remote.rs
+++ b/src/composition/watchers/watcher/remote.rs
@@ -1,0 +1,50 @@
+use crate::options::ProfileOpt;
+use crate::utils::client::StudioClientConfig;
+use crate::RoverError;
+
+use rover_client::operations::subgraph::fetch;
+use rover_client::operations::subgraph::fetch::SubgraphFetchInput;
+use rover_client::shared::GraphRef;
+
+use std::str::FromStr;
+
+/// Remote schemas are fetched from Studio and are a GraphRef and subgraph name combination
+#[derive(Debug, Clone)]
+pub struct RemoteSchema {
+    graph_ref: String,
+    subgraph: String,
+    profile: ProfileOpt,
+    client_config: StudioClientConfig,
+}
+
+impl RemoteSchema {
+    pub fn new(
+        graph_ref: String,
+        subgraph: String,
+        profile: &ProfileOpt,
+        client_config: &StudioClientConfig,
+    ) -> Self {
+        Self {
+            graph_ref,
+            subgraph,
+            profile: profile.clone(),
+            client_config: client_config.clone(),
+        }
+    }
+
+    pub async fn run(&self) -> Result<String, RoverError> {
+        let client = self.client_config.get_authenticated_client(&self.profile)?;
+
+        let response = fetch::run(
+            SubgraphFetchInput {
+                graph_ref: GraphRef::from_str(&self.graph_ref)?,
+                subgraph_name: self.subgraph.clone(),
+            },
+            &client,
+        )
+        .await
+        .map_err(RoverError::from)?;
+
+        Ok(response.sdl.contents)
+    }
+}

--- a/src/composition/watchers/watcher/sdl.rs
+++ b/src/composition/watchers/watcher/sdl.rs
@@ -1,0 +1,16 @@
+/// SDL from a user updating the SupergraphConfig directly
+#[derive(Debug, Clone)]
+pub struct Sdl {
+    /// Changed SDL
+    sdl: String,
+}
+
+impl Sdl {
+    pub fn new(sdl: String) -> Self {
+        Self { sdl }
+    }
+
+    pub fn run(&self) -> String {
+        self.sdl.clone()
+    }
+}

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -112,19 +112,19 @@ impl SubgraphWatcherKind {
 /// A unit struct denoting a change to a subgraph, used by composition to know whether to
 /// recompose.
 #[derive(derive_getters::Getters)]
-pub struct SubgraphSchemaChanged {
+pub struct WatchedSdlChange {
     sdl: String,
 }
 
 impl SubtaskHandleUnit for SubgraphWatcher {
-    type Output = SubgraphSchemaChanged;
+    type Output = WatchedSdlChange;
 
     fn handle(self, sender: UnboundedSender<Self::Output>) -> AbortHandle {
         tokio::spawn(async move {
             let mut watcher = self.watcher.watch().await;
             while let Some(sdl) = watcher.next().await {
                 let _ = sender
-                    .send(SubgraphSchemaChanged { sdl })
+                    .send(WatchedSdlChange { sdl })
                     .tap_err(|err| tracing::error!("{:?}", err));
             }
         })

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -5,9 +5,14 @@ use futures::{Stream, StreamExt};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 
-use crate::{composition::watchers::subtask::SubtaskHandleUnit, utils::client::StudioClientConfig};
+use crate::{
+    composition::watchers::subtask::SubtaskHandleUnit, options::ProfileOpt,
+    utils::client::StudioClientConfig, RoverError,
+};
 
-use super::{file::FileWatcher, introspection::SubgraphIntrospection};
+use super::{
+    file::FileWatcher, introspection::SubgraphIntrospection, remote::RemoteSchema, sdl::Sdl,
+};
 
 #[derive(thiserror::Error, Debug)]
 #[error("Unsupported subgraph introspection source: {:?}", .0)]
@@ -16,9 +21,25 @@ pub struct UnsupportedSchemaSource(SchemaSource);
 /// A subgraph watcher watches subgraphs for changes. It's important to know when a subgraph
 /// changes because it informs any listeners that they may need to react (eg, by recomposing when
 /// the listener is composition)
+#[derive(derive_getters::Getters)]
 pub struct SubgraphWatcher {
     /// The kind of watcher used (eg, file, introspection)
     watcher: SubgraphWatcherKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum NonRepeatingFetch {
+    RemoteSchema(RemoteSchema),
+    Sdl(Sdl),
+}
+
+impl NonRepeatingFetch {
+    pub async fn run(&self) -> Result<String, RoverError> {
+        match self {
+            Self::RemoteSchema(runner) => runner.run().await,
+            Self::Sdl(runner) => Ok(runner.run()),
+        }
+    }
 }
 
 /// The kind of watcher attached to the subgraph. This may be either file watching, when we're
@@ -30,15 +51,18 @@ pub enum SubgraphWatcherKind {
     File(FileWatcher),
     /// Poll an endpoint via introspection.
     Introspect(SubgraphIntrospection),
-    /// Don't ever update, schema is only pulled once.
-    // TODO: figure out what to do with this; is it ever used? can we remove it?
-    _Once(String),
+    /// When there's an in-place change (eg, the SDL in the SupergraphConfig has changed or the
+    /// SchemaSource::Subgraph now has a different subgraph name or points to a different
+    /// GraphRef), we don't watch for changes: we either emit the changed SDL directly or call into
+    /// Studio to get an updated SDL for the new GraphRef/subgraph combination
+    Once(NonRepeatingFetch),
 }
 
 impl SubgraphWatcher {
     /// Derive the right SubgraphWatcher (ie, File, Introspection) from the federation-rs SchemaSource
     pub fn from_schema_source(
         schema_source: SchemaSource,
+        profile: &ProfileOpt,
         client_config: &StudioClientConfig,
         introspection_polling_interval: u64,
     ) -> Result<Self, Box<UnsupportedSchemaSource>> {
@@ -59,8 +83,14 @@ impl SubgraphWatcher {
                     introspection_polling_interval,
                 )),
             }),
-            // TODO: figure out if there are any other sources to worry about; SDL (stdin? not sure) / Subgraph (ie, from graph-ref)
-            unsupported_source => Err(Box::new(UnsupportedSchemaSource(unsupported_source))),
+            SchemaSource::Subgraph { graphref, subgraph } => Ok(Self {
+                watcher: SubgraphWatcherKind::Once(NonRepeatingFetch::RemoteSchema(
+                    RemoteSchema::new(graphref, subgraph, profile, client_config),
+                )),
+            }),
+            SchemaSource::Sdl { sdl } => Ok(Self {
+                watcher: SubgraphWatcherKind::Once(NonRepeatingFetch::Sdl(Sdl::new(sdl))),
+            }),
         }
     }
 }
@@ -74,8 +104,7 @@ impl SubgraphWatcherKind {
         match self {
             Self::File(file_watcher) => file_watcher.clone().watch(),
             Self::Introspect(introspection) => introspection.watch(),
-            // TODO: figure out what this is; sdl? stdin one-off? either way, probs not watching
-            Self::_Once(_) => unimplemented!(),
+            kind => unimplemented!("{kind:?} is not a watcher"),
         }
     }
 }

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -61,6 +61,7 @@ impl SubtaskHandleUnit for SupergraphConfigWatcher {
 #[derive(Getters)]
 pub struct SupergraphConfigDiff {
     added: Vec<(String, SubgraphConfig)>,
+    changed: Vec<(String, SubgraphConfig)>,
     removed: Vec<String>,
 }
 
@@ -71,22 +72,20 @@ impl SupergraphConfigDiff {
         old: &SupergraphConfig,
         new: SupergraphConfig,
     ) -> Result<SupergraphConfigDiff, ConfigError> {
-        let old_subgraph_defs = old.get_subgraph_definitions().tap_err(|err| {
-            // TODO: why do we print here instead of just defering to the caller?
-            errln!(
-                "error getting subgraph definitions from the current supergraph config: {:?}",
-                err
-            )
-        })?;
+        let old_subgraph_names: HashSet<String> = old
+            .clone()
+            .into_iter()
+            .map(|(name, _config)| name)
+            .collect();
+
+        let new_subgraph_names: HashSet<String> = new
+            .clone()
+            .into_iter()
+            .map(|(name, _config)| name)
+            .collect();
 
         // Collect the subgraph definitions from the new supergraph config.
-        let new_subgraphs: BTreeMap<String, SubgraphConfig> = new.into_iter().collect();
-
-        // Collect the old and new subgraph names.
-        let old_subgraph_names: HashSet<String> =
-            HashSet::from_iter(old_subgraph_defs.iter().map(|def| def.name.to_string()));
-        let new_subgraph_names: HashSet<String> =
-            HashSet::from_iter(new_subgraphs.keys().map(|name| name.to_string()));
+        let new_subgraphs: BTreeMap<String, SubgraphConfig> = new.clone().into_iter().collect();
 
         // Compare the old and new subgraph names to find additions.
         let added_names: HashSet<String> =
@@ -102,7 +101,29 @@ impl SupergraphConfigDiff {
             .collect::<Vec<_>>();
         let removed = removed_names.into_iter().cloned().collect::<Vec<_>>();
 
-        Ok(SupergraphConfigDiff { added, removed })
+        // Find any in-place changes (eg, SDL, SchemaSource::Subgraph)
+        let mut changed = vec![];
+        for (old_name, old_config) in old.clone().into_iter() {
+            // Exclude any removed subgraphs
+            if !removed.contains(&old_name) {
+                let found_new = new
+                    .clone()
+                    .into_iter()
+                    .find(|(sub_name, _sub_config)| *sub_name == old_name);
+
+                if let Some((old_name, new_config)) = found_new {
+                    if new_config != old_config {
+                        changed.push((old_name, new_config));
+                    }
+                }
+            }
+        }
+
+        Ok(SupergraphConfigDiff {
+            added,
+            changed,
+            removed,
+        })
     }
 }
 
@@ -146,5 +167,42 @@ mod tests {
             .added()
             .contains(&("subgraph_c".to_string(), subgraph_def.clone())));
         assert!(diff.removed().contains(&"subgraph_b".to_string()));
+    }
+
+    #[test]
+    fn test_supergraph_config_diff_in_place_change() {
+        let subgraph_def = SubgraphConfig {
+            routing_url: None,
+            schema: SchemaSource::Subgraph {
+                graphref: "graph-ref".to_string(),
+                subgraph: "subgraph".to_string(),
+            },
+        };
+
+        let subgraph_def_updated = SubgraphConfig {
+            routing_url: None,
+            schema: SchemaSource::Subgraph {
+                graphref: "updated-graph-ref".to_string(),
+                subgraph: "subgraph".to_string(),
+            },
+        };
+
+        // Create an old supergraph config with subgraph definitions.
+        let old_subgraph_defs: BTreeMap<String, SubgraphConfig> =
+            BTreeMap::from([("subgraph_a".to_string(), subgraph_def.clone())]);
+        let old = SupergraphConfig::new(old_subgraph_defs, None);
+
+        // Create a new supergraph config with 1 new and 1 old subgraph definitions.
+        let new_subgraph_defs: BTreeMap<String, SubgraphConfig> =
+            BTreeMap::from([("subgraph_a".to_string(), subgraph_def_updated.clone())]);
+        let new = SupergraphConfig::new(new_subgraph_defs, None);
+
+        // Assert diff contain correct additions and removals.
+        let diff = SupergraphConfigDiff::new(&old, new).unwrap();
+
+        assert_eq!(diff.changed().len(), 1);
+        assert!(diff
+            .changed()
+            .contains(&("subgraph_a".to_string(), subgraph_def_updated.clone())));
     }
 }


### PR DESCRIPTION
```    
feat(subgraph watching): support SDL, SchemaSource::Subgraph changes
      - when the supergraphconfig has changes to its in-lined SDL or
        subgraph subgraphs (I hate that it's called this because it's so
        confusing), we now have a way of seeing what's changed (rather than
        just added or removed)
      - we no longer use fed-rs's get_subgraph_defintions() because it'll
        error without fully resolved configs (ie, evertying already
        in-lined; for SchemaSource::Subgraph, we won't have that)
      - refetches SchemaSource::Subgraphs when their graphref or subgraph
        name change
      - when a SchemaSource::SDL has its sdl change, we emit that new sdl as
        a change
```