### PR TITLE
feat(composition): support new SDL/Subgraphs

### DIFF
--- a/src/composition/run_composition.rs
+++ b/src/composition/run_composition.rs
@@ -88,7 +88,7 @@ mod tests {
         composition::{
             compose_output,
             events::CompositionEvent,
-            runner::{SubgraphChanged, SubgraphEvent},
+            runner::{SubgraphEvent, SubgraphSchemaChanged},
             supergraph::{
                 binary::{OutputTarget, SupergraphBinary},
                 config::FinalSupergraphConfig,
@@ -144,7 +144,8 @@ mod tests {
             .build();
 
         let subgraph_change_events: BoxStream<SubgraphEvent> =
-            once(async { SubgraphEvent::SubgraphChanged(SubgraphChanged::default()) }).boxed();
+            once(async { SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged::default()) })
+                .boxed();
         let (mut composition_messages, composition_subtask) = Subtask::new(composition_handler);
         let abort_handle = composition_subtask.run(subgraph_change_events);
 

--- a/src/composition/runner.rs
+++ b/src/composition/runner.rs
@@ -267,39 +267,66 @@ impl SubtaskHandleStream for SubgraphWatchers {
                 // If we detect additional diffs, start a new subgraph subtask.
                 // Adding the abort handle to the currentl collection of handles.
                 for (subgraph_name, subgraph_config) in diff.added() {
-                    if let Ok((mut messages, subtask)) = SubgraphWatcher::from_schema_source(
+                    if let Ok(subgraph_watcher) = SubgraphWatcher::from_schema_source(
                         subgraph_config.schema.clone(),
                         &self.profile,
                         &self.client_config,
                         self.introspection_polling_interval,
                     )
-                    .map(|subgraph_watcher| {
-                        Subtask::<SubgraphWatcher, SubgraphSchemaChanged>::new(subgraph_watcher)
-                    })
                     .tap_err(|err| {
                         tracing::warn!(
                             "Cannot configure new subgraph for {subgraph_name}: {:?}",
                             err
                         )
                     }) {
-                        let sender = sender.clone();
-                        let subgraph_name_c = subgraph_name.clone();
-                        let messages_abort_handle = tokio::spawn(async move {
-                            while let Some(change) = messages.next().await {
-                                let _ = sender
-                                    .send(SubgraphEvent::SubgraphChanged(SubgraphChanged {
-                                        name: subgraph_name_c.to_string(),
-                                        sdl: change.sdl().to_string(),
-                                    }))
-                                    .tap_err(|err| tracing::error!("{:?}", err));
-                            }
-                        })
-                        .abort_handle();
-                        let subtask_abort_handle = subtask.run();
-                        abort_handles.insert(
-                            subgraph_name.to_string(),
-                            (messages_abort_handle, subtask_abort_handle),
-                        );
+                        // If a SchemaSource::Subgraph or SchemaSource::Sdl was added, we don't
+                        // want to spin up watchers; rather, we emit a SubgraphChanged event with
+                        // either what we fetch from Studio (for Subgraphs) or what the SupergraphConfig
+                        // has for Sdls
+                        if let SubgraphWatcherKind::Once(non_repeating_fetch) =
+                            subgraph_watcher.watcher()
+                        {
+                            let _ = non_repeating_fetch
+                                .run()
+                                .await
+                                .tap_err(|err| {
+                                    tracing::error!("failed to get {subgraph_name}'s SDL: {err:?}")
+                                })
+                                .map(|sdl| {
+                                    let _ = sender
+                                        .send(SubgraphEvent::SubgraphChanged(SubgraphChanged {
+                                            name: subgraph_name.to_string(),
+                                            sdl,
+                                        }))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                });
+                        // When we have a SchemaSource that's watchable, we start a new subtask
+                        // and add it to our list of subtasks
+                        } else {
+                            let (mut messages, subtask) =
+                                Subtask::<SubgraphWatcher, SubgraphSchemaChanged>::new(
+                                    subgraph_watcher,
+                                );
+
+                            let sender = sender.clone();
+                            let subgraph_name_c = subgraph_name.clone();
+                            let messages_abort_handle = tokio::spawn(async move {
+                                while let Some(change) = messages.next().await {
+                                    let _ = sender
+                                        .send(SubgraphEvent::SubgraphChanged(SubgraphChanged {
+                                            name: subgraph_name_c.to_string(),
+                                            sdl: change.sdl().to_string(),
+                                        }))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                }
+                            })
+                            .abort_handle();
+                            let subtask_abort_handle = subtask.run();
+                            abort_handles.insert(
+                                subgraph_name.to_string(),
+                                (messages_abort_handle, subtask_abort_handle),
+                            );
+                        }
                     }
                 }
 

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -112,19 +112,19 @@ impl SubgraphWatcherKind {
 /// A unit struct denoting a change to a subgraph, used by composition to know whether to
 /// recompose.
 #[derive(derive_getters::Getters)]
-pub struct SubgraphSchemaChanged {
+pub struct WatchedSdlChange {
     sdl: String,
 }
 
 impl SubtaskHandleUnit for SubgraphWatcher {
-    type Output = SubgraphSchemaChanged;
+    type Output = WatchedSdlChange;
 
     fn handle(self, sender: UnboundedSender<Self::Output>) -> AbortHandle {
         tokio::spawn(async move {
             let mut watcher = self.watcher.watch().await;
             while let Some(sdl) = watcher.next().await {
                 let _ = sender
-                    .send(SubgraphSchemaChanged { sdl })
+                    .send(WatchedSdlChange { sdl })
                     .tap_err(|err| tracing::error!("{:?}", err));
             }
         })


### PR DESCRIPTION
  - SDL and SchemaSource::Subgraph additions to the supergraphconfig now either fetch (for subgraphs) from studio or emit their sdl as subgraph change events