### PR TITLE
fix(linting): ignore CHANGELOG links

### DIFF
--- a/xtask/src/tools/lychee.rs
+++ b/xtask/src/tools/lychee.rs
@@ -37,6 +37,9 @@ impl LycheeRunner {
 
         let inputs: Vec<Input> = get_md_files()
             .iter()
+            // Skip the changelog to preserve history, but also to avoid checking hundreds of
+            // PR links and similar that don't need validation
+            .filter(|file| !file.to_string().contains("CHANGELOG"))
             .map(|file| Input {
                 source: InputSource::FsPath(PathBuf::from(file)),
                 file_type_hint: Some(FileType::Markdown),


### PR DESCRIPTION
reduces our overall checks from (at the time of writing) 466 links (lots of PR links in the changelog) to 66; preserves history, too, by not needing to change any links just to get linting to work (eg, if you change `getting-started.md` to `getting-started.mdx`)