### PR TITLE
Fix macOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ executors:
 
   amd_macos: &amd_macos_executor
     macos:
-      xcode: "14.2"
+      xcode: "15.0.0"
     resource_class: macos.m1.large.gen1
     environment:
       XTASK_TARGET: "x86_64-apple-darwin"
@@ -73,7 +73,7 @@ executors:
   # until there is official support for building on real ARM Macs
   arm_macos: &arm_macos_executor
     macos:
-      xcode: "14.2"
+      xcode: "15.0.0"
     resource_class: macos.m1.large.gen1
     environment:
       XTASK_TARGET: "aarch64-apple-darwin"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,8 +530,8 @@ commands:
               - equal: [*arm_macos_executor, << parameters.platform >>]
           steps:
             - run:
-                name: Install OpenSSL@1.1
-                command: brew install openssl@1.1
+                name: Install OpenSSL
+                command: brew install openssl@3
             - run:
                 name: Install p7zip
                 command: brew install p7zip

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         compile_target:
           - target: x86_64-apple-darwin
-            compiles_on: macos-14
+            compiles_on: macos-13-x-large
           - target: aarch64-apple-darwin
-            compiles_on: macos-14
+            compiles_on: macos-13-x-large
           - target: x86_64-pc-windows-msvc
             compiles_on: windows-2022
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         compile_target:
           - target: x86_64-apple-darwin
-            compiles_on: macos-13-x-large
+            compiles_on: macos-13-xlarge
           - target: aarch64-apple-darwin
-            compiles_on: macos-13-x-large
+            compiles_on: macos-13-xlarge
           - target: x86_64-pc-windows-msvc
             compiles_on: windows-2022
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/tests-mac-x86.yml
+++ b/.github/workflows/tests-mac-x86.yml
@@ -5,7 +5,7 @@ jobs:
   build-rover:
     name: Build Rover for macOS x86-64
     # Arm64 runner for cross-compilation
-    runs-on: macos-14
+    runs-on: macos-13-x-large
     steps:
       - uses: actions/checkout@v4
         name: "Checkout rover repo"

--- a/.github/workflows/tests-mac-x86.yml
+++ b/.github/workflows/tests-mac-x86.yml
@@ -5,7 +5,7 @@ jobs:
   build-rover:
     name: Build Rover for macOS x86-64
     # Arm64 runner for cross-compilation
-    runs-on: macos-13-x-large
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
         name: "Checkout rover repo"

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -72,12 +72,12 @@ impl Target {
         } else if self.is_macos() {
             let openssl_path = BREW_OPT
                 .iter()
-                .map(|x| Utf8Path::new(x).join("openssl@1.1"))
+                .map(|x| Utf8Path::new(x).join("openssl@3"))
                 .find(|x| x.exists())
                 .ok_or_else(|| {
                     anyhow!(
-                        "OpenSSL v1.1 is not installed. Please install with `brew install \
-                    openssl@1.1`"
+                        "OpenSSL v3 is not installed. Please install with `brew install \
+                    openssl@3`"
                     )
                 })?;
 


### PR DESCRIPTION
Fixes: #2237 

CI has been broken for Mac since Homebrew pulled support for OpenSSL at the specific version we're requiring. However this appears to be a holdover from older versions of MacOS where Rosetta etc. were less well supported, so in moving this forward we _should_ be able to upgrade as well. 

Green Smoke Test run: https://github.com/apollographql/rover/actions/runs/11515349122/job/32056173251