### PR TITLE
Increase Robustness of Smoke Tests

### DIFF
--- a/tests/e2e/graph/introspect.rs
+++ b/tests/e2e/graph/introspect.rs
@@ -97,7 +97,7 @@ async fn e2e_test_rover_graph_introspect_watch(
     .stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("Could not run command");
     info!("Running command...");
-    while let None = child.stderr {
+    while child.stderr.is_none() {
         info!("Waiting for output to appear from command...");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
@@ -132,7 +132,7 @@ async fn e2e_test_rover_graph_introspect_watch(
         .open(schema_path)
         .expect("Cannot open schema file");
     schema_file
-        .write(new_schema.as_bytes())
+        .write_all(new_schema.as_bytes())
         .expect("Could not update schema");
 
     let mut found = false;

--- a/tests/e2e/graph/introspect.rs
+++ b/tests/e2e/graph/introspect.rs
@@ -1,5 +1,5 @@
 use std::fs::{read_to_string, OpenOptions};
-use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::io::{BufReader, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -16,8 +16,9 @@ use tracing::info;
 use tracing_test::traced_test;
 
 use crate::e2e::{
-    run_single_mutable_subgraph, run_subgraphs_retail_supergraph, test_artifacts_directory,
-    RetailSupergraph, SingleMutableSubgraph,
+    find_matching_log_line, introspection_log_line_prefix, run_single_mutable_subgraph,
+    run_subgraphs_retail_supergraph, test_artifacts_directory, RetailSupergraph,
+    SingleMutableSubgraph,
 };
 
 #[rstest]
@@ -77,49 +78,49 @@ async fn e2e_test_rover_graph_introspect_watch(
     #[future(awt)]
     subgraph: SingleMutableSubgraph,
     test_artifacts_directory: PathBuf,
+    introspection_log_line_prefix: &Regex,
 ) {
-    // Set up the command to output the original file
+    // Create an output file to hold the introspection responses
     let mut out_file = Builder::new()
         .suffix(".json")
         .tempfile()
         .expect("Could not create output file");
+    // Create the Rover command to run the introspection in `--watch` mode
     let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
-    cmd.args([
-        "graph",
-        "introspect",
-        &subgraph.subgraph_url,
-        "--watch",
-        "--format",
-        "json",
-        "--output",
-        out_file.path().to_str().unwrap(),
-    ])
-    .stderr(Stdio::piped());
-    let mut child = cmd.spawn().expect("Could not run command");
-    info!("Running command...");
+    let mut child = cmd
+        .args([
+            "graph",
+            "introspect",
+            &subgraph.subgraph_url,
+            "--watch",
+            "--format",
+            "json",
+            "--output",
+            out_file.path().to_str().unwrap(),
+        ])
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Could not run rover command");
+    info!("Running rover introspection command...");
+
+    // Extract stderr from the child process and attach a reader to it so we can explore
+    // the lines of output
     while child.stderr.is_none() {
         info!("Waiting for output to appear from command...");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+    info!("Attaching to stderr...");
     let stderr = child.stderr.take().unwrap();
     let mut reader = BufReader::new(stderr);
-    let re = Regex::new("Introspection Response").unwrap();
 
-    // Read stderr until such time as we get more than 1 line out of it, i.e. we've received the
-    // introspection request and written it to a file.
-    info!("Waiting for lines to appear...");
-    let mut introspection_line = String::new();
-    reader
-        .read_line(&mut introspection_line)
-        .expect("Could not read line from console process");
-    info!("Line read from spawned process '{introspection_line}'");
-    if !re.is_match(&introspection_line) {
-        panic!("Did not read introspection line correctly");
-    }
-    introspection_line.clear();
+    // Look at the output from stderr and wait until we see a log line that indicates the
+    // introspection response has been successfully received. Then we extract that response
+    // from the output file.
+    find_matching_log_line(&mut reader, introspection_log_line_prefix);
     let original_value: Value = serde_json::from_reader(out_file.as_file()).unwrap();
 
-    // Make a change to the schema
+    // Make a change to the schema to stimulate the need for a new introspection query.
+    info!("Making change to schema to trigger introspection...");
     let schema_path = subgraph
         .directory
         .path()
@@ -135,25 +136,19 @@ async fn e2e_test_rover_graph_introspect_watch(
         .write_all(new_schema.as_bytes())
         .expect("Could not update schema");
 
-    let mut found = false;
-    while !found {
-        reader
-            .read_line(&mut introspection_line)
-            .expect("Could not read line from console process");
-        info!("Line read from spawned process '{introspection_line}'");
-        if re.is_match(&introspection_line) {
-            found = true;
-        } else {
-            introspection_line.clear()
-        }
-    }
+    // Wait for the next introspection log line so we know the response has been received.
+    find_matching_log_line(&mut reader, introspection_log_line_prefix);
+    info!("Killing rover process...");
+    // Kill the watch process to ensure the file doesn't change again now
     child.kill().expect("Could not kill rover process");
 
-    // Get the new result
+    info!("Extract new value from file...");
+    // Get the new result from the file
     out_file
         .seek(SeekFrom::Start(0))
         .expect("Could not rewind file");
     let new_value: Value = serde_json::from_reader(out_file.as_file()).unwrap();
+    info!("Check difference between old schema and new");
     // Ensure that the two are different
     assert_that!(new_value).is_not_equal_to(original_value);
 
@@ -165,6 +160,7 @@ async fn e2e_test_rover_graph_introspect_watch(
         read_to_string(test_artifacts_directory.join("graph/pandas_changed_introspect.graphql"))
             .expect("Could not read in canonical schema");
 
+    info!("Check new schema is as expected...");
     let changes = diff(new_schema, &expected_new_schema).unwrap();
 
     asserting(&format!("changes which was {:?}, has no elements", changes))

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -44,7 +44,6 @@ async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_n
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()
@@ -101,7 +100,6 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()
@@ -122,7 +120,6 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()
@@ -189,7 +186,6 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     let installed = bin_path
         .read_dir()
         .expect("unable to read contents of directory")
-        .into_iter()
         .map(|f| f.expect("failed to get file {file:?} in ${temp_dir:?}"))
         .any(|f| {
             f.file_name()

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -57,7 +57,7 @@ impl RetailSupergraph<'_> {
         self.retail_supergraph_config
             .subgraphs
             .keys()
-            .map(|name| name.clone())
+            .cloned()
             .collect()
     }
 
@@ -177,18 +177,18 @@ async fn run_single_mutable_subgraph() -> SingleMutableSubgraph {
 
     info!("Installing subgraph dependencies");
     cmd!("npm", "run", "clean")
-        .dir(&target.path())
+        .dir(target.path())
         .run()
         .expect("Could not clean directory");
     cmd!("npm", "install")
-        .dir(&target.path())
+        .dir(target.path())
         .run()
         .expect("Could not install subgraph dependencies");
     let port = pick_unused_port().expect("No free ports");
     let subgraph_url = format!("http://localhost:{}", port);
     let task_handle = Command::new("npm")
         .args(["run", "start", "--", &port.to_string()])
-        .current_dir(&target.path())
+        .current_dir(target.path())
         .spawn()
         .expect("Could not spawn subgraph process");
     info!("Testing subgraph connectivity");

--- a/tests/e2e/options/client_timeout.rs
+++ b/tests/e2e/options/client_timeout.rs
@@ -24,7 +24,7 @@ async fn e2e_test_rover_client_timeout_option(
         then.status(status_code);
     });
 
-    let fake_registry = format!("http://{}/graphql", server.address().to_string());
+    let fake_registry = format!("http://{}/graphql", server.address());
 
     // WHEN
     //   - a command supporting the --client-timeout option is invoked

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -98,7 +98,7 @@ async fn e2e_test_rover_subgraph_introspect_watch(
     .stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("Could not run command");
     info!("Running command...");
-    while let None = child.stderr {
+    while child.stderr.is_none() {
         info!("Waiting for output to appear from command...");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
@@ -133,7 +133,7 @@ async fn e2e_test_rover_subgraph_introspect_watch(
         .open(schema_path)
         .expect("Cannot open schema file");
     schema_file
-        .write(new_schema.as_bytes())
+        .write_all(new_schema.as_bytes())
         .expect("Could not update schema");
 
     let mut found = false;

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -1,21 +1,23 @@
 use std::fs::{read_to_string, OpenOptions};
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use assert_cmd::prelude::CommandCargoExt;
 use graphql_schema_diff::diff;
+use regex::Regex;
 use rstest::rstest;
 use serde_json::Value;
 use speculoos::prelude::VecAssertions;
 use speculoos::{assert_that, asserting};
-use tempfile::{Builder, TempDir};
+use tempfile::Builder;
+use tracing::info;
 use tracing_test::traced_test;
 
 use crate::e2e::{
     run_single_mutable_subgraph, run_subgraphs_retail_supergraph, test_artifacts_directory,
-    RetailSupergraph,
+    RetailSupergraph, SingleMutableSubgraph,
 };
 
 #[rstest]
@@ -73,8 +75,8 @@ async fn e2e_test_rover_subgraph_introspect(
 #[traced_test]
 async fn e2e_test_rover_subgraph_introspect_watch(
     #[from(run_single_mutable_subgraph)]
-    #[future]
-    subgraph_details: (String, TempDir, String),
+    #[future(awt)]
+    subgraph: SingleMutableSubgraph,
     test_artifacts_directory: PathBuf,
 ) {
     // Set up the command to output the original file
@@ -82,24 +84,47 @@ async fn e2e_test_rover_subgraph_introspect_watch(
         .suffix(".json")
         .tempfile()
         .expect("Could not create output file");
-    let (url, subgraph_dir, schema_name) = subgraph_details.await;
     let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
     cmd.args([
         "subgraph",
         "introspect",
-        &url,
+        &subgraph.subgraph_url,
         "--watch",
         "--format",
         "json",
         "--output",
         out_file.path().to_str().unwrap(),
-    ]);
+    ])
+    .stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("Could not run command");
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    // Store the result
+    info!("Running command...");
+    while let None = child.stderr {
+        info!("Waiting for output to appear from command...");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    let stderr = child.stderr.take().unwrap();
+    let mut reader = BufReader::new(stderr);
+    let re = Regex::new("Introspection Response").unwrap();
+
+    // Read stderr until such time as we get more than 1 line out of it, i.e. we've received the
+    // introspection request and written it to a file.
+    info!("Waiting for lines to appear...");
+    let mut introspection_line = String::new();
+    reader
+        .read_line(&mut introspection_line)
+        .expect("Could not read line from console process");
+    info!("Line read from spawned process '{introspection_line}'");
+    if !re.is_match(&introspection_line) {
+        panic!("Did not read introspection line correctly");
+    }
+    introspection_line.clear();
     let original_value: Value = serde_json::from_reader(out_file.as_file()).unwrap();
+
     // Make a change to the schema
-    let schema_path = subgraph_dir.into_path().join(schema_name);
+    let schema_path = subgraph
+        .directory
+        .path()
+        .join(subgraph.schema_file_name.clone());
     let schema = read_to_string(&schema_path).expect("Could not read schema file");
     let new_schema = schema.replace("allPandas", "getMeAllThePandas");
     let mut schema_file = OpenOptions::new()
@@ -110,8 +135,21 @@ async fn e2e_test_rover_subgraph_introspect_watch(
     schema_file
         .write(new_schema.as_bytes())
         .expect("Could not update schema");
-    tokio::time::sleep(Duration::from_secs(5)).await;
-    child.kill().unwrap();
+
+    let mut found = false;
+    while !found {
+        reader
+            .read_line(&mut introspection_line)
+            .expect("Could not read line from console process");
+        info!("Line read from spawned process '{introspection_line}'");
+        if re.is_match(&introspection_line) {
+            found = true;
+        } else {
+            introspection_line.clear()
+        }
+    }
+    child.kill().expect("Could not kill rover process");
+
     // Get the new result
     out_file
         .seek(SeekFrom::Start(0))

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -1,7 +1,12 @@
-use std::fs::{read_to_string, OpenOptions};
-use std::io::{BufReader, Seek, SeekFrom, Write};
+use std::fs::read_to_string;
+use std::fs::OpenOptions;
+use std::io::BufReader;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::process::Stdio;
 use std::time::Duration;
 
 use assert_cmd::prelude::CommandCargoExt;
@@ -9,17 +14,20 @@ use graphql_schema_diff::diff;
 use regex::Regex;
 use rstest::rstest;
 use serde_json::Value;
+use speculoos::assert_that;
+use speculoos::asserting;
 use speculoos::prelude::VecAssertions;
-use speculoos::{assert_that, asserting};
 use tempfile::Builder;
 use tracing::info;
 use tracing_test::traced_test;
 
-use crate::e2e::{
-    find_matching_log_line, introspection_log_line_prefix, run_single_mutable_subgraph,
-    run_subgraphs_retail_supergraph, test_artifacts_directory, RetailSupergraph,
-    SingleMutableSubgraph,
-};
+use crate::e2e::find_matching_log_line;
+use crate::e2e::introspection_log_line_prefix;
+use crate::e2e::run_single_mutable_subgraph;
+use crate::e2e::run_subgraphs_retail_supergraph;
+use crate::e2e::test_artifacts_directory;
+use crate::e2e::RetailSupergraph;
+use crate::e2e::SingleMutableSubgraph;
 
 #[rstest]
 #[ignore]
@@ -106,10 +114,18 @@ async fn e2e_test_rover_subgraph_introspect_watch(
 
     // Extract stderr from the child process and attach a reader to it so we can explore
     // the lines of output
-    while child.stderr.is_none() {
-        info!("Waiting for output to appear from command...");
-        tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::select! {
+        _ = async {
+            while child.stderr.is_none() {
+                info!("Waiting for output to appear from command...");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        } => {}
+        _ = tokio::time::sleep(Duration::from_secs(15)) => {
+            panic!("Could not get output from command")
+        }
     }
+
     info!("Attaching to stderr...");
     let stderr = child.stderr.take().unwrap();
     let mut reader = BufReader::new(stderr);

--- a/tests/e2e/subgraph/publish.rs
+++ b/tests/e2e/subgraph/publish.rs
@@ -49,7 +49,7 @@ async fn e2e_test_rover_subgraph_publish(
     let mut rng = rand::thread_rng();
     let id_regex = rand_regex::Regex::compile("[a-zA-Z][a-zA-Z0-9_-]{0,63}", 100)
         .expect("Could not compile regex");
-    let id: String = (&mut rng).sample::<String, &rand_regex::Regex>(&id_regex);
+    let id: String = rng.sample::<String, &rand_regex::Regex>(&id_regex);
     let schema_path = test_artifacts_directory.join("subgraph/perfSubgraph01.graphql");
     info!("Using name {} for subgraph", &id);
 
@@ -67,10 +67,12 @@ async fn e2e_test_rover_subgraph_publish(
         .output()
         .expect("Could not run initial list command");
     let resp: SubgraphListResponse = serde_json::from_slice(list_cmd_output.stdout.as_slice())
-        .expect(&format!(
-            "Could not parse response to struct - Raw: {}",
-            from_utf8(list_cmd_output.stdout.as_slice()).unwrap()
-        ));
+        .unwrap_or_else(|_| {
+            panic!(
+                "Could not parse response to struct - Raw: {}",
+                from_utf8(list_cmd_output.stdout.as_slice()).unwrap()
+            )
+        });
     let initial_subgraphs = resp.get_subgraph_names();
     assert_that(&initial_subgraphs).does_not_contain(&id);
 

--- a/tests/e2e/supergraph/compose.rs
+++ b/tests/e2e/supergraph/compose.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::process::Command;
 
 use assert_cmd::prelude::CommandCargoExt;
@@ -16,7 +17,7 @@ async fn e2e_test_run_rover_supergraph(retail_supergraph: &RetailSupergraph<'_>)
     //   - retail supergraphs representing any set of subgraphs to be composed into a supergraph
     //   (fixture)
     let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
-    cmd.args([
+    let mut args: Vec<String> = vec![
         "supergraph",
         "compose",
         "--config",
@@ -25,9 +26,16 @@ async fn e2e_test_run_rover_supergraph(retail_supergraph: &RetailSupergraph<'_>)
         "composition-result",
         "--elv2-license",
         "accept",
-    ]);
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    if let Ok(version) = env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION") {
+        args.push("--federation-version".to_string());
+        args.push(format!("={version}"));
+    };
+    cmd.args(args);
     cmd.current_dir(retail_supergraph.get_working_directory());
-
     let match_set: Vec<String> = retail_supergraph
         .get_subgraph_names()
         .into_iter()


### PR DESCRIPTION
Over the last week or so we've had several failures of the smoke tests due to issues in the introspection tests. This makes some changes so that those tests are more robust and exit cleanly as appropriate.

We also clean up some other parts of the tests that were incorrect, including an error with passing in the Federation version and some clippies that had not been previously addressed.

Green Smoke Tests here: https://github.com/apollographql/rover/actions/runs/11590320188/job/32268022001