### PR TITLE
Fixing up clippy warnings from tests in codebase

### DIFF
--- a/src/composition/supergraph/config/resolve/subgraph.rs
+++ b/src/composition/supergraph/config/resolve/subgraph.rs
@@ -823,7 +823,7 @@ mod tests {
 
         // THEN we should receive an error that the path was unable to be resolved
         let subject = assert_that!(result).is_err().subject;
-        let _ = if let ResolveSubgraphError::FileNotFound {
+        if let ResolveSubgraphError::FileNotFound {
             subgraph_name: actual_subgraph_name,
             supergraph_config_path: supergraph_yaml_path,
             path,

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -86,11 +86,11 @@ mod tests {
             .expect("Cannot open file");
 
         writeable_file
-            .write("some change".as_bytes())
+            .write_all("some change".as_bytes())
             .expect("couldn't write to file");
 
         let mut output = None;
-        while let None = output {
+        while output.is_none() {
             let _ = tokio::time::sleep(Duration::from_secs(1)).await;
             output = watching.next().await;
         }

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -487,7 +487,7 @@ mod test_get_supergraph_config {
         let supergraph_config_path = third_level_folder.path().join("supergraph.yaml");
         fs::write(
             supergraph_config_path.clone(),
-            &supergraph_config.into_bytes(),
+            supergraph_config.into_bytes(),
         )
         .expect("Could not write supergraph.yaml");
 
@@ -1185,7 +1185,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
       file: ./people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let mut config_path = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1225,7 +1225,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1279,7 +1279,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();


### PR DESCRIPTION
Ran clippy over some of our test code as a result of doing work on the E2E tests and wanted to apply these fixes to the unit tests as well.