### PR TITLE
feat(supergraph compose): new composition pipeline

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,12 +44,12 @@ jobs:
             yum -y install perl-core gcc openssl-devel openssl git
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             . "$HOME/.cargo/env"
-            cargo build --features "composition-rewrite" --target ${{ matrix.compile_target.target }} --test e2e
+            cargo build --target ${{ matrix.compile_target.target }} --test e2e
       - if: ${{ matrix.compile_target.container == '' }}
         name: "Build binaries on host"
         run: |
           rustup target add ${{ matrix.compile_target.target }}
-          cargo build --features "composition-rewrite" --target ${{ matrix.compile_target.target }} --test e2e
+          cargo build --target ${{ matrix.compile_target.target }} --test e2e
       - uses: actions/upload-artifact@v4
         name: "Store built binaries to use later on"
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,12 +44,12 @@ jobs:
             yum -y install perl-core gcc openssl-devel openssl git
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             . "$HOME/.cargo/env"
-            cargo build --target ${{ matrix.compile_target.target }} --test e2e
+            cargo build --features "composition-rewrite" --target ${{ matrix.compile_target.target }} --test e2e
       - if: ${{ matrix.compile_target.container == '' }}
         name: "Build binaries on host"
         run: |
           rustup target add ${{ matrix.compile_target.target }}
-          cargo build --target ${{ matrix.compile_target.target }} --test e2e
+          cargo build --features "composition-rewrite" --target ${{ matrix.compile_target.target }} --test e2e
       - uses: actions/upload-artifact@v4
         name: "Store built binaries to use later on"
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ default = ["composition-js"]
 # because of this GitHub issue: https://github.com/denoland/deno/issues/3711
 composition-js = []
 dev-next = []
+composition-rewrite = []
 
 ### cross-workspace dependencies
 # these dependencies can be used by any other workspace crate by specifying the dependency like so:

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -154,141 +154,141 @@ impl Compose {
         Ok(plugin_exe)
     }
 
-    //#[cfg(feature = "composition-rewrite")]
-    //pub async fn run(
-    //    &self,
-    //    override_install_path: Option<Utf8PathBuf>,
-    //    client_config: StudioClientConfig,
-    //    output_file: Option<Utf8PathBuf>,
-    //) -> RoverResult<RoverOutput> {
-    //    tracing::warn!("using composition-rewrite");
-    //    let mut stdin = stdin();
-    //    let write_file = FsWriteFile::default();
-    //    let read_file = FsReadFile::default();
-    //    let exec_command = TokioCommand::default();
+    #[cfg(feature = "composition-rewrite")]
+    pub async fn run(
+        &self,
+        override_install_path: Option<Utf8PathBuf>,
+        client_config: StudioClientConfig,
+        output_file: Option<Utf8PathBuf>,
+    ) -> RoverResult<RoverOutput> {
+        tracing::warn!("using composition-rewrite");
+        let mut stdin = stdin();
+        let write_file = FsWriteFile::default();
+        let read_file = FsReadFile::default();
+        let exec_command = TokioCommand::default();
 
-    //    let studio_client =
-    //        client_config.get_authenticated_client(&self.opts.plugin_opts.profile.clone())?;
+        let studio_client =
+            client_config.get_authenticated_client(&self.opts.plugin_opts.profile.clone())?;
 
-    //    let supergraph_root = self
-    //        .opts
-    //        .clone()
-    //        .supergraph_config_source()
-    //        .clone()
-    //        .supergraph_yaml
-    //        .and_then(|file| match file {
-    //            FileDescriptorType::File(file) => {
-    //                let mut current_dir =
-    //                    current_dir().expect("Unable to get current directory path");
+        let supergraph_root = self
+            .opts
+            .clone()
+            .supergraph_config_source()
+            .clone()
+            .supergraph_yaml
+            .and_then(|file| match file {
+                FileDescriptorType::File(file) => {
+                    let mut current_dir =
+                        current_dir().expect("Unable to get current directory path");
 
-    //                current_dir.push(file);
-    //                let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
-    //                let parent = path.parent().unwrap().to_path_buf();
-    //                Some(parent)
-    //            }
-    //            FileDescriptorType::Stdin => None,
-    //        });
+                    current_dir.push(file);
+                    let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
+                    let parent = path.parent().unwrap().to_path_buf();
+                    Some(parent)
+                }
+                FileDescriptorType::Stdin => None,
+            });
 
-    //    // Get a FullyResolvedSupergraphConfig from first loading in any remote subgraphs and then
-    //    // a local supergraph config (if present) and then combining them into a fully resolved
-    //    // supergraph config
-    //    let resolver = SupergraphConfigResolver::default()
-    //        .load_remote_subgraphs(
-    //            &studio_client,
-    //            self.opts.supergraph_config_source.graph_ref.as_ref(),
-    //        )
-    //        .await?
-    //        .load_from_file_descriptor(
-    //            &mut stdin,
-    //            self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
-    //        )?
-    //        .fully_resolve_subgraphs(&client_config, &studio_client, supergraph_root.as_ref())
-    //        .await?;
+        // Get a FullyResolvedSupergraphConfig from first loading in any remote subgraphs and then
+        // a local supergraph config (if present) and then combining them into a fully resolved
+        // supergraph config
+        let resolver = SupergraphConfigResolver::default()
+            .load_remote_subgraphs(
+                &studio_client,
+                self.opts.supergraph_config_source.graph_ref.as_ref(),
+            )
+            .await?
+            .load_from_file_descriptor(
+                &mut stdin,
+                self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
+            )?
+            .fully_resolve_subgraphs(&client_config, &studio_client, supergraph_root.as_ref())
+            .await?;
 
-    //    // We convert the FullyResolvedSupergraphConfig into a Supergraph because it makes using
-    //    // Serde easier (said differently: we're using the Federation-rs types here for
-    //    // compatability with Federation-rs tooling later on when we use their supergraph binary to
-    //    // actually run composition)
-    //    let supergraph_config: SupergraphConfig = resolver.clone().try_into()?;
+        // We convert the FullyResolvedSupergraphConfig into a Supergraph because it makes using
+        // Serde easier (said differently: we're using the Federation-rs types here for
+        // compatability with Federation-rs tooling later on when we use their supergraph binary to
+        // actually run composition)
+        let supergraph_config: SupergraphConfig = resolver.clone().try_into()?;
 
-    //    // Convert the FullyResolvedSupergraphConfig to yaml before we save it
-    //    let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
+        // Convert the FullyResolvedSupergraphConfig to yaml before we save it
+        let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
 
-    //    // We're going to save to a temporary place because we don't actually need the supergraph
-    //    // config to stick around; we only need it on disk to point the supergraph binary at
-    //    let supergraph_config_filepath =
-    //        Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
-    //            .expect("Unable to parse path");
+        // We're going to save to a temporary place because we don't actually need the supergraph
+        // config to stick around; we only need it on disk to point the supergraph binary at
+        let supergraph_config_filepath =
+            Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
+                .expect("Unable to parse path");
 
-    //    // Write the supergraph config to disk
-    //    let _ = write_file
-    //        .write_file(
-    //            &supergraph_config_filepath,
-    //            supergraph_config_yaml.as_bytes(),
-    //        )
-    //        .await?;
+        // Write the supergraph config to disk
+        let _ = write_file
+            .write_file(
+                &supergraph_config_filepath,
+                supergraph_config_yaml.as_bytes(),
+            )
+            .await?;
 
-    //    // Use the CLI option for federation over the one we can read off of the supergraph config
-    //    // (but default to the one we can read off the supergraph config)
-    //    let fed_version = if let Some(fed_version) = self.opts.federation_version.as_ref() {
-    //        fed_version
-    //    } else {
-    //        resolver.federation_version()
-    //    };
+        // Use the CLI option for federation over the one we can read off of the supergraph config
+        // (but default to the one we can read off the supergraph config)
+        let fed_version = if let Some(fed_version) = self.opts.federation_version.as_ref() {
+            fed_version
+        } else {
+            resolver.federation_version()
+        };
 
-    //    // We care about the exact version of the federation version because certain options aren't
-    //    // available before 2.9.0 and we gate on that version below
-    //    let exact_version = fed_version
-    //        .get_exact()
-    //        // This should be impossible to get to because we convert to a FederationVersion a few
-    //        // lines above and so _should_ have an exact version
-    //        .ok_or(RoverError::new(anyhow!(
-    //            "failed to get exact Federation version"
-    //        )))?;
+        // We care about the exact version of the federation version because certain options aren't
+        // available before 2.9.0 and we gate on that version below
+        let exact_version = fed_version
+            .get_exact()
+            // This should be impossible to get to because we convert to a FederationVersion a few
+            // lines above and so _should_ have an exact version
+            .ok_or(RoverError::new(anyhow!(
+                "failed to get exact Federation version"
+            )))?;
 
-    //    // Making the output file mutable allows us to change it if we're using a version of the
-    //    // supergraph binary that can't write to file (ie, anything pre-2.9.0)
-    //    let mut output_file = output_file;
+        // Making the output file mutable allows us to change it if we're using a version of the
+        // supergraph binary that can't write to file (ie, anything pre-2.9.0)
+        let mut output_file = output_file;
 
-    //    // When the `--output` flag is used, we need a supergraph binary version that is at least
-    //    // v2.9.0. We ignore that flag for composition when we have anything less than that
-    //    if output_file.is_some()
-    //        && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
-    //    {
-    //        warnln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", fed_version);
-    //        output_file = None;
-    //    }
+        // When the `--output` flag is used, we need a supergraph binary version that is at least
+        // v2.9.0. We ignore that flag for composition when we have anything less than that
+        if output_file.is_some()
+            && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
+        {
+            warnln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", fed_version);
+            output_file = None;
+        }
 
-    //    // Build the supergraph binary, paying special attention to the CLI options
-    //    let supergraph_binary = InstallSupergraph::builder()
-    //        .federation_version(fed_version.clone())
-    //        .elv2_license_accepter(self.opts.plugin_opts.elv2_license_accepter)
-    //        .studio_client_config(client_config.clone())
-    //        .and_override_install_path(override_install_path)
-    //        .skip_update(self.opts.plugin_opts.skip_update)
-    //        .build()
-    //        .install()
-    //        .await?;
+        // Build the supergraph binary, paying special attention to the CLI options
+        let supergraph_binary = InstallSupergraph::builder()
+            .federation_version(fed_version.clone())
+            .elv2_license_accepter(self.opts.plugin_opts.elv2_license_accepter)
+            .studio_client_config(client_config.clone())
+            .and_override_install_path(override_install_path)
+            .skip_update(self.opts.plugin_opts.skip_update)
+            .build()
+            .install()
+            .await?;
 
-    //    // Federation versions and supergraph versions are synonymous, but have different types
-    //    // representing them depending on their use (eg, we only ever have an exact
-    //    // SupergraphVersion because we can only ever use an exact version of the binary, where the
-    //    // FederationVersion can just point to latest to get the latest version--these are similar,
-    //    // but represent different ways of using the underlying version)
-    //    let supergraph_version: SupergraphVersion = fed_version.clone().try_into()?;
+        // Federation versions and supergraph versions are synonymous, but have different types
+        // representing them depending on their use (eg, we only ever have an exact
+        // SupergraphVersion because we can only ever use an exact version of the binary, where the
+        // FederationVersion can just point to latest to get the latest version--these are similar,
+        // but represent different ways of using the underlying version)
+        let supergraph_version: SupergraphVersion = fed_version.clone().try_into()?;
 
-    //    let supergraph_binary = SupergraphBinary::builder()
-    //        .exe(supergraph_binary)
-    //        .output_target(output_file)
-    //        .version(supergraph_version)
-    //        .build();
+        let supergraph_binary = SupergraphBinary::builder()
+            .exe(supergraph_binary)
+            .output_target(output_file)
+            .version(supergraph_version)
+            .build();
 
-    //    let result = supergraph_binary
-    //        .compose(&exec_command, &read_file, supergraph_config_filepath)
-    //        .await?;
+        let result = supergraph_binary
+            .compose(&exec_command, &read_file, supergraph_config_filepath)
+            .await?;
 
-    //    Ok(RoverOutput::CompositionResult(result.into()))
-    //}
+        Ok(RoverOutput::CompositionResult(result.into()))
+    }
 
     #[cfg(not(feature = "composition-rewrite"))]
     pub async fn run(

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -231,10 +231,10 @@ impl Compose {
         // Use the CLI option for federation over the one we can read off of the supergraph config
         // (but default to the one we can read off the supergraph config)
         let fed_version = self
-                .opts
-                .federation_version
-                .as_ref()
-                .unwrap_or(resolver.federation_version());
+            .opts
+            .federation_version
+            .as_ref()
+            .unwrap_or(resolver.federation_version());
 
         // We care about the exact version of the federation version because certain options aren't
         // available before 2.9.0 and we gate on that version below

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -1,5 +1,7 @@
+// TODO: remove once we're no longer using the composition-rewrite feature flag
 #[allow(unused_imports)]
 use std::{
+    env::current_dir,
     fs::File,
     io::{stdin, Read, Write},
     process::Command,
@@ -7,6 +9,8 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+
+// TODO: remove once we're no longer using the composition-rewrite feature flag
 #[cfg(not(feature = "dev-next"))]
 use apollo_federation_types::config::FederationVersion::LatestFedTwo;
 use apollo_federation_types::{
@@ -21,9 +25,11 @@ use rover_std::warnln;
 use semver::Version;
 use serde::Serialize;
 
+// TODO: remove once we're no longer using the composition-rewrite feature flag
 #[allow(unused_imports)]
 use tempfile::tempdir;
 
+// TODO: remove once we're no longer using the composition-rewrite feature flag
 #[allow(unused_imports)]
 use crate::{
     command::{
@@ -156,8 +162,13 @@ impl Compose {
         output_file: Option<Utf8PathBuf>,
     ) -> RoverResult<RoverOutput> {
         tracing::warn!("using composition-rewrite");
-        let profile = self.opts.plugin_opts.profile.clone();
         let mut stdin = stdin();
+        let write_file = FsWriteFile::default();
+        let read_file = FsReadFile::default();
+        let exec_command = TokioCommand::default();
+
+        let studio_client =
+            client_config.get_authenticated_client(&self.opts.plugin_opts.profile.clone())?;
 
         let supergraph_root = self
             .opts
@@ -166,29 +177,50 @@ impl Compose {
             .clone()
             .supergraph_yaml
             .and_then(|file| match file {
-                FileDescriptorType::File(file) => Some(file),
+                FileDescriptorType::File(file) => {
+                    let mut current_dir =
+                        current_dir().expect("Unable to get current directory path");
+
+                    current_dir.push(file);
+                    let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
+                    let parent = path.parent().unwrap().to_path_buf();
+                    Some(parent)
+                }
                 FileDescriptorType::Stdin => None,
             });
 
-        let maybe_source_type = self.opts.supergraph_config_source.supergraph_yaml.clone();
-        let maybe_graph_ref = self.opts.supergraph_config_source.graph_ref.clone();
-        let studio_client = client_config.get_authenticated_client(&profile)?;
-
+        // Get a FullyResolvedSupergraphConfig from first loading in any remote subgraphs and then
+        // a local supergraph config (if present) and then combining them into a fully resolved
+        // supergraph config
         let resolver = SupergraphConfigResolver::default()
-            .load_remote_subgraphs(&studio_client, maybe_graph_ref.as_ref())
+            .load_remote_subgraphs(
+                &studio_client,
+                self.opts.supergraph_config_source.graph_ref.as_ref(),
+            )
             .await?
-            .load_from_file_descriptor(&mut stdin, maybe_source_type.as_ref())?
+            .load_from_file_descriptor(
+                &mut stdin,
+                self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
+            )?
             .fully_resolve_subgraphs(&client_config, &studio_client, supergraph_root.as_ref())
             .await?;
 
+        // We convert the FullyResolvedSupergraphConfig into a Supergraph because it makes using
+        // Serde easier (said differently: we're using the Federation-rs types here for
+        // compatability with Federation-rs tooling later on when we use their supergraph binary to
+        // actually run composition)
         let supergraph_config: SupergraphConfig = resolver.clone().try_into()?;
-        let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
-        let write_file = FsWriteFile::default();
 
+        // Convert the FullyResolvedSupergraphConfig to yaml before we save it
+        let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
+
+        // We're going to save to a temporary place because we don't actually need the supergraph
+        // config to stick around; we only need it on disk to point the supergraph binary at
         let supergraph_config_filepath =
             Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
                 .expect("Unable to parse path");
 
+        // Write the supergraph config to disk
         let _ = write_file
             .write_file(
                 &supergraph_config_filepath,
@@ -196,14 +228,39 @@ impl Compose {
             )
             .await?;
 
+        // Use the CLI option for federation over the one we can read off of the supergraph config
+        // (but default to the one we can read off the supergraph config)
         let fed_version = if let Some(fed_version) = self.opts.federation_version.as_ref() {
             fed_version
         } else {
             resolver.federation_version()
         };
 
-        let exec_command = TokioCommand::default();
-        let supergraph_bin = InstallSupergraph::builder()
+        // We care about the exact version of the federation version because certain options aren't
+        // available before 2.9.0 and we gate on that version below
+        let exact_version = fed_version
+            .get_exact()
+            // This should be impossible to get to because we convert to a FederationVersion a few
+            // lines above and so _should_ have an exact version
+            .ok_or(RoverError::new(anyhow!(
+                "failed to get exact Federation version"
+            )))?;
+
+        // Making the output file mutable allows us to change it if we're using a version of the
+        // supergraph binary that can't write to file (ie, anything pre-2.9.0)
+        let mut output_file = output_file;
+
+        // When the `--output` flag is used, we need a supergraph binary version that is at least
+        // v2.9.0. We ignore that flag for composition when we have anything less than that
+        if output_file.is_some()
+            && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
+        {
+            warnln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", fed_version);
+            output_file = None;
+        }
+
+        // Build the supergraph binary, paying special attention to the CLI options
+        let supergraph_binary = InstallSupergraph::builder()
             .federation_version(fed_version.clone())
             .elv2_license_accepter(self.opts.plugin_opts.elv2_license_accepter)
             .studio_client_config(client_config.clone())
@@ -213,15 +270,18 @@ impl Compose {
             .install()
             .await?;
 
+        // Federation versions and supergraph versions are synonymous, but have different types
+        // representing them depending on their use (eg, we only ever have an exact
+        // SupergraphVersion because we can only ever use an exact version of the binary, where the
+        // FederationVersion can just point to latest to get the latest version--these are similar,
+        // but represent different ways of using the underlying version)
         let supergraph_version: SupergraphVersion = fed_version.clone().try_into()?;
 
         let supergraph_binary = SupergraphBinary::builder()
-            .exe(supergraph_bin)
+            .exe(supergraph_binary)
             .output_target(output_file)
             .version(supergraph_version)
             .build();
-
-        let read_file = FsReadFile::default();
 
         let result = supergraph_binary
             .compose(&exec_command, &read_file, supergraph_config_filepath)

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -230,11 +230,11 @@ impl Compose {
 
         // Use the CLI option for federation over the one we can read off of the supergraph config
         // (but default to the one we can read off the supergraph config)
-        let fed_version = if let Some(fed_version) = self.opts.federation_version.as_ref() {
-            fed_version
-        } else {
-            resolver.federation_version()
-        };
+        let fed_version = self
+                .opts
+                .federation_version
+                .as_ref()
+                .unwrap_or(resolver.federation_version());
 
         // We care about the exact version of the federation version because certain options aren't
         // available before 2.9.0 and we gate on that version below

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -154,141 +154,141 @@ impl Compose {
         Ok(plugin_exe)
     }
 
-    #[cfg(feature = "composition-rewrite")]
-    pub async fn run(
-        &self,
-        override_install_path: Option<Utf8PathBuf>,
-        client_config: StudioClientConfig,
-        output_file: Option<Utf8PathBuf>,
-    ) -> RoverResult<RoverOutput> {
-        tracing::warn!("using composition-rewrite");
-        let mut stdin = stdin();
-        let write_file = FsWriteFile::default();
-        let read_file = FsReadFile::default();
-        let exec_command = TokioCommand::default();
+    //#[cfg(feature = "composition-rewrite")]
+    //pub async fn run(
+    //    &self,
+    //    override_install_path: Option<Utf8PathBuf>,
+    //    client_config: StudioClientConfig,
+    //    output_file: Option<Utf8PathBuf>,
+    //) -> RoverResult<RoverOutput> {
+    //    tracing::warn!("using composition-rewrite");
+    //    let mut stdin = stdin();
+    //    let write_file = FsWriteFile::default();
+    //    let read_file = FsReadFile::default();
+    //    let exec_command = TokioCommand::default();
 
-        let studio_client =
-            client_config.get_authenticated_client(&self.opts.plugin_opts.profile.clone())?;
+    //    let studio_client =
+    //        client_config.get_authenticated_client(&self.opts.plugin_opts.profile.clone())?;
 
-        let supergraph_root = self
-            .opts
-            .clone()
-            .supergraph_config_source()
-            .clone()
-            .supergraph_yaml
-            .and_then(|file| match file {
-                FileDescriptorType::File(file) => {
-                    let mut current_dir =
-                        current_dir().expect("Unable to get current directory path");
+    //    let supergraph_root = self
+    //        .opts
+    //        .clone()
+    //        .supergraph_config_source()
+    //        .clone()
+    //        .supergraph_yaml
+    //        .and_then(|file| match file {
+    //            FileDescriptorType::File(file) => {
+    //                let mut current_dir =
+    //                    current_dir().expect("Unable to get current directory path");
 
-                    current_dir.push(file);
-                    let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
-                    let parent = path.parent().unwrap().to_path_buf();
-                    Some(parent)
-                }
-                FileDescriptorType::Stdin => None,
-            });
+    //                current_dir.push(file);
+    //                let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
+    //                let parent = path.parent().unwrap().to_path_buf();
+    //                Some(parent)
+    //            }
+    //            FileDescriptorType::Stdin => None,
+    //        });
 
-        // Get a FullyResolvedSupergraphConfig from first loading in any remote subgraphs and then
-        // a local supergraph config (if present) and then combining them into a fully resolved
-        // supergraph config
-        let resolver = SupergraphConfigResolver::default()
-            .load_remote_subgraphs(
-                &studio_client,
-                self.opts.supergraph_config_source.graph_ref.as_ref(),
-            )
-            .await?
-            .load_from_file_descriptor(
-                &mut stdin,
-                self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
-            )?
-            .fully_resolve_subgraphs(&client_config, &studio_client, supergraph_root.as_ref())
-            .await?;
+    //    // Get a FullyResolvedSupergraphConfig from first loading in any remote subgraphs and then
+    //    // a local supergraph config (if present) and then combining them into a fully resolved
+    //    // supergraph config
+    //    let resolver = SupergraphConfigResolver::default()
+    //        .load_remote_subgraphs(
+    //            &studio_client,
+    //            self.opts.supergraph_config_source.graph_ref.as_ref(),
+    //        )
+    //        .await?
+    //        .load_from_file_descriptor(
+    //            &mut stdin,
+    //            self.opts.supergraph_config_source.supergraph_yaml.as_ref(),
+    //        )?
+    //        .fully_resolve_subgraphs(&client_config, &studio_client, supergraph_root.as_ref())
+    //        .await?;
 
-        // We convert the FullyResolvedSupergraphConfig into a Supergraph because it makes using
-        // Serde easier (said differently: we're using the Federation-rs types here for
-        // compatability with Federation-rs tooling later on when we use their supergraph binary to
-        // actually run composition)
-        let supergraph_config: SupergraphConfig = resolver.clone().try_into()?;
+    //    // We convert the FullyResolvedSupergraphConfig into a Supergraph because it makes using
+    //    // Serde easier (said differently: we're using the Federation-rs types here for
+    //    // compatability with Federation-rs tooling later on when we use their supergraph binary to
+    //    // actually run composition)
+    //    let supergraph_config: SupergraphConfig = resolver.clone().try_into()?;
 
-        // Convert the FullyResolvedSupergraphConfig to yaml before we save it
-        let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
+    //    // Convert the FullyResolvedSupergraphConfig to yaml before we save it
+    //    let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
 
-        // We're going to save to a temporary place because we don't actually need the supergraph
-        // config to stick around; we only need it on disk to point the supergraph binary at
-        let supergraph_config_filepath =
-            Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
-                .expect("Unable to parse path");
+    //    // We're going to save to a temporary place because we don't actually need the supergraph
+    //    // config to stick around; we only need it on disk to point the supergraph binary at
+    //    let supergraph_config_filepath =
+    //        Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
+    //            .expect("Unable to parse path");
 
-        // Write the supergraph config to disk
-        let _ = write_file
-            .write_file(
-                &supergraph_config_filepath,
-                supergraph_config_yaml.as_bytes(),
-            )
-            .await?;
+    //    // Write the supergraph config to disk
+    //    let _ = write_file
+    //        .write_file(
+    //            &supergraph_config_filepath,
+    //            supergraph_config_yaml.as_bytes(),
+    //        )
+    //        .await?;
 
-        // Use the CLI option for federation over the one we can read off of the supergraph config
-        // (but default to the one we can read off the supergraph config)
-        let fed_version = if let Some(fed_version) = self.opts.federation_version.as_ref() {
-            fed_version
-        } else {
-            resolver.federation_version()
-        };
+    //    // Use the CLI option for federation over the one we can read off of the supergraph config
+    //    // (but default to the one we can read off the supergraph config)
+    //    let fed_version = if let Some(fed_version) = self.opts.federation_version.as_ref() {
+    //        fed_version
+    //    } else {
+    //        resolver.federation_version()
+    //    };
 
-        // We care about the exact version of the federation version because certain options aren't
-        // available before 2.9.0 and we gate on that version below
-        let exact_version = fed_version
-            .get_exact()
-            // This should be impossible to get to because we convert to a FederationVersion a few
-            // lines above and so _should_ have an exact version
-            .ok_or(RoverError::new(anyhow!(
-                "failed to get exact Federation version"
-            )))?;
+    //    // We care about the exact version of the federation version because certain options aren't
+    //    // available before 2.9.0 and we gate on that version below
+    //    let exact_version = fed_version
+    //        .get_exact()
+    //        // This should be impossible to get to because we convert to a FederationVersion a few
+    //        // lines above and so _should_ have an exact version
+    //        .ok_or(RoverError::new(anyhow!(
+    //            "failed to get exact Federation version"
+    //        )))?;
 
-        // Making the output file mutable allows us to change it if we're using a version of the
-        // supergraph binary that can't write to file (ie, anything pre-2.9.0)
-        let mut output_file = output_file;
+    //    // Making the output file mutable allows us to change it if we're using a version of the
+    //    // supergraph binary that can't write to file (ie, anything pre-2.9.0)
+    //    let mut output_file = output_file;
 
-        // When the `--output` flag is used, we need a supergraph binary version that is at least
-        // v2.9.0. We ignore that flag for composition when we have anything less than that
-        if output_file.is_some()
-            && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
-        {
-            warnln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", fed_version);
-            output_file = None;
-        }
+    //    // When the `--output` flag is used, we need a supergraph binary version that is at least
+    //    // v2.9.0. We ignore that flag for composition when we have anything less than that
+    //    if output_file.is_some()
+    //        && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
+    //    {
+    //        warnln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", fed_version);
+    //        output_file = None;
+    //    }
 
-        // Build the supergraph binary, paying special attention to the CLI options
-        let supergraph_binary = InstallSupergraph::builder()
-            .federation_version(fed_version.clone())
-            .elv2_license_accepter(self.opts.plugin_opts.elv2_license_accepter)
-            .studio_client_config(client_config.clone())
-            .and_override_install_path(override_install_path)
-            .skip_update(self.opts.plugin_opts.skip_update)
-            .build()
-            .install()
-            .await?;
+    //    // Build the supergraph binary, paying special attention to the CLI options
+    //    let supergraph_binary = InstallSupergraph::builder()
+    //        .federation_version(fed_version.clone())
+    //        .elv2_license_accepter(self.opts.plugin_opts.elv2_license_accepter)
+    //        .studio_client_config(client_config.clone())
+    //        .and_override_install_path(override_install_path)
+    //        .skip_update(self.opts.plugin_opts.skip_update)
+    //        .build()
+    //        .install()
+    //        .await?;
 
-        // Federation versions and supergraph versions are synonymous, but have different types
-        // representing them depending on their use (eg, we only ever have an exact
-        // SupergraphVersion because we can only ever use an exact version of the binary, where the
-        // FederationVersion can just point to latest to get the latest version--these are similar,
-        // but represent different ways of using the underlying version)
-        let supergraph_version: SupergraphVersion = fed_version.clone().try_into()?;
+    //    // Federation versions and supergraph versions are synonymous, but have different types
+    //    // representing them depending on their use (eg, we only ever have an exact
+    //    // SupergraphVersion because we can only ever use an exact version of the binary, where the
+    //    // FederationVersion can just point to latest to get the latest version--these are similar,
+    //    // but represent different ways of using the underlying version)
+    //    let supergraph_version: SupergraphVersion = fed_version.clone().try_into()?;
 
-        let supergraph_binary = SupergraphBinary::builder()
-            .exe(supergraph_binary)
-            .output_target(output_file)
-            .version(supergraph_version)
-            .build();
+    //    let supergraph_binary = SupergraphBinary::builder()
+    //        .exe(supergraph_binary)
+    //        .output_target(output_file)
+    //        .version(supergraph_version)
+    //        .build();
 
-        let result = supergraph_binary
-            .compose(&exec_command, &read_file, supergraph_config_filepath)
-            .await?;
+    //    let result = supergraph_binary
+    //        .compose(&exec_command, &read_file, supergraph_config_filepath)
+    //        .await?;
 
-        Ok(RoverOutput::CompositionResult(result.into()))
-    }
+    //    Ok(RoverOutput::CompositionResult(result.into()))
+    //}
 
     #[cfg(not(feature = "composition-rewrite"))]
     pub async fn run(

--- a/src/command/supergraph/compose/mod.rs
+++ b/src/command/supergraph/compose/mod.rs
@@ -10,6 +10,9 @@ pub(crate) mod do_compose;
 #[cfg(feature = "composition-js")]
 pub(crate) use do_compose::Compose;
 
+#[cfg(feature = "composition-js")]
+use crate::composition::CompositionSuccess;
+
 use apollo_federation_types::rover::BuildHint;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -17,4 +20,16 @@ pub struct CompositionOutput {
     pub supergraph_sdl: String,
     pub hints: Vec<BuildHint>,
     pub federation_version: Option<String>,
+}
+
+// Temporary conversion from new CompositionSuccess type to old CompositionOutput
+#[cfg(feature = "composition-js")]
+impl From<CompositionSuccess> for CompositionOutput {
+    fn from(value: CompositionSuccess) -> Self {
+        Self {
+            supergraph_sdl: value.supergraph_sdl().clone(),
+            hints: value.hints().to_vec(),
+            federation_version: Some(value.federation_version().to_string()),
+        }
+    }
 }

--- a/src/command/supergraph/compose/mod.rs
+++ b/src/command/supergraph/compose/mod.rs
@@ -22,7 +22,9 @@ pub struct CompositionOutput {
     pub federation_version: Option<String>,
 }
 
-// Temporary conversion from new CompositionSuccess type to old CompositionOutput
+// Temporary conversion from new CompositionSuccess type to old CompositionOutput. In the future,
+// we can change the output of run() in do_compose.rs to just be CompositionSuccess because if we
+// get to the output at all, it'll be a success (we error early when things fail)
 #[cfg(feature = "composition-js")]
 impl From<CompositionSuccess> for CompositionOutput {
     fn from(value: CompositionSuccess) -> Self {

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -99,6 +99,15 @@ impl OutputTarget {
     }
 }
 
+impl From<Option<Utf8PathBuf>> for OutputTarget {
+    fn from(value: Option<Utf8PathBuf>) -> Self {
+        match value {
+            Some(file_path) => OutputTarget::File(file_path),
+            None => OutputTarget::Stdout,
+        }
+    }
+}
+
 impl From<std::io::Error> for CompositionError {
     fn from(error: std::io::Error) -> Self {
         CompositionError::Binary {

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -99,6 +99,8 @@ impl OutputTarget {
     }
 }
 
+/// Make an optional Utf8PathBuf into an OutputTarget; if we have some path, use it as a file; if
+/// we have no path, we use stdout
 impl From<Option<Utf8PathBuf>> for OutputTarget {
     fn from(value: Option<Utf8PathBuf>) -> Self {
         match value {
@@ -145,7 +147,6 @@ impl SupergraphBinary {
         supergraph_config_path: Utf8PathBuf,
     ) -> Result<CompositionSuccess, CompositionError> {
         let args = self.prepare_compose_args(&supergraph_config_path);
-
         let output = exec_impl
             .exec_command(&self.exe, &args)
             .await
@@ -156,7 +157,6 @@ impl SupergraphBinary {
 
         let output = match &self.output_target {
             OutputTarget::File(path) => {
-                println!("shouldn't be here");
                 read_file_impl
                     .read_file(path)
                     .await

--- a/src/composition/supergraph/config/mod.rs
+++ b/src/composition/supergraph/config/mod.rs
@@ -226,7 +226,7 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
         self,
         introspect_subgraph_impl: &impl IntrospectSubgraph,
         fetch_remote_subgraph_impl: &impl FetchRemoteSubgraph,
-        supergraph_config_root: &Utf8PathBuf,
+        supergraph_config_root: Option<&Utf8PathBuf>,
     ) -> Result<FullyResolvedSupergraphConfig, ResolveSupergraphConfigError> {
         if !self.state.subgraphs.is_empty() {
             let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()
@@ -453,7 +453,7 @@ mod tests {
             .fully_resolve_subgraphs(
                 &mock_introspect_subgraph,
                 &mock_fetch_remote_subgraph,
-                &local_supergraph_config_path,
+                Some(&local_supergraph_config_path),
             )
             .await?;
 
@@ -618,7 +618,7 @@ mod tests {
             .fully_resolve_subgraphs(
                 &mock_introspect_subgraph,
                 &mock_fetch_remote_subgraph,
-                &local_supergraph_config_path,
+                Some(&local_supergraph_config_path),
             )
             .await?;
 
@@ -778,7 +778,7 @@ mod tests {
             .fully_resolve_subgraphs(
                 &mock_introspect_subgraph,
                 &mock_fetch_remote_subgraph,
-                &local_supergraph_config_path,
+                Some(&local_supergraph_config_path),
             )
             .await?;
 

--- a/src/composition/supergraph/config/resolve/mod.rs
+++ b/src/composition/supergraph/config/resolve/mod.rs
@@ -81,7 +81,7 @@ impl FullyResolvedSupergraphConfig {
     pub async fn resolve(
         introspect_subgraph_impl: &impl IntrospectSubgraph,
         fetch_remote_subgraph_impl: &impl FetchRemoteSubgraph,
-        supergraph_config_root: &Utf8PathBuf,
+        supergraph_config_root: Option<&Utf8PathBuf>,
         unresolved_supergraph_config: UnresolvedSupergraphConfig,
     ) -> Result<FullyResolvedSupergraphConfig, ResolveSupergraphConfigError> {
         let subgraphs = stream::iter(unresolved_supergraph_config.subgraphs.into_iter().map(
@@ -570,7 +570,10 @@ mod tests {
         let result = FullyResolvedSupergraphConfig::resolve(
             &mock_introspect_subgraph,
             &mock_fetch_remote_subgraph,
-            &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf()).unwrap(),
+            Some(
+                &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf())
+                    .unwrap(),
+            ),
             unresolved_supergraph_config,
         )
         .await;
@@ -772,7 +775,10 @@ mod tests {
         let result = FullyResolvedSupergraphConfig::resolve(
             &mock_introspect_subgraph,
             &mock_fetch_remote_subgraph,
-            &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf()).unwrap(),
+            Some(
+                &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf())
+                    .unwrap(),
+            ),
             unresolved_supergraph_config,
         )
         .await;

--- a/src/composition/supergraph/version.rs
+++ b/src/composition/supergraph/version.rs
@@ -64,21 +64,21 @@ lazy_static::lazy_static! {
 impl TryFrom<FederationVersion> for SupergraphVersion {
     type Error = SupergraphVersionError;
     fn try_from(federation_version: FederationVersion) -> Result<Self, Self::Error> {
-        let supergraph = LATEST_PLUGIN_VERSIONS["supergraph"]
-            .as_object()
-            .expect("JSON malformed: top-level `supergraph` should be an object");
+        let supergraph = LATEST_PLUGIN_VERSIONS["supergraph"].as_object();
+        let supergraph = supergraph
+            .ok_or(SupergraphVersionError::Conversion { error: "JSON malformed: top-level `supergraph` should be an object in latest_plugion_versions.json".to_string() })?;
 
         let supergraph_versions = supergraph
             .get("versions")
-            .expect("JSON malformed: `supergraph.versions` did not exist");
+            .ok_or(SupergraphVersionError::Conversion { error: "JSON malformed: `supergraph.versions` did not exist in latest_plugion_versions.json".to_string() })?;
 
         match federation_version {
             FederationVersion::LatestFedOne => {
                 let latest_federation_one = supergraph_versions
                     .get("latest-0")
-                    .expect("JSON malformed: `supergraph.versions.latest-0` did not exist")
+                    .ok_or(SupergraphVersionError::Conversion { error: "JSON malformed: `supergraph.versions.latest-0` did not exist in latest_plugin_versions.json".to_string() })?
                     .as_str()
-                    .expect("JSON malformed: `supergraph.versions.latest-0` was not a string")
+                    .ok_or(SupergraphVersionError::Conversion { error: "JSON malformed: `supergraph.versions.latest-0` was not a string in latest_plugin_versions.json".to_string() })?
                     .replace("v", "");
 
                 Ok(SupergraphVersion::new(
@@ -92,9 +92,9 @@ impl TryFrom<FederationVersion> for SupergraphVersion {
             FederationVersion::LatestFedTwo => {
                 let latest_federation_two = supergraph_versions
                     .get("latest-2")
-                    .expect("JSON malformed: `supergraph.versions.latest-2` did not exist")
+                    .ok_or(SupergraphVersionError::Conversion { error: "JSON malformed: `supergraph.versions.latest-2` did not exist in latest_plugin_versions.json".to_string() })?
                     .as_str()
-                    .expect("JSON malformed: `supergraph.versions.latest-2` was not a string")
+                    .ok_or(SupergraphVersionError::Conversion { error: "JSON malformed: `supergraph.versions.latest-2` was not a string in latest_plugin_versions.json".to_string() })?
                     .replace("v", "");
 
                 Ok(SupergraphVersion::new(

--- a/src/composition/supergraph/version.rs
+++ b/src/composition/supergraph/version.rs
@@ -51,6 +51,16 @@ lazy_static::lazy_static! {
 
 }
 
+/// FederationVersion is the apollo_federation_types's view of the version of federation (ie, the
+/// spec and its implementation by Apollo) in use. This can be an exact version or point to the
+/// latest of a major version (eg, latest of version 1, latest of version 2). The
+/// SupergraphVersion, however, is the version of the supergraph binary. These are synonymous, but
+/// different; FederationVersion can be inexact by pointing to the latest of some major version
+/// while SupergraphVersion must be exact because we must use an exact version of the binary
+///
+/// Development note: when we have latest-*, we not only get an exact version, we get an exact
+/// version specified in our latest_plugins_versions.json. This version might be different than the
+/// actual latest version if we haven't updated that file
 impl TryFrom<FederationVersion> for SupergraphVersion {
     type Error = SupergraphVersionError;
     fn try_from(federation_version: FederationVersion) -> Result<Self, Self::Error> {

--- a/src/composition/supergraph/version.rs
+++ b/src/composition/supergraph/version.rs
@@ -47,7 +47,7 @@ impl TryFrom<SupergraphVersion> for FederationVersion {
 }
 
 lazy_static::lazy_static! {
-    static ref LATEST_PLUGIN_VERSIONS: Value = serde_json::from_str(include_str!("../../../latest_plugin_versions.json")).expect("could not read latest_plugin_versions.json from the root of the repo, which is needed to supply latest versions to `rover supergraph compsoe`.");
+    static ref LATEST_PLUGIN_VERSIONS: Value = serde_json::from_str(include_str!("../../../latest_plugin_versions.json")).expect("could not read latest_plugin_versions.json from the root of the repo, which is needed to supply latest versions to `rover supergraph compose`.");
 
 }
 

--- a/src/composition/supergraph/version.rs
+++ b/src/composition/supergraph/version.rs
@@ -2,11 +2,14 @@ use std::{fmt::Display, str::FromStr};
 
 use apollo_federation_types::config::FederationVersion;
 use semver::Version;
+use serde_json::Value;
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum SupergraphVersionError {
     #[error("Unsupported Federation version: {}", .version.to_string())]
     UnsupportedFederationVersion { version: SupergraphVersion },
+    #[error("Unable to get version: {}", .error)]
+    Conversion { error: String },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -43,6 +46,62 @@ impl TryFrom<SupergraphVersion> for FederationVersion {
     }
 }
 
+lazy_static::lazy_static! {
+    static ref LATEST_PLUGIN_VERSIONS: Value = serde_json::from_str(include_str!("../../../latest_plugin_versions.json")).expect("could not read latest_plugin_versions.json from the root of the repo, which is needed to supply latest versions to `rover supergraph compsoe`.");
+
+}
+
+impl TryFrom<FederationVersion> for SupergraphVersion {
+    type Error = SupergraphVersionError;
+    fn try_from(federation_version: FederationVersion) -> Result<Self, Self::Error> {
+        let supergraph = LATEST_PLUGIN_VERSIONS["supergraph"]
+            .as_object()
+            .expect("JSON malformed: top-level `supergraph` should be an object");
+
+        let supergraph_versions = supergraph
+            .get("versions")
+            .expect("JSON malformed: `supergraph.versions` did not exist");
+
+        match federation_version {
+            FederationVersion::LatestFedOne => {
+                let latest_federation_one = supergraph_versions
+                    .get("latest-0")
+                    .expect("JSON malformed: `supergraph.versions.latest-0` did not exist")
+                    .as_str()
+                    .expect("JSON malformed: `supergraph.versions.latest-0` was not a string")
+                    .replace("v", "");
+
+                Ok(SupergraphVersion::new(
+                    Version::from_str(&latest_federation_one).map_err(|err| {
+                        SupergraphVersionError::Conversion {
+                            error: err.to_string(),
+                        }
+                    })?,
+                ))
+            }
+            FederationVersion::LatestFedTwo => {
+                let latest_federation_two = supergraph_versions
+                    .get("latest-2")
+                    .expect("JSON malformed: `supergraph.versions.latest-2` did not exist")
+                    .as_str()
+                    .expect("JSON malformed: `supergraph.versions.latest-2` was not a string")
+                    .replace("v", "");
+
+                Ok(SupergraphVersion::new(
+                    Version::from_str(&latest_federation_two).map_err(|err| {
+                        SupergraphVersionError::Conversion {
+                            error: err.to_string(),
+                        }
+                    })?,
+                ))
+            }
+            FederationVersion::ExactFedOne(version) | FederationVersion::ExactFedTwo(version) => {
+                Ok(SupergraphVersion::new(version))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -66,6 +125,44 @@ mod tests {
         Version::from_str("2.9.0").unwrap()
     }
 
+    fn latest_fed_one() -> Version {
+        let supergraph = LATEST_PLUGIN_VERSIONS["supergraph"]
+            .as_object()
+            .expect("JSON malformed: top-level `supergraph` should be an object");
+
+        let supergraph_versions = supergraph
+            .get("versions")
+            .expect("JSON malformed: `supergraph.versions` did not exist");
+
+        let latest_federation_one = supergraph_versions
+            .get("latest-0")
+            .expect("JSON malformed: `supergraph.versions.latest-0` did not exist")
+            .as_str()
+            .expect("JSON malformed: `supergraph.versions.latest-0` was not a string")
+            .replace("v", "");
+
+        Version::from_str(&latest_federation_one).unwrap()
+    }
+
+    fn latest_fed_two() -> Version {
+        let supergraph = LATEST_PLUGIN_VERSIONS["supergraph"]
+            .as_object()
+            .expect("JSON malformed: top-level `supergraph` should be an object");
+
+        let supergraph_versions = supergraph
+            .get("versions")
+            .expect("JSON malformed: `supergraph.versions` did not exist");
+
+        let latest_federation_two = supergraph_versions
+            .get("latest-2")
+            .expect("JSON malformed: `supergraph.versions.latest-2` did not exist")
+            .as_str()
+            .expect("JSON malformed: `supergraph.versions.latest-2` was not a string")
+            .replace("v", "");
+
+        Version::from_str(&latest_federation_two).unwrap()
+    }
+
     #[rstest]
     #[case::fed_one(fed_one(), false)]
     #[case::fed_one(fed_two_eight(), false)]
@@ -77,6 +174,31 @@ mod tests {
     ) {
         let supergraph_version = SupergraphVersion::new(federation_version);
         assert_that!(supergraph_version.supports_output_flag()).is_equal_to(expected_result);
+    }
+
+    #[rstest]
+    #[case::exact_fed_one(
+        FederationVersion::ExactFedOne(fed_one()),
+        Ok(SupergraphVersion::new(fed_one()))
+    )]
+    #[case::exact_fed_two(
+        FederationVersion::ExactFedTwo(fed_two_eight()),
+        Ok(SupergraphVersion::new(fed_two_eight()))
+    )]
+    #[case::latest_fed_one(
+        FederationVersion::LatestFedOne,
+        Ok(SupergraphVersion::new(latest_fed_one()))
+    )]
+    #[case::latest_fed_two(
+        FederationVersion::LatestFedTwo,
+        Ok(SupergraphVersion::new(latest_fed_two()))
+    )]
+    fn test_tryfrom_fedversion_for_supergraphversion(
+        #[case] fed_version: FederationVersion,
+        #[case] expected: Result<SupergraphVersion, SupergraphVersionError>,
+    ) {
+        let supergraph_version = TryInto::<SupergraphVersion>::try_into(fed_version);
+        assert_that!(supergraph_version).is_equal_to(expected)
     }
 
     #[rstest]

--- a/src/utils/effect/exec.rs
+++ b/src/utils/effect/exec.rs
@@ -20,7 +20,7 @@ pub trait ExecCommand {
     ) -> Result<Output, Self::Error>;
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct TokioCommand {}
 
 #[async_trait]

--- a/src/utils/effect/read_file.rs
+++ b/src/utils/effect/read_file.rs
@@ -14,7 +14,7 @@ pub trait ReadFile {
     async fn read_file(&self, path: &Utf8PathBuf) -> Result<String, Self::Error>;
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct FsReadFile {}
 
 #[async_trait]

--- a/src/utils/effect/write_file.rs
+++ b/src/utils/effect/write_file.rs
@@ -14,7 +14,7 @@ pub trait WriteFile {
     async fn write_file(&self, path: &Utf8PathBuf, contents: &[u8]) -> Result<(), Self::Error>;
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct FsWriteFile {}
 
 #[async_trait]

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -487,7 +487,7 @@ mod test_get_supergraph_config {
         let supergraph_config_path = third_level_folder.path().join("supergraph.yaml");
         fs::write(
             supergraph_config_path.clone(),
-            supergraph_config.into_bytes(),
+            &supergraph_config.into_bytes(),
         )
         .expect("Could not write supergraph.yaml");
 
@@ -804,14 +804,12 @@ pub(crate) async fn resolve_supergraph_yaml(
                             Some(parent) => {
                                 let mut schema_path = parent.to_path_buf();
                                 schema_path.push(file);
-                                println!("schema path from old run version: {schema_path:?}");
                                 schema_path
                             }
                             None => file.clone(),
                         },
                         FileDescriptorType::Stdin => file.clone(),
                     };
-                    println!("relative schema path from old run: {relative_schema_path:?}");
 
                     Fs::read_file(relative_schema_path)
                         .map_err(|e| {
@@ -1187,7 +1185,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
       file: ./people.graphql"#,
-            latest_fed2_version
+            latest_fed2_version.to_string()
         );
         let tmp_home = TempDir::new().unwrap();
         let mut config_path = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1227,7 +1225,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version
+            latest_fed2_version.to_string()
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1281,7 +1279,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version
+            latest_fed2_version.to_string()
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -1696,7 +1696,7 @@ type _Service {\n  sdl: String\n}"#;
     }
 }
 
-fn expand_supergraph_yaml(content: &str) -> RoverResult<SupergraphConfig> {
+pub fn expand_supergraph_yaml(content: &str) -> RoverResult<SupergraphConfig> {
     serde_yaml::from_str(content)
         .map_err(RoverError::from)
         .and_then(expand)

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -804,12 +804,14 @@ pub(crate) async fn resolve_supergraph_yaml(
                             Some(parent) => {
                                 let mut schema_path = parent.to_path_buf();
                                 schema_path.push(file);
+                                println!("schema path from old run version: {schema_path:?}");
                                 schema_path
                             }
                             None => file.clone(),
                         },
                         FileDescriptorType::Stdin => file.clone(),
                     };
+                    println!("relative schema path from old run: {relative_schema_path:?}");
 
                     Fs::read_file(relative_schema_path)
                         .map_err(|e| {

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -166,10 +166,7 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
 
     let latest_version_from_config_file = &versions[binary_name]["versions"][config_version_name]
         .to_string()
-        //.replace("v", "=")
         .replace("\"", "");
-
-    println!("latest_version: {latest_version_from_config_file:?}");
 
     cmd.env("APOLLO_HOME", temp_dir.clone());
     cmd.args([
@@ -183,7 +180,6 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     //   - it successfully installs
     let formatted_latest_version = latest_version_from_config_file.replace("v", "-v");
     let downloaded_binary_name = format!("{binary_name}{formatted_latest_version}");
-    println!("downloaded_binary_name: {downloaded_binary_name:?}");
 
     let installed = bin_path
         .read_dir()

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -144,15 +144,14 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
 }
 
 #[rstest]
-#[case::router_latest_1("router", "latest", "latest-1")]
-#[case::supergraph_latest_0("supergraph", "latest-0", "latest-0")]
-#[case::supergraph_latest_2("supergraph", "latest-2", "latest-2")]
+#[case::router_latest_1("router", "latest-1")]
+#[case::supergraph_latest_0("supergraph", "latest-0")]
+#[case::supergraph_latest_2("supergraph", "latest-2")]
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     #[case] binary_name: &str,
-    #[case] command_version_name: &str,
     #[case] config_version_name: &str,
 ) {
     let temp_dir = Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap();
@@ -165,23 +164,26 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     let versions: Value = serde_json::from_str(&config_file_contents)
         .expect("failed to get json out of latest_plugin_versions.json");
 
-    let latest_version = &versions[binary_name]["versions"][config_version_name]
+    let latest_version_from_config_file = &versions[binary_name]["versions"][config_version_name]
         .to_string()
-        .replace("v", "=")
+        //.replace("v", "=")
         .replace("\"", "");
+
+    println!("latest_version: {latest_version_from_config_file:?}");
 
     cmd.env("APOLLO_HOME", temp_dir.clone());
     cmd.args([
         "install",
         "--plugin",
-        &format!("{binary_name}@{command_version_name}"),
+        &format!("{binary_name}@{latest_version_from_config_file}"),
     ]);
     cmd.output().expect("Could not run command");
 
     // THEN
     //   - it successfully installs
-    let formatted_latest_version = latest_version.replace("=", "-v");
+    let formatted_latest_version = latest_version_from_config_file.replace("v", "-v");
     let downloaded_binary_name = format!("{binary_name}{formatted_latest_version}");
+    println!("downloaded_binary_name: {downloaded_binary_name:?}");
 
     let installed = bin_path
         .read_dir()


### PR DESCRIPTION
[smoke tests](https://github.com/apollographql/rover/actions/runs/11712628826)

to rerun, modify the smoke test yaml file with the target feature (two places): `cargo build --features "composition-rewrite" --target ${{ matrix.compile_target.target }} --test e2e`