### PR TITLE
Enable remote proxy binary downloads

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -51,8 +51,7 @@ iwr 'https://rover.apollo.dev/win/v0.26.2' | iex
 Both the bash and powershell scripts support the `APOLLO_ROVER_DOWNLOAD_GITHUB_HOST` environment variable,
 which defaults to `https://github.com/apollographql/rover/releases/download`.
 
-This can be set in your environment to specify a remote mirror or proxy to github release download
-url for the Apollo Rover GitHub repository.
+This can be set in your environment to specify a remote mirror or proxy to a GitHub release download URL for the Apollo Rover GitHub repository.
 
 For example, if your remote host is `my-mirror-proxy.com/artifacts/github-com`:
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -46,7 +46,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 iwr 'https://rover.apollo.dev/win/v0.26.2' | iex
 ```
 
-#### Installing from a binary mirror using the bash and powershell scripts
+#### Installing from a binary mirror using the bash and PowerShell scripts
 
 Both the bash and powershell scripts support the `APOLLO_ROVER_DOWNLOAD_GITHUB_HOST` environment variable,
 which defaults to `https://github.com/apollographql/rover/releases/download`.

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -63,7 +63,7 @@ In a bash shell:
 export APOLLO_ROVER_DOWNLOAD_GITHUB_HOST="https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
 ```
 
-Or from a PowerShell:
+- From a PowerShell:
 
 ```powershell
 # for PowerShell (Windows)

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -54,7 +54,7 @@ which defaults to `https://github.com/apollographql/rover/releases/download`.
 This can be set in your environment to specify a remote mirror or proxy to github release download
 url for the Apollo Rover GitHub repository.
 
-Example, if your remote host is `my-mirror-proxy.com/artifacts/github-com`:
+For example, if your remote host is `my-mirror-proxy.com/artifacts/github-com`:
 
 - From a bash shell:
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -56,7 +56,7 @@ url for the Apollo Rover GitHub repository.
 
 Example, if your remote host is `my-mirror-proxy.com/artifacts/github-com`:
 
-In a bash shell:
+- From a bash shell:
 
 ```bash
 # for bash (Mac/Linux)

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -71,7 +71,7 @@ $env:APOLLO_ROVER_DOWNLOAD_GITHUB_HOST = "https://my-mirror-proxy.com/artifacts/
 ```
 
 This variable also supports basic authentication.
-Set the format of the url to `https://<username>:<password>@<remote-host>/apollographql/rover/releases/download`
+Set the format of the URL to `https://<username>:<password>@<remote-host>/apollographql/rover/releases/download`
 
 ### `npm` installer
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -70,8 +70,8 @@ Or from a PowerShell:
 $env:APOLLO_ROVER_DOWNLOAD_GITHUB_HOST = "https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
 ```
 
-This variable also supports basic authentication, but be aware that the password/token will appear in the output
-of the terminal. Set the format of the url to `https://<username>:<password>@<remote-host>/apollographql/rover/releases/download`
+This variable also supports basic authentication.
+Set the format of the url to `https://<username>:<password>@<remote-host>/apollographql/rover/releases/download`
 
 ### `npm` installer
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -46,6 +46,33 @@ To install a **specific version** of Rover (recommended for CI environments to e
 iwr 'https://rover.apollo.dev/win/v0.26.2' | iex
 ```
 
+#### Installing from a binary mirror using the bash and powershell scripts
+
+Both the bash and powershell scripts support the `APOLLO_ROVER_BINARY_REMOTE` environment variable,
+which defaults to `https://github.com/apollographql/rover/releases/download`.
+
+This can be set in your environment to specify a remote mirror or proxy to github release download
+url for the Apollo Rover GitHub repository.
+
+Example, if your remote host is `my-mirror-proxy.com/artifacts/github-com`:
+
+In a bash shell:
+
+```bash
+# for bash (Mac/Linux)
+export APOLLO_ROVER_BINARY_REMOTE="https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
+```
+
+Or from a PowerShell:
+
+```powershell
+# for PowerShell (Windows)
+$env:APOLLO_ROVER_BINARY_REMOTE = "https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
+```
+
+This variable also supports basic authentication, but be aware that the password/token will appear in the output
+of the terminal. Set the format of the url to `https://<username>:<password>@<remote-host>/apollographql/rover/releases/download`
+
 ### `npm` installer
 
 Rover is distributed on npm for integration with your JavaScript projects.
@@ -56,11 +83,11 @@ Internally, the `npm` installer downloads router binaries from `https://rover.ap
 
 1. Setting the `APOLLO_ROVER_DOWNLOAD_HOST` environment variable.
 
-    <Note>
-    
-    This environment variable also changes the host that plugins for `rover supergraph compose` and `rover dev` are downloaded from. By default, `rover dev` attempts to install the latest version of plugins for the router and composition. To maintain this behavior, an `X-Version: vX.X.X` header must be present in the response from the binary mirror. To circumvent the need for this header, plugin versions can instead be pinned with the `APOLLO_ROVER_DEV_COMPOSITION_VERSION` and `APOLLO_ROVER_DEV_ROUTER_VERSION` environment variables. For more details, see [versioning for `rover dev`](./commands/dev/#versioning).
+   <Note>
 
-    </Note>
+   This environment variable also changes the host that plugins for `rover supergraph compose` and `rover dev` are downloaded from. By default, `rover dev` attempts to install the latest version of plugins for the router and composition. To maintain this behavior, an `X-Version: vX.X.X` header must be present in the response from the binary mirror. To circumvent the need for this header, plugin versions can instead be pinned with the `APOLLO_ROVER_DEV_COMPOSITION_VERSION` and `APOLLO_ROVER_DEV_ROUTER_VERSION` environment variables. For more details, see [versioning for `rover dev`](./commands/dev/#versioning).
+
+   </Note>
 
 1. Adding the following to your global or local `.npmrc`:
 
@@ -80,7 +107,7 @@ You can then call `rover <parameters>` directly in your `package.json` [scripts]
 
 <Note>
 
-When using `npx`, the `-p @apollo/rover` argument is necessary to specify that the `@apollo/rover` package provides the `rover` command.  See [`npx`'s documentation](https://www.npmjs.com/package/npx#description) for more information.
+When using `npx`, the `-p @apollo/rover` argument is necessary to specify that the `@apollo/rover` package provides the `rover` command. See [`npx`'s documentation](https://www.npmjs.com/package/npx#description) for more information.
 
 </Note>
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -48,7 +48,7 @@ iwr 'https://rover.apollo.dev/win/v0.26.2' | iex
 
 #### Installing from a binary mirror using the bash and powershell scripts
 
-Both the bash and powershell scripts support the `APOLLO_ROVER_BINARY_REMOTE` environment variable,
+Both the bash and powershell scripts support the `APOLLO_ROVER_DOWNLOAD_GITHUB_HOST` environment variable,
 which defaults to `https://github.com/apollographql/rover/releases/download`.
 
 This can be set in your environment to specify a remote mirror or proxy to github release download
@@ -60,14 +60,14 @@ In a bash shell:
 
 ```bash
 # for bash (Mac/Linux)
-export APOLLO_ROVER_BINARY_REMOTE="https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
+export APOLLO_ROVER_DOWNLOAD_GITHUB_HOST="https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
 ```
 
 Or from a PowerShell:
 
 ```powershell
 # for PowerShell (Windows)
-$env:APOLLO_ROVER_BINARY_REMOTE = "https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
+$env:APOLLO_ROVER_DOWNLOAD_GITHUB_HOST = "https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
 ```
 
 This variable also supports basic authentication, but be aware that the password/token will appear in the output

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -15,7 +15,7 @@
 
 set -u
 
-BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_BINARY_REMOTE:="https://github.com/apollographql/rover/releases/download"}"
+BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_DOWNLOAD_GITHUB_HOST:="https://github.com/apollographql/rover/releases/download"}"
 
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -15,7 +15,7 @@
 
 set -u
 
-BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download"
+BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_BINARY_REMOTE:="https://github.com/apollographql/rover/releases/download"}"
 
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -63,13 +63,15 @@ download_binary_and_run_installer() {
     local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t rover)"
     local _file="$_dir/input.tar.gz"
     local _rover="$_dir/rover$_ext"
+    local _safe_url
 
-    say "downloading rover from $_url" 1>&2
+    _safe_url=$(echo "$_url" | sed  -E 's|https://[^@]+@|https://|')
+    say "downloading rover from $_safe_url" 1>&2
 
     ensure mkdir -p "$_dir"
     downloader "$_url" "$_file"
     if [ $? != 0 ]; then
-      say "failed to download $_url"
+      say "failed to download $_safe_url"
       say "this may be a standard network error, but it may also indicate"
       say "that rover's release process is not working. When in doubt"
       say "please feel free to open an issue!"

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -37,12 +37,16 @@ function Install-Binary($rover_install_args) {
 }
 
 function Download($version) {
-  $base_url = $env:APOLLO_ROVER_BINARY_REMOTE
-  if (-not $base_url) {
-    $base_url = "https://github.com/apollographql/rover/releases/download"
+  $binary_download_prefix = $env:APOLLO_ROVER_DOWNLOAD_GITHUB_HOST
+  if (-not $binary_download_prefix) {
+    $binary_download_prefix = "https://github.com/apollographql/rover/releases/download"
   }
-  $url = "$base_url/$version/rover-$version-x86_64-pc-windows-msvc.tar.gz"
-  "Downloading Rover from $url" | Out-Host
+  $url = "$binary_download_prefix/$version/rover-$version-x86_64-pc-windows-msvc.tar.gz"
+
+  # Remove credentials from the URL for logging
+  $safe_url = $url -replace "https://[^@]+@", "https://"
+
+  "Downloading Rover from $safe_url" | Out-Host
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\rover.tar.gz"
   $wc = New-Object Net.Webclient

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -37,7 +37,11 @@ function Install-Binary($rover_install_args) {
 }
 
 function Download($version) {
-  $url = "https://github.com/apollographql/rover/releases/download/$version/rover-$version-x86_64-pc-windows-msvc.tar.gz"
+  $base_url = $env:APOLLO_ROVER_BINARY_REMOTE
+  if (-not $base_url) {
+    $base_url = "https://github.com/apollographql/rover/releases/download"
+  }
+  $url = "$base_url/$version/rover-$version-x86_64-pc-windows-msvc.tar.gz"
   "Downloading Rover from $url" | Out-Host
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\rover.tar.gz"


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

This PR adds the ability to specify a proxy/mirror remote for the binary installation methods for apollo rover. This functionality was added for the npm installer in #1713 and #1675, and is being added for the router binary installation script in https://github.com/apollographql/router/pull/6244