### PR TITLE
Fix `cargo-deny` errors blocking CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2119,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -2136,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2155,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2166,15 +2166,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -2184,9 +2184,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,7 @@ ignore = [
     "RUSTSEC-2024-0320",
     # `instant` is now unmaintained. We depend on this in two ways, once via notify and then also via backoff.
     # Notify have already merged a PR to produce a version that does not contain this vulnerability, but
-    # we need to wait till this is released before we can upgradel Until then we can safely ignore
+    # we need to wait till this is released before we can upgrade. Until then we can safely ignore
     # this.
     "RUSTSEC-2024-0384"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,12 @@ ignore = [
     # `yaml-rust`, a dependency of `apollo-federation-types` via `serde_yaml`, is unmaintained. Represents no
     # security risk to us at present, and when/if `apollo-federation-types` decides to move their YAML
     # library else where we can remove this.
-    "RUSTSEC-2024-0320"
+    "RUSTSEC-2024-0320",
+    # `instant` is now unmaintained. We depend on this in two ways, once via notify and then also via backoff.
+    # Notify have already merged a PR to produce a version that does not contain this vulnerability, but
+    # we need to wait till this is released before we can upgradel Until then we can safely ignore
+    # this.
+    "RUSTSEC-2024-0384"
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Fixes up errors related to a yanked version of `futures-util` and a now unmaintained crate `instant`. 

`futures-util` can easily be updated, and so has been, `instant` is more complicated however as we depend on it via `notify` and `backoff`. `notify` have already merged a PR that will fix this but there's no new version yet and `backoff` seems almost unmaintained. Therefore we're electing to ignore this for now until we can update `notify` and can punt the decision about replacing `backoff` until later on.