### PR TITLE
docs: add solutions link

### DIFF
--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -137,6 +137,11 @@ jobs:
 
 ```
 
+You can also use this [Apollo Solutions repository](https://github.com/apollosolutions/rover-actions) install Rover on GitHub action runners.
+Once installed, `rover` is added to `PATH`, so it can be used in subsequent steps.
+
+<SolutionsNote />
+
 ## Bitbucket Pipelines
 
 The following is a full example configuration for Bitbucket Pipelines. It shows how to:


### PR DESCRIPTION
This PR adds links to relevant repositories in the apollosolutions organization.
https://github.com/apollographql/docs-rewrite/pull/343 must merge first since it adds a shared component used in this PR.