### PR TITLE
Add LSP functionality to Rover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,11 +30,23 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -141,6 +153,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
+name = "apollo-compiler"
+version = "1.0.0-beta.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875f39060728ac3e775fc3fe5421225d6df92c4d5155a9524cdb198f05006d36"
+dependencies = [
+ "ahash 0.8.11",
+ "apollo-parser 0.8.2",
+ "ariadne 0.4.1",
+ "indexmap 2.5.0",
+ "rowan",
+ "serde",
+ "serde_json_bytes",
+ "thiserror",
+ "triomphe",
+ "typed-arena",
+ "uuid",
+]
+
+[[package]]
+name = "apollo-composition"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6864cf58167a074ac909b387cebdbc0a6957d7eb95b6e4cdaf7df8c9cd46108a"
+dependencies = [
+ "apollo-compiler",
+ "apollo-federation",
+ "apollo-federation-types",
+ "either",
+]
+
+[[package]]
 name = "apollo-encoder"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +191,34 @@ checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
 dependencies = [
  "apollo-parser 0.7.7",
  "thiserror",
+]
+
+[[package]]
+name = "apollo-federation"
+version = "2.0.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b327840a1c216f7a1e6ac1a4fee347a9dee4fe7e3db94f5f9756337f5754969c"
+dependencies = [
+ "apollo-compiler",
+ "derive_more",
+ "either",
+ "http 0.2.12",
+ "indexmap 2.5.0",
+ "itertools 0.13.0",
+ "lazy_static",
+ "multimap",
+ "nom",
+ "nom_locate",
+ "petgraph",
+ "serde",
+ "serde_json",
+ "serde_json_bytes",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "time",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -164,6 +235,34 @@ dependencies = [
  "serde_with",
  "serde_yaml 0.8.26",
  "thiserror",
+ "url",
+]
+
+[[package]]
+name = "apollo-language-server"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e82651825f3f99089803394c0f68b573fe6195993892099bf2fa6387ba4438a"
+dependencies = [
+ "apollo-compiler",
+ "apollo-composition",
+ "apollo-federation",
+ "apollo-federation-types",
+ "apollo-parser 0.8.2",
+ "debounced",
+ "futures",
+ "indexmap 2.5.0",
+ "itertools 0.13.0",
+ "lsp-types",
+ "memoize",
+ "once_cell",
+ "ropey",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-lsp",
+ "tracing",
  "url",
 ]
 
@@ -203,6 +302,17 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "ariadne"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
+dependencies = [
+ "concolor",
+ "unicode-width",
+ "yansi 1.0.1",
+]
 
 [[package]]
 name = "ariadne"
@@ -564,6 +674,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,53 +715,6 @@ dependencies = [
  "fs_extra",
  "libc",
  "paste",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.1",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.1",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -878,6 +952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,7 +996,7 @@ version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d73155ae6b28cf5de4cfc29aeb02b8a1c6dab883cb015d15cd514e42766846"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.14.5",
@@ -1177,6 +1257,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,49 +1299,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
-dependencies = [
- "futures-core",
- "prost",
- "prost-types",
- "tonic",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "hyper-util",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -1601,6 +1668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debounced"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107e5cd9b5163c19751e53eef634cae25cf5ed5f6d0c81125feaa92e43703cc7"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1749,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2417,6 +2507,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2424,21 +2517,8 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
-]
-
-[[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "base64 0.21.7",
- "byteorder",
- "flate2",
- "nom",
- "num-traits",
 ]
 
 [[package]]
@@ -2681,7 +2761,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3203,6 +3283,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cc127b7c3d270be504572364f9569761a180b981919dd0d87693a7f5fb7829"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,12 +3569,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -3590,12 +3705,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3606,6 +3715,29 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df4051db13d0816cf23196d3baa216385ae099339f5d0645a8d9ff2305e82b8"
+dependencies = [
+ "lazy_static",
+ "lru",
+ "memoize-inner",
+]
+
+[[package]]
+name = "memoize-inner"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bdece7e91f0d1e33df7b46ec187a93ea0d4e642113a1039ac8bfdd4a3273ac"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "mime"
@@ -3707,6 +3839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3758,6 +3899,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -3896,6 +4048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -4187,6 +4348,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,6 +4400,8 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.5.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4433,38 +4641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -4807,11 +4983,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rover"
 version = "0.26.3"
 dependencies = [
  "anyhow",
  "apollo-federation-types",
+ "apollo-language-server",
  "apollo-parser 0.8.2",
  "assert-json-diff",
  "assert_cmd",
@@ -4886,6 +5073,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tower 0.5.2",
+ "tower-lsp",
  "tower-test",
  "tracing",
  "tracing-test",
@@ -4902,7 +5090,7 @@ dependencies = [
  "apollo-encoder",
  "apollo-federation-types",
  "apollo-parser 0.8.2",
- "ariadne",
+ "ariadne 0.5.0",
  "backoff",
  "buildstructor",
  "camino",
@@ -4998,7 +5186,6 @@ dependencies = [
  "anyhow",
  "camino",
  "console",
- "console-subscriber",
  "notify",
  "rstest",
  "speculoos",
@@ -5006,7 +5193,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tracing",
  "url",
@@ -5331,10 +5517,26 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_json_bytes"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ecd92a088fb2500b2f146c9ddc5da9950bb7264d3f00932cd2a6fb369c26c46"
+dependencies = [
+ "ahash 0.8.11",
+ "bytes",
+ "indexmap 2.5.0",
+ "jsonpath-rust",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5361,6 +5563,17 @@ checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5720,6 +5933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
 name = "str_inflector"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6035,7 +6254,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -6107,7 +6328,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6238,36 +6458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.7",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6275,11 +6465,8 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -6346,6 +6533,40 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "tower-service"
@@ -6452,6 +6673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "trust-dns-proto"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6522,6 +6753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typed-builder"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,6 +6783,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -6654,6 +6897,7 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6929,6 +7173,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6952,6 +7205,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6987,6 +7255,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6999,6 +7273,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7008,6 +7288,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7029,6 +7315,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7038,6 +7330,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7053,6 +7351,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7062,6 +7366,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875f39060728ac3e775fc3fe5421225d6df92c4d5155a9524cdb198f05006d36"
+checksum = "71153ad85c85f7aa63f0e0a5868912c220bb48e4c764556f5841d37fc17b0103"
 dependencies = [
  "ahash 0.8.11",
  "apollo-parser 0.8.2",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-composition"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6864cf58167a074ac909b387cebdbc0a6957d7eb95b6e4cdaf7df8c9cd46108a"
+checksum = "01d82be69fce8ac07544017fe8cd52befc61d4548d3233bd1757984d56c53804"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.0.0-alpha.7"
+version = "2.0.0-preview.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b327840a1c216f7a1e6ac1a4fee347a9dee4fe7e3db94f5f9756337f5754969c"
+checksum = "3c87a5a622646520e2e7df15ed33de1558e9d6eaaa7834eeafd02a8378cd73d2"
 dependencies = [
  "apollo-compiler",
  "derive_more",
@@ -206,10 +206,13 @@ dependencies = [
  "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static",
+ "line-col",
  "multimap",
  "nom",
  "nom_locate",
+ "once_cell",
  "petgraph",
+ "regex",
  "serde",
  "serde_json",
  "serde_json_bytes",
@@ -240,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-language-server"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e82651825f3f99089803394c0f68b573fe6195993892099bf2fa6387ba4438a"
+checksum = "a2e0b40ad3867c874a5b1bb243aab4ae8fda8efd1d1b14816a674202894ea066"
 dependencies = [
  "apollo-compiler",
  "apollo-composition",
@@ -2761,7 +2764,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -3482,6 +3485,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "line-col"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
 
 [[package]]
 name = "linked-hash-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
+tower-lsp = { version = "0.20.0" }
 tracing = { workspace = true }
 which = { workspace = true }
 uuid = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ apollo-encoder = "0.8"
 # https://github.com/apollographql/federation-rs
 apollo-federation-types = "0.14.1"
 
-apollo-language-server = { version = "0.3.0", default-features = false, features = ["tokio"] }
+apollo-language-server = { version = "0.3.4", default-features = false, features = ["tokio"] }
 
 # crates.io dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ apollo-encoder = "0.8"
 # https://github.com/apollographql/federation-rs
 apollo-federation-types = "0.14.1"
 
+apollo-language-server = { version = "0.3.0", default-features = false, features = ["tokio"] }
+
 # crates.io dependencies
 anyhow = "1"
 ariadne = "0.5"
@@ -168,6 +170,7 @@ zip = "2.0"
 anyhow = { workspace = true }
 assert_fs = { workspace = true }
 async-trait = { workspace = true }
+apollo-language-server = { workspace = true}
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
 billboard = { workspace = true }

--- a/crates/robot-panic/src/lib.rs
+++ b/crates/robot-panic/src/lib.rs
@@ -93,7 +93,7 @@ macro_rules! setup_panic {
         #[cfg(not(debug_assertions))]
         match ::std::env::var("RUST_BACKTRACE") {
             Err(_) => {
-                panic::set_hook(Box::new(move |info: &PanicInfo| {
+                panic::set_hook(Box::new(move |info: &PanicHookInfo| {
                     let crash_report = get_report(&$meta, info);
                     print_msg(&crash_report, &$meta)
                         .expect("robot-panic: printing error message to console failed");
@@ -105,7 +105,7 @@ macro_rules! setup_panic {
 
     () => {
         #[allow(unused_imports)]
-        use std::panic::{self, PanicInfo};
+        use std::panic::{self, PanicHookInfo};
         #[allow(unused_imports)]
         use $crate::{get_report, print_msg, Metadata};
 
@@ -120,7 +120,7 @@ macro_rules! setup_panic {
                     repository: env!("CARGO_PKG_REPOSITORY").into(),
                 };
 
-                panic::set_hook(Box::new(move |info: &PanicInfo| {
+                panic::set_hook(Box::new(move |info: &PanicHookInfo| {
                     let crash_report = get_report(&meta, info);
                     print_msg(&crash_report, &meta)
                         .expect("robot-panic: printing error message to console failed");

--- a/crates/rover-std/Cargo.toml
+++ b/crates/rover-std/Cargo.toml
@@ -14,11 +14,9 @@ notify = { workspace = true }
 tap = { workspace = true }
 tokio = { workspace = true, features = [ "macros", "rt", "rt-multi-thread", "time" ] }
 tokio-util = { workspace = true}
-tokio-stream = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-console-subscriber = "0.4.0"
 
 [dev-dependencies]
 notify = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -64,6 +64,24 @@ version = "*"
 expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
 license-files = [{ path = "COPYRIGHT", hash = 0x39f8ad31 }]
 
+[[licenses.clarify]]
+name = "apollo-language-server"
+version = "*"
+expression = "Elastic-2.0"
+license-files = [{ path = "LICENSE.md", hash = 0x5fc4a573 }]
+
+[[licenses.exceptions]]
+name = "apollo-language-server"
+allow = ["Elastic-2.0"]
+
+[[licenses.exceptions]]
+name = "apollo-federation"
+allow = ["Elastic-2.0"]
+
+[[licenses.exceptions]]
+name = "apollo-composition"
+allow = ["Elastic-2.0"]
+
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -234,6 +234,8 @@ impl Rover {
             Command::Explain(command) => command.run(),
             Command::PersistedQueries(command) => command.run(self.get_client_config()?).await,
             Command::License(command) => command.run(self.get_client_config()?).await,
+            #[cfg(feature = "composition-js")]
+            Command::Lsp(command) => command.run(self.get_client_config()?).await,
         }
     }
 
@@ -432,6 +434,11 @@ pub enum Command {
 
     /// Commands for fetching offline licenses
     License(command::License),
+
+    /// Start the language server
+    #[cfg(feature = "composition-js")]
+    #[clap(hide = true)]
+    Lsp(command::Lsp),
 }
 
 #[derive(Default, ValueEnum, Debug, Serialize, Clone, Copy, Eq, PartialEq)]

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -15,6 +15,7 @@ use rover_std::{errln, infoln, warnln};
 use semver::Version;
 use tower::ServiceExt;
 
+use crate::composition::supergraph::binary::OutputTarget;
 use crate::{
     command::{
         dev::{OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION},
@@ -171,6 +172,8 @@ impl Dev {
                 fetch_remote_subgraph_factory.boxed_clone(),
                 self.opts.subgraph_opts.subgraph_polling_interval,
                 tmp_config_dir_path.clone(),
+                OutputTarget::Stdout,
+                false,
             )
             .await?;
 

--- a/src/command/lsp/errors.rs
+++ b/src/command/lsp/errors.rs
@@ -1,0 +1,11 @@
+use camino::Utf8PathBuf;
+
+use crate::composition::CompositionError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum StartCompositionError {
+    #[error("Could not convert Supergraph path to URL")]
+    SupergraphYamlUrlConversionFailed(Utf8PathBuf),
+    #[error("Could not run initial composition")]
+    InitialCompositionFailed(#[from] CompositionError),
+}

--- a/src/command/lsp/errors.rs
+++ b/src/command/lsp/errors.rs
@@ -1,11 +1,25 @@
-use camino::Utf8PathBuf;
+use anyhow::Error;
+use camino::{FromPathBufError, Utf8PathBuf};
 
+use crate::composition::pipeline::CompositionPipelineError;
+use crate::composition::supergraph::config::resolver::ResolveSupergraphConfigError;
+use crate::composition::supergraph::install::InstallSupergraphError;
 use crate::composition::CompositionError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum StartCompositionError {
     #[error("Could not convert Supergraph path to URL")]
     SupergraphYamlUrlConversionFailed(Utf8PathBuf),
+    #[error("Could not create HTTP service")]
+    HttpServiceCreationFailed(#[from] Error),
+    #[error("Could not initialise the composition pipeline")]
+    InitialisingCompositionPipelineFailed(#[from] CompositionPipelineError),
     #[error("Could not run initial composition")]
     InitialCompositionFailed(#[from] CompositionError),
+    #[error("Could not install supergraph plugin")]
+    InstallSupergraphPluginFailed(#[from] InstallSupergraphError),
+    #[error("Could not resolve Supergraph Config")]
+    ResolvingSupergraphConfigFailed(#[from] ResolveSupergraphConfigError),
+    #[error("Could not establish temporary directory")]
+    TemporaryDirectoryCouldNotBeEstablished(#[from] FromPathBufError),
 }

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -57,6 +57,12 @@ pub struct LspOpts {
     #[serde(skip_serializing)]
     #[arg(long = "supergraph-config")]
     supergraph_yaml: Option<Utf8PathBuf>,
+
+    /// The number of seconds to wait between polling requests to any subgraphs that
+    /// are being introspected for their schema
+    #[arg(long = "polling-interval", short = 'i', default_value = "5")]
+    #[serde(skip_serializing)]
+    introspection_polling_interval: u64,
 }
 
 impl Lsp {
@@ -336,7 +342,7 @@ async fn create_composition_stream(
             FsWriteFile::default(),
             client_config.service()?,
             fetch_remote_subgraph_factory.boxed_clone(),
-            1,
+            lsp_opts.introspection_polling_interval,
             Utf8PathBuf::try_from(temp_dir())?,
             OutputTarget::InMemory,
             true,

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -6,7 +6,7 @@ use std::io::stdin;
 
 use anyhow::Error;
 use apollo_federation_types::config::FederationVersion::LatestFedTwo;
-use apollo_language_server::{ApolloLanguageServer, Config};
+use apollo_language_server::{ApolloLanguageServer, Config, MaxSpecVersions};
 use camino::Utf8PathBuf;
 use clap::Parser;
 use futures::StreamExt;
@@ -95,6 +95,10 @@ async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverR
                     enable_auto_composition: false,
                     force_federation: false,
                     disable_telemetry: false,
+                    max_spec_versions: MaxSpecVersions {
+                        connect: None,
+                        federation: None,
+                    },
                 },
                 HashMap::new(),
             );
@@ -118,6 +122,10 @@ async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverR
                     enable_auto_composition: false,
                     force_federation: false,
                     disable_telemetry: false,
+                    max_spec_versions: MaxSpecVersions {
+                        connect: None,
+                        federation: None,
+                    },
                 },
                 HashMap::from_iter(
                     lazily_resolved_supergraph_config

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -1,0 +1,297 @@
+mod errors;
+
+use std::collections::HashMap;
+use std::env::temp_dir;
+use std::io::stdin;
+
+use anyhow::Error;
+use apollo_federation_types::config::FederationVersion::LatestFedTwo;
+use apollo_language_server::{ApolloLanguageServer, Config};
+use camino::Utf8PathBuf;
+use clap::Parser;
+use futures::StreamExt;
+use serde::Serialize;
+use tower_lsp::lsp_types::{Diagnostic, Range};
+use tower_lsp::Server;
+use tracing::debug;
+use url::Url;
+
+use crate::command::lsp::errors::StartCompositionError;
+use crate::command::lsp::errors::StartCompositionError::SupergraphYamlUrlConversionFailed;
+use crate::composition::events::CompositionEvent;
+use crate::composition::runner::Runner;
+use crate::composition::supergraph::config::lazy::LazilyResolvedSupergraphConfig;
+use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::MakeFetchRemoteSubgraph;
+use crate::composition::supergraph::config::resolver::fetch_remote_subgraphs::MakeFetchRemoteSubgraphs;
+use crate::composition::supergraph::config::resolver::{
+    ResolveSupergraphConfigError, SubgraphPrompt, SupergraphConfigResolver,
+};
+use crate::composition::supergraph::install::InstallSupergraph;
+use crate::composition::SupergraphConfigResolutionError::PathDoesNotPointToAFile;
+use crate::composition::{
+    CompositionError, CompositionSubgraphAdded, CompositionSubgraphRemoved, CompositionSuccess,
+    SupergraphConfigResolutionError,
+};
+use crate::options::ProfileOpt;
+use crate::utils::effect::exec::TokioCommand;
+use crate::utils::effect::install::InstallBinary;
+use crate::utils::effect::read_file::FsReadFile;
+use crate::utils::effect::write_file::FsWriteFile;
+use crate::{
+    options::PluginOpts,
+    utils::{client::StudioClientConfig, parsers::FileDescriptorType},
+    RoverOutput, RoverResult,
+};
+
+#[derive(Debug, Serialize, Parser)]
+pub struct Lsp {
+    #[clap(flatten)]
+    pub(crate) opts: LspOpts,
+}
+
+#[derive(Clone, Debug, Serialize, Parser)]
+pub struct LspOpts {
+    #[clap(flatten)]
+    pub plugin_opts: PluginOpts,
+
+    /// The absolute path to the supergraph configuration file.
+    #[serde(skip_serializing)]
+    #[arg(long = "supergraph-config")]
+    supergraph_yaml: Option<Utf8PathBuf>,
+}
+
+impl Lsp {
+    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        self.opts
+            .plugin_opts
+            .prompt_for_license_accept(&client_config)?;
+
+        run_lsp(client_config, self.opts.clone()).await?;
+        Ok(RoverOutput::EmptySuccess)
+    }
+}
+
+async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverResult<()> {
+    let supergraph_yaml_path = lsp_opts.supergraph_yaml.as_ref().and_then(|path| {
+        if path.is_relative() {
+            Some(
+                Utf8PathBuf::try_from(std::env::current_dir().ok()?)
+                    .ok()?
+                    .join(path),
+            )
+        } else {
+            Some(path.clone())
+        }
+    });
+
+    // Early return if there is no `supergraph.yaml` given as there is no further need to construct
+    // anything
+    let (service, socket) = match supergraph_yaml_path {
+        None => {
+            let (service, socket, _receiver) = ApolloLanguageServer::build_service(
+                Config {
+                    // TODO Do we need to worry about these now?
+                    root_uri: String::default(),
+                    enable_auto_composition: false,
+                    force_federation: false,
+                    disable_telemetry: false,
+                },
+                HashMap::new(),
+            );
+            (service, socket)
+        }
+        Some(supergraph_yaml_path) => {
+            // Resolve Supergraph Config -> Lazy
+            let lazily_resolved_supergraph_config = generate_lazily_resolved_supergraph_config(
+                supergraph_yaml_path.clone(),
+                client_config.clone(),
+                lsp_opts.plugin_opts.profile.clone(),
+            )
+            .await?;
+            let supergraph_yaml_url = Url::from_file_path(supergraph_yaml_path.clone())
+                .map_err(|_| SupergraphYamlUrlConversionFailed(supergraph_yaml_path.clone()))?;
+            debug!("Supergraph Config Root: {:?}", supergraph_yaml_url);
+            // Generate the config needed to spin up the Language Server
+            let (service, socket, _receiver) = ApolloLanguageServer::build_service(
+                Config {
+                    root_uri: String::from(supergraph_yaml_url.clone()),
+                    enable_auto_composition: false,
+                    force_federation: false,
+                    disable_telemetry: false,
+                },
+                HashMap::from_iter(
+                    lazily_resolved_supergraph_config
+                        .subgraphs()
+                        .iter()
+                        .map(|(a, b)| (a.to_string(), b.schema().clone())),
+                ),
+            );
+            // Start running composition
+            start_composition(
+                lazily_resolved_supergraph_config,
+                supergraph_yaml_url,
+                client_config,
+                lsp_opts,
+                service.inner().to_owned(),
+            )
+            .await?;
+            (service, socket)
+        }
+    };
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let server = Server::new(stdin, stdout, socket);
+    server.serve(service).await;
+    Ok(())
+}
+
+async fn generate_lazily_resolved_supergraph_config(
+    supergraph_yaml_path: Utf8PathBuf,
+    client_config: StudioClientConfig,
+    profile: ProfileOpt,
+) -> Result<LazilyResolvedSupergraphConfig, SupergraphConfigResolutionError> {
+    let make_fetch_remote_subgraphs = MakeFetchRemoteSubgraphs::builder()
+        .studio_client_config(client_config)
+        .profile(profile)
+        .build();
+    // Get the SupergraphConfig in a form we can use
+    let supergraph_config = SupergraphConfigResolver::default()
+        .load_remote_subgraphs(make_fetch_remote_subgraphs, None)
+        .await?
+        .load_from_file_descriptor(
+            &mut stdin(),
+            Some(&FileDescriptorType::File(supergraph_yaml_path.clone())),
+        )?;
+    if let Some(parent) = supergraph_yaml_path.parent() {
+        Ok(supergraph_config
+            .lazily_resolve_subgraphs(Some(&parent.to_owned()), &SubgraphPrompt::default())
+            .await?)
+    } else {
+        Err(PathDoesNotPointToAFile(
+            supergraph_yaml_path.into_std_path_buf(),
+        ))
+    }
+}
+
+async fn start_composition(
+    lazily_resolved_supergraph_config: LazilyResolvedSupergraphConfig,
+    supergraph_yaml_url: Url,
+    client_config: StudioClientConfig,
+    lsp_opts: LspOpts,
+    language_server: ApolloLanguageServer,
+) -> Result<(), StartCompositionError> {
+    let federation_version = lazily_resolved_supergraph_config
+        .federation_version()
+        .clone()
+        .unwrap_or(LatestFedTwo);
+
+    // Spawn a separate thread to handle composition and passing that data to the language server
+    tokio::spawn(async move {
+        // TODO: Let the supergraph binary exist inside its own task that can respond to being re-installed etc.
+        let supergraph_binary =
+            InstallSupergraph::new(federation_version.clone(), client_config.clone())
+                .install(
+                    None,
+                    lsp_opts.plugin_opts.elv2_license_accepter,
+                    lsp_opts.plugin_opts.skip_update,
+                )
+                .await?;
+
+        let make_fetch_remote_subgraph = MakeFetchRemoteSubgraph::builder()
+            .studio_client_config(client_config.clone())
+            .profile(lsp_opts.plugin_opts.profile.clone())
+            .build();
+
+        // Spin up Runner
+        let mut stream = Runner::default()
+            .setup_subgraph_watchers(
+                lazily_resolved_supergraph_config.subgraphs().clone(),
+                &lsp_opts.plugin_opts.profile,
+                &client_config,
+                500,
+            )
+            .setup_supergraph_config_watcher(lazily_resolved_supergraph_config.clone())
+            .setup_composition_watcher(
+                lazily_resolved_supergraph_config
+                    .fully_resolve(&client_config, make_fetch_remote_subgraph)
+                    .await
+                    .map_err(ResolveSupergraphConfigError::ResolveSubgraphs)?,
+                supergraph_binary,
+                TokioCommand::default(),
+                FsReadFile::default(),
+                FsWriteFile::default(),
+                Utf8PathBuf::try_from(temp_dir())?,
+                true,
+            )
+            .run();
+
+        while let Some(event) = stream.next().await {
+            match event {
+                CompositionEvent::Started => {
+                    // Even though it's hidden by library calls, this function emits a WorkDoneProgressBegin event,
+                    // which is paired with a WorkDoneProgressEnd event, sent by the `composition_did_update` function.
+                    // Any refactoring needs to ensure that we don't break this ordering, otherwise the LSP may well
+                    // cease to function in a useful way.
+                    language_server.composition_did_start().await;
+                }
+                CompositionEvent::Success(CompositionSuccess {
+                    supergraph_sdl,
+                    federation_version,
+                    hints,
+                }) => {
+                    debug!("Successfully composed with version {}", federation_version);
+                    // Clear any previous errors on `supergraph.yaml`
+                    language_server
+                        .publish_diagnostics(supergraph_yaml_url.clone(), vec![])
+                        .await;
+                    language_server
+                        .composition_did_update(
+                            Some(supergraph_sdl),
+                            hints.into_iter().map(Into::into).collect(),
+                            None,
+                        )
+                        .await;
+                }
+                CompositionEvent::Error(CompositionError::Build { source: errors }) => {
+                    debug!(
+                        ?errors,
+                        "Composition {federation_version} completed with errors"
+                    );
+                    // Clear any previous errors on `supergraph.yaml`
+                    language_server
+                        .publish_diagnostics(supergraph_yaml_url.clone(), vec![])
+                        .await;
+                    language_server
+                        .composition_did_update(
+                            None,
+                            errors.into_iter().map(Into::into).collect(),
+                            None,
+                        )
+                        .await
+                }
+                CompositionEvent::Error(err) => {
+                    debug!("Composition {federation_version} failed: {err}");
+                    let message = format!("Failed run composition {federation_version}: {err}",);
+                    let diagnostic = Diagnostic::new_simple(Range::default(), message);
+                    language_server
+                        .publish_diagnostics(supergraph_yaml_url.clone(), vec![diagnostic])
+                        .await;
+                }
+                CompositionEvent::SubgraphAdded(CompositionSubgraphAdded {
+                    name,
+                    schema_source,
+                }) => {
+                    debug!("Subgraph {} added", name);
+                    language_server.add_subgraph(name, schema_source).await;
+                }
+                CompositionEvent::SubgraphRemoved(CompositionSubgraphRemoved { name }) => {
+                    debug!("Subgraph {} removed", name);
+                    language_server.remove_subgraph(&name).await;
+                }
+            }
+        }
+        Ok::<(), Error>(())
+    });
+    Ok(())
+}

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -20,6 +20,7 @@ use crate::command::lsp::errors::StartCompositionError;
 use crate::command::lsp::errors::StartCompositionError::SupergraphYamlUrlConversionFailed;
 use crate::composition::events::CompositionEvent;
 use crate::composition::runner::Runner;
+use crate::composition::supergraph::binary::OutputTarget;
 use crate::composition::supergraph::config::lazy::LazilyResolvedSupergraphConfig;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::MakeFetchRemoteSubgraph;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraphs::MakeFetchRemoteSubgraphs;
@@ -231,6 +232,7 @@ async fn start_composition(
                 FsWriteFile::default(),
                 Utf8PathBuf::try_from(temp_dir())?,
                 true,
+                OutputTarget::InMemory,
             )
             .run();
 

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -96,7 +96,6 @@ async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverR
         None => {
             let (service, socket, _receiver) = ApolloLanguageServer::build_service(
                 Config {
-                    // TODO Do we need to worry about these now?
                     root_uri: String::default(),
                     enable_auto_composition: false,
                     force_federation: false,
@@ -270,7 +269,7 @@ async fn start_composition(
                 }
                 CompositionEvent::Error(err) => {
                     debug!("Composition failed: {err}");
-                    let message = format!("Failed run composition: {err}",);
+                    let message = format!("Failed run composition: {err}");
                     let diagnostic = Diagnostic::new_simple(Range::default(), message);
                     language_server
                         .publish_diagnostics(supergraph_yaml_url.clone(), vec![diagnostic])

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,6 +8,8 @@ mod graph;
 mod info;
 pub(crate) mod install;
 mod license;
+#[cfg(feature = "composition-js")]
+mod lsp;
 pub(crate) mod output;
 mod persisted_queries;
 mod readme;
@@ -26,6 +28,8 @@ pub use graph::Graph;
 pub use info::Info;
 pub use install::Install;
 pub use license::License;
+#[cfg(feature = "composition-js")]
+pub use lsp::Lsp;
 pub use output::RoverOutput;
 pub use persisted_queries::PersistedQueries;
 pub use readme::Readme;

--- a/src/composition/events/mod.rs
+++ b/src/composition/events/mod.rs
@@ -1,4 +1,6 @@
-use super::{CompositionError, CompositionSuccess};
+use super::{
+    CompositionError, CompositionSubgraphAdded, CompositionSubgraphRemoved, CompositionSuccess,
+};
 
 /// Events emitted from composition
 #[derive(Debug)]
@@ -10,4 +12,8 @@ pub enum CompositionEvent {
     Success(CompositionSuccess),
     /// Composition errored
     Error(CompositionError),
+    /// Subgraph Added
+    SubgraphAdded(CompositionSubgraphAdded),
+    /// SubgraphRemoved
+    SubgraphRemoved(CompositionSubgraphRemoved),
 }

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -1,11 +1,18 @@
 use std::fmt::Debug;
+use std::path::PathBuf;
 
+use anyhow::Error;
+use apollo_federation_types::config::SchemaSource;
 use apollo_federation_types::{
     config::FederationVersion,
     rover::{BuildErrors, BuildHint},
 };
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
+
+use crate::composition::supergraph::config::resolver::{
+    LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
+};
 
 pub mod events;
 pub mod pipeline;
@@ -20,9 +27,9 @@ mod watchers;
 
 #[derive(Getters, Debug, Clone, Eq, PartialEq)]
 pub struct CompositionSuccess {
-    supergraph_sdl: String,
-    hints: Vec<BuildHint>,
-    federation_version: FederationVersion,
+    pub(crate) supergraph_sdl: String,
+    pub(crate) hints: Vec<BuildHint>,
+    pub(crate) federation_version: FederationVersion,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -50,7 +57,35 @@ pub enum CompositionError {
         error: Box<dyn std::error::Error + Send + Sync>,
     },
     #[error("Encountered {} while trying to build a supergraph.", .source.length_string())]
-    Build { source: BuildErrors },
+    Build {
+        source: BuildErrors,
+        federation_version: FederationVersion,
+    },
     #[error("Serialization error.\n{}", .0)]
     SerdeYaml(#[from] serde_yaml::Error),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct CompositionSubgraphAdded {
+    pub(crate) name: String,
+    pub(crate) schema_source: SchemaSource,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct CompositionSubgraphRemoved {
+    pub(crate) name: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SupergraphConfigResolutionError {
+    #[error("Could not instantiate Studio Client")]
+    StudioClientInitialisationFailed(#[from] Error),
+    #[error("Could not load remote subgraphs")]
+    LoadRemoteSubgraphsFailed(#[from] LoadRemoteSubgraphsError),
+    #[error("Could not load supergraph config from local file")]
+    LoadLocalSupergraphConfigFailed(#[from] LoadSupergraphConfigError),
+    #[error("Could not resolve local and remote elements into complete SupergraphConfig")]
+    ResolveSupergraphConfigFailed(#[from] ResolveSupergraphConfigError),
+    #[error("Path `{0}` does not point to a file")]
+    PathDoesNotPointToAFile(PathBuf),
 }

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -259,6 +259,7 @@ impl CompositionPipeline<state::Run> {
         make_fetch_remote_subgraph: FetchRemoteSubgraphFactory,
         introspection_polling_interval: u64,
         output_dir: Utf8PathBuf,
+        compose_on_initialisation: bool,
     ) -> Result<CompositionRunner<ExecC, ReadF, WriteF>, CompositionPipelineError>
     where
         ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
@@ -289,6 +290,7 @@ impl CompositionPipeline<state::Run> {
                 read_file,
                 write_file,
                 output_dir,
+                compose_on_initialisation,
             );
         Ok(runner)
     }

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -259,6 +259,7 @@ impl CompositionPipeline<state::Run> {
         make_fetch_remote_subgraph: FetchRemoteSubgraphFactory,
         introspection_polling_interval: u64,
         output_dir: Utf8PathBuf,
+        output_target: OutputTarget,
         compose_on_initialisation: bool,
     ) -> Result<CompositionRunner<ExecC, ReadF, WriteF>, CompositionPipelineError>
     where
@@ -291,6 +292,7 @@ impl CompositionPipeline<state::Run> {
                 write_file,
                 output_dir,
                 compose_on_initialisation,
+                output_target,
             );
         Ok(runner)
     }

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -135,6 +135,7 @@ impl Runner<state::SetupCompositionWatcher> {
         write_file: WriteF,
         temp_dir: Utf8PathBuf,
         compose_on_initialisation: bool,
+        output_target: OutputTarget,
     ) -> Runner<state::Run<ExecC, ReadF, WriteF>>
     where
         ExecC: ExecCommand + Debug + Eq + PartialEq + Send + Sync + 'static,
@@ -150,6 +151,7 @@ impl Runner<state::SetupCompositionWatcher> {
             .write_file(write_file)
             .temp_dir(temp_dir)
             .compose_on_initialisation(compose_on_initialisation)
+            .output_target(output_target)
             .build();
         Runner {
             state: state::Run {

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -134,6 +134,7 @@ impl Runner<state::SetupCompositionWatcher> {
         read_file: ReadF,
         write_file: WriteF,
         temp_dir: Utf8PathBuf,
+        compose_on_initialisation: bool,
     ) -> Runner<state::Run<ExecC, ReadF, WriteF>>
     where
         ExecC: ExecCommand + Debug + Eq + PartialEq + Send + Sync + 'static,
@@ -148,6 +149,7 @@ impl Runner<state::SetupCompositionWatcher> {
             .read_file(read_file)
             .write_file(write_file)
             .temp_dir(temp_dir)
+            .compose_on_initialisation(compose_on_initialisation)
             .build();
         Runner {
             state: state::Run {

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -13,16 +13,7 @@ use futures::stream::{BoxStream, StreamExt};
 use rover_http::HttpService;
 use tower::ServiceExt;
 
-use crate::{
-    composition::watchers::watcher::{
-        file::FileWatcher, supergraph_config::SupergraphConfigWatcher,
-    },
-    subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit},
-    utils::effect::{exec::ExecCommand, read_file::ReadFile, write_file::WriteFile},
-};
-
 use self::state::SetupSubgraphWatchers;
-
 use super::{
     events::CompositionEvent,
     supergraph::{
@@ -35,6 +26,14 @@ use super::{
         },
     },
     watchers::{composition::CompositionWatcher, subgraphs::SubgraphWatchers},
+};
+use crate::composition::supergraph::binary::OutputTarget;
+use crate::{
+    composition::watchers::watcher::{
+        file::FileWatcher, supergraph_config::SupergraphConfigWatcher,
+    },
+    subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit},
+    utils::effect::{exec::ExecCommand, read_file::ReadFile, write_file::WriteFile},
 };
 
 mod state;

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -161,10 +161,11 @@ impl SupergraphBinary {
             .map(|build_output| CompositionSuccess {
                 hints: build_output.hints,
                 supergraph_sdl: build_output.supergraph_sdl,
-                federation_version,
+                federation_version: federation_version.clone(),
             })
             .map_err(|build_errors| CompositionError::Build {
                 source: build_errors,
+                federation_version,
             })
     }
 

--- a/src/composition/supergraph/config/error/subgraph.rs
+++ b/src/composition/supergraph/config/error/subgraph.rs
@@ -16,6 +16,8 @@ pub enum ResolveSubgraphError {
         supergraph_config_path: Utf8PathBuf,
         /// Supplied path to the subgraph schema file
         path: PathBuf,
+        /// The result of joining the paths together, that caused the failure
+        joined_path: PathBuf,
         /// The source error
         source: std::io::Error,
     },

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -7,22 +7,22 @@ use futures::{stream, StreamExt, TryFutureExt};
 use itertools::Itertools;
 use tower::{Service, ServiceExt};
 
+use super::FullyResolvedSubgraph;
+use crate::composition::supergraph::config::full::introspect::ResolveIntrospectSubgraphFactory;
+use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
 use crate::composition::supergraph::config::{
-    error::ResolveSubgraphError,
-    resolver::{fetch_remote_subgraph::FetchRemoteSubgraphFactory, ResolveSupergraphConfigError},
+    error::ResolveSubgraphError, resolver::ResolveSupergraphConfigError,
     unresolved::UnresolvedSupergraphConfig,
 };
-
-use super::{introspect::ResolveIntrospectSubgraphFactory, FullyResolvedSubgraph};
 
 /// Represents a [`SupergraphConfig`] that has a known [`FederationVersion`] and
 /// its subgraph [`SchemaSource`]s reduced to [`SchemaSource::Sdl`]
 #[derive(Clone, Debug, Eq, PartialEq, Getters)]
 #[cfg_attr(test, derive(buildstructor::Builder))]
 pub struct FullyResolvedSupergraphConfig {
-    origin_path: Option<Utf8PathBuf>,
-    subgraphs: BTreeMap<String, FullyResolvedSubgraph>,
-    federation_version: FederationVersion,
+    pub(crate) origin_path: Option<Utf8PathBuf>,
+    pub(crate) subgraphs: BTreeMap<String, FullyResolvedSubgraph>,
+    pub(crate) federation_version: FederationVersion,
 }
 
 impl From<FullyResolvedSupergraphConfig> for SupergraphConfig {

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -100,8 +100,12 @@ impl FullyResolvedSupergraphConfig {
     }
 
     /// Updates the subgraph with the provided name using the provided schema
-    pub fn update_subgraph_schema(&mut self, name: String, subgraph: FullyResolvedSubgraph) {
-        self.subgraphs.insert(name, subgraph);
+    pub fn update_subgraph_schema(
+        &mut self,
+        name: String,
+        subgraph: FullyResolvedSubgraph,
+    ) -> Option<FullyResolvedSubgraph> {
+        self.subgraphs.insert(name, subgraph)
     }
 
     /// Removes the subgraph with the name provided

--- a/src/composition/supergraph/config/unresolved/subgraph.rs
+++ b/src/composition/supergraph/config/unresolved/subgraph.rs
@@ -38,6 +38,7 @@ impl UnresolvedSubgraph {
                 subgraph_name: self.name.to_string(),
                 supergraph_config_path: root.clone(),
                 path: path.as_std_path().to_path_buf(),
+                joined_path: joined_path.as_std_path().to_path_buf(),
                 source: err,
             }),
         }

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -861,6 +861,7 @@ mod tests {
             (
                 sdl_subgraph_name.clone(),
                 LazilyResolvedSubgraph::builder()
+                    .name(sdl_subgraph_name.clone())
                     .schema(SchemaSource::Sdl {
                         sdl: sdl_subgraph_scenario.sdl.clone(),
                     })
@@ -876,6 +877,7 @@ mod tests {
                             .join(file_subgraph_scenario.schema_file_path)
                             .canonicalize_utf8()?,
                     })
+                    .name(file_subgraph_name.clone())
                     .routing_url(file_subgraph_scenario.routing_url)
                     .name(file_subgraph_name.to_string())
                     .build(),
@@ -887,6 +889,7 @@ mod tests {
                         graphref: remote_subgraph_scenario.graph_ref.to_string(),
                         subgraph: remote_subgraph_scenario.subgraph_name.clone(),
                     })
+                    .name(remote_subgraph_name.clone())
                     .routing_url(remote_subgraph_scenario.routing_url.clone())
                     .name(remote_subgraph_name.to_string())
                     .build(),
@@ -902,6 +905,7 @@ mod tests {
                             introspect_subgraph_scenario.introspection_headers.clone(),
                         ),
                     })
+                    .name(introspect_subgraph_name.clone())
                     .routing_url(introspect_subgraph_scenario.routing_url.clone())
                     .name(introspect_subgraph_name.to_string())
                     .build(),

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -6,9 +6,8 @@ use buildstructor::buildstructor;
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 
-use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
-
 use super::UnresolvedSubgraph;
+use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
 
 /// Object that represents a [`SupergraphConfig`] that requires resolution
 #[derive(Getters)]
@@ -49,7 +48,6 @@ impl UnresolvedSupergraphConfig {
 
 #[cfg(test)]
 mod tests {
-
     use std::{
         collections::{BTreeMap, HashSet},
         str::FromStr,
@@ -865,7 +863,6 @@ mod tests {
                     .schema(SchemaSource::Sdl {
                         sdl: sdl_subgraph_scenario.sdl.clone(),
                     })
-                    .name(sdl_subgraph_name.to_string())
                     .routing_url(sdl_subgraph_scenario.routing_url.to_string())
                     .build(),
             ),
@@ -879,7 +876,6 @@ mod tests {
                     })
                     .name(file_subgraph_name.clone())
                     .routing_url(file_subgraph_scenario.routing_url)
-                    .name(file_subgraph_name.to_string())
                     .build(),
             ),
             (
@@ -891,7 +887,6 @@ mod tests {
                     })
                     .name(remote_subgraph_name.clone())
                     .routing_url(remote_subgraph_scenario.routing_url.clone())
-                    .name(remote_subgraph_name.to_string())
                     .build(),
             ),
             (
@@ -907,7 +902,6 @@ mod tests {
                     })
                     .name(introspect_subgraph_name.clone())
                     .routing_url(introspect_subgraph_scenario.routing_url.clone())
-                    .name(introspect_subgraph_name.to_string())
                     .build(),
             ),
         ]);

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -155,7 +155,7 @@ where
 
         let write_file_result = self
             .write_file
-            .write_file(&target_file, supergraph_config_yaml.as_bytes())
+            .write_file(target_file, supergraph_config_yaml.as_bytes())
             .await;
 
         if let Err(err) = write_file_result {
@@ -173,16 +173,14 @@ where
         &self,
         target_file: &Utf8PathBuf,
     ) -> Result<CompositionSuccess, CompositionError> {
-        let output = self
-            .supergraph_binary
+        self.supergraph_binary
             .compose(
                 &self.exec_command,
                 &self.read_file,
                 &OutputTarget::Stdout,
                 target_file.clone(),
             )
-            .await;
-        output
+            .await
     }
 }
 
@@ -207,6 +205,7 @@ mod tests {
     use speculoos::prelude::*;
     use tracing_test::traced_test;
 
+    use super::CompositionWatcher;
     use crate::{
         composition::{
             events::CompositionEvent,
@@ -222,8 +221,6 @@ mod tests {
             exec::MockExecCommand, read_file::MockReadFile, write_file::MockWriteFile,
         },
     };
-
-    use super::CompositionWatcher;
 
     #[rstest]
     #[case::success(false, serde_json::to_string(&default_composition_json()).unwrap())]

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -6,7 +6,9 @@ use rover_std::{errln, infoln};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 use tokio_stream::StreamExt;
+use tracing::error;
 
+use crate::composition::{CompositionError, CompositionSuccess};
 use crate::{
     composition::{
         events::CompositionEvent,
@@ -28,6 +30,7 @@ pub struct CompositionWatcher<ExecC, ReadF, WriteF> {
     read_file: ReadF,
     write_file: WriteF,
     temp_dir: Utf8PathBuf,
+    compose_on_initialisation: bool,
 }
 
 impl<ExecC, ReadF, WriteF> SubtaskHandleStream for CompositionWatcher<ExecC, ReadF, WriteF>
@@ -48,6 +51,31 @@ where
             let mut supergraph_config = self.supergraph_config.clone();
             let target_file = self.temp_dir.join("supergraph.yaml");
             async move {
+                if self.compose_on_initialisation {
+                    if let Err(err) = self
+                        .setup_temporary_supergraph_yaml(&supergraph_config, &target_file)
+                        .await
+                    {
+                        error!("Could not setup initial supergraph schema: {}", err);
+                    };
+                    let _ = sender
+                        .send(CompositionEvent::Started)
+                        .tap_err(|err| error!("{:?}", err));
+                    let output = self.run_composition(&target_file).await;
+                    match output {
+                        Ok(success) => {
+                            let _ = sender
+                                .send(CompositionEvent::Success(success))
+                                .tap_err(|err| error!("{:?}", err));
+                        }
+                        Err(err) => {
+                            let _ = sender
+                                .send(CompositionEvent::Error(err))
+                                .tap_err(|err| error!("{:?}", err));
+                        }
+                    }
+                }
+
                 while let Some(event) = input.next().await {
                     match event {
                         SubgraphEvent::SubgraphChanged(subgraph_schema_changed) => {
@@ -67,61 +95,94 @@ where
                         }
                     }
 
-                    let supergraph_config = SupergraphConfig::from(supergraph_config.clone());
-                    let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config);
-
-                    let supergraph_config_yaml = match supergraph_config_yaml {
-                        Ok(supergraph_config_yaml) => supergraph_config_yaml,
-                        Err(err) => {
-                            errln!("Failed to serialize supergraph config into yaml");
-                            tracing::error!("{:?}", err);
-                            continue;
-                        }
-                    };
-
-                    let write_file_result = self
-                        .write_file
-                        .write_file(&target_file, supergraph_config_yaml.as_bytes())
-                        .await;
-
-                    if let Err(err) = write_file_result {
-                        errln!("Failed to write the supergraph config to disk");
-                        tracing::error!("{:?}", err);
+                    if let Err(err) = self
+                        .setup_temporary_supergraph_yaml(&supergraph_config, &target_file)
+                        .await
+                    {
+                        error!("Could not setup supergraph schema: {}", err);
                         continue;
-                    }
+                    };
 
                     let _ = sender
                         .send(CompositionEvent::Started)
-                        .tap_err(|err| tracing::error!("{:?}", err));
+                        .tap_err(|err| error!("{:?}", err));
 
-                    let output = self
-                        .supergraph_binary
-                        .compose(
-                            &self.exec_command,
-                            &self.read_file,
-                            &OutputTarget::Stdout,
-                            target_file.clone(),
-                        )
-                        .await;
+                    let output = self.run_composition(&target_file).await;
 
                     match output {
                         Ok(success) => {
                             infoln!("Composition successful.");
                             let _ = sender
                                 .send(CompositionEvent::Success(success))
-                                .tap_err(|err| tracing::error!("{:?}", err));
+                                .tap_err(|err| error!("{:?}", err));
                         }
                         Err(err) => {
                             errln!("Composition failed.");
                             let _ = sender
                                 .send(CompositionEvent::Error(err))
-                                .tap_err(|err| tracing::error!("{:?}", err));
+                                .tap_err(|err| error!("{:?}", err));
                         }
                     }
                 }
             }
         })
         .abort_handle()
+    }
+}
+
+impl<ExecC, ReadF, WriteF> CompositionWatcher<ExecC, ReadF, WriteF>
+where
+    ExecC: 'static + ExecCommand + Send + Sync,
+    ReadF: 'static + ReadFile + Send + Sync,
+    WriteF: 'static + Send + Sync + WriteFile,
+{
+    async fn setup_temporary_supergraph_yaml(
+        &self,
+        supergraph_config: &FullyResolvedSupergraphConfig,
+        target_file: &Utf8PathBuf,
+    ) -> Result<(), CompositionError> {
+        let supergraph_config = SupergraphConfig::from(supergraph_config.clone());
+        let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config);
+
+        let supergraph_config_yaml = match supergraph_config_yaml {
+            Ok(supergraph_config_yaml) => supergraph_config_yaml,
+            Err(err) => {
+                errln!("Failed to serialize supergraph config into yaml");
+                error!("{:?}", err);
+                return Err(CompositionError::SerdeYaml(err));
+            }
+        };
+
+        let write_file_result = self
+            .write_file
+            .write_file(&target_file, supergraph_config_yaml.as_bytes())
+            .await;
+
+        if let Err(err) = write_file_result {
+            errln!("Failed to write the supergraph config to disk");
+            error!("{:?}", err);
+            Err(CompositionError::WriteFile {
+                path: target_file.clone(),
+                error: Box::new(err),
+            })
+        } else {
+            Ok(())
+        }
+    }
+    async fn run_composition(
+        &self,
+        target_file: &Utf8PathBuf,
+    ) -> Result<CompositionSuccess, CompositionError> {
+        let output = self
+            .supergraph_binary
+            .compose(
+                &self.exec_command,
+                &self.read_file,
+                &OutputTarget::Stdout,
+                target_file.clone(),
+            )
+            .await;
+        output
     }
 }
 
@@ -238,6 +299,7 @@ mod tests {
             .read_file(mock_read_file)
             .write_file(mock_write_file)
             .temp_dir(temp_dir_path)
+            .compose_on_initialisation(false)
             .build();
 
         let subgraph_change_events: BoxStream<SubgraphEvent> = once(async {

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -100,7 +100,7 @@ pub enum SubgraphEvent {
 }
 /// An event denoting that the subgraph has changed, emitting its name and the SDL reflecting that
 /// change
-#[derive(derive_getters::Getters, Eq, PartialEq, Debug)]
+#[derive(derive_getters::Getters, Eq, PartialEq, Debug, Clone)]
 pub struct SubgraphSchemaChanged {
     /// Subgraph name
     name: String,

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -126,27 +126,32 @@ impl SupergraphConfigDiff {
         old: &SupergraphConfig,
         new: SupergraphConfig,
     ) -> Result<SupergraphConfigDiff, ConfigError> {
-        let old_subgraph_names: HashSet<String> = old
+        let old_subgraph_names_and_urls: HashSet<(String, Option<String>)> = old
             .clone()
             .into_iter()
-            .map(|(name, _config)| name)
+            .map(|(name, config)| (name, config.routing_url))
             .collect();
 
-        let new_subgraph_names: HashSet<String> = new
+        let new_subgraph_names_and_urls: HashSet<(String, Option<String>)> = new
             .clone()
             .into_iter()
-            .map(|(name, _config)| name)
+            .map(|(name, config)| (name, config.routing_url))
             .collect();
 
         // Collect the subgraph definitions from the new supergraph config.
         let new_subgraphs: BTreeMap<String, SubgraphConfig> = new.clone().into_iter().collect();
 
         // Compare the old and new subgraph names to find additions.
-        let added_names: HashSet<String> =
-            HashSet::from_iter(new_subgraph_names.difference(&old_subgraph_names).cloned());
+        let added_names: HashSet<String> = new_subgraph_names_and_urls
+            .difference(&old_subgraph_names_and_urls)
+            .map(|(a, _)| a.clone())
+            .collect();
 
         // Compare the old and new subgraph names to find removals.
-        let removed_names = old_subgraph_names.difference(&new_subgraph_names);
+        let removed_names: HashSet<String> = old_subgraph_names_and_urls
+            .difference(&new_subgraph_names_and_urls)
+            .map(|(a, _)| a.clone())
+            .collect();
 
         // Filter the added and removed subgraphs from the new supergraph config.
         let added = new_subgraphs
@@ -154,7 +159,7 @@ impl SupergraphConfigDiff {
             .into_iter()
             .filter(|(name, _)| added_names.contains(name))
             .collect::<Vec<_>>();
-        let removed = removed_names.into_iter().cloned().collect::<Vec<_>>();
+        let removed = removed_names.into_iter().collect::<Vec<_>>();
 
         // Find any in-place changes (eg, SDL, SchemaSource::Subgraph)
         let changed = old
@@ -183,10 +188,10 @@ impl SupergraphConfigDiff {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
     use std::collections::BTreeMap;
 
     use apollo_federation_types::config::{SchemaSource, SubgraphConfig, SupergraphConfig};
+    use rstest::rstest;
 
     use super::SupergraphConfigDiff;
 


### PR DESCRIPTION
Now that the LSP has been finalised, and composition has been refactored such that it can consume events in the same way that `rover dev` does we can unify the two together. 

This has been tested by running a custom build version of Rover against VSCode and it seems to function as intended. We will need to hash out a few more things in the review overall but this is a very positive step forwards