### PR TITLE
Support WhoAmI operation as a tower service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,7 @@ dependencies = [
  "tower 0.5.1",
  "tower-test",
  "tracing",
+ "tracing-test",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,7 +4716,10 @@ dependencies = [
  "reqwest 0.12.7",
  "robot-panic",
  "rover-client",
+ "rover-graphql",
+ "rover-http",
  "rover-std",
+ "rover-studio",
  "rstest",
  "semver",
  "serde",
@@ -4769,19 +4772,28 @@ dependencies = [
  "humantime",
  "hyper 1.4.1",
  "indoc",
+ "itertools 0.13.0",
  "pretty_assertions",
  "prettytable-rs",
  "regex",
  "reqwest 0.12.7",
+ "rover-graphql",
+ "rover-http",
  "rover-std",
+ "rover-studio",
  "rstest",
  "semver",
  "serde",
  "serde_json",
+ "speculoos",
  "strip-ansi-escapes",
  "thiserror",
  "tokio",
+ "tokio-test",
+ "tower 0.5.1",
+ "tower-test",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4875,6 +4887,7 @@ dependencies = [
  "tower 0.5.1",
  "tower-test",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ tower-test = "0.4.0"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.3"
+tracing-test = "0.2.5"
 which = "7"
 wsl = "0.1"
 uuid = "1"
@@ -246,5 +247,5 @@ reqwest = { workspace = true, features = ["native-tls-vendored"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 speculoos = { workspace = true }
-tracing-test = "0.2.5"
+tracing-test = { workspace = true }
 temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default = ["composition-js"]
 # notably, it is disabled for x86_64-unknown-linux-musl builds
 # because of this GitHub issue: https://github.com/denoland/deno/issues/3711
 composition-js = []
-dev-next = []
+dev-next = ["composition-rewrite"]
 composition-rewrite = []
 
 ### cross-workspace dependencies
@@ -197,7 +197,10 @@ os_info = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 robot-panic = { workspace = true }
 rover-client = { workspace = true }
+rover-graphql = { workspace = true }
+rover-http = { workspace = true }
 rover-std = { workspace = true }
+rover-studio = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -68,3 +68,4 @@ speculoos = { workspace = true }
 strip-ansi-escapes = { workspace = true }
 tower-test = { workspace = true }
 tokio-test = { workspace = true }
+tracing-test = { workspace = true }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -24,6 +24,7 @@ graphql_client = { workspace = true }
 houston = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
+itertools = { workspace = true }
 prettytable-rs = { workspace = true }
 reqwest = { workspace = true, features = [
     "blocking",
@@ -33,14 +34,19 @@ reqwest = { workspace = true, features = [
     "native-tls-vendored",
     "socks",
 ] }
+rover-graphql = { workspace = true }
+rover-http = { workspace = true }
 rover-std = { workspace = true }
+rover-studio = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
+url = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }
@@ -57,5 +63,8 @@ reqwest = { workspace = true, features = [
 indoc = { workspace = true}
 httpmock = { workspace = true }
 pretty_assertions = { workspace = true }
-strip-ansi-escapes = { workspace = true }
 rstest = { workspace = true }
+speculoos = { workspace = true }
+strip-ansi-escapes = { workspace = true }
+tower-test = { workspace = true }
+tokio-test = { workspace = true }

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -52,7 +52,7 @@ impl StudioClient {
             credential,
             graphql_endpoint: graphql_endpoint.to_string(),
             reqwest_client: client.clone(),
-            client: GraphQLClient::new(graphql_endpoint, client, retry_period.clone()),
+            client: GraphQLClient::new(graphql_endpoint, client, retry_period),
             version: version.to_string(),
             is_sudo,
             retry_period,
@@ -133,7 +133,7 @@ impl StudioClient {
                 self.version.to_string(),
                 self.is_sudo,
             )?))
-            .layer(RetryLayer::new(RetryPolicy::new(self.retry_period.clone())))
+            .layer(RetryLayer::new(RetryPolicy::new(self.retry_period)))
             .service(
                 ReqwestService::builder()
                     .client(self.reqwest_client.clone())

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -5,18 +5,36 @@ use crate::{
 };
 
 use houston::{Credential, CredentialOrigin};
-use std::time::Duration;
+use rover_graphql::{GraphQLLayer, GraphQLService};
+use rover_http::{retry::RetryPolicy, HttpService, ReqwestService};
+use rover_studio::{HttpStudioServiceError, HttpStudioServiceLayer};
+use std::{str::FromStr, time::Duration};
+use tower::{retry::RetryLayer, util::BoxCloneServiceLayer, ServiceBuilder};
 
 use graphql_client::GraphQLQuery;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Client as ReqwestClient;
+use url::Url;
+
+#[derive(thiserror::Error, Debug)]
+pub enum InitStudioServiceError {
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    StudioService(#[from] HttpStudioServiceError),
+}
 
 /// Represents a client for making GraphQL requests to Apollo Studio.
 pub struct StudioClient {
     pub credential: Credential,
+    graphql_endpoint: String,
     client: GraphQLClient,
+    reqwest_client: ReqwestClient,
     version: String,
     is_sudo: bool,
+    retry_period: Option<Duration>,
 }
 
 impl StudioClient {
@@ -32,9 +50,12 @@ impl StudioClient {
     ) -> StudioClient {
         StudioClient {
             credential,
-            client: GraphQLClient::new(graphql_endpoint, client, retry_period),
+            graphql_endpoint: graphql_endpoint.to_string(),
+            reqwest_client: client.clone(),
+            client: GraphQLClient::new(graphql_endpoint, client, retry_period.clone()),
             version: version.to_string(),
             is_sudo,
+            retry_period,
         }
     }
 
@@ -101,5 +122,23 @@ impl StudioClient {
 
     pub fn get_credential_origin(&self) -> CredentialOrigin {
         self.credential.origin.clone()
+    }
+
+    pub fn service(&self) -> Result<GraphQLService<HttpService>, InitStudioServiceError> {
+        let service = ServiceBuilder::new()
+            .layer(GraphQLLayer::default())
+            .layer(BoxCloneServiceLayer::new(HttpStudioServiceLayer::new(
+                Url::from_str(&self.graphql_endpoint)?,
+                self.credential.clone(),
+                self.version.to_string(),
+                self.is_sudo,
+            )?))
+            .layer(RetryLayer::new(RetryPolicy::new(self.retry_period.clone())))
+            .service(
+                ReqwestService::builder()
+                    .client(self.reqwest_client.clone())
+                    .build()?,
+            );
+        Ok(service)
     }
 }

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -1,4 +1,8 @@
+use std::fmt::Debug;
+
 use apollo_federation_types::rover::BuildErrors;
+use itertools::Itertools;
+use rover_graphql::GraphQLServiceError;
 use thiserror::Error;
 
 use crate::shared::{CheckTaskStatus, CheckWorkflowResponse, GraphRef, LintResponse};
@@ -241,6 +245,9 @@ pub enum RoverClientError {
 
     #[error("Cannot operate on a non-cloud graph ref {graph_ref}")]
     NonCloudGraphRef { graph_ref: GraphRef },
+
+    #[error("Could not instantiate the service.")]
+    ServiceError(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 fn contract_publish_errors_msg(msgs: &[String], no_launch: &bool) -> String {
@@ -334,6 +341,25 @@ fn check_workflow_error_msg(check_response: &CheckWorkflowResponse) -> String {
                 "The changes in the schema you proposed caused {} and {} checks to fail.",
                 all_but_last, last[0]
             )
+        }
+    }
+}
+
+impl<T: Debug + Send + Sync> From<GraphQLServiceError<T>> for RoverClientError {
+    fn from(value: GraphQLServiceError<T>) -> Self {
+        match value {
+            GraphQLServiceError::NoData(_) => RoverClientError::GraphQl {
+                msg: value.to_string(),
+            },
+            GraphQLServiceError::PartialError { errors, .. } => {
+                let errors = errors.iter().map(|err| err.to_string()).join("\n");
+                RoverClientError::GraphQl {
+                    msg: format!("Response returned with errors:\n{}", errors),
+                }
+            }
+            _ => RoverClientError::ClientError {
+                msg: value.to_string(),
+            },
         }
     }
 }

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -247,7 +247,7 @@ pub enum RoverClientError {
     NonCloudGraphRef { graph_ref: GraphRef },
 
     #[error("Could not instantiate the service.")]
-    ServiceError(Box<dyn std::error::Error + Send + Sync + 'static>),
+    ServiceError(Box<dyn std::error::Error + Send + Sync>),
 }
 
 fn contract_publish_errors_msg(msgs: &[String], no_launch: &bool) -> String {

--- a/crates/rover-client/src/operations/config/who_am_i/mod.rs
+++ b/crates/rover-client/src/operations/config/who_am_i/mod.rs
@@ -1,5 +1,7 @@
 mod runner;
+mod service;
 mod types;
 
 pub use runner::run;
+pub use service::{WhoAmI, WhoAmIError, WhoAmIRequest};
 pub use types::{Actor, ConfigWhoAmIInput, RegistryIdentity};

--- a/crates/rover-client/src/operations/config/who_am_i/runner.rs
+++ b/crates/rover-client/src/operations/config/who_am_i/runner.rs
@@ -1,123 +1,22 @@
 use crate::blocking::StudioClient;
-use crate::operations::config::who_am_i::{
-    types::{QueryActorType, QueryResponseData, RegistryIdentity},
-    Actor, ConfigWhoAmIInput,
-};
+use crate::operations::config::who_am_i::types::RegistryIdentity;
 use crate::RoverClientError;
 
-use houston::CredentialOrigin;
+use tower::{Service, ServiceExt};
 
-use graphql_client::*;
-
-#[derive(GraphQLQuery)]
-// The paths are relative to the directory where your `Cargo.toml` is located.
-// Both json and the GraphQL schema language are supported as sources for the schema
-#[graphql(
-    query_path = "src/operations/config/who_am_i/who_am_i_query.graphql",
-    schema_path = ".schema/schema.graphql",
-    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
-    deprecated = "warn"
-)]
-/// This struct is used to generate the module containing `Variables` and
-/// `ResponseData` structs.
-/// Snake case of this name is the mod name. i.e. config_who_am_i_query
-pub(crate) struct ConfigWhoAmIQuery;
+use super::service::{WhoAmI, WhoAmIRequest};
 
 /// Get info from the registry about an API key, i.e. the name/id of the
 /// user/graph and what kind of key it is (GRAPH/USER/Other)
-pub async fn run(
-    input: ConfigWhoAmIInput,
-    client: &StudioClient,
-) -> Result<RegistryIdentity, RoverClientError> {
-    let response_data = client.post::<ConfigWhoAmIQuery>(input.into()).await?;
-    get_identity_from_response_data(response_data, client.get_credential_origin())
-}
-
-fn get_identity_from_response_data(
-    response_data: QueryResponseData,
-    credential_origin: CredentialOrigin,
-) -> Result<RegistryIdentity, RoverClientError> {
-    if let Some(me) = response_data.me {
-        // I believe for the purposes of the CLI, we only care about users and
-        // graphs as api key actors, since that's all we _should_ get.
-        // I think it's safe to only include those two kinds of actors in the enum
-        // more here: https://studio-staging.apollographql.com/graph/engine/schema/reference/enums/ActorType?variant=prod
-
-        let key_actor_type = match me.as_actor.type_ {
-            QueryActorType::GRAPH => Actor::GRAPH,
-            QueryActorType::USER => Actor::USER,
-            _ => Actor::OTHER,
-        };
-
-        let graph_title = match me.on {
-            config_who_am_i_query::ConfigWhoAmIQueryMeOn::Graph(s) => Some(s.title),
-            _ => None,
-        };
-
-        Ok(RegistryIdentity {
-            id: me.id,
-            graph_title,
-            key_actor_type,
-            credential_origin,
-        })
-    } else {
-        Err(RoverClientError::InvalidKey)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-    #[test]
-    fn get_identity_from_response_data_works_for_users() {
-        let json_response = json!({
-            "me": {
-              "__typename": "User",
-              "title": "SearchForTunaService",
-              "id": "gh.nobodydefinitelyhasthisusernamelol",
-              "asActor": {
-                "type": "USER"
-              },
-            }
-        });
-        let data: config_who_am_i_query::ResponseData =
-            serde_json::from_value(json_response).unwrap();
-        let output = get_identity_from_response_data(data, CredentialOrigin::EnvVar);
-
-        let expected_identity = RegistryIdentity {
-            id: "gh.nobodydefinitelyhasthisusernamelol".to_string(),
-            graph_title: None,
-            key_actor_type: Actor::USER,
-            credential_origin: CredentialOrigin::EnvVar,
-        };
-        assert!(output.is_ok());
-        assert_eq!(output.unwrap(), expected_identity);
-    }
-
-    #[test]
-    fn get_identity_from_response_data_works_for_services() {
-        let json_response = json!({
-            "me": {
-              "__typename": "Graph",
-              "title": "GraphKeyService",
-              "id": "big-ol-graph-key-lolol",
-              "asActor": {
-                "type": "GRAPH"
-              },
-            }
-        });
-        let data: config_who_am_i_query::ResponseData =
-            serde_json::from_value(json_response).unwrap();
-        let output = get_identity_from_response_data(data, CredentialOrigin::EnvVar);
-
-        let expected_identity = RegistryIdentity {
-            id: "big-ol-graph-key-lolol".to_string(),
-            graph_title: Some("GraphKeyService".to_string()),
-            key_actor_type: Actor::GRAPH,
-            credential_origin: CredentialOrigin::EnvVar,
-        };
-        assert!(output.is_ok());
-        assert_eq!(output.unwrap(), expected_identity);
-    }
+pub async fn run(client: &StudioClient) -> Result<RegistryIdentity, RoverClientError> {
+    let mut service = WhoAmI::new(
+        client
+            .service()
+            .map_err(|err| RoverClientError::ServiceError(Box::new(err)))?,
+    );
+    let service = service.ready().await?;
+    let identity = service
+        .call(WhoAmIRequest::new(client.get_credential_origin()))
+        .await?;
+    Ok(identity)
 }

--- a/crates/rover-client/src/operations/config/who_am_i/service.rs
+++ b/crates/rover-client/src/operations/config/who_am_i/service.rs
@@ -1,0 +1,243 @@
+use std::{fmt, future::Future, pin::Pin};
+
+use graphql_client::GraphQLQuery;
+use houston::CredentialOrigin;
+use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+use tower::Service;
+
+use crate::RoverClientError;
+
+use super::{types::QueryVariables, Actor, ConfigWhoAmIInput, RegistryIdentity};
+
+#[derive(GraphQLQuery)]
+// The paths are relative to the directory where your `Cargo.toml` is located.
+// Both json and the GraphQL schema language are supported as sources for the schema
+#[graphql(
+    query_path = "src/operations/config/who_am_i/who_am_i_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+/// This struct is used to generate the module containing `Variables` and
+/// `ResponseData` structs.
+/// Snake case of this name is the mod name. i.e. config_who_am_i_query
+pub struct ConfigWhoAmIQuery;
+
+impl fmt::Debug for config_who_am_i_query::Variables {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("Variables").finish()
+    }
+}
+
+impl PartialEq for config_who_am_i_query::Variables {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum WhoAmIError {
+    #[error("Invalid key")]
+    InvalidKey,
+    #[error(transparent)]
+    GraphQL(#[from] GraphQLServiceError<<ConfigWhoAmIQuery as GraphQLQuery>::ResponseData>),
+}
+
+impl From<WhoAmIError> for RoverClientError {
+    fn from(value: WhoAmIError) -> Self {
+        match value {
+            WhoAmIError::InvalidKey => RoverClientError::InvalidKey,
+            WhoAmIError::GraphQL(err) => err.into(),
+        }
+    }
+}
+
+pub struct WhoAmIRequest {
+    input: ConfigWhoAmIInput,
+    credential_origin: CredentialOrigin,
+}
+
+impl WhoAmIRequest {
+    pub fn new(credential_origin: CredentialOrigin) -> WhoAmIRequest {
+        WhoAmIRequest {
+            input: ConfigWhoAmIInput {},
+            credential_origin,
+        }
+    }
+}
+
+pub struct WhoAmI<S> {
+    inner: S,
+}
+
+impl<S> WhoAmI<S> {
+    pub fn new(inner: S) -> WhoAmI<S> {
+        WhoAmI { inner }
+    }
+}
+
+impl<S, Fut> Service<WhoAmIRequest> for WhoAmI<S>
+where
+    S: Service<
+            GraphQLRequest<ConfigWhoAmIQuery>,
+            Response = config_who_am_i_query::ResponseData,
+            Error = GraphQLServiceError<config_who_am_i_query::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = RegistryIdentity;
+    type Error = WhoAmIError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        tower::Service::<GraphQLRequest<ConfigWhoAmIQuery>>::poll_ready(&mut self.inner, cx)
+            .map_err(WhoAmIError::from)
+    }
+
+    fn call(&mut self, req: WhoAmIRequest) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let fut = async move {
+            inner
+                .call(GraphQLRequest::<ConfigWhoAmIQuery>::new(
+                    QueryVariables::from(req.input),
+                ))
+                .await
+                .map_err(WhoAmIError::from)
+                .and_then(|response_data: config_who_am_i_query::ResponseData| {
+                    if let Some(me) = response_data.me {
+                        // I believe for the purposes of the CLI, we only care about users and
+                        // graphs as api key actors, since that's all we _should_ get.
+                        // I think it's safe to only include those two kinds of actors in the enum
+                        // more here: https://studio-staging.apollographql.com/graph/engine/schema/reference/enums/ActorType?variant=prod
+
+                        let key_actor_type = match me.as_actor.type_ {
+                            config_who_am_i_query::ActorType::GRAPH => Actor::GRAPH,
+                            config_who_am_i_query::ActorType::USER => Actor::USER,
+                            _ => Actor::OTHER,
+                        };
+
+                        let graph_title = match me.on {
+                            config_who_am_i_query::ConfigWhoAmIQueryMeOn::Graph(s) => Some(s.title),
+                            _ => None,
+                        };
+
+                        Ok(RegistryIdentity {
+                            id: me.id,
+                            graph_title,
+                            key_actor_type,
+                            credential_origin: req.credential_origin,
+                        })
+                    } else {
+                        Err(WhoAmIError::InvalidKey)
+                    }
+                })
+        };
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use speculoos::prelude::*;
+    use tower::{ServiceBuilder, ServiceExt};
+    use tower_test::{assert_request_eq, mock};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_identity_from_response_data_works_for_users() {
+        let (service, mut handle) =
+            mock::spawn::<GraphQLRequest<ConfigWhoAmIQuery>, config_who_am_i_query::ResponseData>();
+
+        let inner = ServiceBuilder::new()
+            .map_err(GraphQLServiceError::UpstreamService)
+            .service(service.into_inner());
+        let mut who_am_i = WhoAmI::new(inner);
+        let who_am_i = who_am_i.ready().await.unwrap();
+
+        let response = who_am_i.call(WhoAmIRequest::new(CredentialOrigin::EnvVar));
+
+        let json_response = json!({
+            "me": {
+              "__typename": "User",
+              "title": "SearchForTunaService",
+              "id": "gh.nobodydefinitelyhasthisusernamelol",
+              "asActor": {
+                "type": "USER"
+              },
+            }
+        });
+
+        let response_data: config_who_am_i_query::ResponseData =
+            serde_json::from_value(json_response).unwrap();
+
+        assert_request_eq!(
+            handle,
+            GraphQLRequest::new(config_who_am_i_query::Variables {})
+        )
+        .send_response(response_data);
+
+        let output = response.await;
+
+        let expected_identity = RegistryIdentity {
+            id: "gh.nobodydefinitelyhasthisusernamelol".to_string(),
+            graph_title: None,
+            key_actor_type: Actor::USER,
+            credential_origin: CredentialOrigin::EnvVar,
+        };
+        assert_that!(output).is_ok().is_equal_to(expected_identity);
+    }
+
+    #[tokio::test]
+    async fn get_identity_from_response_data_works_for_services() {
+        let (service, mut handle) =
+            mock::spawn::<GraphQLRequest<ConfigWhoAmIQuery>, config_who_am_i_query::ResponseData>();
+
+        let inner = ServiceBuilder::new()
+            .map_err(GraphQLServiceError::UpstreamService)
+            .service(service.into_inner());
+        let mut who_am_i = WhoAmI::new(inner);
+        let who_am_i = who_am_i.ready().await.unwrap();
+
+        let response = who_am_i.call(WhoAmIRequest::new(CredentialOrigin::EnvVar));
+
+        let json_response = json!({
+            "me": {
+              "__typename": "Graph",
+              "title": "GraphKeyService",
+              "id": "big-ol-graph-key-lolol",
+              "asActor": {
+                "type": "GRAPH"
+              },
+            }
+        });
+
+        let response_data: config_who_am_i_query::ResponseData =
+            serde_json::from_value(json_response).unwrap();
+
+        assert_request_eq!(
+            handle,
+            GraphQLRequest::new(config_who_am_i_query::Variables {})
+        )
+        .send_response(response_data);
+
+        let output = response.await;
+
+        let expected_identity = RegistryIdentity {
+            id: "big-ol-graph-key-lolol".to_string(),
+            graph_title: Some("GraphKeyService".to_string()),
+            key_actor_type: Actor::GRAPH,
+            credential_origin: CredentialOrigin::EnvVar,
+        };
+        assert!(output.is_ok());
+        assert_eq!(output.unwrap(), expected_identity);
+    }
+}

--- a/crates/rover-client/src/operations/config/who_am_i/types.rs
+++ b/crates/rover-client/src/operations/config/who_am_i/types.rs
@@ -1,12 +1,10 @@
 use std::fmt::{Display, Formatter, Result};
 
-use super::runner::config_who_am_i_query;
+use super::service::config_who_am_i_query;
 
 use houston::CredentialOrigin;
 
-pub(crate) type QueryResponseData = config_who_am_i_query::ResponseData;
 pub(crate) type QueryVariables = config_who_am_i_query::Variables;
-pub(crate) type QueryActorType = config_who_am_i_query::ActorType;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct RegistryIdentity {

--- a/crates/rover-studio/Cargo.toml
+++ b/crates/rover-studio/Cargo.toml
@@ -17,6 +17,7 @@ rover-http = { workspace = true }
 tower = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/src/command/config/whoami.rs
+++ b/src/command/config/whoami.rs
@@ -1,9 +1,7 @@
 use anyhow::anyhow;
 use clap::Parser;
 use rover_client::blocking::StudioClient;
-use rover_client::operations::config::who_am_i::{
-    self, Actor, ConfigWhoAmIInput, RegistryIdentity,
-};
+use rover_client::operations::config::who_am_i::{self, Actor, RegistryIdentity};
 use serde::Serialize;
 
 use houston::{mask_key, CredentialOrigin};
@@ -34,7 +32,7 @@ impl WhoAmI {
         let client = client_config.get_authenticated_client(&self.profile)?;
         eprintln!("Checking identity of your API key against the registry.");
 
-        let identity = who_am_i::run(ConfigWhoAmIInput {}, &client).await?;
+        let identity = who_am_i::run(&client).await?;
 
         if !self.is_valid_actor_type(&identity) {
             return Err(RoverError::from(anyhow!(

--- a/src/command/dev/legacy/router/command.rs
+++ b/src/command/dev/legacy/router/command.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use crossbeam_channel::Sender;
-use rover_client::operations::config::who_am_i::{self, Actor, ConfigWhoAmIInput};
+use rover_client::operations::config::who_am_i::{self, Actor};
 use rover_std::warnln;
 
 use crate::options::ProfileOpt;
@@ -60,7 +60,7 @@ impl BackgroundTask {
                     );
                 })
             {
-                if let Some(api_key) =   who_am_i::run(ConfigWhoAmIInput {}, &client).await.map_or_else(|err| {
+                if let Some(api_key) =   who_am_i::run(&client).await.map_or_else(|err| {
                     warnln!("Could not determine the type of configured credentials, Router may fail to start if Enterprise features are enabled: {err}");
                     Some(client.credential.api_key.clone())
                 }, |identity| {

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -317,6 +317,7 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                 }
                 RoverClientError::InvalidRouterConfig { .. } => (None, None),
                 RoverClientError::NonCloudGraphRef { .. } => (None, None),
+                RoverClientError::ServiceError(_) => (None, None),
             };
             return RoverErrorMetadata {
                 json_version: JsonVersion::default(),

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::env;
 use std::io::BufRead;
 use std::io::BufReader;
-use std::path::Path;
 use std::path::PathBuf;
 use std::process::ChildStderr;
 use std::time::Duration;


### PR DESCRIPTION
Adds WhoAmI as a tower operation so that it can be used generically as a trait.
```
async fn do_a_who_am_i_thing<S: Service<WhoAmIRequest>>(mut s: S)
```
It is also decoupled from the bundle of operations that is `StudioClient` so that it can be mocked in a more targeted way during tests (see the tests involved, as they do not rely on mocking the full HTTP lifecycle).
