### PR TITLE
Ensure that rover dev can start without a declared router config

### DIFF
--- a/src/command/dev/next/router/binary.rs
+++ b/src/command/dev/next/router/binary.rs
@@ -25,6 +25,10 @@ pub enum RouterLog {
 
 #[derive(thiserror::Error, Debug)]
 pub enum RunRouterBinaryError {
+    #[error("Service failed to come into a ready state: {:?}", .err)]
+    ServiceReadyError {
+        err: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[error("Failed to run router command: {:?}", err)]
     Spawn {
         err: Box<dyn std::error::Error + Send + Sync>,
@@ -33,8 +37,13 @@ pub enum RunRouterBinaryError {
     OutputCapture { descriptor: String },
     #[error("Failed healthcheck for router")]
     HealthCheckFailed,
-    #[error("Something went wrong with an internal dependency, {}: {}", .dependency, .error)]
-    Internal { dependency: String, error: String },
+    #[error("Something went wrong with an internal dependency, {}: {}", .dependency, .err)]
+    Internal { dependency: String, err: String },
+    #[error("Failed to write file to path: {}. {}", .path, .err)]
+    WriteFileError {
+        path: Utf8PathBuf,
+        err: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/command/dev/next/router/config/mod.rs
+++ b/src/command/dev/next/router/config/mod.rs
@@ -114,53 +114,48 @@ impl RunRouterConfig<RunRouterConfigReadConfig> {
     pub async fn with_config<ReadF: ReadFile<Error = RoverStdError>>(
         self,
         read_file_impl: &ReadF,
-        path: &Utf8PathBuf,
+        path: Option<&Utf8PathBuf>,
     ) -> Result<RunRouterConfig<RunRouterConfigFinal>, ReadRouterConfigError> {
-        Fs::assert_path_exists(&path).map_err(ReadRouterConfigError::Fs)?;
+        match path {
+            Some(path) => {
+                Fs::assert_path_exists(&path).map_err(ReadRouterConfigError::Fs)?;
 
-        let state = match read_file_impl.read_file(&path).await {
-            Ok(contents) => {
-                let yaml = serde_yaml::from_str(&contents).map_err(|err| {
-                    ReadRouterConfigError::Deserialization {
-                        path: path.clone(),
-                        source: err,
+                match read_file_impl.read_file(&path).await {
+                    Ok(contents) => {
+                        let yaml = serde_yaml::from_str(&contents).map_err(|err| {
+                            ReadRouterConfigError::Deserialization {
+                                path: path.clone(),
+                                source: err,
+                            }
+                        })?;
+
+                        let router_config = RouterConfigParser::new(&yaml);
+                        let address = router_config.address()?;
+                        let address = address
+                            .map(RouterAddress::from)
+                            .unwrap_or(self.state.router_address);
+                        let health_check_enabled = router_config.health_check_enabled();
+                        let health_check_endpoint = router_config.health_check_endpoint()?;
+                        let listen_path = router_config.listen_path()?;
+
+                        Ok(RunRouterConfigFinal {
+                            listen_path,
+                            address,
+                            health_check_enabled,
+                            health_check_endpoint,
+                            raw_config: contents.to_string(),
+                        })
                     }
-                })?;
-
-                let router_config = RouterConfigParser::new(&yaml);
-                let address = router_config.address()?;
-                let address = address
-                    .map(RouterAddress::from)
-                    .unwrap_or(self.state.router_address);
-                let health_check_enabled = router_config.health_check_enabled();
-                let health_check_endpoint = router_config.health_check_endpoint()?;
-                let listen_path = router_config.listen_path()?;
-
-                RunRouterConfigFinal {
-                    listen_path,
-                    address,
-                    health_check_enabled,
-                    health_check_endpoint,
-                    raw_config: contents.to_string(),
+                    Err(RoverStdError::EmptyFile { .. }) => Ok(RunRouterConfigFinal::default()),
+                    Err(err) => Err(ReadRouterConfigError::ReadFile {
+                        path: path.clone(),
+                        source: Box::new(err),
+                    }),
                 }
             }
-            Err(RoverStdError::EmptyFile { .. }) => {
-                // TODO: assumption to check; I'm not writing to the temp file because we don't
-                // need to yet, we only need to return the in-memory RunRouterConfigFinal and
-                // somewhere down the line of actually running the router will we write to file
-                // (that we're watching, which will emit a new router config event)
-                let default_config = RunRouterConfigFinal::default();
-                default_config
-            }
-            Err(err) => {
-                return Err(ReadRouterConfigError::ReadFile {
-                    path: path.clone(),
-                    source: Box::new(err),
-                });
-            }
-        };
-
-        Ok(RunRouterConfig { state })
+            None => Ok(RunRouterConfigFinal::default()),
+        }
+        .map(|state| RunRouterConfig { state })
     }
 }
 

--- a/src/utils/effect/write_file.rs
+++ b/src/utils/effect/write_file.rs
@@ -1,6 +1,11 @@
+use std::pin::Pin;
+
 use async_trait::async_trait;
+use buildstructor::Builder;
 use camino::Utf8PathBuf;
+use futures::Future;
 use rover_std::{Fs, RoverStdError};
+use tower::Service;
 
 #[cfg_attr(test, derive(thiserror::Error, Debug))]
 #[cfg(test)]
@@ -22,5 +27,29 @@ impl WriteFile for FsWriteFile {
     type Error = RoverStdError;
     async fn write_file(&self, path: &Utf8PathBuf, contents: &[u8]) -> Result<(), Self::Error> {
         Fs::write_file(path, contents)
+    }
+}
+
+#[derive(Builder)]
+pub struct WriteFileRequest {
+    path: Utf8PathBuf,
+    contents: Option<Vec<u8>>,
+}
+
+impl Service<WriteFileRequest> for FsWriteFile {
+    type Response = ();
+    type Error = RoverStdError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: WriteFileRequest) -> Self::Future {
+        let fut = async { Fs::write_file(req.path, req.contents.unwrap_or_default()) };
+        Box::pin(fut)
     }
 }


### PR DESCRIPTION
`rover dev` should be able to start without a declared router config