### PR TITLE
dev/next: log router output

### DIFF
--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -122,11 +122,8 @@ impl Dev {
 
         while let Some(router_log) = run_router.router_logs().next().await {
             match router_log {
-                Ok(RouterLog::Stdout(router_log)) => {
-                    tracing::info!("{}", router_log);
-                }
-                Ok(RouterLog::Stderr(router_log)) => {
-                    tracing::error!("{:?}", router_log);
+                Ok(router_log) => {
+                    eprintln!("{}", router_log);
                 }
                 Err(err) => {
                     tracing::error!("{:?}", err);

--- a/src/command/dev/next/router/binary.rs
+++ b/src/command/dev/next/router/binary.rs
@@ -50,7 +50,7 @@ impl fmt::Display for RouterLog {
                         "WARN" => write!(f, "{} {}", warn_prefix, &message)?,
                         "ERROR" => write!(f, "{} {}", error_prefix, &message)?,
                         "UNKNOWN" => write!(f, "{} {}", unknown_prefix, &message)?,
-                        _ => write!(f, "{} {}", unknown_prefix, &message)?
+                        _ => write!(f, "{} {}", unknown_prefix, &message)?,
                     };
                     Ok(())
                 } else {

--- a/src/command/dev/next/router/binary.rs
+++ b/src/command/dev/next/router/binary.rs
@@ -50,7 +50,7 @@ impl fmt::Display for RouterLog {
                         "WARN" => write!(f, "{} {}", warn_prefix, &message)?,
                         "ERROR" => write!(f, "{} {}", error_prefix, &message)?,
                         "UNKNOWN" => write!(f, "{} {}", unknown_prefix, &message)?,
-                        _ => {}
+                        _ => write!(f, "{} {}", unknown_prefix, &message)?
                     };
                     Ok(())
                 } else {

--- a/src/command/dev/next/router/binary.rs
+++ b/src/command/dev/next/router/binary.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, process::Stdio};
+use std::{collections::HashMap, fmt, process::Stdio};
 
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use futures::TryFutureExt;
+use rover_std::Style;
 use semver::Version;
 use tap::TapFallible;
 use tokio::{
@@ -21,6 +22,46 @@ use super::config::remote::RemoteRouterConfig;
 pub enum RouterLog {
     Stdout(String),
     Stderr(String),
+}
+
+impl fmt::Display for RouterLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let warn_prefix = Style::WarningPrefix.paint("WARN:");
+        let error_prefix = Style::ErrorPrefix.paint("ERROR:");
+        let unknown_prefix = Style::ErrorPrefix.paint("UNKNOWN:");
+        match self {
+            Self::Stdout(stdout) => {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(stdout) {
+                    let fields = &parsed["fields"];
+                    let level = parsed["level"].as_str().unwrap_or("UNKNOWN");
+                    let message = fields["message"]
+                        .as_str()
+                        .or_else(|| {
+                            // Message is in a slightly different location depending on the
+                            // version of Router
+                            parsed["message"].as_str()
+                        })
+                        .unwrap_or(stdout);
+
+                    match level {
+                        "INFO" => tracing::info!(%message),
+                        "DEBUG" => tracing::debug!(%message),
+                        "TRACE" => tracing::trace!(%message),
+                        "WARN" => write!(f, "{} {}", warn_prefix, &message)?,
+                        "ERROR" => write!(f, "{} {}", error_prefix, &message)?,
+                        "UNKNOWN" => write!(f, "{} {}", unknown_prefix, &message)?,
+                        _ => {}
+                    };
+                    Ok(())
+                } else {
+                    write!(f, "{} {}", warn_prefix, &stdout)
+                }
+            }
+            Self::Stderr(stderr) => {
+                write!(f, "{} {}", error_prefix, &stderr)
+            }
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -193,53 +193,6 @@ impl RunRouter<state::Run> {
             _,
         ) = Subtask::new(run_router_binary);
 
-        // Start a background process that listens for router log events and displays them to the
-        // user.
-        let warn_prefix = Style::WarningPrefix.paint("WARN:");
-        let error_prefix = Style::ErrorPrefix.paint("ERROR:");
-        let unknown_prefix = Style::ErrorPrefix.paint("UNKNOWN:");
-        tokio::task::spawn(async move {
-            while let Some(event) = router_log_events.next().await {
-                if let Ok(log) = event {
-                    match log {
-                        RouterLog::Stdout(stdout) => {
-                            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stdout) {
-                                let fields = &parsed["fields"];
-                                let level = parsed["level"].as_str().unwrap_or("UNKNOWN");
-                                let message = fields["message"]
-                                    .as_str()
-                                    .or_else(|| {
-                                        // Message is in a slightly different location depending on the
-                                        // version of Router
-                                        parsed["message"].as_str()
-                                    })
-                                    .unwrap_or(&stdout);
-
-                                match level {
-                                    "INFO" => tracing::info!(%message),
-                                    "DEBUG" => tracing::debug!(%message),
-                                    "TRACE" => tracing::trace!(%message),
-                                    "WARN" => eprintln!("{} {}", warn_prefix, &message),
-                                    "ERROR" => {
-                                        eprintln!("{} {}", error_prefix, &message)
-                                    }
-                                    "UNKNOWN" => {
-                                        eprintln!("{} {}", unknown_prefix, &message)
-                                    }
-                                    _ => {}
-                                }
-                            } else {
-                                eprintln!("{} {}", warn_prefix, &stdout)
-                            }
-                        }
-                        RouterLog::Stderr(stderr) => {
-                            eprintln!("{} {}", error_prefix, &stderr)
-                        }
-                    };
-                }
-            }
-        });
-
         let abort_router = SubtaskRunUnit::run(run_router_binary_subtask);
 
         self.wait_for_healthy_router(&studio_client_config).await?;

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -195,47 +195,10 @@ impl RunRouter<state::Run> {
 
         // Start a background process that listens for router log events and displays them to the
         // user.
-        let warn_prefix = Style::WarningPrefix.paint("WARN:");
-        let error_prefix = Style::ErrorPrefix.paint("ERROR:");
-        let unknown_prefix = Style::ErrorPrefix.paint("UNKNOWN:");
         tokio::task::spawn(async move {
             while let Some(event) = router_log_events.next().await {
                 if let Ok(log) = event {
-                    match log {
-                        RouterLog::Stdout(stdout) => {
-                            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stdout) {
-                                let fields = &parsed["fields"];
-                                let level = parsed["level"].as_str().unwrap_or("UNKNOWN");
-                                let message = fields["message"]
-                                    .as_str()
-                                    .or_else(|| {
-                                        // Message is in a slightly different location depending on the
-                                        // version of Router
-                                        parsed["message"].as_str()
-                                    })
-                                    .unwrap_or(&stdout);
-
-                                match level {
-                                    "INFO" => tracing::info!(%message),
-                                    "DEBUG" => tracing::debug!(%message),
-                                    "TRACE" => tracing::trace!(%message),
-                                    "WARN" => eprintln!("{} {}", warn_prefix, &message),
-                                    "ERROR" => {
-                                        eprintln!("{} {}", error_prefix, &message)
-                                    }
-                                    "UNKNOWN" => {
-                                        eprintln!("{} {}", unknown_prefix, &message)
-                                    }
-                                    _ => {}
-                                }
-                            } else {
-                                eprintln!("{} {}", warn_prefix, &stdout)
-                            }
-                        }
-                        RouterLog::Stderr(stderr) => {
-                            eprintln!("{} {}", error_prefix, &stderr)
-                        }
-                    };
+                    println!("{}", log);
                 }
             }
         });

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -8,7 +8,7 @@ use rover_client::{
     operations::config::who_am_i::{RegistryIdentity, WhoAmIError, WhoAmIRequest},
     shared::GraphRef,
 };
-use rover_std::{RoverStdError, Style};
+use rover_std::RoverStdError;
 use tokio::{process::Child, time::sleep};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tower::{Service, ServiceExt};

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -193,16 +193,6 @@ impl RunRouter<state::Run> {
             _,
         ) = Subtask::new(run_router_binary);
 
-        // Start a background process that listens for router log events and displays them to the
-        // user.
-        tokio::task::spawn(async move {
-            while let Some(event) = router_log_events.next().await {
-                if let Ok(log) = event {
-                    eprintln!("{}", log);
-                }
-            }
-        });
-
         let abort_router = SubtaskRunUnit::run(run_router_binary_subtask);
 
         self.wait_for_healthy_router(&studio_client_config).await?;

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -198,7 +198,7 @@ impl RunRouter<state::Run> {
         tokio::task::spawn(async move {
             while let Some(event) = router_log_events.next().await {
                 if let Ok(log) = event {
-                    println!("{}", log);
+                    eprintln!("{}", log);
                 }
             }
         });


### PR DESCRIPTION
Similar to the [legacy implementation](https://github.com/apollographql/rover/blob/main/src/command/dev/legacy/router/runner.rs#L192-L233), this PR logs output from the running `router` binary.