### PR TITLE
Fix rover dev startup

### DIFF
--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -67,7 +67,6 @@ impl Dev {
         let federation_version = self.opts.supergraph_opts.federation_version.clone();
         let profile = self.opts.plugin_opts.profile.clone();
         let graph_ref = self.opts.supergraph_opts.graph_ref.clone();
-        let composition_output = tmp_config_dir_path.join("supergraph.graphql");
 
         let one_shot_composition = OneShotComposition::builder()
             .client_config(client_config.clone())


### PR DESCRIPTION
Fixes rover dev startup from exiting too soon by listening to router logs in a loop (unless the router panics).

This also consolidates some composition output, where we skip outputting to a file for one-shot composition, as one-shots produce `CompositionOutput`, which we need to refine into an SDL file as a second step.