### PR TITLE
Watch subgraphs when rover dev runs

### DIFF
--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -1,28 +1,24 @@
 #![warn(missing_docs)]
 
+use std::io::stdin;
+
 use anyhow::anyhow;
 use apollo_federation_types::config::RouterVersion;
 use camino::Utf8PathBuf;
 use futures::StreamExt;
 use houston::{Config, Profile};
-use router::{
-    install::InstallRouter,
-    run::RunRouter,
-    watchers::{file::FileWatcher, router_config::RouterConfigWatcher},
-};
+use router::{install::InstallRouter, run::RunRouter, watchers::file::FileWatcher};
 use rover_client::operations::config::who_am_i::WhoAmI;
-use tower::{Service, ServiceExt};
 
 use crate::{
     command::Dev,
-    composition::runner::OneShotComposition,
-    subtask::{Subtask, SubtaskRunUnit},
+    composition::pipeline::CompositionPipeline,
     utils::{
         client::StudioClientConfig,
         effect::{
             exec::{TokioCommand, TokioSpawn},
             read_file::FsReadFile,
-            write_file::{FsWriteFile, WriteFileRequest},
+            write_file::FsWriteFile,
         },
     },
     RoverError, RoverOutput, RoverResult,
@@ -45,7 +41,7 @@ impl Dev {
         let elv2_license_accepter = self.opts.plugin_opts.elv2_license_accepter;
         let skip_update = self.opts.plugin_opts.skip_update;
         let read_file_impl = FsReadFile::default();
-        let mut write_file_impl = FsWriteFile::default();
+        let write_file_impl = FsWriteFile::default();
         let exec_command_impl = TokioCommand::default();
         let router_address = RouterAddress::new(
             self.opts.supergraph_opts.supergraph_address,
@@ -63,26 +59,38 @@ impl Dev {
             .await
             .map_err(|err| RoverError::new(anyhow!("{}", err)))?;
 
-        let supergraph_yaml = self.opts.supergraph_opts.clone().supergraph_config_path;
-        let federation_version = self.opts.supergraph_opts.federation_version.clone();
-        let profile = self.opts.plugin_opts.profile.clone();
-        let graph_ref = self.opts.supergraph_opts.graph_ref.clone();
+        let profile = &self.opts.plugin_opts.profile;
+        let graph_ref = &self.opts.supergraph_opts.graph_ref;
+        let supergraph_config_path = &self.opts.supergraph_opts.clone().supergraph_config_path;
 
-        let one_shot_composition = OneShotComposition::builder()
-            .client_config(client_config.clone())
-            .profile(profile.clone())
-            .elv2_license_accepter(elv2_license_accepter)
-            .skip_update(skip_update)
-            .and_federation_version(federation_version)
-            .and_graph_ref(graph_ref.clone())
-            .and_supergraph_yaml(supergraph_yaml)
-            .and_override_install_path(override_install_path.clone())
-            .build();
+        let service = client_config.get_authenticated_client(profile)?.service()?;
+        let service = WhoAmI::new(service);
 
-        let supergraph_schema = one_shot_composition
-            .compose(&read_file_impl, &write_file_impl, &exec_command_impl)
+        let composition_pipeline = CompositionPipeline::default()
+            .init(
+                &mut stdin(),
+                &client_config.get_authenticated_client(profile)?,
+                supergraph_config_path.clone(),
+                graph_ref.clone(),
+            )
             .await?
-            .supergraph_sdl;
+            .resolve_federation_version(
+                &client_config,
+                &client_config.get_authenticated_client(profile)?,
+                self.opts.supergraph_opts.federation_version.clone(),
+            )
+            .await?
+            .install_supergraph_binary(
+                client_config.clone(),
+                override_install_path.clone(),
+                elv2_license_accepter,
+                skip_update,
+            )
+            .await?;
+        let composition_success = composition_pipeline
+            .compose(&exec_command_impl, &read_file_impl, &write_file_impl, None)
+            .await?;
+        let supergraph_schema = composition_success.supergraph_sdl();
 
         // TODO: figure out how to actually get this; maybe based on fed version? didn't see a cli
         // opt
@@ -91,10 +99,19 @@ impl Dev {
         let credential =
             Profile::get_credential(&profile.profile_name, &Config::new(None::<&String>, None)?)?;
 
-        let service = client_config
-            .get_authenticated_client(&profile)?
-            .service()?;
-        let service = WhoAmI::new(service);
+        let composition_runner = composition_pipeline
+            .runner(
+                exec_command_impl,
+                read_file_impl.clone(),
+                write_file_impl.clone(),
+                profile,
+                &client_config,
+                self.opts.subgraph_opts.subgraph_polling_interval,
+                tmp_config_dir_path.clone(),
+            )
+            .await?;
+
+        let composition_messages = composition_runner.run();
 
         let mut run_router = RunRouter::default()
             .install::<InstallRouter>(
@@ -107,17 +124,17 @@ impl Dev {
             .await?
             .load_config(&read_file_impl, router_address, router_config_path)
             .await?
-            .load_remote_config(service, graph_ref, Some(credential))
+            .load_remote_config(service, graph_ref.clone(), Some(credential))
             .await
             .run(
                 FsWriteFile::default(),
                 TokioSpawn::default(),
                 &tmp_config_dir_path,
-                client_config,
+                client_config.clone(),
                 supergraph_schema,
             )
             .await?
-            .watch_for_changes(write_file_impl)
+            .watch_for_changes(write_file_impl, composition_messages)
             .await;
 
         while let Some(router_log) = run_router.router_logs().next().await {

--- a/src/command/dev/next/router/hot_reload.rs
+++ b/src/command/dev/next/router/hot_reload.rs
@@ -7,10 +7,8 @@ use crate::{subtask::SubtaskHandleStream, utils::effect::write_file::WriteFile};
 
 use super::config::RouterConfig;
 
-pub struct SupergraphSchema(String);
-
 pub enum RouterUpdateEvent {
-    SchemaChanged { schema: SupergraphSchema },
+    SchemaChanged { schema: String },
     ConfigChanged { config: RouterConfig },
 }
 
@@ -44,7 +42,7 @@ where
                 match router_update_event {
                     RouterUpdateEvent::SchemaChanged { schema } => {
                         match write_file_impl
-                            .write_file(&self.schema, schema.0.as_bytes())
+                            .write_file(&self.schema, schema.as_bytes())
                             .await
                         {
                             Ok(_) => {

--- a/src/composition/events/mod.rs
+++ b/src/composition/events/mod.rs
@@ -1,7 +1,7 @@
 use super::{CompositionError, CompositionSuccess};
 
 /// Events emitted from composition
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum CompositionEvent {
     /// The composition has started and may not have finished yet. This is useful for letting users
     /// know composition is running

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -1,0 +1,273 @@
+use std::{env::current_dir, fmt::Debug, fs::canonicalize};
+
+use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
+use camino::Utf8PathBuf;
+use rover_client::shared::GraphRef;
+use tempfile::tempdir;
+
+use crate::{
+    options::{LicenseAccepter, ProfileOpt},
+    utils::{
+        client::StudioClientConfig,
+        effect::{
+            exec::ExecCommand, fetch_remote_subgraph::FetchRemoteSubgraph,
+            fetch_remote_subgraphs::FetchRemoteSubgraphs, install::InstallBinary,
+            introspect::IntrospectSubgraph, read_file::ReadFile, read_stdin::ReadStdin,
+            write_file::WriteFile,
+        },
+        parsers::FileDescriptorType,
+    },
+};
+
+use super::{
+    runner::{CompositionRunner, Runner},
+    supergraph::{
+        binary::OutputTarget,
+        config::{
+            full::FullyResolvedSubgraphs,
+            resolver::{
+                LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
+                SupergraphConfigResolver,
+            },
+        },
+        install::{InstallSupergraph, InstallSupergraphError},
+    },
+    CompositionError, CompositionSuccess,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum CompositionPipelineError {
+    #[error("Failed to load remote subgraphs.\n{}", .0)]
+    LoadRemoteSubgraphs(#[from] LoadRemoteSubgraphsError),
+    #[error("Failed to load the supergraph config.\n{}", .0)]
+    LoadSupergraphConfig(#[from] LoadSupergraphConfigError),
+    #[error("Failed to resolve the supergraph config.\n{}", .0)]
+    ResolveSupergraphConfig(#[from] ResolveSupergraphConfigError),
+    #[error("IO error.\n{}", .0)]
+    Io(#[from] std::io::Error),
+    #[error("Serialization error.\n{}", .0)]
+    SerdeYaml(#[from] serde_yaml::Error),
+    #[error("Error writing file: {}.\n{}", .path, .err)]
+    WriteFile {
+        path: Utf8PathBuf,
+        err: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("Failed to install the supergraph binary.\n{}", .0)]
+    InstallSupergraph(#[from] InstallSupergraphError),
+}
+
+pub struct CompositionPipeline<State> {
+    state: State,
+}
+
+impl Default for CompositionPipeline<state::Init> {
+    fn default() -> Self {
+        CompositionPipeline { state: state::Init }
+    }
+}
+
+impl CompositionPipeline<state::Init> {
+    pub async fn init(
+        self,
+        read_stdin_impl: &mut impl ReadStdin,
+        fetch_remote_subgraphs_impl: &impl FetchRemoteSubgraphs,
+        supergraph_yaml: Option<FileDescriptorType>,
+        graph_ref: Option<GraphRef>,
+    ) -> Result<CompositionPipeline<state::ResolveFederationVersion>, CompositionPipelineError>
+    {
+        let supergraph_yaml = supergraph_yaml.and_then(|supergraph_yaml| match supergraph_yaml {
+            FileDescriptorType::File(file) => canonicalize(file)
+                .ok()
+                .map(|file| FileDescriptorType::File(Utf8PathBuf::from_path_buf(file).unwrap())),
+            FileDescriptorType::Stdin => Some(FileDescriptorType::Stdin),
+        });
+        let supergraph_root = supergraph_yaml.clone().and_then(|file| match file {
+            FileDescriptorType::File(file) => {
+                let mut current_dir = current_dir().expect("Unable to get current directory path");
+
+                current_dir.push(file);
+                let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
+                let parent = path.parent().unwrap().to_path_buf();
+                Some(parent)
+            }
+            FileDescriptorType::Stdin => None,
+        });
+        let resolver = SupergraphConfigResolver::default()
+            .load_remote_subgraphs(fetch_remote_subgraphs_impl, graph_ref.as_ref())
+            .await?
+            .load_from_file_descriptor(read_stdin_impl, supergraph_yaml.as_ref())?;
+        Ok(CompositionPipeline {
+            state: state::ResolveFederationVersion {
+                resolver,
+                supergraph_root,
+            },
+        })
+    }
+}
+
+impl CompositionPipeline<state::ResolveFederationVersion> {
+    pub async fn resolve_federation_version(
+        self,
+        introspect_subgraph_impl: &impl IntrospectSubgraph,
+        fetch_remote_subgraph_impl: &impl FetchRemoteSubgraph,
+        federation_version: Option<FederationVersion>,
+    ) -> Result<CompositionPipeline<state::InstallSupergraph>, CompositionPipelineError> {
+        let fully_resolved_supergraph_config = self
+            .state
+            .resolver
+            .fully_resolve_subgraphs(
+                introspect_subgraph_impl,
+                fetch_remote_subgraph_impl,
+                self.state.supergraph_root.as_ref(),
+            )
+            .await?;
+        let federation_version = federation_version.unwrap_or_else(|| {
+            fully_resolved_supergraph_config
+                .federation_version()
+                .clone()
+        });
+        Ok(CompositionPipeline {
+            state: state::InstallSupergraph {
+                resolver: self.state.resolver,
+                supergraph_root: self.state.supergraph_root,
+                fully_resolved_supergraph_config,
+                federation_version,
+            },
+        })
+    }
+}
+
+impl CompositionPipeline<state::InstallSupergraph> {
+    pub async fn install_supergraph_binary(
+        self,
+        studio_client_config: StudioClientConfig,
+        override_install_path: Option<Utf8PathBuf>,
+        elv2_license_accepter: LicenseAccepter,
+        skip_update: bool,
+    ) -> Result<CompositionPipeline<state::Run>, CompositionPipelineError> {
+        let supergraph_binary =
+            InstallSupergraph::new(self.state.federation_version, studio_client_config)
+                .install(override_install_path, elv2_license_accepter, skip_update)
+                .await?;
+
+        Ok(CompositionPipeline {
+            state: state::Run {
+                resolver: self.state.resolver,
+                supergraph_root: self.state.supergraph_root,
+                fully_resolved_supergraph_config: self.state.fully_resolved_supergraph_config,
+                supergraph_binary,
+            },
+        })
+    }
+}
+
+impl CompositionPipeline<state::Run> {
+    pub async fn compose(
+        &self,
+        exec_command_impl: &impl ExecCommand,
+        read_file_impl: &impl ReadFile,
+        write_file_impl: &impl WriteFile,
+        output_file: Option<Utf8PathBuf>,
+    ) -> Result<CompositionSuccess, CompositionError> {
+        let supergraph_config_filepath =
+            Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
+                .expect("Unable to parse path");
+        write_file_impl
+            .write_file(
+                &supergraph_config_filepath,
+                serde_yaml::to_string(&SupergraphConfig::from(
+                    self.state.fully_resolved_supergraph_config.clone(),
+                ))?
+                .as_bytes(),
+            )
+            .await
+            .map_err(|err| CompositionError::WriteFile {
+                path: supergraph_config_filepath.clone(),
+                error: Box::new(err),
+            })?;
+
+        let result = self
+            .state
+            .supergraph_binary
+            .compose(
+                exec_command_impl,
+                read_file_impl,
+                &output_file
+                    .map(OutputTarget::File)
+                    .unwrap_or(OutputTarget::Stdout),
+                supergraph_config_filepath,
+            )
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn runner<ExecC, ReadF, WriteF>(
+        &self,
+        exec_command: ExecC,
+        read_file: ReadF,
+        write_file: WriteF,
+        profile: &ProfileOpt,
+        client_config: &StudioClientConfig,
+        introspection_polling_interval: u64,
+        output_dir: Utf8PathBuf,
+    ) -> Result<CompositionRunner<ExecC, ReadF, WriteF>, CompositionPipelineError>
+    where
+        ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
+        ExecC: ExecCommand + Debug + Eq + PartialEq + Send + Sync + 'static,
+        WriteF: WriteFile + Debug + Eq + PartialEq + Send + Sync + 'static,
+    {
+        let lazily_resolved_supergraph_config = self
+            .state
+            .resolver
+            .lazily_resolve_subgraphs(self.state.supergraph_root.as_ref())
+            .await?;
+        let subgraphs = lazily_resolved_supergraph_config.subgraphs().clone();
+        let runner = Runner::default()
+            .setup_subgraph_watchers(
+                subgraphs,
+                profile,
+                client_config,
+                introspection_polling_interval,
+            )
+            .setup_supergraph_config_watcher(lazily_resolved_supergraph_config)
+            .setup_composition_watcher(
+                self.state.fully_resolved_supergraph_config.clone(),
+                self.state.supergraph_binary.clone(),
+                exec_command,
+                read_file,
+                write_file,
+                output_dir,
+            );
+        Ok(runner)
+    }
+}
+
+mod state {
+    use apollo_federation_types::config::FederationVersion;
+    use camino::Utf8PathBuf;
+
+    use crate::composition::supergraph::{
+        binary::SupergraphBinary,
+        config::{
+            full::FullyResolvedSupergraphConfig, resolver::InitializedSupergraphConfigResolver,
+        },
+    };
+
+    pub struct Init;
+    pub struct ResolveFederationVersion {
+        pub resolver: InitializedSupergraphConfigResolver,
+        pub supergraph_root: Option<Utf8PathBuf>,
+    }
+    pub struct InstallSupergraph {
+        pub resolver: InitializedSupergraphConfigResolver,
+        pub supergraph_root: Option<Utf8PathBuf>,
+        pub fully_resolved_supergraph_config: FullyResolvedSupergraphConfig,
+        pub federation_version: FederationVersion,
+    }
+    pub struct Run {
+        pub resolver: InitializedSupergraphConfigResolver,
+        pub supergraph_root: Option<Utf8PathBuf>,
+        pub fully_resolved_supergraph_config: FullyResolvedSupergraphConfig,
+        pub supergraph_binary: SupergraphBinary,
+    }
+}

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -23,12 +23,9 @@ use super::{
     runner::{CompositionRunner, Runner},
     supergraph::{
         binary::OutputTarget,
-        config::{
-            full::FullyResolvedSubgraphs,
-            resolver::{
-                LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
-                SupergraphConfigResolver,
-            },
+        config::resolver::{
+            LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
+            SupergraphConfigResolver,
         },
         install::{InstallSupergraph, InstallSupergraphError},
     },
@@ -201,6 +198,7 @@ impl CompositionPipeline<state::Run> {
         Ok(result)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn runner<ExecC, ReadF, WriteF>(
         &self,
         exec_command: ExecC,

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -3,35 +3,21 @@
 
 #![warn(missing_docs)]
 
-use std::{collections::BTreeMap, env::current_dir, fmt::Debug, io::stdin};
+use std::{collections::BTreeMap, fmt::Debug};
 
-//use std::{env::current_dir, fs::File, process::Command, str};
-
-use anyhow::anyhow;
-use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
-use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use futures::stream::{BoxStream, StreamExt};
-use rover_client::shared::GraphRef;
-use rover_std::warnln;
-use tempfile::tempdir;
 
 use crate::{
-    command::supergraph::compose::CompositionOutput,
-    composition::{
-        supergraph::install::InstallSupergraph,
-        watchers::watcher::{file::FileWatcher, supergraph_config::SupergraphConfigWatcher},
+    composition::watchers::watcher::{
+        file::FileWatcher, supergraph_config::SupergraphConfigWatcher,
     },
-    options::{LicenseAccepter, ProfileOpt},
+    options::ProfileOpt,
     subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit},
     utils::{
         client::StudioClientConfig,
-        effect::{
-            exec::ExecCommand, install::InstallBinary, read_file::ReadFile, write_file::WriteFile,
-        },
-        parsers::FileDescriptorType,
+        effect::{exec::ExecCommand, read_file::ReadFile, write_file::WriteFile},
     },
-    RoverError, RoverResult,
 };
 
 use self::state::SetupSubgraphWatchers;
@@ -39,11 +25,10 @@ use self::state::SetupSubgraphWatchers;
 use super::{
     events::CompositionEvent,
     supergraph::{
-        binary::{OutputTarget, SupergraphBinary},
+        binary::SupergraphBinary,
         config::{
-            full::FullyResolvedSubgraphs,
+            full::FullyResolvedSupergraphConfig,
             lazy::{LazilyResolvedSubgraph, LazilyResolvedSupergraphConfig},
-            resolver::SupergraphConfigResolver,
         },
     },
     watchers::{composition::CompositionWatcher, subgraphs::SubgraphWatchers},
@@ -64,140 +49,6 @@ mod state;
 // TODO: handle retry flag for subgraphs (see rover dev help)
 pub struct Runner<State> {
     state: State,
-}
-
-/// Everything necessary to run composition once
-#[derive(Builder)]
-pub struct OneShotComposition {
-    override_install_path: Option<Utf8PathBuf>,
-    federation_version: Option<FederationVersion>,
-    client_config: StudioClientConfig,
-    profile: ProfileOpt,
-    supergraph_yaml: Option<FileDescriptorType>,
-    output_file: Option<Utf8PathBuf>,
-    graph_ref: Option<GraphRef>,
-    elv2_license_accepter: LicenseAccepter,
-    skip_update: bool,
-}
-
-impl OneShotComposition {
-    /// Runs composition
-    pub async fn compose<ReadF: ReadFile, WriteF: WriteFile, Exec: ExecCommand>(
-        self,
-        read_file_impl: &ReadF,
-        write_file_impl: &WriteF,
-        exec_command_impl: &Exec,
-    ) -> RoverResult<CompositionOutput> {
-        let mut stdin = stdin();
-
-        let supergraph_root = self.supergraph_yaml.clone().and_then(|file| match file {
-            FileDescriptorType::File(file) => {
-                let mut current_dir = current_dir().expect("Unable to get current directory path");
-
-                current_dir.push(file);
-                let path = Utf8PathBuf::from_path_buf(current_dir).unwrap();
-                let parent = path.parent().unwrap().to_path_buf();
-                Some(parent)
-            }
-            FileDescriptorType::Stdin => None,
-        });
-
-        let studio_client = self
-            .client_config
-            .get_authenticated_client(&self.profile.clone())?;
-
-        // Get a FullyResolvedSupergraphConfig from first loading in any remote subgraphs and then
-        // a local supergraph config (if present) and then combining them into a fully resolved
-        // supergraph config
-        let resolver = SupergraphConfigResolver::default()
-            .load_remote_subgraphs(&studio_client, self.graph_ref.as_ref())
-            .await?
-            .load_from_file_descriptor(&mut stdin, self.supergraph_yaml.as_ref())?
-            .fully_resolve_subgraphs(
-                &self.client_config,
-                &studio_client,
-                supergraph_root.as_ref(),
-            )
-            .await?;
-
-        // We convert the FullyResolvedSupergraphConfig into a Supergraph because it makes using
-        // Serde easier (said differently: we're using the Federation-rs types here for
-        // compatability with Federation-rs tooling later on when we use their supergraph binary to
-        // actually run composition)
-        let supergraph_config: SupergraphConfig = resolver.clone().into();
-
-        // Convert the FullyResolvedSupergraphConfig to yaml before we save it
-        let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config)?;
-
-        // We're going to save to a temporary place because we don't actually need the supergraph
-        // config to stick around; we only need it on disk to point the supergraph binary at
-        let supergraph_config_filepath =
-            Utf8PathBuf::from_path_buf(tempdir()?.path().join("supergraph.yaml"))
-                .expect("Unable to parse path");
-
-        tracing::debug!("{:?}", supergraph_config_yaml);
-
-        // Write the supergraph config to disk
-        write_file_impl
-            .write_file(
-                &supergraph_config_filepath,
-                supergraph_config_yaml.as_bytes(),
-            )
-            .await?;
-
-        // Use the CLI option for federation over the one we can read off of the supergraph config
-        // (but default to the one we can read off the supergraph config)
-        let fed_version = self
-            .federation_version
-            .as_ref()
-            .unwrap_or(resolver.federation_version());
-
-        // We care about the exact version of the federation version because certain options aren't
-        // available before 2.9.0 and we gate on that version below
-        let exact_version = fed_version
-            .get_exact()
-            // This should be impossible to get to because we convert to a FederationVersion a few
-            // lines above and so _should_ have an exact version
-            .ok_or(RoverError::new(anyhow!(
-                "failed to get exact Federation version"
-            )))?;
-
-        // Making the output file mutable allows us to change it if we're using a version of the
-        // supergraph binary that can't write to file (ie, anything pre-2.9.0)
-        let mut output_file = self.output_file;
-
-        // When the `--output` flag is used, we need a supergraph binary version that is at least
-        // v2.9.0. We ignore that flag for composition when we have anything less than that
-        if output_file.is_some()
-            && (exact_version.major < 2 || (exact_version.major == 2 && exact_version.minor < 9))
-        {
-            warnln!("ignoring `--output` because it is not supported in this version of the dependent binary, `supergraph`: {}. Upgrade to Federation 2.9.0 or greater to install a version of the binary that supports it.", fed_version);
-            output_file = None;
-        }
-
-        // Build the supergraph binary, paying special attention to the CLI options
-        let supergraph_binary =
-            InstallSupergraph::new(fed_version.clone(), self.client_config.clone())
-                .install(
-                    self.override_install_path,
-                    self.elv2_license_accepter,
-                    self.skip_update,
-                )
-                .await?;
-
-        let result = supergraph_binary
-            .compose(
-                exec_command_impl,
-                read_file_impl,
-                &output_file
-                    .map(OutputTarget::File)
-                    .unwrap_or(OutputTarget::Stdout),
-                supergraph_config_filepath,
-            )
-            .await?;
-
-        Ok(result.into())
-    }
 }
 
 impl Default for Runner<SetupSubgraphWatchers> {
@@ -239,6 +90,14 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
         // events.
         // We could return None here if we received a supergraph config directly from stdin. In
         // that case, we don't want to configure a watcher.
+        tracing::info!(
+            "Setting up SupergraphConfigWatcher from origin: {}",
+            supergraph_config
+                .origin_path()
+                .as_ref()
+                .map(|x| x.to_string())
+                .unwrap_or_default()
+        );
         let supergraph_config_watcher = if let Some(origin_path) = supergraph_config.origin_path() {
             let f = FileWatcher::new(origin_path.clone());
             let watcher = SupergraphConfigWatcher::new(f, supergraph_config);
@@ -258,29 +117,27 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
 impl Runner<state::SetupCompositionWatcher> {
     /// Configures the composition watcher
     #[allow(clippy::too_many_arguments)]
-    pub fn setup_composition_watcher<ReadF, ExecC, WriteF>(
+    pub fn setup_composition_watcher<ExecC, ReadF, WriteF>(
         self,
-        subgraphs: FullyResolvedSubgraphs,
+        supergraph_config: FullyResolvedSupergraphConfig,
         supergraph_binary: SupergraphBinary,
         exec_command: ExecC,
         read_file: ReadF,
         write_file: WriteF,
-        output_target: OutputTarget,
         temp_dir: Utf8PathBuf,
-    ) -> Runner<state::Run<ReadF, ExecC, WriteF>>
+    ) -> Runner<state::Run<ExecC, ReadF, WriteF>>
     where
-        ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
         ExecC: ExecCommand + Debug + Eq + PartialEq + Send + Sync + 'static,
+        ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
         WriteF: WriteFile + Debug + Eq + PartialEq + Send + Sync + 'static,
     {
         // Create a handler for supergraph composition events.
         let composition_watcher = CompositionWatcher::builder()
-            .subgraphs(subgraphs)
+            .supergraph_config(supergraph_config)
             .supergraph_binary(supergraph_binary)
             .exec_command(exec_command)
             .read_file(read_file)
             .write_file(write_file)
-            .output_target(output_target)
             .temp_dir(temp_dir)
             .build();
         Runner {
@@ -293,25 +150,35 @@ impl Runner<state::SetupCompositionWatcher> {
     }
 }
 
-impl<ReadF, ExecC, WriteF> Runner<state::Run<ReadF, ExecC, WriteF>>
+/// Alias for a [`Runner`] that is ready to be run
+pub type CompositionRunner<ExecC, ReadF, WriteF> = Runner<state::Run<ExecC, ReadF, WriteF>>;
+
+impl<ExecC, ReadF, WriteF> Runner<state::Run<ExecC, ReadF, WriteF>>
 where
-    ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
     ExecC: ExecCommand + Debug + Eq + PartialEq + Send + Sync + 'static,
+    ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
     WriteF: WriteFile + Debug + Eq + PartialEq + Send + Sync + 'static,
 {
     /// Runs the [`Runner`]
     pub fn run(self) -> BoxStream<'static, CompositionEvent> {
-        let (supergraph_config_stream, supergraph_config_subtask) =
-            if let Some(supergraph_config_watcher) = self.state.supergraph_config_watcher {
-                let (supergraph_config_stream, supergraph_config_subtask) =
-                    Subtask::new(supergraph_config_watcher);
-                (
-                    supergraph_config_stream.boxed(),
-                    Some(supergraph_config_subtask),
-                )
-            } else {
-                (tokio_stream::empty().boxed(), None)
-            };
+        let (supergraph_config_stream, supergraph_config_subtask) = if let Some(
+            supergraph_config_watcher,
+        ) =
+            self.state.supergraph_config_watcher
+        {
+            tracing::info!("Watching subgraphs for changes...");
+            let (supergraph_config_stream, supergraph_config_subtask) =
+                Subtask::new(supergraph_config_watcher);
+            (
+                supergraph_config_stream.boxed(),
+                Some(supergraph_config_subtask),
+            )
+        } else {
+            tracing::warn!(
+                    "No supergraph config detected, changes to subgraph configurations will not be applied automatically"
+                );
+            (tokio_stream::empty().boxed(), None)
+        };
 
         let (subgraph_change_stream, subgraph_watcher_subtask) =
             Subtask::new(self.state.subgraph_watchers);

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -194,7 +194,6 @@ mod tests {
             FullyResolvedSubgraph::builder()
                 .schema(subgraph_scenario.sdl)
                 .and_routing_url(subgraph_scenario.unresolved_subgraph.routing_url().clone())
-                .is_fed_two(false)
                 .build(),
         )];
         let federation_version = federation_version_resolver
@@ -228,7 +227,6 @@ mod tests {
             FullyResolvedSubgraph::builder()
                 .schema(subgraph_scenario.sdl)
                 .and_routing_url(subgraph_scenario.unresolved_subgraph.routing_url().clone())
-                .is_fed_two(false)
                 .build(),
         )];
         let federation_version = federation_version_resolver
@@ -261,7 +259,6 @@ mod tests {
             FullyResolvedSubgraph::builder()
                 .schema(subgraph_scenario.sdl)
                 .and_routing_url(subgraph_scenario.unresolved_subgraph.routing_url().clone())
-                .is_fed_two(true)
                 .build(),
         )];
         let federation_version = federation_version_resolver

--- a/src/composition/supergraph/config/full/subgraph.rs
+++ b/src/composition/supergraph/config/full/subgraph.rs
@@ -124,6 +124,7 @@ impl FullyResolvedSubgraph {
         }
     }
 
+    /// Mutably updates this subgraph's schema
     pub fn update_schema(&mut self, schema: String) {
         self.schema = schema;
     }

--- a/src/composition/supergraph/config/full/subgraph.rs
+++ b/src/composition/supergraph/config/full/subgraph.rs
@@ -20,7 +20,6 @@ use crate::{
 pub struct FullyResolvedSubgraph {
     #[getter(skip)]
     routing_url: Option<String>,
-    #[getter(skip)]
     schema: String,
     is_fed_two: bool,
 }
@@ -123,6 +122,10 @@ impl FullyResolvedSubgraph {
                 })
             }
         }
+    }
+
+    pub fn update_schema(&mut self, schema: String) {
+        self.schema = schema;
     }
 }
 

--- a/src/composition/supergraph/config/full/subgraphs.rs
+++ b/src/composition/supergraph/config/full/subgraphs.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use apollo_federation_types::config::{SchemaSource, SubgraphConfig, SupergraphConfig};
 use thiserror::Error;
 
+use super::FullyResolvedSupergraphConfig;
+
 /// Error that occurs when a subgraph schema source is invalid
 #[derive(Error, Debug)]
 #[error("Invalid schema source: {:?}", .schema_source)]
@@ -69,5 +71,17 @@ impl From<FullyResolvedSubgraphs> for SupergraphConfig {
             )
         }));
         SupergraphConfig::new(subgraphs, None)
+    }
+}
+
+impl From<FullyResolvedSupergraphConfig> for FullyResolvedSubgraphs {
+    fn from(value: FullyResolvedSupergraphConfig) -> Self {
+        let subgraphs = value
+            .subgraphs()
+            .clone()
+            .into_iter()
+            .map(|(name, subgraph)| (name, subgraph.schema().clone()))
+            .collect();
+        FullyResolvedSubgraphs { subgraphs }
     }
 }

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -80,12 +80,14 @@ impl FullyResolvedSupergraphConfig {
         }
     }
 
+    /// Updates the subgraph with the provided name using the provided schema
     pub fn update_subgraph_schema(&mut self, name: &str, schema: String) {
         if let Some(subgraph) = self.subgraphs.get_mut(name) {
             subgraph.update_schema(schema);
         }
     }
 
+    /// Removes the subgraph with the name provided
     pub fn remove_subgraph(&mut self, name: &str) {
         self.subgraphs.remove(name);
     }

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -19,6 +19,7 @@ use super::FullyResolvedSubgraph;
 /// Represents a [`SupergraphConfig`] that has a known [`FederationVersion`] and
 /// its subgraph [`SchemaSource`]s reduced to [`SchemaSource::Sdl`]
 #[derive(Clone, Debug, Eq, PartialEq, Getters)]
+#[cfg_attr(test, derive(buildstructor::Builder))]
 pub struct FullyResolvedSupergraphConfig {
     origin_path: Option<Utf8PathBuf>,
     subgraphs: BTreeMap<String, FullyResolvedSubgraph>,
@@ -81,10 +82,8 @@ impl FullyResolvedSupergraphConfig {
     }
 
     /// Updates the subgraph with the provided name using the provided schema
-    pub fn update_subgraph_schema(&mut self, name: &str, schema: String) {
-        if let Some(subgraph) = self.subgraphs.get_mut(name) {
-            subgraph.update_schema(schema);
-        }
+    pub fn update_subgraph_schema(&mut self, name: String, subgraph: FullyResolvedSubgraph) {
+        self.subgraphs.insert(name, subgraph);
     }
 
     /// Removes the subgraph with the name provided

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -67,6 +67,8 @@ impl FullyResolvedSupergraphConfig {
             let subgraphs = BTreeMap::from_iter(subgraphs);
             let federation_version = unresolved_supergraph_config
                 .federation_version_resolver()
+                .clone()
+                .ok_or_else(|| ResolveSupergraphConfigError::MissingFederationVersionResolver)?
                 .resolve(subgraphs.iter())?;
             Ok(FullyResolvedSupergraphConfig {
                 origin_path: unresolved_supergraph_config.origin_path().clone(),
@@ -76,5 +78,15 @@ impl FullyResolvedSupergraphConfig {
         } else {
             Err(ResolveSupergraphConfigError::ResolveSubgraphs(errors))
         }
+    }
+
+    pub fn update_subgraph_schema(&mut self, name: &str, schema: String) {
+        if let Some(subgraph) = self.subgraphs.get_mut(name) {
+            subgraph.update_schema(schema);
+        }
+    }
+
+    pub fn remove_subgraph(&mut self, name: &str) {
+        self.subgraphs.remove(name);
     }
 }

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -36,7 +36,7 @@ impl LazilyResolvedSupergraphConfig {
                 .into_iter()
                 .map(|(name, unresolved_subgraph)| async move {
                     let result = LazilyResolvedSubgraph::resolve(
-                        &supergraph_config_root,
+                        supergraph_config_root,
                         unresolved_subgraph.clone(),
                     )?;
                     Ok((name.to_string(), result))

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -29,15 +29,19 @@ impl LazilyResolvedSupergraphConfig {
         supergraph_config_root: &Utf8PathBuf,
         unresolved_supergraph_config: UnresolvedSupergraphConfig,
     ) -> Result<LazilyResolvedSupergraphConfig, Vec<ResolveSubgraphError>> {
-        let subgraphs = stream::iter(unresolved_supergraph_config.subgraphs().iter().map(
-            |(name, unresolved_subgraph)| async {
-                let result = LazilyResolvedSubgraph::resolve(
-                    supergraph_config_root,
-                    unresolved_subgraph.clone(),
-                )?;
-                Ok((name.to_string(), result))
-            },
-        ))
+        let subgraphs = stream::iter(
+            unresolved_supergraph_config
+                .subgraphs()
+                .clone()
+                .into_iter()
+                .map(|(name, unresolved_subgraph)| async move {
+                    let result = LazilyResolvedSubgraph::resolve(
+                        &supergraph_config_root,
+                        unresolved_subgraph.clone(),
+                    )?;
+                    Ok((name.to_string(), result))
+                }),
+        )
         .buffer_unordered(50)
         .collect::<Vec<Result<(String, LazilyResolvedSubgraph), ResolveSubgraphError>>>()
         .await;

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -15,7 +15,7 @@ use super::UnresolvedSubgraph;
 pub struct UnresolvedSupergraphConfig {
     origin_path: Option<Utf8PathBuf>,
     subgraphs: BTreeMap<String, UnresolvedSubgraph>,
-    federation_version_resolver: FederationVersionResolverFromSubgraphs,
+    federation_version_resolver: Option<FederationVersionResolverFromSubgraphs>,
 }
 
 #[buildstructor]
@@ -25,7 +25,7 @@ impl UnresolvedSupergraphConfig {
     pub fn new(
         origin_path: Option<Utf8PathBuf>,
         subgraphs: BTreeMap<String, SubgraphConfig>,
-        federation_version_resolver: FederationVersionResolverFromSubgraphs,
+        federation_version_resolver: Option<FederationVersionResolverFromSubgraphs>,
     ) -> UnresolvedSupergraphConfig {
         let subgraphs = BTreeMap::from_iter(
             subgraphs
@@ -41,7 +41,9 @@ impl UnresolvedSupergraphConfig {
 
     /// Provides the target federation version provided by the user
     pub fn target_federation_version(&self) -> Option<FederationVersion> {
-        self.federation_version_resolver.target_federation_version()
+        self.federation_version_resolver
+            .clone()
+            .and_then(|resolver| resolver.target_federation_version())
     }
 }
 

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -289,9 +289,9 @@ mod tests {
         let unresolved_supergraph_config = UnresolvedSupergraphConfig {
             origin_path: None,
             subgraphs: unresolved_subgraphs,
-            federation_version_resolver: FederationVersionResolverFromSubgraphs::new(
+            federation_version_resolver: Some(FederationVersionResolverFromSubgraphs::new(
                 target_federation_version,
-            ),
+            )),
         };
 
         let RemoteSubgraphScenario {
@@ -363,11 +363,6 @@ mod tests {
                 sdl_subgraph_name.clone(),
                 FullyResolvedSubgraph::builder()
                     .schema(sdl_subgraph_scenario.sdl.clone())
-                    .is_fed_two(
-                        sdl_subgraph_scenario
-                            .subgraph_federation_version
-                            .is_fed_two(),
-                    )
                     .build(),
             ),
             (
@@ -375,11 +370,6 @@ mod tests {
                 FullyResolvedSubgraph::builder()
                     .routing_url(file_subgraph_scenario.routing_url.clone())
                     .schema(file_subgraph_scenario.sdl.clone())
-                    .is_fed_two(
-                        file_subgraph_scenario
-                            .subgraph_federation_version
-                            .is_fed_two(),
-                    )
                     .build(),
             ),
             (
@@ -387,11 +377,6 @@ mod tests {
                 FullyResolvedSubgraph::builder()
                     .routing_url(remote_subgraph_routing_url.clone())
                     .schema(remote_subgraph_scenario.sdl.clone())
-                    .is_fed_two(
-                        remote_subgraph_scenario
-                            .subgraph_federation_version
-                            .is_fed_two(),
-                    )
                     .build(),
             ),
             (
@@ -399,11 +384,6 @@ mod tests {
                 FullyResolvedSubgraph::builder()
                     .routing_url(introspect_subgraph_routing_url.clone())
                     .schema(introspect_subgraph_scenario.sdl.clone())
-                    .is_fed_two(
-                        introspect_subgraph_scenario
-                            .subgraph_federation_version
-                            .is_fed_two(),
-                    )
                     .build(),
             ),
         ]);
@@ -496,9 +476,9 @@ mod tests {
         let unresolved_supergraph_config = UnresolvedSupergraphConfig {
             origin_path: None,
             subgraphs: unresolved_subgraphs,
-            federation_version_resolver: FederationVersionResolverFromSubgraphs::new(Some(
+            federation_version_resolver: Some(FederationVersionResolverFromSubgraphs::new(Some(
                 target_federation_version.clone(),
-            )),
+            ))),
         };
 
         let RemoteSubgraphScenario {
@@ -642,7 +622,7 @@ mod tests {
         let unresolved_supergraph_config = UnresolvedSupergraphConfig {
             origin_path: Some(supergraph_config_origin_path),
             subgraphs: unresolved_subgraphs,
-            federation_version_resolver: FederationVersionResolverFromSubgraphs::new(None),
+            federation_version_resolver: Some(FederationVersionResolverFromSubgraphs::new(None)),
         };
 
         let result = LazilyResolvedSupergraphConfig::resolve(

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -120,6 +120,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                 let subgraph_name_c = subgraph_name.clone();
                 let messages_abort_handle = tokio::task::spawn(async move {
                     while let Some(change) = messages.next().await {
+                        tracing::info!("Subgraph change detected: {:?}", change);
                         let _ = sender
                             .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
                                 name: subgraph_name_c.clone(),
@@ -204,6 +205,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                 }
 
                 for (name, subgraph_config) in diff.changed() {
+                    eprintln!("Change detected for subgraph: `{}`", name);
                     if let Ok(watcher) = SubgraphWatcher::from_schema_source(
                         subgraph_config.schema.clone(),
                         &self.profile,

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -1,4 +1,5 @@
 use camino::Utf8PathBuf;
+use derive_getters::Getters;
 use futures::{stream::BoxStream, StreamExt};
 use rover_std::{errln, Fs, RoverStdError};
 use tap::TapFallible;
@@ -6,7 +7,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 /// File watcher specifically for files related to composition
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Getters)]
 pub struct FileWatcher {
     /// The filepath to watch
     path: Utf8PathBuf,

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -1,7 +1,5 @@
-use std::{marker::Send, pin::Pin};
-
 use apollo_federation_types::config::SchemaSource;
-use futures::{stream::BoxStream, Stream, StreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -22,6 +22,7 @@ pub struct UnsupportedSchemaSource(SchemaSource);
 pub struct SubgraphWatcher {
     /// The kind of watcher used (eg, file, introspection)
     watcher: SubgraphWatcherKind,
+    routing_url: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +59,7 @@ pub enum SubgraphWatcherKind {
 impl SubgraphWatcher {
     /// Derive the right SubgraphWatcher (ie, File, Introspection) from the federation-rs SchemaSource
     pub fn from_schema_source(
+        routing_url: Option<String>,
         schema_source: SchemaSource,
         profile: &ProfileOpt,
         client_config: &StudioClientConfig,
@@ -68,6 +70,7 @@ impl SubgraphWatcher {
         match schema_source {
             SchemaSource::File { file } => Ok(Self {
                 watcher: SubgraphWatcherKind::File(FileWatcher::new(file)),
+                routing_url,
             }),
             SchemaSource::SubgraphIntrospection {
                 subgraph_url,
@@ -79,14 +82,17 @@ impl SubgraphWatcher {
                     client_config,
                     introspection_polling_interval,
                 )),
+                routing_url,
             }),
             SchemaSource::Subgraph { graphref, subgraph } => Ok(Self {
                 watcher: SubgraphWatcherKind::Once(NonRepeatingFetch::RemoteSchema(
                     RemoteSchema::new(graphref, subgraph, profile, client_config),
                 )),
+                routing_url,
             }),
             SchemaSource::Sdl { sdl } => Ok(Self {
                 watcher: SubgraphWatcherKind::Once(NonRepeatingFetch::Sdl(Sdl::new(sdl))),
+                routing_url,
             }),
         }
     }

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -8,7 +8,9 @@ use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 
 use crate::{
-    composition::supergraph::config::lazy::LazilyResolvedSupergraphConfig,
+    composition::supergraph::config::{
+        lazy::LazilyResolvedSupergraphConfig, unresolved::UnresolvedSupergraphConfig,
+    },
     subtask::SubtaskHandleUnit,
 };
 
@@ -36,33 +38,72 @@ impl SubtaskHandleUnit for SupergraphConfigWatcher {
     type Output = SupergraphConfigDiff;
 
     fn handle(self, sender: UnboundedSender<Self::Output>) -> AbortHandle {
-        tokio::spawn(async move {
+        let supergraph_config_path = self.file_watcher.path().clone();
+        tokio::spawn({
+            async move {
+                let supergraph_config_path = supergraph_config_path.clone();
             let mut latest_supergraph_config = self.supergraph_config.clone();
-            while let Some(contents) = self.file_watcher.clone().watch().next().await {
+            let file_watcher = self.file_watcher.clone();
+            while let Some(contents) = file_watcher.clone().watch().next().await {
+                eprintln!("{} changed. Applying changes to the session.", supergraph_config_path);
+                tracing::info!(
+                    "{} changed. Parsing it as a `SupergraphConfig`",
+                    supergraph_config_path
+                );
                 match SupergraphConfig::new_from_yaml(&contents) {
                     Ok(supergraph_config) => {
-                        if let Ok(supergraph_config_diff) = SupergraphConfigDiff::new(
-                            &latest_supergraph_config,
-                            supergraph_config.clone(),
-                        ) {
-                            let _ = sender
-                                .send(supergraph_config_diff)
-                                .tap_err(|err| tracing::error!("{:?}", err));
+                        let subgraphs = BTreeMap::from_iter(supergraph_config.clone().into_iter());
+                        let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()
+                            .origin_path(supergraph_config_path.clone())
+                            .subgraphs(subgraphs)
+                            .build();
+                        let supergraph_config = LazilyResolvedSupergraphConfig::resolve(
+                            &supergraph_config_path.parent().unwrap().to_path_buf(),
+                            unresolved_supergraph_config,
+                        )
+                            .await.map(SupergraphConfig::from);
+
+                        match supergraph_config {
+                            Ok(supergraph_config) => {
+                                let supergraph_config_diff = SupergraphConfigDiff::new(
+                                    &latest_supergraph_config,
+                                    supergraph_config.clone(),
+                                );
+                                match supergraph_config_diff {
+                                    Ok(supergraph_config_diff) =>  {
+                                        let _ = sender
+                                            .send(supergraph_config_diff)
+                                            .tap_err(|err| tracing::error!("{:?}", err));
+                                    }
+                                    Err(err) => {
+                                        tracing::error!("Failed to construct a diff between the current and previous `SupergraphConfig`s.\n{}", err);
+                                    }
+                                }
+
+                                latest_supergraph_config = supergraph_config;
+                            }
+                            Err(err) => {
+                                errln!(
+                                    "Failed to lazily resolve the supergraph config at {}.\n{}",
+                                    self.file_watcher.path(),
+                                    itertools::join(err, "\n")
+                                );
+                            }
                         }
-                        latest_supergraph_config = supergraph_config;
                     }
                     Err(err) => {
                         tracing::error!("could not parse supergraph config file: {:?}", err);
-                        errln!("could not parse supergraph config file: {:?}", err);
+                        errln!("Could not parse supergraph config file.\n{}", err);
                     }
                 }
             }
+                      }
         })
         .abort_handle()
     }
 }
 
-#[derive(Getters)]
+#[derive(Getters, Debug)]
 pub struct SupergraphConfigDiff {
     added: Vec<(String, SubgraphConfig)>,
     changed: Vec<(String, SubgraphConfig)>,
@@ -100,28 +141,34 @@ impl SupergraphConfigDiff {
 
         // Filter the added and removed subgraphs from the new supergraph config.
         let added = new_subgraphs
+            .clone()
             .into_iter()
             .filter(|(name, _)| added_names.contains(name))
             .collect::<Vec<_>>();
         let removed = removed_names.into_iter().cloned().collect::<Vec<_>>();
 
         // Find any in-place changes (eg, SDL, SchemaSource::Subgraph)
-        let mut changed = vec![];
-        for (old_name, old_config) in old.clone().into_iter() {
-            // Exclude any removed subgraphs
-            if !removed.contains(&old_name) {
-                let found_new = new
-                    .clone()
-                    .into_iter()
-                    .find(|(sub_name, _sub_config)| *sub_name == old_name);
-
-                if let Some((old_name, new_config)) = found_new {
-                    if new_config != old_config {
-                        changed.push((old_name, new_config));
+        let changed = old
+            .clone()
+            .into_iter()
+            .filter(|(old_name, _)| !removed.contains(old_name))
+            .filter_map(|(old_name, old_subgraph)| {
+                new_subgraphs.get(&old_name).and_then(|new_subgraph| {
+                    let new_subgraph = new_subgraph.clone();
+                    tracing::info!(
+                        "old:\n{:?}\nnew:\n{:?}\neq:{}",
+                        old_subgraph,
+                        new_subgraph,
+                        old_subgraph == new_subgraph
+                    );
+                    if old_subgraph == new_subgraph {
+                        None
+                    } else {
+                        Some((old_name, new_subgraph))
                     }
-                }
-            }
-        }
+                })
+            })
+            .collect::<Vec<_>>();
 
         Ok(SupergraphConfigDiff {
             added,

--- a/src/subtask.rs
+++ b/src/subtask.rs
@@ -107,6 +107,10 @@ impl<T, Output> Subtask<T, Output> {
             Subtask { inner, sender: tx },
         )
     }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
 }
 
 impl<T: SubtaskHandleUnit<Output = Output>, Output> SubtaskRunUnit for Subtask<T, Output> {

--- a/src/utils/effect/read_file.rs
+++ b/src/utils/effect/read_file.rs
@@ -10,7 +10,7 @@ pub struct MockReadFileError {}
 #[cfg_attr(test, mockall::automock(type Error = MockReadFileError;))]
 #[async_trait]
 pub trait ReadFile {
-    type Error: std::error::Error + Send + 'static;
+    type Error: std::error::Error + Send + Sync + 'static;
     async fn read_file(&self, path: &Utf8PathBuf) -> Result<String, Self::Error>;
 }
 


### PR DESCRIPTION
Refactors OneShotComposition into a CompositionPipeline so that we can consistently create a one-and-done composition artifact and then kick off subgraph watchers for running with LSP or Rover Dev.

Additionally, this adds watching subgraphs to the pipeline and fixes a few issues along the way.