### PR TITLE
Fix for `Unable to send to filewatcher receiver because it closed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,6 +4886,7 @@ dependencies = [
  "timber",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tower 0.5.1",
  "tower-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ termimad = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "process", "sync"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rover-std/src/fs.rs
+++ b/crates/rover-std/src/fs.rs
@@ -347,6 +347,7 @@ impl Fs {
                         // fn, and thereby dropping the poll_watcher and ending the background
                         // thread's synchronous loop
                         cancellation_token_c.cancelled().await;
+                        tracing::debug!("Dropping file watcher for: {:?}", path);
                     }
                     // If we fail to watch the file for some reason, don't panic, but let the user know
                     // that something went wrong

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -46,6 +46,7 @@ impl Dev {
         let read_file_impl = FsReadFile::default();
         let write_file_impl = FsWriteFile::default();
         let exec_command_impl = TokioCommand::default();
+
         let router_address = RouterAddress::new(
             self.opts.supergraph_opts.supergraph_address,
             self.opts.supergraph_opts.supergraph_port,

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -67,14 +67,15 @@ impl FullyResolvedSupergraphConfig {
                     unresolved_subgraph.clone(),
                 )
                 .map_ok(|result| (name.to_string(), result))
+                .map_err(|err| (name.to_string(), err))
             },
         ))
         .buffer_unordered(50)
-        .collect::<Vec<Result<(String, FullyResolvedSubgraph), ResolveSubgraphError>>>()
+        .collect::<Vec<Result<(String, FullyResolvedSubgraph), (String, ResolveSubgraphError)>>>()
         .await;
         let (subgraphs, errors): (
             Vec<(String, FullyResolvedSubgraph)>,
-            Vec<ResolveSubgraphError>,
+            Vec<(String, ResolveSubgraphError)>,
         ) = subgraphs.into_iter().partition_result();
         if errors.is_empty() {
             let subgraphs = BTreeMap::from_iter(subgraphs);
@@ -89,7 +90,9 @@ impl FullyResolvedSupergraphConfig {
                 federation_version,
             })
         } else {
-            Err(ResolveSupergraphConfigError::ResolveSubgraphs(errors))
+            Err(ResolveSupergraphConfigError::ResolveSubgraphs(
+                BTreeMap::from_iter(errors.into_iter()),
+            ))
         }
     }
 

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -73,6 +73,7 @@ impl FullyResolvedSupergraphConfig {
         .buffer_unordered(50)
         .collect::<Vec<Result<(String, FullyResolvedSubgraph), (String, ResolveSubgraphError)>>>()
         .await;
+        #[allow(clippy::type_complexity)]
         let (subgraphs, errors): (
             Vec<(String, FullyResolvedSubgraph)>,
             Vec<(String, ResolveSubgraphError)>,

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -46,6 +46,7 @@ impl LazilyResolvedSupergraphConfig {
         .buffer_unordered(50)
         .collect::<Vec<Result<(String, LazilyResolvedSubgraph), (String, ResolveSubgraphError)>>>()
         .await;
+        #[allow(clippy::type_complexity)]
         let (subgraphs, errors): (
             Vec<(String, LazilyResolvedSubgraph)>,
             Vec<(String, ResolveSubgraphError)>,

--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -210,10 +210,16 @@ pub enum ResolveSupergraphConfigError {
     /// Occurs when the caller neither loads a remote supergraph config nor a local one
     #[error("No source found for supergraph config")]
     NoSource,
+    /// Occurs when supergraph resolution is attempted without a supergraph root
+    #[error("Unable to resolve supergraph config. Suprgraph config oot is missing")]
+    MissingSupergraphConfigRoot,
     /// Occurs when the underlying resolver strategy can't resolve one or more
     /// of the subgraphs described in the supergraph config
-    #[error("Unable to resolve subgraphs.\n{}", ::itertools::join(.0, "\n"))]
-    ResolveSubgraphs(Vec<ResolveSubgraphError>),
+    #[error(
+        "Unable to resolve subgraphs.\n{}",
+        ::itertools::join(.0.iter().map(|(n, e)| format!("{}: {}", n, e)), "\n")
+    )]
+    ResolveSubgraphs(BTreeMap<String, ResolveSubgraphError>),
     /// Occurs when the user-selected `FederationVersion` is within Federation 1 boundaries, but the
     /// subgraphs use the `@link` directive, which requires Federation 2
     #[error(transparent)]
@@ -267,11 +273,8 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
         &self,
         supergraph_config_root: Option<&Utf8PathBuf>,
     ) -> Result<LazilyResolvedSupergraphConfig, ResolveSupergraphConfigError> {
-        let supergraph_config_root = supergraph_config_root.ok_or_else(|| {
-            ResolveSupergraphConfigError::ResolveSubgraphs(vec![
-                ResolveSubgraphError::SupergraphConfigMissing,
-            ])
-        })?;
+        let supergraph_config_root = supergraph_config_root
+            .ok_or_else(|| ResolveSupergraphConfigError::MissingSupergraphConfigRoot)?;
 
         if !self.state.subgraphs.is_empty() {
             let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -249,7 +249,7 @@ impl SubgraphHandles {
             // either what we fetch from Studio (for Subgraphs) or what the SupergraphConfig
             // has for Sdls
             if let SubgraphWatcherKind::Once(subgraph_config) = subgraph_watcher.watcher() {
-                self.add_oneshot_subgraph_to_session(subgraph, &subgraph_watcher, &subgraph_config)
+                self.add_oneshot_subgraph_to_session(subgraph, &subgraph_watcher, subgraph_config)
                     .await;
             } else {
                 // When we have a SchemaSource that's watchable, we start a new subtask

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 use super::watcher::{
-    subgraph::{SubgraphWatcher, SubgraphWatcherKind, WatchedSdlChange},
+    subgraph::{NonRepeatingFetch, SubgraphWatcher, SubgraphWatcherKind, WatchedSdlChange},
     supergraph_config::SupergraphConfigDiff,
 };
 
@@ -127,33 +127,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
         mut input: BoxStream<'static, Self::Input>,
     ) -> AbortHandle {
         tokio::task::spawn(async move {
-            let mut abort_handles: HashMap<String, (AbortHandle, AbortHandle)> = HashMap::new();
-            // Start a background task for each of the subtask watchers that listens for change
-            // events and send each event to the parent sender to be consumed by the composition
-            // handler.
-            // We also collect the abort handles for each background task in order to gracefully
-            // shut down.
-            for (subgraph_name, (mut messages, subtask)) in self.watchers.into_iter() {
-                let sender = sender.clone();
-                let subgraph_name_c = subgraph_name.clone();
-                let routing_url = subtask.inner().routing_url().clone();
-                let messages_abort_handle = tokio::task::spawn(async move {
-                    while let Some(change) = messages.next().await {
-                        let routing_url = routing_url.clone();
-                        tracing::info!("Subgraph change detected: {:?}", change);
-                        let _ = sender
-                            .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
-                                name: subgraph_name_c.clone(),
-                                sdl: change.sdl().to_string(),
-                                routing_url,
-                            }))
-                            .tap_err(|err| tracing::error!("{:?}", err));
-                    }
-                })
-                .abort_handle();
-                let subtask_abort_handle = subtask.run();
-                abort_handles.insert(subgraph_name, (messages_abort_handle, subtask_abort_handle));
-            }
+            let mut subgraph_handles = SubgraphHandles::new(sender.clone(), self.watchers.into_iter());
 
             // Wait for supergraph diff events received from the input stream.
             while let Some(diff) = input.next().await {
@@ -162,155 +136,235 @@ impl SubtaskHandleStream for SubgraphWatchers {
                         // If we detect additional diffs, start a new subgraph subtask.
                         // Adding the abort handle to the currentl collection of handles.
                         for (subgraph_name, subgraph_config) in diff.added() {
-                            eprintln!("Adding subgraph to session: `{}`", subgraph_name);
-                            if let Ok(subgraph_watcher) = SubgraphWatcher::from_schema_source(
-                                subgraph_config.routing_url.clone(),
-                                subgraph_config.schema.clone(),
+                            subgraph_handles.add(
+                                subgraph_name,
+                                subgraph_config,
                                 &self.profile,
                                 &self.client_config,
-                                self.introspection_polling_interval,
-                            )
-                            .tap_err(|err| {
-                                tracing::warn!(
-                                    "Cannot configure new subgraph for {subgraph_name}: {:?}",
-                                    err
-                                )
-                            }) {
-                                // If a SchemaSource::Subgraph or SchemaSource::Sdl was added, we don't
-                                // want to spin up watchers; rather, we emit a SubgraphSchemaChanged event with
-                                // either what we fetch from Studio (for Subgraphs) or what the SupergraphConfig
-                                // has for Sdls
-                                if let SubgraphWatcherKind::Once(non_repeating_fetch) =
-                                    subgraph_watcher.watcher()
-                                {
-                                    let _ = non_repeating_fetch
-                                        .run()
-                                        .await
-                                        .tap_err(|err| {
-                                            tracing::error!(
-                                                "failed to get {subgraph_name}'s SDL: {err:?}"
-                                            )
-                                        })
-                                        .map(|sdl| {
-                                            let _ = sender
-                                                .send(SubgraphEvent::SubgraphChanged(
-                                                    SubgraphSchemaChanged {
-                                                        name: subgraph_name.to_string(),
-                                                        sdl,
-                                                        routing_url: subgraph_watcher
-                                                            .routing_url()
-                                                            .clone(),
-                                                    },
-                                                ))
-                                                .tap_err(|err| tracing::error!("{:?}", err));
-                                        });
-                                    // When we have a SchemaSource that's watchable, we start a new subtask
-                                    // and add it to our list of subtasks
-                                } else {
-                                    let (mut messages, subtask) =
-                                        Subtask::<SubgraphWatcher, WatchedSdlChange>::new(
-                                            subgraph_watcher,
-                                        );
-
-                                    let sender = sender.clone();
-                                    let subgraph_name_c = subgraph_name.clone();
-                                    let routing_url = subtask.inner().routing_url().clone();
-                                    let messages_abort_handle = tokio::spawn(async move {
-                                        while let Some(change) = messages.next().await {
-                                            let routing_url = routing_url.clone();
-                                            let _ = sender
-                                                .send(SubgraphEvent::SubgraphChanged(
-                                                    SubgraphSchemaChanged {
-                                                        name: subgraph_name_c.to_string(),
-                                                        sdl: change.sdl().to_string(),
-                                                        routing_url,
-                                                    },
-                                                ))
-                                                .tap_err(|err| tracing::error!("{:?}", err));
-                                        }
-                                    })
-                                    .abort_handle();
-                                    let subtask_abort_handle = subtask.run();
-                                    abort_handles.insert(
-                                        subgraph_name.to_string(),
-                                        (messages_abort_handle, subtask_abort_handle),
-                                    );
-                                }
-                            }
+                                self.introspection_polling_interval
+                            ).await;
                         }
 
-                        for (name, subgraph_config) in diff.changed() {
-                            eprintln!("Change detected for subgraph: `{}`", name);
-                            if let Ok(watcher) = SubgraphWatcher::from_schema_source(
-                                subgraph_config.routing_url.clone(),
-                                subgraph_config.schema.clone(),
+                        for (subgraph_name, subgraph_config) in diff.changed() {
+                            subgraph_handles.update(subgraph_name,
+                                subgraph_config,
                                 &self.profile,
                                 &self.client_config,
-                                self.introspection_polling_interval,
-                            )
-                            .tap_err(|err| tracing::error!("Unable to get watcher: {err:?}"))
-                            {
-                                if let SubgraphWatcherKind::Once(non_repeating_fetch) =
-                                    watcher.watcher()
-                                {
-                                    let _ = non_repeating_fetch
-                                        .run()
-                                        .await
-                                        .tap_err(|err| {
-                                            tracing::error!("failed to get {name}'s SDL: {err:?}")
-                                        })
-                                        .map(|sdl| {
-                                            let _ = sender
-                                                .send(SubgraphEvent::SubgraphChanged(
-                                                    SubgraphSchemaChanged {
-                                                        name: name.to_string(),
-                                                        sdl,
-                                                        routing_url: watcher.routing_url().clone(),
-                                                    },
-                                                ))
-                                                .tap_err(|err| tracing::error!("{:?}", err));
-                                        });
-                                }
-                            }
+                                self.introspection_polling_interval
+                            ).await;
                         }
 
                         // If we detect removal diffs, stop the subtask for the removed subgraph.
-                        for name in diff.removed() {
-                            eprintln!("Removing subgraph from session: `{}`", name);
-                            if let Some((messages_abort_handle, subtask_abort_handle)) =
-                                abort_handles.get(name)
-                            {
-                                messages_abort_handle.abort();
-                                subtask_abort_handle.abort();
-                                abort_handles.remove(name);
-                                let _ = sender
-                                    .send(SubgraphEvent::SubgraphRemoved(SubgraphSchemaRemoved {
-                                        name: name.to_string(),
-                                    }))
-                                    .tap_err(|err| tracing::error!("{:?}", err));
-                            }
+                        for subgraph_name in diff.removed() {
+                            eprintln!("Removing subgraph from session: `{}`", subgraph_name);
+                            subgraph_handles.remove(subgraph_name);
                         }
                     }
                     Err(errs) => {
-                        for (subgraph, _) in errs {
-                            errln!("Error detected with the config for {}. Removing it from the session.", subgraph);
-                            if let Some(abort_handle) = abort_handles.get(&subgraph) {
-                                abort_handle.0.abort();
-                                abort_handle.1.abort();
-                                abort_handles.remove(&subgraph);
-                            }
-
-                            let _ = sender
-                                .send(SubgraphEvent::SubgraphRemoved(SubgraphSchemaRemoved {
-                                    name: subgraph.to_string(),
-                                }))
-                                .tap_err(|err| tracing::error!("{:?}", err));
+                        for (subgraph_name, _) in errs {
+                            errln!("Error detected with the config for {}. Removing it from the session.", subgraph_name);
+                            subgraph_handles.remove(&subgraph_name);
                         }
                     }
                 }
             }
         })
         .abort_handle()
+    }
+}
+
+struct SubgraphHandles {
+    abort_handles: HashMap<String, (AbortHandle, AbortHandle)>,
+    sender: UnboundedSender<SubgraphEvent>,
+}
+
+impl SubgraphHandles {
+    pub fn new(
+        sender: UnboundedSender<SubgraphEvent>,
+        watchers: impl Iterator<
+            Item = (
+                String,
+                (
+                    UnboundedReceiverStream<WatchedSdlChange>,
+                    Subtask<SubgraphWatcher, WatchedSdlChange>,
+                ),
+            ),
+        >,
+    ) -> SubgraphHandles {
+        let mut abort_handles = HashMap::new();
+        // Start a background task for each of the subtask watchers that listens for change
+        // events and send each event to the parent sender to be consumed by the composition
+        // handler.
+        // We also collect the abort handles for each background task in order to gracefully
+        // shut down.
+        for (subgraph_name, (mut messages, subtask)) in watchers {
+            let messages_abort_handle = tokio::task::spawn({
+                let subgraph_name = subgraph_name.to_string();
+                let sender = sender.clone();
+                let routing_url = subtask.inner().routing_url().clone();
+                async move {
+                    while let Some(change) = messages.next().await {
+                        let routing_url = routing_url.clone();
+                        tracing::info!("Subgraph change detected: {:?}", change);
+                        let _ = sender
+                            .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
+                                name: subgraph_name.to_string(),
+                                sdl: change.sdl().to_string(),
+                                routing_url,
+                            }))
+                            .tap_err(|err| tracing::error!("{:?}", err));
+                    }
+                }
+            })
+            .abort_handle();
+            let subtask_abort_handle = subtask.run();
+            abort_handles.insert(subgraph_name, (messages_abort_handle, subtask_abort_handle));
+        }
+        SubgraphHandles {
+            sender,
+            abort_handles,
+        }
+    }
+
+    pub async fn add(
+        &mut self,
+        subgraph: &str,
+        subgraph_config: &SubgraphConfig,
+        profile: &ProfileOpt,
+        client_config: &StudioClientConfig,
+        introspection_polling_interval: u64,
+    ) {
+        eprintln!("Adding subgraph to session: `{}`", subgraph);
+        if let Ok(subgraph_watcher) = SubgraphWatcher::from_schema_source(
+            subgraph_config.routing_url.clone(),
+            subgraph_config.schema.clone(),
+            profile,
+            client_config,
+            introspection_polling_interval,
+        )
+        .tap_err(|err| tracing::warn!("Cannot configure new subgraph for {subgraph}: {:?}", err))
+        {
+            // If a SchemaSource::Subgraph or SchemaSource::Sdl was added, we don't
+            // want to spin up watchers; rather, we emit a SubgraphSchemaChanged event with
+            // either what we fetch from Studio (for Subgraphs) or what the SupergraphConfig
+            // has for Sdls
+            if let SubgraphWatcherKind::Once(subgraph_config) = subgraph_watcher.watcher() {
+                self.add_oneshot_subgraph_to_session(subgraph, &subgraph_watcher, &subgraph_config)
+                    .await;
+            } else {
+                // When we have a SchemaSource that's watchable, we start a new subtask
+                // and add it to our list of subtasks
+                self.add_streaming_subgraph_to_session(subgraph, subgraph_watcher)
+                    .await;
+            }
+        }
+    }
+
+    pub async fn update(
+        &mut self,
+        subgraph: &str,
+        subgraph_config: &SubgraphConfig,
+        profile: &ProfileOpt,
+        client_config: &StudioClientConfig,
+        introspection_polling_interval: u64,
+    ) {
+        eprintln!("Change detected for subgraph: `{}`", subgraph);
+        if let Ok(watcher) = SubgraphWatcher::from_schema_source(
+            subgraph_config.routing_url.clone(),
+            subgraph_config.schema.clone(),
+            profile,
+            client_config,
+            introspection_polling_interval,
+        )
+        .tap_err(|err| tracing::error!("Unable to get watcher: {err:?}"))
+        {
+            if let SubgraphWatcherKind::Once(non_repeating_fetch) = watcher.watcher() {
+                let _ = non_repeating_fetch
+                    .run()
+                    .await
+                    .tap_err(|err| tracing::error!("failed to get {subgraph}'s SDL: {err:?}"))
+                    .map(|sdl| {
+                        let _ = self
+                            .sender
+                            .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
+                                name: subgraph.to_string(),
+                                sdl,
+                                routing_url: watcher.routing_url().clone(),
+                            }))
+                            .tap_err(|err| tracing::error!("{:?}", err));
+                    });
+            }
+        }
+    }
+
+    pub fn remove(&mut self, subgraph: &str) {
+        if let Some(abort_handle) = self.abort_handles.get(subgraph) {
+            abort_handle.0.abort();
+            abort_handle.1.abort();
+            self.abort_handles.remove(subgraph);
+        }
+
+        let _ = self
+            .sender
+            .send(SubgraphEvent::SubgraphRemoved(SubgraphSchemaRemoved {
+                name: subgraph.to_string(),
+            }))
+            .tap_err(|err| tracing::error!("{:?}", err));
+    }
+
+    async fn add_oneshot_subgraph_to_session(
+        &mut self,
+        subgraph: &str,
+        subgraph_watcher: &SubgraphWatcher,
+        non_repeating_fetch: &NonRepeatingFetch,
+    ) {
+        let _ = non_repeating_fetch
+            .run()
+            .await
+            .tap_err(|err| tracing::error!("failed to get {subgraph}'s SDL: {err:?}"))
+            .map(|sdl| {
+                let _ = self
+                    .sender
+                    .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
+                        name: subgraph.to_string(),
+                        sdl,
+                        routing_url: subgraph_watcher.routing_url().clone(),
+                    }))
+                    .tap_err(|err| tracing::error!("{:?}", err));
+            });
+    }
+
+    async fn add_streaming_subgraph_to_session(
+        &mut self,
+        subgraph: &str,
+        subgraph_watcher: SubgraphWatcher,
+    ) {
+        let (mut messages, subtask) =
+            Subtask::<SubgraphWatcher, WatchedSdlChange>::new(subgraph_watcher);
+
+        let routing_url = subtask.inner().routing_url().clone();
+        let messages_abort_handle = tokio::spawn({
+            let sender = self.sender.clone();
+            let subgraph_name = subgraph.to_string();
+            async move {
+                while let Some(change) = messages.next().await {
+                    let routing_url = routing_url.clone();
+                    let _ = sender
+                        .send(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged {
+                            name: subgraph_name.to_string(),
+                            sdl: change.sdl().to_string(),
+                            routing_url,
+                        }))
+                        .tap_err(|err| tracing::error!("{:?}", err));
+                }
+            }
+        })
+        .abort_handle();
+        let subtask_abort_handle = subtask.run();
+        self.abort_handles.insert(
+            subgraph.to_string(),
+            (messages_abort_handle, subtask_abort_handle),
+        );
     }
 }
 

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 use futures::{stream::BoxStream, StreamExt};
@@ -5,18 +7,23 @@ use rover_std::{errln, Fs, RoverStdError};
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::DropGuard;
 
 /// File watcher specifically for files related to composition
-#[derive(Clone, Debug, Getters)]
+#[derive(Debug, Getters)]
 pub struct FileWatcher {
     /// The filepath to watch
     path: Utf8PathBuf,
+    drop_guard: OnceLock<DropGuard>,
 }
 
 impl FileWatcher {
     /// Create a new filewatcher
     pub fn new(path: Utf8PathBuf) -> Self {
-        Self { path }
+        Self {
+            path,
+            drop_guard: OnceLock::new(),
+        }
     }
 
     /// Watch a file
@@ -27,33 +34,38 @@ impl FileWatcher {
     /// Development note: in the future, we might consider a way to kill the watcher when the
     /// rover-std::fs filewatcher dies. Right now, the stream remains active and we can
     /// indefinitely loop on a close filewatcher
-    pub fn watch(self) -> BoxStream<'static, String> {
-        let path = self.path;
+    pub fn watch(&self) -> BoxStream<'static, String> {
         let (file_tx, file_rx) = unbounded_channel();
         let output = UnboundedReceiverStream::new(file_rx);
-        let cancellation_token = Fs::watch_file(path.as_path().into(), file_tx);
+        let cancellation_token = Fs::watch_file(self.path.as_path().into(), file_tx);
+        self.drop_guard
+            .set(cancellation_token.clone().drop_guard())
+            .unwrap();
 
         output
-            .filter_map(move |result| {
-                let path = path.clone();
-                let cancellation_token = cancellation_token.clone();
-                async move {
-                    // We cancel the filewatching when the file has been removed because it
-                    // can no longer be watched
-                    if let Err(RoverStdError::FileRemoved { file }) = &result {
-                        tracing::error!("Closing file watcher for {file}");
-                        errln!("Closing file watcher for {file:?}");
-                        cancellation_token.cancel();
-                    }
+            .filter_map({
+                let path = self.path.clone();
+                move |result| {
+                    let cancellation_token = cancellation_token.clone();
+                    let path = path.clone();
+                    async move {
+                        // We cancel the filewatching when the file has been removed because it
+                        // can no longer be watched
+                        if let Err(RoverStdError::FileRemoved { file }) = &result {
+                            tracing::error!("Closing file watcher for {file}");
+                            errln!("Closing file watcher for {file:?}");
+                            cancellation_token.cancel();
+                        }
 
-                    result
-                        .and_then(|_| {
-                            Fs::read_file(path.clone()).tap_err(|err| {
-                                tracing::error!("Could not read file: {:?}", err);
-                                errln!("error reading file: {:?}", err);
+                        result
+                            .and_then(|_| {
+                                Fs::read_file(path.clone()).tap_err(|err| {
+                                    tracing::error!("Could not read file: {:?}", err);
+                                    errln!("error reading file: {:?}", err);
+                                })
                             })
-                        })
-                        .ok()
+                            .ok()
+                    }
                 }
             })
             .boxed()

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -43,7 +43,7 @@ impl NonRepeatingFetch {
 /// The kind of watcher attached to the subgraph. This may be either file watching, when we're
 /// paying attention to a particular subgraph's SDL file, or introspection, when we get the SDL by
 /// polling an endpoint that has introspection enabled
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum SubgraphWatcherKind {
     /// Watch a file on disk.
     File(FileWatcher),
@@ -105,7 +105,10 @@ impl SubgraphWatcherKind {
     /// more flexible to get type safety.
     fn watch(&self) -> Option<BoxStream<String>> {
         match self {
-            Self::File(file_watcher) => Some(file_watcher.clone().watch()),
+            Self::File(file_watcher) => {
+                tracing::warn!("Watching subgraph file {:?}", file_watcher.path());
+                Some(file_watcher.watch())
+            }
             Self::Introspect(introspection) => Some(introspection.watch()),
             kind => {
                 tracing::debug!("{kind:?} is not watchable. Skipping");


### PR DESCRIPTION
Adds a DropGuard to FileWatchers and ensures that `watch` for the supergraph config doesn't get called repeatedly in the `while let` loop in SupergraphConfigWatcher.

We'll need to encode this a bit better into the API in the long term, but this unblocks the problem for now.