### PR TITLE
Bring `dev` launch to parity with legacy

### DIFF
--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -3,6 +3,7 @@
 use std::io::stdin;
 
 use anyhow::anyhow;
+use apollo_federation_types::config::FederationVersion::LatestFedTwo;
 use apollo_federation_types::config::RouterVersion;
 use camino::Utf8PathBuf;
 use futures::StreamExt;
@@ -94,7 +95,11 @@ impl Dev {
             .resolve_federation_version(
                 &client_config,
                 make_fetch_remote_subgraph,
-                self.opts.supergraph_opts.federation_version.clone(),
+                self.opts
+                    .supergraph_opts
+                    .federation_version
+                    .clone()
+                    .or(Some(LatestFedTwo)),
             )
             .await?
             .install_supergraph_binary(

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -7,7 +7,6 @@ use apollo_federation_types::config::FederationVersion::LatestFedTwo;
 use apollo_federation_types::config::RouterVersion;
 use camino::Utf8PathBuf;
 use futures::StreamExt;
-use tokio::io::AsyncWriteExt;
 use houston::{Config, Profile};
 use router::{install::InstallRouter, run::RunRouter, watchers::file::FileWatcher};
 use rover_client::operations::config::who_am_i::WhoAmI;

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -9,7 +9,9 @@ use futures::StreamExt;
 use houston::{Config, Profile};
 use router::{install::InstallRouter, run::RunRouter, watchers::file::FileWatcher};
 use rover_client::operations::config::who_am_i::WhoAmI;
+use rover_std::infoln;
 
+use self::router::config::{RouterAddress, RunRouterConfig};
 use crate::{
     command::Dev,
     composition::{
@@ -29,8 +31,6 @@ use crate::{
     },
     RoverError, RoverOutput, RoverResult,
 };
-
-use self::router::config::{RouterAddress, RunRouterConfig};
 
 mod router;
 
@@ -65,6 +65,9 @@ impl Dev {
 
         let profile = &self.opts.plugin_opts.profile;
         let graph_ref = &self.opts.supergraph_opts.graph_ref;
+        if let Some(graph_ref) = graph_ref {
+            eprintln!("retrieving subgraphs remotely from {graph_ref}")
+        }
         let supergraph_config_path = &self.opts.supergraph_opts.clone().supergraph_config_path;
 
         let service = client_config.get_authenticated_client(profile)?.service()?;

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -9,7 +9,7 @@ use futures::StreamExt;
 use houston::{Config, Profile};
 use router::{install::InstallRouter, run::RunRouter, watchers::file::FileWatcher};
 use rover_client::operations::config::who_am_i::WhoAmI;
-use rover_std::infoln;
+use rover_std::{infoln, warnln};
 
 use self::router::config::{RouterAddress, RunRouterConfig};
 use crate::{
@@ -103,6 +103,7 @@ impl Dev {
                 skip_update,
             )
             .await?;
+
         let composition_success = composition_pipeline
             .compose(&exec_command_impl, &read_file_impl, &write_file_impl, None)
             .await?;
@@ -173,6 +174,10 @@ impl Dev {
                 else => break,
             }
         }
+
+        warnln!(
+            "Do not run this command in production! It is intended for local development only."
+        );
 
         Ok(RoverOutput::EmptySuccess)
     }

--- a/src/command/dev/next/router/config/mod.rs
+++ b/src/command/dev/next/router/config/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use buildstructor::buildstructor;
@@ -6,12 +7,11 @@ use http::Uri;
 use rover_std::{Fs, RoverStdError};
 use thiserror::Error;
 
-use crate::utils::effect::read_file::ReadFile;
-
 use self::{
     parser::{ParseRouterConfigError, RouterConfigParser},
     state::{RunRouterConfigDefault, RunRouterConfigFinal, RunRouterConfigReadConfig},
 };
+use crate::utils::effect::read_file::ReadFile;
 
 mod parser;
 pub mod remote;
@@ -51,6 +51,19 @@ impl RouterAddress {
         let host = host.unwrap_or(DEFAULT_ROUTER_IP_ADDR);
         let port = port.unwrap_or(DEFAULT_ROUTER_PORT);
         RouterAddress { host, port }
+    }
+}
+
+impl Display for RouterAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let host = self
+            .host
+            .to_string()
+            .replace("127.0.0.1", "localhost")
+            .replace("0.0.0.0", "localhost")
+            .replace("[::]", "localhost")
+            .replace("[::1]", "localhost");
+        write!(f, "http://{}:{}", host, self.port)
     }
 }
 

--- a/src/command/dev/next/router/config/mod.rs
+++ b/src/command/dev/next/router/config/mod.rs
@@ -191,6 +191,10 @@ impl RunRouterConfig<RunRouterConfigFinal> {
         &self.state.health_check_endpoint
     }
 
+    pub fn raw_config(&self) -> String {
+        self.state.raw_config.clone()
+    }
+
     #[allow(unused)]
     pub fn router_config(&self) -> RouterConfig {
         RouterConfig(self.state.raw_config.to_string())

--- a/src/command/dev/next/router/config/parser.rs
+++ b/src/command/dev/next/router/config/parser.rs
@@ -84,7 +84,7 @@ impl<'a> RouterConfigParser<'a> {
             .and_then(|addr_and_port| Some(Uri::from_str(addr_and_port)))
             // See https://www.apollographql.com/docs/graphos/routing/self-hosted/health-checks for
             // defaults
-            .unwrap_or(Uri::from_str("127.0.0.1:8088"))
+            .unwrap_or(Uri::from_str("http://127.0.0.1:8088"))
             .map_err(|err| ParseRouterConfigError::ListenPath {
                 path: "health_check.listen",
                 source: err,
@@ -161,8 +161,8 @@ health_check:
         );
         let config_yaml = serde_yaml::from_str(&config_yaml_str)?;
         let router_config = RouterConfigParser { yaml: &config_yaml };
-        let health_check = router_config.health_check();
-        assert_that!(health_check).is_equal_to(is_health_check_enabled);
+        let health_check = router_config.health_check_endpoint();
+        assert_that!(health_check.is_ok()).is_equal_to(is_health_check_enabled);
         Ok(())
     }
 
@@ -174,9 +174,8 @@ health_check:
         };
         let config_yaml = serde_yaml::from_str(&config_yaml_str)?;
         let router_config = RouterConfigParser { yaml: &config_yaml };
-        let health_check = router_config.health_check();
-        assert_that!(health_check).is_false();
-        Ok(())
+        let health_check = router_config.health_check_endpoint();
+        assert_that!(health_check).is_equal_to(Ok(Uri::from_str("http://127.0.0.1:8088/health")?))
     }
 
     #[rstest]

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 
 pub struct RunRouter<S> {
-    state: S,
+    pub(crate) state: S,
 }
 
 impl Default for RunRouter<state::Install> {

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -163,6 +163,7 @@ impl RunRouter<state::Run> {
             .call(
                 WriteFileRequest::builder()
                     .path(hot_reload_config_path.clone())
+                    .contents(Vec::from(self.state.config.raw_config()))
                     .build(),
             )
             .await

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -54,7 +54,7 @@ pub enum CompositionPipelineError {
 }
 
 pub struct CompositionPipeline<State> {
-    state: State,
+    pub(crate) state: State,
 }
 
 impl Default for CompositionPipeline<state::Init> {

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -6,18 +6,6 @@ use rover_client::shared::GraphRef;
 use tempfile::tempdir;
 use tower::MakeService;
 
-use crate::{
-    options::{LicenseAccepter, ProfileOpt},
-    utils::{
-        client::StudioClientConfig,
-        effect::{
-            exec::ExecCommand, install::InstallBinary, introspect::IntrospectSubgraph,
-            read_file::ReadFile, read_stdin::ReadStdin, write_file::WriteFile,
-        },
-        parsers::FileDescriptorType,
-    },
-};
-
 use super::{
     runner::{CompositionRunner, Runner},
     supergraph::{
@@ -31,6 +19,17 @@ use super::{
         install::{InstallSupergraph, InstallSupergraphError},
     },
     CompositionError, CompositionSuccess,
+};
+use crate::{
+    options::{LicenseAccepter, ProfileOpt},
+    utils::{
+        client::StudioClientConfig,
+        effect::{
+            exec::ExecCommand, install::InstallBinary, introspect::IntrospectSubgraph,
+            read_file::ReadFile, read_stdin::ReadStdin, write_file::WriteFile,
+        },
+        parsers::FileDescriptorType,
+    },
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -98,10 +97,12 @@ impl CompositionPipeline<state::Init> {
             }
             FileDescriptorType::Stdin => None,
         });
+        eprintln!("merging supergraph schema files");
         let resolver = SupergraphConfigResolver::default()
             .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
             .await?
             .load_from_file_descriptor(read_stdin_impl, supergraph_yaml.as_ref())?;
+        eprintln!("supergraph config loaded successfully");
         Ok(CompositionPipeline {
             state: state::ResolveFederationVersion {
                 resolver,

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -6,9 +6,8 @@ use std::marker::PhantomData;
 use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
 use derive_getters::Getters;
 
-use crate::command::supergraph::compose::do_compose::SupergraphComposeOpts;
-
 use super::full::FullyResolvedSubgraph;
+use crate::command::supergraph::compose::do_compose::SupergraphComposeOpts;
 
 mod state {
     #[derive(Clone, Debug)]
@@ -166,9 +165,8 @@ mod tests {
     use apollo_federation_types::config::{FederationVersion, SubgraphConfig, SupergraphConfig};
     use speculoos::prelude::*;
 
-    use crate::composition::supergraph::config::{full::FullyResolvedSubgraph, scenario::*};
-
     use super::FederationVersionResolverFromSupergraphConfig;
+    use crate::composition::supergraph::config::{full::FullyResolvedSubgraph, scenario::*};
 
     /// Test showing that federation version is selected from the user-specified fed version
     /// over local supergraph config or resolved subgraphs
@@ -189,7 +187,7 @@ mod tests {
         let supergraph_config =
             SupergraphConfig::new(unresolved_subgraphs, Some(FederationVersion::LatestFedOne));
 
-        let resolved_subgraphs = vec![(
+        let resolved_subgraphs = [(
             subgraph_name.to_string(),
             FullyResolvedSubgraph::builder()
                 .schema(subgraph_scenario.sdl)
@@ -222,7 +220,7 @@ mod tests {
         let supergraph_config =
             SupergraphConfig::new(unresolved_subgraphs, Some(FederationVersion::LatestFedTwo));
 
-        let resolved_subgraphs = vec![(
+        let resolved_subgraphs = [(
             subgraph_name.to_string(),
             FullyResolvedSubgraph::builder()
                 .schema(subgraph_scenario.sdl)
@@ -254,7 +252,7 @@ mod tests {
         let federation_version_resolver = FederationVersionResolverFromSupergraphConfig::default();
         let supergraph_config = SupergraphConfig::new(unresolved_subgraphs, None);
 
-        let resolved_subgraphs = vec![(
+        let resolved_subgraphs = [(
             subgraph_name.to_string(),
             FullyResolvedSubgraph::builder()
                 .schema(subgraph_scenario.sdl)

--- a/src/composition/supergraph/config/full/subgraph.rs
+++ b/src/composition/supergraph/config/full/subgraph.rs
@@ -24,7 +24,7 @@ pub struct FullyResolvedSubgraph {
     #[getter(skip)]
     routing_url: Option<String>,
     schema: String,
-    is_fed_two: bool,
+    pub(crate) is_fed_two: bool,
 }
 
 #[buildstructor]

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -1,14 +1,14 @@
 use apollo_federation_types::config::SchemaSource;
 use futures::{stream::BoxStream, StreamExt};
+use rover_std::{errln, infoln};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 
-use crate::{
-    options::ProfileOpt, subtask::SubtaskHandleUnit, utils::client::StudioClientConfig, RoverError,
-};
-
 use super::{
     file::FileWatcher, introspection::SubgraphIntrospection, remote::RemoteSchema, sdl::Sdl,
+};
+use crate::{
+    options::ProfileOpt, subtask::SubtaskHandleUnit, utils::client::StudioClientConfig, RoverError,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -64,26 +64,34 @@ impl SubgraphWatcher {
         profile: &ProfileOpt,
         client_config: &StudioClientConfig,
         introspection_polling_interval: u64,
+        subgraph_name: String,
     ) -> Result<Self, Box<UnsupportedSchemaSource>> {
+        eprintln!("starting a session with the '{subgraph_name}' subgraph");
         // SchemaSource comes from Apollo Federation types. Importantly, it strips comments and
         // directives from introspection (but not when the source is a file)
         match schema_source {
-            SchemaSource::File { file } => Ok(Self {
-                watcher: SubgraphWatcherKind::File(FileWatcher::new(file)),
-                routing_url,
-            }),
+            SchemaSource::File { file } => {
+                infoln!("Watching {} for changes", file.as_std_path().display());
+                Ok(Self {
+                    watcher: SubgraphWatcherKind::File(FileWatcher::new(file)),
+                    routing_url,
+                })
+            }
             SchemaSource::SubgraphIntrospection {
                 subgraph_url,
                 introspection_headers,
-            } => Ok(Self {
-                watcher: SubgraphWatcherKind::Introspect(SubgraphIntrospection::new(
-                    subgraph_url.clone(),
-                    introspection_headers.map(|header_map| header_map.into_iter().collect()),
-                    client_config,
-                    introspection_polling_interval,
-                )),
-                routing_url: routing_url.or_else(|| Some(subgraph_url.to_string())),
-            }),
+            } => {
+                eprintln!("polling {subgraph_url} every {introspection_polling_interval} seconds");
+                Ok(Self {
+                    watcher: SubgraphWatcherKind::Introspect(SubgraphIntrospection::new(
+                        subgraph_url.clone(),
+                        introspection_headers.map(|header_map| header_map.into_iter().collect()),
+                        client_config,
+                        introspection_polling_interval,
+                    )),
+                    routing_url: routing_url.or_else(|| Some(subgraph_url.to_string())),
+                })
+            }
             SchemaSource::Subgraph { graphref, subgraph } => Ok(Self {
                 watcher: SubgraphWatcherKind::Once(NonRepeatingFetch::RemoteSchema(
                     RemoteSchema::new(graphref, subgraph, profile, client_config),

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -1,6 +1,6 @@
 use apollo_federation_types::config::SchemaSource;
 use futures::{stream::BoxStream, StreamExt};
-use rover_std::{errln, infoln};
+use rover_std::infoln;
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 

--- a/src/utils/supergraph_config.rs
+++ b/src/utils/supergraph_config.rs
@@ -487,7 +487,7 @@ mod test_get_supergraph_config {
         let supergraph_config_path = third_level_folder.path().join("supergraph.yaml");
         fs::write(
             supergraph_config_path.clone(),
-            &supergraph_config.into_bytes(),
+            supergraph_config.into_bytes(),
         )
         .expect("Could not write supergraph.yaml");
 
@@ -568,8 +568,9 @@ fn merge_supergraph_configs(
 
 #[cfg(test)]
 mod test_merge_supergraph_configs {
-    use super::*;
     use rstest::{fixture, rstest};
+
+    use super::*;
 
     #[fixture]
     #[once]
@@ -1048,6 +1049,7 @@ mod test_resolve_supergraph_yaml {
     use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
     use assert_fs::TempDir;
     use camino::Utf8PathBuf;
+    use houston::Config;
     use httpmock::MockServer;
     use indoc::indoc;
     use rstest::{fixture, rstest};
@@ -1056,13 +1058,10 @@ mod test_resolve_supergraph_yaml {
     use speculoos::assert_that;
     use speculoos::prelude::{ResultAssertions, VecAssertions};
 
-    use houston::Config;
-
+    use super::*;
     use crate::options::ProfileOpt;
     use crate::utils::client::{ClientBuilder, StudioClientConfig};
     use crate::utils::parsers::FileDescriptorType;
-
-    use super::*;
 
     #[fixture]
     fn profile_opt() -> ProfileOpt {
@@ -1185,7 +1184,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
       file: ./people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let mut config_path = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1225,7 +1224,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();
@@ -1279,7 +1278,7 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
         file: ../../people.graphql"#,
-            latest_fed2_version.to_string()
+            latest_fed2_version
         );
         let tmp_home = TempDir::new().unwrap();
         let tmp_dir = Utf8PathBuf::try_from(tmp_home.path().to_path_buf()).unwrap();


### PR DESCRIPTION
This PR implements the following requirements specified in the test plan 

> **When I start rover dev with a supergraph config and --graph-ref**
> 
> If the subgraphs compose
> * I should see “starting a session with the ‘<subgraph name>’' subgraph” for each subgraph in the config
> * I should see “composing supergraph with Federation < federation version >” with the version of federation in the supergraph config
>    * If `--federation-version` is specified, this is the value that appears
>    * If no federation version is specified, the latest Fed2 version should be used
>    * If a Fed1 version is specified with Fed2 subgraphs, composition should fail specifying that this was the reason
>* If the supergraph does not compose
>    * I should see an error explaining why the supergraph composition failed

Have included screenshots below for comparison purposes

**Old dev launch**
![Screenshot 2024-12-20 at 11 13 43](https://github.com/user-attachments/assets/1c2e46e0-6d73-4760-80d6-af1d960c66da)

**New dev launch**
![Screenshot 2024-12-20 at 11 14 41](https://github.com/user-attachments/assets/c13eb8fc-569a-41af-ba1b-5f087b969715)

**Specifying a Federation Version**
![Screenshot 2024-12-20 at 11 15 49](https://github.com/user-attachments/assets/539e01c7-324a-431d-a1c5-86e7498a5a1c)

**Specifying a Fed 1 Version with Fed 2 Subgraphs**
![Screenshot 2024-12-20 at 11 17 08](https://github.com/user-attachments/assets/40a37813-029d-4195-a5ea-c0e6ab45431f)

**Supergraph doesn't compose**
![Screenshot 2024-12-20 at 11 17 51](https://github.com/user-attachments/assets/29836f06-2bea-4004-aa29-60029f7f9768)


