### PR TITLE
[BGS-121]  Fixes > When I start rover dev with --graph-ref I get 'Unable to resolve supergraph config. Supergraph config root is missing'

### DIFF
--- a/src/composition/supergraph/config/full/subgraph.rs
+++ b/src/composition/supergraph/config/full/subgraph.rs
@@ -43,7 +43,7 @@ impl FullyResolvedSubgraph {
     pub async fn resolve<MakeFetchSubgraph>(
         introspect_subgraph_impl: &impl IntrospectSubgraph,
         mut fetch_remote_subgraph_impl: MakeFetchSubgraph,
-        supergraph_config_root: Option<&Utf8PathBuf>,
+        supergraph_config_root: &Utf8PathBuf,
         unresolved_subgraph: UnresolvedSubgraph,
     ) -> Result<FullyResolvedSubgraph, ResolveSubgraphError>
     where
@@ -53,8 +53,6 @@ impl FullyResolvedSubgraph {
     {
         match unresolved_subgraph.schema() {
             SchemaSource::File { file } => {
-                let supergraph_config_root =
-                    supergraph_config_root.ok_or(ResolveSubgraphError::SupergraphConfigMissing)?;
                 let file = unresolved_subgraph.resolve_file_path(supergraph_config_root, file)?;
                 let schema =
                     Fs::read_file(&file).map_err(|err| ResolveSubgraphError::Fs(Box::new(err)))?;

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -48,7 +48,7 @@ impl FullyResolvedSupergraphConfig {
     pub async fn resolve<MakeFetchSubgraph>(
         introspect_subgraph_impl: &impl IntrospectSubgraph,
         fetch_remote_subgraph_impl: MakeFetchSubgraph,
-        supergraph_config_root: Option<&Utf8PathBuf>,
+        supergraph_config_root: &Utf8PathBuf,
         unresolved_supergraph_config: UnresolvedSupergraphConfig,
     ) -> Result<FullyResolvedSupergraphConfig, ResolveSupergraphConfigError>
     where

--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -245,7 +245,7 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
         &self,
         introspect_subgraph_impl: &impl IntrospectSubgraph,
         fetch_remote_subgraph_impl: MakeFetchSubgraph,
-        supergraph_config_root: Option<&Utf8PathBuf>,
+        supergraph_config_root: &Utf8PathBuf,
         prompt: &impl Prompt,
     ) -> Result<FullyResolvedSupergraphConfig, ResolveSupergraphConfigError>
     where
@@ -316,12 +316,9 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
     /// config is piped through stdin
     pub async fn lazily_resolve_subgraphs(
         &self,
-        supergraph_config_root: Option<&Utf8PathBuf>,
+        supergraph_config_root: &Utf8PathBuf,
         prompt: &impl Prompt,
     ) -> Result<LazilyResolvedSupergraphConfig, ResolveSupergraphConfigError> {
-        let supergraph_config_root = supergraph_config_root
-            .ok_or_else(|| ResolveSupergraphConfigError::MissingSupergraphConfigRoot)?;
-
         if !self.state.subgraphs.is_empty() {
             let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()
                 .and_origin_path(self.state.origin_path.clone())

--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -646,7 +646,7 @@ mod tests {
             .fully_resolve_subgraphs(
                 &mock_introspect_subgraph,
                 make_fetch_remote_subgraph_service,
-                Some(&local_supergraph_config_path),
+                &local_supergraph_config_path,
                 &MockPrompt::default(),
             )
             .await?;
@@ -823,7 +823,7 @@ mod tests {
             .fully_resolve_subgraphs(
                 &mock_introspect_subgraph,
                 make_fetch_remote_subgraph_service,
-                Some(&local_supergraph_config_path),
+                &local_supergraph_config_path,
                 &MockPrompt::default(),
             )
             .await?;
@@ -995,7 +995,7 @@ mod tests {
             .fully_resolve_subgraphs(
                 &mock_introspect_subgraph,
                 make_fetch_remote_subgraph_service,
-                Some(&local_supergraph_config_path),
+                &local_supergraph_config_path,
                 &MockPrompt::default(),
             )
             .await?;

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -363,10 +363,7 @@ mod tests {
         let result = FullyResolvedSupergraphConfig::resolve(
             &mock_introspect_subgraph,
             make_fetch_remote_subgraph_service,
-            Some(
-                &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf())
-                    .unwrap(),
-            ),
+            &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf()).unwrap(),
             unresolved_supergraph_config,
         )
         .await;
@@ -562,10 +559,7 @@ mod tests {
         let result = FullyResolvedSupergraphConfig::resolve(
             &mock_introspect_subgraph,
             make_fetch_remote_subgraph_service,
-            Some(
-                &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf())
-                    .unwrap(),
-            ),
+            &Utf8PathBuf::from_path_buf(supergraph_config_root_dir.path().to_path_buf()).unwrap(),
             unresolved_supergraph_config,
         )
         .await;


### PR DESCRIPTION
This code path serves two variants:
* the supergraph config is fetched from a graph-ref
* the supergraph config is read off disk

The current code is failing because of a typecheck on `supergraph_root_config`, a `pwd` like value for building a filepath. This value is not needed or expected in the use case when supergraph if fetched from a graph-ref.

The solution here is a little novel; to require that the `supergraph_root_config` be passed as an unwrapped value so the resolver function no longer requires a hard unwrap or else, and doesn't get triggered when called in the the `--graph-ref` mode.