### PR TITLE
Revert "Consolidate file watchers"

### DIFF
--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -108,7 +108,7 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
                 .unwrap_or_default()
         );
         let supergraph_config_watcher = if let Some(origin_path) = supergraph_config.origin_path() {
-            let f = FileWatcher::basic(origin_path.clone());
+            let f = FileWatcher::new(origin_path.clone());
             let watcher = SupergraphConfigWatcher::new(f, supergraph_config);
             Some(watcher)
         } else {

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -1,73 +1,108 @@
-use std::{pin::Pin, sync::Arc};
+use std::sync::{Arc, OnceLock};
 
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
-use futures::{stream::BoxStream, Future, StreamExt, TryFutureExt};
+use futures::{stream::BoxStream, StreamExt, TryFutureExt};
 use rover_std::{errln, Fs, RoverStdError};
 use tap::TapFallible;
 use tokio::sync::{mpsc::unbounded_channel, Mutex};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::DropGuard;
-use tower::{util::BoxCloneService, Service, ServiceExt};
+use tower::{Service, ServiceExt};
 
 use crate::composition::supergraph::config::{
     error::ResolveSubgraphError,
     full::{FullyResolveSubgraphService, FullyResolvedSubgraph},
 };
 
-pub type SubgraphFileWatcher = FileWatcher<FullyResolvedSubgraph, ResolveSubgraphError>;
-pub type BasicFileWatcher = FileWatcher<String, RoverStdError>;
-
 /// File watcher specifically for files related to composition
 #[derive(Debug, Getters)]
-pub struct FileWatcher<T, E> {
+pub struct FileWatcher {
     /// The filepath to watch
     path: Utf8PathBuf,
-    resolver: BoxCloneService<(), T, E>,
+    drop_guard: OnceLock<DropGuard>,
+}
+
+impl FileWatcher {
+    /// Create a new filewatcher
+    pub fn new(path: Utf8PathBuf) -> Self {
+        Self {
+            path,
+            drop_guard: OnceLock::new(),
+        }
+    }
+
+    pub async fn fetch(&self) -> Result<String, RoverStdError> {
+        Fs::read_file(self.path.clone())
+    }
+
+    /// Watch a file
+    ///
+    /// When a file is removed, the internal rover-std::fs filewatcher will be cancelled. The
+    /// composition filewatcher's stream will still be active, however
+    ///
+    /// Development note: in the future, we might consider a way to kill the watcher when the
+    /// rover-std::fs filewatcher dies. Right now, the stream remains active and we can
+    /// indefinitely loop on a close filewatcher
+    pub async fn watch(&self) -> BoxStream<'static, String> {
+        let (file_tx, file_rx) = unbounded_channel();
+        let output = UnboundedReceiverStream::new(file_rx);
+        let cancellation_token = Fs::watch_file(self.path.as_path().into(), file_tx);
+        self.drop_guard
+            .set(cancellation_token.clone().drop_guard())
+            .unwrap();
+
+        output
+            .filter_map({
+                let path = self.path.clone();
+                move |result| {
+                    let cancellation_token = cancellation_token.clone();
+                    let path = path.clone();
+                    async move {
+                        // We cancel the filewatching when the file has been removed because it
+                        // can no longer be watched
+                        if let Err(RoverStdError::FileRemoved { file }) = &result {
+                            tracing::error!("Closing file watcher for {file}");
+                            errln!("Closing file watcher for {file:?}");
+                            cancellation_token.cancel();
+                        }
+
+                        match result {
+                            Ok(_) => Fs::read_file(path)
+                                .tap_err(|err| tracing::error!("Could not read file: {:?}", err))
+                                .ok(),
+                            Err(err) => {
+                                errln!("error reading file: {:?}", err);
+                                None
+                            }
+                        }
+                    }
+                }
+            })
+            .boxed()
+    }
+}
+
+/// File watcher specifically for files related to composition
+#[derive(Debug, Clone, Getters)]
+pub struct SubgraphFileWatcher {
+    /// The filepath to watch
+    path: Utf8PathBuf,
+    resolver: FullyResolveSubgraphService,
     drop_guard: Arc<Mutex<Option<DropGuard>>>,
 }
 
-// rust couldn't figure out how to derive this
-impl<T, E> Clone for FileWatcher<T, E> {
-    fn clone(&self) -> Self {
-        FileWatcher {
-            path: self.path.clone(),
-            resolver: self.resolver.clone(),
-            drop_guard: self.drop_guard.clone(),
-        }
-    }
-}
-
-impl FileWatcher<String, RoverStdError> {
-    /// Create a new BasicFileWatcher
-    pub fn basic(path: Utf8PathBuf) -> FileWatcher<String, RoverStdError> {
-        let resolver = BasicFileResolver { path: path.clone() };
-        let resolver = resolver.boxed_clone();
-        Self {
-            path,
-            resolver,
-            drop_guard: Arc::new(Mutex::new(None)),
-        }
-    }
-}
-
-impl FileWatcher<FullyResolvedSubgraph, ResolveSubgraphError> {
+impl SubgraphFileWatcher {
     /// Create a new filewatcher
-    pub fn subgraph(path: Utf8PathBuf, resolver: FullyResolveSubgraphService) -> Self {
+    pub fn new(path: Utf8PathBuf, resolver: FullyResolveSubgraphService) -> Self {
         Self {
             path,
             resolver,
             drop_guard: Arc::new(Mutex::new(None)),
         }
     }
-}
 
-impl<T, E> FileWatcher<T, E>
-where
-    T: 'static,
-    E: std::error::Error + 'static,
-{
-    pub async fn fetch(mut self) -> Result<T, E> {
+    pub async fn fetch(mut self) -> Result<FullyResolvedSubgraph, ResolveSubgraphError> {
         self.resolver.ready().await?.call(()).await
     }
 
@@ -79,7 +114,7 @@ where
     /// Development note: in the future, we might consider a way to kill the watcher when the
     /// rover-std::fs filewatcher dies. Right now, the stream remains active and we can
     /// indefinitely loop on a close filewatcher
-    pub async fn watch(self) -> BoxStream<'static, T> {
+    pub async fn watch(self) -> BoxStream<'static, FullyResolvedSubgraph> {
         let (file_tx, file_rx) = unbounded_channel();
         let output = UnboundedReceiverStream::new(file_rx);
         let cancellation_token = Fs::watch_file(self.path.as_path().into(), file_tx);
@@ -110,15 +145,8 @@ where
                                 .await
                                 .tap_err(|err| tracing::error!("Could not read file: {:?}", err))
                                 .ok(),
-                            Err(RoverStdError::FileRemoved { file }) => {
-                                tracing::error!("Closing file watcher for {file}");
-                                errln!("Closing file watcher for {file:?}");
-                                cancellation_token.cancel();
-                                None
-                            }
                             Err(err) => {
-                                tracing::error!("File watcher error: {:?}", err);
-                                cancellation_token.cancel();
+                                errln!("error reading file: {:?}", err);
                                 None
                             }
                         }
@@ -129,36 +157,12 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct BasicFileResolver {
-    path: Utf8PathBuf,
-}
-
-impl Service<()> for BasicFileResolver {
-    type Response = String;
-    type Error = RoverStdError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, _req: ()) -> Self::Future {
-        let path = self.path.clone();
-        let fut = async move { Fs::read_file(path) };
-        Box::pin(fut)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{fs::OpenOptions, io::Write, time::Duration};
 
     use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
-    use assert_fs::{prelude::*, TempDir};
+    use assert_fs::TempDir;
     use speculoos::prelude::*;
     use tokio::time::timeout;
     use tower::ServiceExt;
@@ -174,8 +178,7 @@ mod tests {
     async fn it_watches() {
         let root = TempDir::new().unwrap();
         let supergraph_config_root = Utf8PathBuf::from_path_buf(root.path().to_path_buf()).unwrap();
-        let child = root.child("supergraph.yaml");
-        let path = Utf8PathBuf::from_path_buf(child.path().to_path_buf()).unwrap();
+        let path = supergraph_config_root.join("supergraph.yaml");
         let subgraph_name = "file-subgraph";
         let routing_url = "https://example.com/graphql";
         let resolve_file_subgraph = ResolveFileSubgraph::builder()
@@ -191,17 +194,35 @@ mod tests {
             .build()
             .boxed_clone();
 
-        let sdl = "type Query { test: String }";
-        child.write_str(sdl).expect("couldn't write to file");
+        let mut writeable_file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(path.clone())
+            .expect("Cannot open file");
 
-        let watcher = FileWatcher::subgraph(path.clone(), resolve_file_subgraph);
+        let sdl = "type Query { test: String }";
+        writeable_file
+            .write_all(sdl.as_bytes())
+            .expect("couldn't write to file");
+
+        let watcher = SubgraphFileWatcher::new(path.clone(), resolve_file_subgraph);
         // SubgraphFileWatcher has a DropGuard associated with it that cancels the underlying FileWatcher's CancellationToken when dropped, so we must retain a reference until this test finishes. This can be fixed if we migrate this to a `Subtask` implementation to make it safer and more explicit
         let _watcher = watcher.clone();
         let mut watching = watcher.watch().await;
         let _ = tokio::time::sleep(Duration::from_millis(500)).await;
 
+        let mut writeable_file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .expect("Cannot open file");
+
         let sdl = "type Query { test: String! }";
-        child.write_str(sdl).expect("couldn't write to file");
+
+        writeable_file
+            .write_all(sdl.as_bytes())
+            .expect("couldn't write to file");
 
         let output = timeout(Duration::from_secs(5), watching.next()).await;
 

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -176,7 +176,8 @@ mod tests {
     #[tokio::test]
     #[traced_test(level = "error")]
     async fn it_watches() {
-        let root = TempDir::new().unwrap();
+        let root = tempfile::Builder::new().tempdir().unwrap();
+        //let root = TempDir::new().unwrap();
         let supergraph_config_root = Utf8PathBuf::from_path_buf(root.path().to_path_buf()).unwrap();
         let path = supergraph_config_root.join("supergraph.yaml");
         let subgraph_name = "file-subgraph";

--- a/src/composition/watchers/watcher/subgraph.rs
+++ b/src/composition/watchers/watcher/subgraph.rs
@@ -10,13 +10,10 @@ use tower::{Service, ServiceExt};
 
 use super::{file::SubgraphFileWatcher, introspection::SubgraphIntrospection};
 use crate::{
-    composition::{
-        supergraph::config::{
-            error::ResolveSubgraphError,
-            full::{FullyResolveSubgraphService, FullyResolvedSubgraph},
-            lazy::LazilyResolvedSubgraph,
-        },
-        watchers::watcher::file::FileWatcher,
+    composition::supergraph::config::{
+        error::ResolveSubgraphError,
+        full::{FullyResolveSubgraphService, FullyResolvedSubgraph},
+        lazy::LazilyResolvedSubgraph,
     },
     subtask::SubtaskHandleUnit,
 };
@@ -88,7 +85,7 @@ impl SubgraphWatcher {
             SchemaSource::File { file } => {
                 infoln!("Watching {} for changes", file.as_std_path().display());
                 Self {
-                    watcher: SubgraphWatcherKind::File(FileWatcher::subgraph(
+                    watcher: SubgraphWatcherKind::File(SubgraphFileWatcher::new(
                         file.clone(),
                         resolver,
                     )),

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -15,17 +15,17 @@ use crate::{
     subtask::SubtaskHandleUnit,
 };
 
-use super::file::BasicFileWatcher;
+use super::file::FileWatcher;
 
 #[derive(Debug)]
 pub struct SupergraphConfigWatcher {
-    file_watcher: BasicFileWatcher,
+    file_watcher: FileWatcher,
     supergraph_config: SupergraphConfig,
 }
 
 impl SupergraphConfigWatcher {
     pub fn new(
-        file_watcher: BasicFileWatcher,
+        file_watcher: FileWatcher,
         supergraph_config: LazilyResolvedSupergraphConfig,
     ) -> SupergraphConfigWatcher {
         SupergraphConfigWatcher {


### PR DESCRIPTION
Reverts apollographql/rover#2334

something in this PR makes the windows filewatcher test fail and seems to be prematurely dropping the filewatcher (as confirmed in the lsp):

```
starting a session with the 'listings' subgraph
==> Watching /Users/jonathanrainer/Documents/Experiments/lsp_testing/odyssey-connectors-rest-intro/listings.graphql for changes
   INFO rover::composition::runner: Setting up SupergraphConfigWatcher from origin: /Users/jonathanrainer/Documents/Experiments/lsp_testing/odyssey-connectors-rest-intro/supergraph.yaml
    at src/composition/runner/mod.rs:101

   INFO rover::composition::runner: Watching subgraphs for changes...
    at src/composition/runner/mod.rs:181

   WARN rover::composition::watchers::watcher::supergraph_config: Running SupergraphConfigWatcher
    at src/composition/watchers/watcher/supergraph_config.rs:41

...

   INFO rover_std::fs: checking existence of parent path in '/tmp/supergraph.yaml'
    at crates/rover-std/src/fs.rs:59

  DEBUG rover_std::fs: attempting to canonicalize parent path '/tmp'
    at crates/rover-std/src/fs.rs:100

  DEBUG rover_std::fs: Dropping file watcher for: "/Users/jonathanrainer/Documents/Experiments/lsp_testing/odyssey-connectors-rest-intro/supergraph.yaml"
    at crates/rover-std/src/fs.rs:350

  DEBUG rover_std::fs: final canonical path is /private/tmp/supergraph.yaml
    at crates/rover-std/src/fs.rs:77

  DEBUG rover_std::fs: Dropping file watcher for: "/Users/jonathanrainer/Documents/Experiments/lsp_testing/odyssey-connectors-rest-intro/listings.graphql"
    at crates/rover-std/src/fs.rs:350
    ```
    
    reverting fixes both of these, but I'm not 100% sure why; reverting for now and creating a cleanup ticket to re-consolidate when we've more time