### PR TITLE
[BGS-144] Introspection watcher should notify when subgraph hosts change connection status.

### DIFF
--- a/src/composition/supergraph/config/error/subgraph.rs
+++ b/src/composition/supergraph/config/error/subgraph.rs
@@ -26,7 +26,7 @@ pub enum ResolveSubgraphError {
     #[error(transparent)]
     Fs(Box<dyn std::error::Error + Send + Sync>),
     /// Occurs when a introspection against a subgraph fails
-    #[error("Failed to introspect the subgraph {subgraph_name}.")]
+    #[error("Failed to introspect the subgraph \"{subgraph_name}\".")]
     IntrospectionError {
         /// The subgraph name that failed to be resolved
         subgraph_name: String,

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -170,7 +170,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                 match diff {
                     Ok(diff) => {
                         // If we detect additional diffs, start a new subgraph subtask.
-                        // Adding the abort handle to the currentl collection of handles.
+                        // Adding the abort handle to the current collection of handles.
                         for (subgraph_name, subgraph_config) in diff.added() {
                             let _ = subgraph_handles.add(
                                 subgraph_name,

--- a/src/composition/watchers/watcher/introspection.rs
+++ b/src/composition/watchers/watcher/introspection.rs
@@ -12,6 +12,8 @@ use crate::{
     watch::Watch,
 };
 
+use rover_std::{errln, infoln};
+
 /// Subgraph introspection
 #[derive(Debug, Clone)]
 pub struct SubgraphIntrospection {
@@ -51,16 +53,20 @@ impl SubgraphIntrospection {
             .filter_map(|change| async move {
                 match change {
                     Ok(subgraph) => {
-                        eprintln!(
-                            "Connectivity restored for subgraph \"{}\".\n",
+                        infoln!(
+                            "Connectivity restored for subgraph \"{}\".",
                             subgraph.name()
                         );
                         Some(subgraph)
                     }
                     Err(err) => {
-                        eprintln!("Error detected communicating with subgraph: {}", err);
-                        eprintln!("Note: Schema changes will not be reflected.");
-                        eprintln!("Will retry but subgraph logs should be inspected.\n\n");
+                        errln!(
+                            "{} \
+Error communicating with subgraph.
+* Schema changes will not be reflected.
+* Inspect subgraph logs for more information.",
+                            err
+                        );
                         tracing::error!("{:?}", err);
                         None
                     }

--- a/src/composition/watchers/watcher/introspection.rs
+++ b/src/composition/watchers/watcher/introspection.rs
@@ -50,8 +50,17 @@ impl SubgraphIntrospection {
             .skip(1)
             .filter_map(|change| async move {
                 match change {
-                    Ok(subgraph) => Some(subgraph),
+                    Ok(subgraph) => {
+                        eprintln!(
+                            "Connectivity restored for subgraph \"{}\".\n",
+                            subgraph.name()
+                        );
+                        Some(subgraph)
+                    }
                     Err(err) => {
+                        eprintln!("Error detected communicating with subgraph: {}", err);
+                        eprintln!("Note: Schema changes will not be reflected.");
+                        eprintln!("Will retry but subgraph logs should be inspected.\n\n");
                         tracing::error!("{:?}", err);
                         None
                     }


### PR DESCRIPTION
When using introspection watcher, and one of the services is killed, expect that user will receive message to stdout that shows a connection error message, and should see a resolution message when connectivity is restored.

Reproduction:
Start rover dev with a supergraph (see https://apollographql.atlassian.net/browse/BGS-144 for one detailed setup)
Kill any of the subgraph servers. 

Expected:
View console messages and see message similar to:
> Error detected communicating with subgraph: Failed to introspect the subgraph "users".
> Note: Schema changes will not be reflected.
> Will retry but subgraph logs should be inspected.

Restart the stopped server.

Expected:
View console messages and see message similar to:

> Connectivity restored for subgraph "shipping".



