### PR TITLE
[BGS-146] [messages] rover stderr should emit `successfully updated router config` after valid edit when --router-config is passed.

### DIFF
--- a/src/command/dev/next/router/hot_reload.rs
+++ b/src/command/dev/next/router/hot_reload.rs
@@ -7,6 +7,8 @@ use crate::{subtask::SubtaskHandleStream, utils::effect::write_file::WriteFile};
 
 use super::config::RouterConfig;
 
+use rover_std::{debugln, errln, infoln};
+
 pub enum RouterUpdateEvent {
     SchemaChanged { schema: String },
     ConfigChanged { config: RouterConfig },
@@ -69,12 +71,17 @@ where
                                 let _ = sender.send(message).tap_err(|err| {
                                     tracing::error!("Unable to send message. Error: {:?}", err)
                                 });
+                                infoln!("Router config updated.");
+                                debugln!("{}", config.inner());
                             }
                             Err(err) => {
+                                let error_message =
+                                    format!("Router config failed to update. {}", &err);
                                 let message = HotReloadEvent::ConfigWritten(Err(Box::new(err)));
                                 let _ = sender.send(message).tap_err(|err| {
                                     tracing::error!("Unable to send message. Error: {:?}", err)
                                 });
+                                errln!("{}", error_message);
                             }
                         }
                     }


### PR DESCRIPTION
This PR adds a message to stdout when the `--router-config` is updated while being watched.