### PR TITLE
[BGS-147] [messages] when a subgraph schema is changed, stderr prints message `updating the schema for the '{subgraph_name}' subgraph in the session`

### DIFF
--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -2,7 +2,7 @@ use apollo_federation_types::config::SupergraphConfig;
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use futures::stream::BoxStream;
-use rover_std::errln;
+use rover_std::{errln, infoln};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 use tokio_stream::StreamExt;
@@ -52,7 +52,9 @@ where
                     match event {
                         SubgraphEvent::SubgraphChanged(subgraph_schema_changed) => {
                             let name = subgraph_schema_changed.name();
-                            tracing::info!("Schema change detected for subgraph: {}", name);
+                            let message = format!("Schema change detected for subgraph: {}", &name);
+                            infoln!("{}", message);
+                            tracing::info!(message);
                             supergraph_config.update_subgraph_schema(
                                 name.to_string(),
                                 subgraph_schema_changed.into(),


### PR DESCRIPTION
This PR prints a message to stderr when the schema is updated.