### PR TITLE
[BGS-148] [messages] user adding/removing/changing a schema should see stderr print `successfully composed`.

### DIFF
--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -106,11 +106,13 @@ where
 
                     match output {
                         Ok(success) => {
+                            infoln!("Composition successful.");
                             let _ = sender
                                 .send(CompositionEvent::Success(success))
                                 .tap_err(|err| tracing::error!("{:?}", err));
                         }
                         Err(err) => {
+                            errln!("Composition failed.");
                             let _ = sender
                                 .send(CompositionEvent::Error(err))
                                 .tap_err(|err| tracing::error!("{:?}", err));


### PR DESCRIPTION
This PR adds some user messages on stderr when a watched supergraph re-composes.