### PR TITLE
[BGS-150] [messages] when router config doesn’t exist at the path provided in `--router-config`, stderr should receive message `{path} does not exist, creating a router config from CLI options.`

### DIFF
--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -62,12 +62,6 @@ impl Dev {
 
         let router_config_path = self.opts.supergraph_opts.router_config_path.clone();
 
-        let _config = RunRouterConfig::default()
-            .with_address(router_address)
-            .with_config(&read_file_impl, router_config_path.as_ref())
-            .await
-            .map_err(|err| RoverError::new(anyhow!("{}", err)))?;
-
         let profile = &self.opts.plugin_opts.profile;
         let graph_ref = &self.opts.supergraph_opts.graph_ref;
         if let Some(graph_ref) = graph_ref {


### PR DESCRIPTION
This PR implements a message, and a (previously existing) feature.

Prior to this PR, on the dev-next line, when starting up with an invalid `--router-config` filepath, the process would crash with an error.

With this PR, the user will be given a notification that the file was not found, and that we are building a router-config from command line options on their behalf.