### PR TITLE
ROVER-279 Funnels Errors from Supergraph Config Deserialisation to LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6404,6 +6404,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ timber = { workspace = true }
 termimad = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "process", "sync"] }
-tokio-stream = { workspace = true }
+tokio-stream = { workspace = true, features = ["sync"]}
 tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -269,7 +269,7 @@ async fn start_composition(
                 }
                 CompositionEvent::Error(err) => {
                     debug!("Composition failed: {err}");
-                    let message = format!("Failed run composition: {err}");
+                    let message = format!("Composition failed to run: {err}",);
                     let diagnostic = Diagnostic::new_simple(Range::default(), message);
                     language_server
                         .publish_diagnostics(supergraph_yaml_url.clone(), vec![diagnostic])

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -63,6 +63,8 @@ pub enum CompositionError {
     },
     #[error("Serialization error.\n{}", .0)]
     SerdeYaml(#[from] serde_yaml::Error),
+    #[error("{}", .0)]
+    InvalidSupergraphConfig(String),
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -28,11 +28,12 @@ use super::{
     watchers::{composition::CompositionWatcher, subgraphs::SubgraphWatchers},
 };
 use crate::composition::supergraph::binary::OutputTarget;
+use crate::subtask::{BroadcastSubtask, SubtaskRunUnit};
 use crate::{
     composition::watchers::watcher::{
         file::FileWatcher, supergraph_config::SupergraphConfigWatcher,
     },
-    subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit},
+    subtask::{Subtask, SubtaskRunStream},
     utils::effect::{exec::ExecCommand, read_file::ReadFile, write_file::WriteFile},
 };
 
@@ -180,7 +181,7 @@ where
         {
             tracing::info!("Watching subgraphs for changes...");
             let (supergraph_config_stream, supergraph_config_subtask) =
-                Subtask::new(supergraph_config_watcher);
+                BroadcastSubtask::new(supergraph_config_watcher);
             (
                 supergraph_config_stream.boxed(),
                 Some(supergraph_config_subtask),

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use camino::Utf8PathBuf;
-use futures::stream::{BoxStream, StreamExt};
+use futures::stream::{select, BoxStream, StreamExt};
 use rover_http::HttpService;
 use tower::ServiceExt;
 
@@ -28,6 +28,7 @@ use super::{
     watchers::{composition::CompositionWatcher, subgraphs::SubgraphWatchers},
 };
 use crate::composition::supergraph::binary::OutputTarget;
+use crate::composition::watchers::federation::FederationWatcher;
 use crate::subtask::{BroadcastSubtask, SubtaskRunUnit};
 use crate::{
     composition::watchers::watcher::{
@@ -174,27 +175,32 @@ where
 {
     /// Runs the [`Runner`]
     pub fn run(self) -> BoxStream<'static, CompositionEvent> {
-        let (supergraph_config_stream, supergraph_config_subtask) = if let Some(
-            supergraph_config_watcher,
-        ) =
-            self.state.supergraph_config_watcher
-        {
-            tracing::info!("Watching subgraphs for changes...");
-            let (supergraph_config_stream, supergraph_config_subtask) =
-                BroadcastSubtask::new(supergraph_config_watcher);
-            (
-                supergraph_config_stream.boxed(),
-                Some(supergraph_config_subtask),
-            )
-        } else {
-            tracing::warn!(
+        let (supergraph_config_stream, supergraph_config_stream_2, supergraph_config_subtask) =
+            if let Some(supergraph_config_watcher) = self.state.supergraph_config_watcher {
+                tracing::info!("Watching subgraphs for changes...");
+                let (supergraph_config_stream, supergraph_config_subtask) =
+                    BroadcastSubtask::new(supergraph_config_watcher);
+                (
+                    supergraph_config_stream.boxed(),
+                    supergraph_config_subtask.subscribe().boxed(),
+                    Some(supergraph_config_subtask),
+                )
+            } else {
+                tracing::warn!(
                     "No supergraph config detected, changes to subgraph configurations will not be applied automatically"
                 );
-            (tokio_stream::empty().boxed(), None)
-        };
+                (
+                    tokio_stream::empty().boxed(),
+                    tokio_stream::empty().boxed(),
+                    None,
+                )
+            };
 
         let (subgraph_change_stream, subgraph_watcher_subtask) =
             Subtask::new(self.state.subgraph_watchers);
+
+        let (federation_watcher_stream, federation_watcher_subtask) =
+            Subtask::new(FederationWatcher {});
 
         // Create a new subtask for the composition handler, passing in a stream of subgraph change
         // events in order to trigger recomposition.
@@ -203,13 +209,39 @@ where
         composition_subtask.run(subgraph_change_stream.boxed());
 
         // Start subgraph watchers, listening for events from the supergraph change stream.
-        subgraph_watcher_subtask.run(supergraph_config_stream);
+        subgraph_watcher_subtask.run(
+            supergraph_config_stream
+                .filter_map(|recv_res| async move {
+                    match recv_res {
+                        Ok(res) => Some(res),
+                        Err(e) => {
+                            tracing::warn!("Error receiving from broadcast stream: {:?}", e);
+                            None
+                        }
+                    }
+                })
+                .boxed(),
+        );
+
+        federation_watcher_subtask.run(
+            supergraph_config_stream_2
+                .filter_map(|recv_res| async move {
+                    match recv_res {
+                        Ok(res) => Some(res),
+                        Err(e) => {
+                            tracing::warn!("Error receiving from broadcast stream: {:?}", e);
+                            None
+                        }
+                    }
+                })
+                .boxed(),
+        );
 
         // Start the supergraph watcher subtask.
         if let Some(supergraph_config_subtask) = supergraph_config_subtask {
             supergraph_config_subtask.run();
         }
 
-        composition_messages.boxed()
+        select(composition_messages, federation_watcher_stream).boxed()
     }
 }

--- a/src/composition/supergraph/config/full/subgraph/file.rs
+++ b/src/composition/supergraph/config/full/subgraph/file.rs
@@ -1,6 +1,7 @@
 //! Utilities that allow for resolving file-based subgraphs
 
 use std::pin::Pin;
+use std::sync::Arc;
 
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
@@ -8,11 +9,10 @@ use futures::Future;
 use rover_std::Fs;
 use tower::Service;
 
+use super::FullyResolvedSubgraph;
 use crate::composition::supergraph::config::{
     error::ResolveSubgraphError, unresolved::UnresolvedSubgraph,
 };
-
-use super::FullyResolvedSubgraph;
 
 /// Service that resolves a file-based subgraph
 #[derive(Clone, Builder)]
@@ -41,8 +41,9 @@ impl Service<()> for ResolveFileSubgraph {
         let subgraph_name = unresolved_subgraph.name().to_string();
         let fut = async move {
             let file = unresolved_subgraph.resolve_file_path(&supergraph_config_root, &path)?;
-            let schema =
-                Fs::read_file(&file).map_err(|err| ResolveSubgraphError::Fs(Box::new(err)))?;
+            let schema = Fs::read_file(&file).map_err(|err| ResolveSubgraphError::Fs {
+                source: Arc::new(Box::new(err)),
+            })?;
             let routing_url = unresolved_subgraph.routing_url().clone().ok_or_else(|| {
                 ResolveSubgraphError::MissingRoutingUrl {
                     subgraph: unresolved_subgraph.name().to_string(),

--- a/src/composition/supergraph/config/full/subgraph/remote.rs
+++ b/src/composition/supergraph/config/full/subgraph/remote.rs
@@ -1,18 +1,18 @@
 //! Utilities that resolve subgraphs from Apollo Studio
 
 use std::pin::Pin;
+use std::sync::Arc;
 
 use buildstructor::Builder;
 use futures::Future;
 use rover_client::shared::GraphRef;
 use tower::{Service, ServiceExt};
 
+use super::FullyResolvedSubgraph;
 use crate::composition::supergraph::config::{
     error::ResolveSubgraphError,
     resolver::fetch_remote_subgraph::{FetchRemoteSubgraphRequest, RemoteSubgraph},
 };
-
-use super::FullyResolvedSubgraph;
 
 /// Service that resolves a remote subgraph from Apollo Studio
 #[derive(Clone, Builder)]
@@ -46,7 +46,7 @@ where
             .poll_ready(cx)
             .map_err(|err| ResolveSubgraphError::FetchRemoteSdlError {
                 subgraph_name: self.subgraph_name.to_string(),
-                source: Box::new(err),
+                source: Arc::new(Box::new(err)),
             })
     }
 
@@ -62,7 +62,7 @@ where
                 .await
                 .map_err(|err| ResolveSubgraphError::FetchRemoteSdlError {
                     subgraph_name: subgraph_name.to_string(),
-                    source: Box::new(err),
+                    source: Arc::new(Box::new(err)),
                 })?
                 .call(
                     FetchRemoteSubgraphRequest::builder()
@@ -73,7 +73,7 @@ where
                 .await
                 .map_err(|err| ResolveSubgraphError::FetchRemoteSdlError {
                     subgraph_name: subgraph_name.to_string(),
-                    source: Box::new(err),
+                    source: Arc::new(Box::new(err)),
                 })?;
             let schema = remote_subgraph.schema().clone();
             let routing_url =

--- a/src/composition/supergraph/config/unresolved/subgraph.rs
+++ b/src/composition/supergraph/config/unresolved/subgraph.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
@@ -39,7 +41,7 @@ impl UnresolvedSubgraph {
                 supergraph_config_path: root.clone(),
                 path: path.as_std_path().to_path_buf(),
                 joined_path: joined_path.as_std_path().to_path_buf(),
-                source: err,
+                source: Arc::new(err),
             }),
         }
     }

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -48,6 +48,7 @@ impl UnresolvedSupergraphConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::{
         collections::{BTreeMap, HashSet},
         str::FromStr,
@@ -436,7 +437,7 @@ mod tests {
                         .boxed_clone()
                         .map_err(move |err| ResolveSubgraphError::IntrospectionError {
                             subgraph_name: introspect_subgraph_name.to_string(),
-                            source: err,
+                            source: Arc::new(err),
                         })
                         .service(resolve_introspect_subgraph_service.into_inner()),
                 );
@@ -464,7 +465,7 @@ mod tests {
                     let introspect_subgraph_name = introspect_subgraph_name.to_string();
                     move |err| ResolveSubgraphError::IntrospectionError {
                         subgraph_name: introspect_subgraph_name.to_string(),
-                        source: err,
+                        source: Arc::new(err),
                     }
                 })
                 .service(resolve_introspect_subgraph_factory.into_inner()),
@@ -732,7 +733,7 @@ mod tests {
                         .boxed_clone()
                         .map_err(move |err| ResolveSubgraphError::IntrospectionError {
                             subgraph_name: introspect_subgraph_name.to_string(),
-                            source: err,
+                            source: Arc::new(err),
                         })
                         .service(resolve_introspect_subgraph_service.into_inner()),
                 );
@@ -745,7 +746,7 @@ mod tests {
                     let introspect_subgraph_name = introspect_subgraph_name.to_string();
                     move |err| ResolveSubgraphError::IntrospectionError {
                         subgraph_name: introspect_subgraph_name.to_string(),
-                        source: err,
+                        source: Arc::new(err),
                     }
                 })
                 .service(resolve_introspect_subgraph_factory.into_inner()),

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -1,0 +1,38 @@
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::task::AbortHandle;
+
+use crate::composition::events::CompositionEvent;
+use crate::composition::watchers::watcher::supergraph_config::{
+    SupergraphConfigDiff, SupergraphConfigSerialisationError,
+};
+use crate::subtask::SubtaskHandleStream;
+
+pub struct FederationWatcher {}
+
+impl SubtaskHandleStream for FederationWatcher {
+    type Input = Result<SupergraphConfigDiff, SupergraphConfigSerialisationError>;
+
+    type Output = CompositionEvent;
+
+    fn handle(
+        self,
+        _: UnboundedSender<Self::Output>,
+        mut input: BoxStream<'static, Self::Input>,
+    ) -> AbortHandle {
+        tokio::task::spawn(async move {
+            while let Some(recv_res) = input.next().await {
+                match recv_res {
+                    Err(SupergraphConfigSerialisationError::DeserializingConfigError {
+                        ..
+                    }) => {
+                        tracing::error!("Here's your error!");
+                    }
+                    _ => (),
+                }
+            }
+        })
+        .abort_handle()
+    }
+}

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -26,17 +26,15 @@ impl SubtaskHandleStream for FederationWatcher {
     ) -> AbortHandle {
         tokio::task::spawn(async move {
             while let Some(recv_res) = input.next().await {
-                match recv_res {
-                    Err(SupergraphConfigSerialisationError::DeserializingConfigError {
-                        source,
-                    }) => {
-                        let _ = sender
-                            .send(CompositionEvent::Error(
-                                CompositionError::InvalidSupergraphConfig(source.message()),
-                            ))
-                            .tap_err(|err| error!("{:?}", err));
-                    }
-                    _ => (),
+                if let Err(SupergraphConfigSerialisationError::DeserializingConfigError {
+                    source,
+                }) = recv_res
+                {
+                    let _ = sender
+                        .send(CompositionEvent::Error(
+                            CompositionError::InvalidSupergraphConfig(source.message()),
+                        ))
+                        .tap_err(|err| error!("{:?}", err));
                 }
             }
         })

--- a/src/composition/watchers/mod.rs
+++ b/src/composition/watchers/mod.rs
@@ -1,3 +1,4 @@
 pub mod composition;
+pub mod federation;
 pub mod subgraphs;
 pub mod watcher;

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -7,7 +7,12 @@ use itertools::Itertools;
 use rover_std::errln;
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
+use super::watcher::{
+    subgraph::{NonRepeatingFetch, SubgraphWatcher, SubgraphWatcherKind},
+    supergraph_config::SupergraphConfigDiff,
+};
 use crate::{
     composition::supergraph::config::{
         error::ResolveSubgraphError,
@@ -17,11 +22,6 @@ use crate::{
         unresolved::UnresolvedSubgraph,
     },
     subtask::{Subtask, SubtaskHandleStream, SubtaskRunUnit},
-};
-
-use super::watcher::{
-    subgraph::{NonRepeatingFetch, SubgraphWatcher, SubgraphWatcherKind},
-    supergraph_config::SupergraphConfigDiff,
 };
 
 #[derive(Debug)]
@@ -148,7 +148,10 @@ pub struct SubgraphSchemaRemoved {
 }
 
 impl SubtaskHandleStream for SubgraphWatchers {
-    type Input = Result<SupergraphConfigDiff, BTreeMap<String, ResolveSubgraphError>>;
+    type Input = Result<
+        Result<SupergraphConfigDiff, BTreeMap<String, ResolveSubgraphError>>,
+        BroadcastStreamRecvError,
+    >;
     type Output = SubgraphEvent;
 
     fn handle(
@@ -166,40 +169,48 @@ impl SubtaskHandleStream for SubgraphWatchers {
             );
 
             // Wait for supergraph diff events received from the input stream.
-            while let Some(diff) = input.next().await {
-                match diff {
+            while let Some(recv_res) = input.next().await {
+                match recv_res {
                     Ok(diff) => {
-                        // If we detect additional diffs, start a new subgraph subtask.
-                        // Adding the abort handle to the current collection of handles.
-                        for (subgraph_name, subgraph_config) in diff.added() {
-                            let _ = subgraph_handles.add(
-                                subgraph_name,
-                                subgraph_config,
-                                self.introspection_polling_interval
-                            ).await.tap_err(|err| tracing::error!("{:?}", err));
-                        }
+                        match diff {
+                            Ok(diff) => {
+                                // If we detect additional diffs, start a new subgraph subtask.
+                                // Adding the abort handle to the current collection of handles.
+                                for (subgraph_name, subgraph_config) in diff.added() {
+                                    let _ = subgraph_handles.add(
+                                        subgraph_name,
+                                        subgraph_config,
+                                        self.introspection_polling_interval
+                                    ).await.tap_err(|err| tracing::error!("{:?}", err));
+                                }
 
-                        for (subgraph_name, subgraph_config) in diff.changed() {
-                            let _ = subgraph_handles.update(
-                                subgraph_name,
-                                subgraph_config,
-                                self.introspection_polling_interval
-                            ).await.tap_err(|err| tracing::error!("{:?}", err));
-                        }
+                                for (subgraph_name, subgraph_config) in diff.changed() {
+                                    let _ = subgraph_handles.update(
+                                        subgraph_name,
+                                        subgraph_config,
+                                        self.introspection_polling_interval
+                                    ).await.tap_err(|err| tracing::error!("{:?}", err));
+                                }
 
-                        // If we detect removal diffs, stop the subtask for the removed subgraph.
-                        for subgraph_name in diff.removed() {
-                            eprintln!("Removing subgraph from session: `{}`", subgraph_name);
-                            subgraph_handles.remove(subgraph_name);
+                                // If we detect removal diffs, stop the subtask for the removed subgraph.
+                                for subgraph_name in diff.removed() {
+                                    eprintln!("Removing subgraph from session: `{}`", subgraph_name);
+                                    subgraph_handles.remove(subgraph_name);
+                                }
+                            }
+                            Err(errs) => {
+                                for (subgraph_name, _) in errs {
+                                    errln!("Error detected with the config for {}. Removing it from the session.", subgraph_name);
+                                    subgraph_handles.remove(&subgraph_name);
+                                }
+                            }
                         }
                     }
-                    Err(errs) => {
-                        for (subgraph_name, _) in errs {
-                            errln!("Error detected with the config for {}. Removing it from the session.", subgraph_name);
-                            subgraph_handles.remove(&subgraph_name);
-                        }
+                    Err(b_err) => {
+                        tracing::error!("Error in receiving from broadcast stream {}", b_err);
                     }
                 }
+
             }
         })
         .abort_handle()
@@ -410,6 +421,7 @@ mod tests {
     use speculoos::prelude::*;
     use tower::ServiceBuilder;
 
+    use super::SubgraphWatchers;
     use crate::composition::supergraph::config::{
         error::ResolveSubgraphError,
         full::{
@@ -425,8 +437,6 @@ mod tests {
             FetchRemoteSubgraphService, MakeFetchRemoteSubgraphError, RemoteSubgraph,
         },
     };
-
-    use super::SubgraphWatchers;
 
     #[tokio::test]
     async fn test_subgraph_watchers_new() {

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -407,6 +407,8 @@ impl SubgraphHandles {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use apollo_federation_types::config::SchemaSource;
     use camino::Utf8PathBuf;
     use speculoos::prelude::*;
@@ -494,7 +496,7 @@ mod tests {
                 send_response.send_response(
                     ServiceBuilder::new()
                         .boxed_clone()
-                        .map_err(ResolveSubgraphError::ServiceReady)
+                        .map_err(|e| ResolveSubgraphError::ServiceReady(Arc::new(e)))
                         .service(resolve_introspect_subgraph_service.into_inner()),
                 );
             }
@@ -503,7 +505,7 @@ mod tests {
         let resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory =
             ServiceBuilder::new()
                 .boxed_clone()
-                .map_err(ResolveSubgraphError::ServiceReady)
+                .map_err(|e| ResolveSubgraphError::ServiceReady(Arc::new(e)))
                 .service(resolve_introspect_subgraph_factory.into_inner());
 
         let (fetch_remote_subgraph_service, mut fetch_remote_subgraph_service_handle) =

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -162,16 +162,14 @@ mod tests {
     use std::{fs::OpenOptions, io::Write, time::Duration};
 
     use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
-    use assert_fs::TempDir;
     use speculoos::prelude::*;
     use tokio::time::timeout;
     use tower::ServiceExt;
     use tracing_test::traced_test;
 
+    use super::*;
     use crate::composition::supergraph::config::full::file::ResolveFileSubgraph;
     use crate::composition::supergraph::config::unresolved::UnresolvedSubgraph;
-
-    use super::*;
 
     #[tokio::test]
     #[traced_test(level = "error")]

--- a/src/subtask.rs
+++ b/src/subtask.rs
@@ -5,6 +5,7 @@
 //!
 //!   SubtaskHandleUnit - for receiving events,
 //!   SubtaskHandleStream - for both receiving and emitting events
+//!   SubtaskHandleMultiStream - for both receiving and emitting events to multiple channels (broadcast semantics)
 //!
 //! There are examples in the codebase for both, but they follow a similar pattern: a `handle`
 //! function is implemented that receives an `UnboundedSender<Self::Output>` for some `Output`
@@ -55,11 +56,13 @@
 //! ```
 
 use futures::stream::BoxStream;
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::Sender;
 use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedSender},
     task::AbortHandle,
 };
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream};
 
 /// A trait whose implementation will be able to send events
 pub trait SubtaskHandleUnit {
@@ -76,6 +79,13 @@ pub trait SubtaskHandleStream {
         sender: UnboundedSender<Self::Output>,
         input: BoxStream<'static, Self::Input>,
     ) -> AbortHandle;
+}
+
+/// A trait whose implementation will be able to send events to multiple channels with
+/// broadcast semantics.
+pub trait SubtaskHandleMultiStream {
+    type Output;
+    fn handle(self, sender: Sender<Self::Output>) -> AbortHandle;
 }
 
 /// A trait whose implementation can run a subtask that only ingests messages
@@ -109,18 +119,45 @@ impl<T, Output> Subtask<T, Output> {
     }
 }
 
+#[derive(Debug)]
+pub struct BroadcastSubtask<T, Output> {
+    inner: T,
+    sender: Sender<Output>,
+}
+
+impl<T, Output: Clone + Send + 'static> BroadcastSubtask<T, Output> {
+    /// Crates a new Subtask with bounded channels for transmitting and receiving in a broadcast
+    /// manner. A version of transmitter is returned to the caller so that it can be used to send
+    /// messages to the Subtask's receiver, however more can be acquired via the subscribe method.
+    pub fn new(inner: T) -> (BroadcastStream<Output>, BroadcastSubtask<T, Output>) {
+        let (tx, rx) = broadcast::channel(100);
+        (
+            BroadcastStream::new(rx),
+            BroadcastSubtask { inner, sender: tx },
+        )
+    }
+}
+
 impl<T: SubtaskHandleUnit<Output = Output>, Output> SubtaskRunUnit for Subtask<T, Output> {
     /// Begin running the subtask, calling handle() on the type implementing the SubTaskHandleUnit trait
     fn run(self) -> AbortHandle {
         self.inner.handle(self.sender)
     }
 }
-
 impl<T: SubtaskHandleStream<Output = Output>, Output> SubtaskRunStream for Subtask<T, Output> {
     type Input = T::Input;
 
     /// Begin running the subtask with a stream of events, calling handle() on the type implementing the SubTaskHandleStream trait
     fn run(self, input: BoxStream<'static, Self::Input>) -> AbortHandle {
         self.inner.handle(self.sender, input)
+    }
+}
+
+impl<T: SubtaskHandleMultiStream<Output = Output>, Output> SubtaskRunUnit
+    for BroadcastSubtask<T, Output>
+{
+    /// Begin running the subtask, calling handle() on the type implementing the SubTaskHandleUnit trait
+    fn run(self) -> AbortHandle {
+        self.inner.handle(self.sender)
     }
 }

--- a/src/subtask.rs
+++ b/src/subtask.rs
@@ -136,6 +136,10 @@ impl<T, Output: Clone + Send + 'static> BroadcastSubtask<T, Output> {
             BroadcastSubtask { inner, sender: tx },
         )
     }
+
+    pub fn subscribe(&self) -> BroadcastStream<Output> {
+        BroadcastStream::new(self.sender.subscribe())
+    }
 }
 
 impl<T: SubtaskHandleUnit<Output = Output>, Output> SubtaskRunUnit for Subtask<T, Output> {


### PR DESCRIPTION
**THIS CANNOT BE MERGED UNTIL ROVER-245 HAS**

So the key observation here is that the LSP needs to get back the details of errors that occur when we try and deserialise the Supergraph YAML and before this it didn't, those errors were simply printed into the DEBUG logs and then thrown away. In order to do this I've had to add a few more concepts into the work done on Subtasks etc. because in order to do this properly we need a Subtask that can send events across to multiple places (with broadcast semantics).

So the key changes in this PR follow the 3 commits:

1. Introduce the concept of a BroadcastSubtask, so this is a subtask which acts like an ordinary subtask, except that you can ask it for more streams of events and it will give them to you, via a `.subscribe()` method, which copies the interface of a `tokio` BroadcastStream. This does have consequences for the kind of data you can send out of these subtasks (i.e. all the data has to be Cloneable) but as this is a specific use-case I see no issue with this.
2. Introduce a new concept of a FederationWatcher (I'm not entirely sold on this name, and if someone has a better one let me know!) - This is essentially a Subtask that also watches the events produced by the SupergraphConfigWatcher but acts differently depending on what those events are. Initially it just printed but in the future we can use this new Subtask to watch, and hopefully update, the supergraph binary we're using (which is work that will come down the track in short order)
3. With all of that in mind, add the ability to feed those errors back into the LSP itself, so they display in the IDE, an example of which is shown below

![Screenshot 2025-01-08 at 13 37 58](https://github.com/user-attachments/assets/741f6b73-e099-4161-b636-730b9b20454f)
