### PR TITLE
ROVER-257 Hot-reloading of Federation Version in `supergraph.yaml`

### DIFF
--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -15,6 +15,7 @@ use rover_std::{errln, infoln, warnln};
 use semver::Version;
 use tower::ServiceExt;
 
+use self::router::config::{RouterAddress, RunRouterConfig};
 use crate::composition::supergraph::binary::OutputTarget;
 use crate::{
     command::{
@@ -42,8 +43,6 @@ use crate::{
     },
     RoverOutput, RoverResult,
 };
-
-use self::router::config::RouterAddress;
 
 mod router;
 
@@ -174,6 +173,9 @@ impl Dev {
                 tmp_config_dir_path.clone(),
                 OutputTarget::Stdout,
                 false,
+                client_config,
+                self.opts.plugin_opts.elv2_license_accepter,
+                self.opts.plugin_opts.skip_update,
             )
             .await?;
 

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -17,6 +17,7 @@ use tower::ServiceExt;
 
 use self::router::config::{RouterAddress, RunRouterConfig};
 use crate::composition::supergraph::binary::OutputTarget;
+use crate::composition::FederationUpdaterConfig;
 use crate::{
     command::{
         dev::{OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION},
@@ -162,6 +163,17 @@ impl Dev {
             &Config::new(home_override.as_ref(), api_key_override)?,
         )?;
 
+        // Set up an updater config, but only if we're not overriding the version ourselves. If
+        // we are then we don't need one, so it becomes None.
+        let federation_updater_config = match self.opts.supergraph_opts.federation_version {
+            Some(_) => None,
+            None => Some(FederationUpdaterConfig {
+                studio_client_config: client_config,
+                elv2_licence_accepter: elv2_license_accepter,
+                skip_update,
+            }),
+        };
+
         let composition_runner = composition_pipeline
             .runner(
                 exec_command_impl,
@@ -173,9 +185,7 @@ impl Dev {
                 tmp_config_dir_path.clone(),
                 OutputTarget::Stdout,
                 false,
-                client_config,
-                self.opts.plugin_opts.elv2_license_accepter,
-                self.opts.plugin_opts.skip_update,
+                federation_updater_config,
             )
             .await?;
 

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -168,7 +168,7 @@ impl Dev {
         let federation_updater_config = match self.opts.supergraph_opts.federation_version {
             Some(_) => None,
             None => Some(FederationUpdaterConfig {
-                studio_client_config: client_config,
+                studio_client_config: client_config.clone(),
                 elv2_licence_accepter: elv2_license_accepter,
                 skip_update,
             }),

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -332,7 +332,6 @@ impl RunRouter<state::Watch> {
 
         let composition_messages =
             tokio_stream::StreamExt::filter_map(composition_messages, |event| match event {
-                CompositionEvent::Started => None,
                 CompositionEvent::Error(err) => {
                     tracing::error!("Composition error {:?}", err);
                     None
@@ -340,6 +339,7 @@ impl RunRouter<state::Watch> {
                 CompositionEvent::Success(success) => Some(RouterUpdateEvent::SchemaChanged {
                     schema: success.supergraph_sdl().to_string(),
                 }),
+                _ => None,
             })
             .boxed();
 

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -31,7 +31,7 @@ use crate::composition::supergraph::install::InstallSupergraphError;
 use crate::composition::SupergraphConfigResolutionError::PathDoesNotPointToAFile;
 use crate::composition::{
     CompositionError, CompositionSubgraphAdded, CompositionSubgraphRemoved, CompositionSuccess,
-    SupergraphConfigResolutionError,
+    FederationUpdaterConfig, SupergraphConfigResolutionError,
 };
 use crate::options::ProfileOpt;
 use crate::utils::effect::exec::TokioCommand;
@@ -351,9 +351,11 @@ async fn create_composition_stream(
             Utf8PathBuf::try_from(temp_dir())?,
             OutputTarget::InMemory,
             true,
-            client_config,
-            lsp_opts.plugin_opts.elv2_license_accepter,
-            lsp_opts.plugin_opts.skip_update,
+            Some(FederationUpdaterConfig {
+                studio_client_config: client_config,
+                elv2_licence_accepter: lsp_opts.plugin_opts.elv2_license_accepter,
+                skip_update: lsp_opts.plugin_opts.skip_update,
+            }),
         )
         .await?
         .run())

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -345,6 +345,9 @@ async fn create_composition_stream(
             Utf8PathBuf::try_from(temp_dir())?,
             OutputTarget::InMemory,
             true,
+            client_config,
+            lsp_opts.plugin_opts.elv2_license_accepter,
+            lsp_opts.plugin_opts.skip_update,
         )
         .await?
         .run())

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -14,6 +14,8 @@ use crate::composition::supergraph::config::resolver::{
     LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
 };
 use crate::composition::supergraph::install::InstallSupergraphError;
+use crate::options::LicenseAccepter;
+use crate::utils::client::StudioClientConfig;
 
 pub mod events;
 pub mod pipeline;
@@ -25,6 +27,13 @@ pub mod types;
 
 #[cfg(feature = "composition-js")]
 mod watchers;
+
+#[derive(Debug, Clone)]
+pub struct FederationUpdaterConfig {
+    pub(crate) studio_client_config: StudioClientConfig,
+    pub(crate) elv2_licence_accepter: LicenseAccepter,
+    pub(crate) skip_update: bool,
+}
 
 #[derive(Getters, Debug, Clone, Eq, PartialEq)]
 pub struct CompositionSuccess {

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -66,7 +66,7 @@ pub enum CompositionError {
     SerdeYaml(#[from] serde_yaml::Error),
     #[error("{}", .0)]
     InvalidSupergraphConfig(String),
-    #[error("Could not update Federation Version")]
+    #[error("Error when updating Federation Version:\n{}", .0)]
     ErrorUpdatingFederationVersion(#[from] InstallSupergraphError),
 }
 

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -13,6 +13,7 @@ use derive_getters::Getters;
 use crate::composition::supergraph::config::resolver::{
     LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
 };
+use crate::composition::supergraph::install::InstallSupergraphError;
 
 pub mod events;
 pub mod pipeline;
@@ -65,6 +66,8 @@ pub enum CompositionError {
     SerdeYaml(#[from] serde_yaml::Error),
     #[error("{}", .0)]
     InvalidSupergraphConfig(String),
+    #[error("Could not update Federation Version")]
+    ErrorUpdatingFederationVersion(#[from] InstallSupergraphError),
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -28,7 +28,7 @@ use super::{
         },
         install::{InstallSupergraph, InstallSupergraphError},
     },
-    CompositionError, CompositionSuccess,
+    CompositionError, CompositionSuccess, FederationUpdaterConfig,
 };
 use crate::composition::pipeline::CompositionPipelineError::FederationOneWithFederationTwoSubgraphs;
 use crate::{
@@ -261,9 +261,7 @@ impl CompositionPipeline<state::Run> {
         output_dir: Utf8PathBuf,
         output_target: OutputTarget,
         compose_on_initialisation: bool,
-        studio_client_config: StudioClientConfig,
-        elv2_licence_accepter: LicenseAccepter,
-        skip_update: bool,
+        federation_updater_config: Option<FederationUpdaterConfig>,
     ) -> Result<CompositionRunner<ExecC, ReadF, WriteF>, CompositionPipelineError>
     where
         ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
@@ -296,9 +294,7 @@ impl CompositionPipeline<state::Run> {
                 output_dir,
                 compose_on_initialisation,
                 output_target,
-                studio_client_config,
-                elv2_licence_accepter,
-                skip_update,
+                federation_updater_config,
             );
         Ok(runner)
     }

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -261,6 +261,9 @@ impl CompositionPipeline<state::Run> {
         output_dir: Utf8PathBuf,
         output_target: OutputTarget,
         compose_on_initialisation: bool,
+        studio_client_config: StudioClientConfig,
+        elv2_licence_accepter: LicenseAccepter,
+        skip_update: bool,
     ) -> Result<CompositionRunner<ExecC, ReadF, WriteF>, CompositionPipelineError>
     where
         ReadF: ReadFile + Debug + Eq + PartialEq + Send + Sync + 'static,
@@ -293,6 +296,9 @@ impl CompositionPipeline<state::Run> {
                 output_dir,
                 compose_on_initialisation,
                 output_target,
+                studio_client_config,
+                elv2_licence_accepter,
+                skip_update,
             );
         Ok(runner)
     }

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -209,7 +209,7 @@ where
         // events in order to trigger recomposition.
         let (composition_messages, composition_subtask) =
             Subtask::new(self.state.composition_watcher);
-        composition_subtask.run(subgraph_change_stream.boxed());
+        composition_subtask.run(select(subgraph_change_stream, federation_watcher_stream).boxed());
 
         // Start subgraph watchers, listening for events from the supergraph change stream.
         subgraph_watcher_subtask.run(
@@ -245,6 +245,6 @@ where
             supergraph_config_subtask.run();
         }
 
-        select(composition_messages, federation_watcher_stream).boxed()
+        composition_messages.boxed()
     }
 }

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -28,8 +28,11 @@ use super::{
     watchers::{composition::CompositionWatcher, subgraphs::SubgraphWatchers},
 };
 use crate::composition::supergraph::binary::OutputTarget;
+use crate::composition::watchers::composition::FederationUpdaterConfig;
 use crate::composition::watchers::federation::FederationWatcher;
+use crate::options::LicenseAccepter;
 use crate::subtask::{BroadcastSubtask, SubtaskRunUnit};
+use crate::utils::client::StudioClientConfig;
 use crate::{
     composition::watchers::watcher::{
         file::FileWatcher, supergraph_config::SupergraphConfigWatcher,
@@ -137,6 +140,9 @@ impl Runner<state::SetupCompositionWatcher> {
         temp_dir: Utf8PathBuf,
         compose_on_initialisation: bool,
         output_target: OutputTarget,
+        studio_client_config: StudioClientConfig,
+        elv2_licence_accepter: LicenseAccepter,
+        skip_update: bool,
     ) -> Runner<state::Run<ExecC, ReadF, WriteF>>
     where
         ExecC: ExecCommand + Debug + Eq + PartialEq + Send + Sync + 'static,
@@ -153,6 +159,11 @@ impl Runner<state::SetupCompositionWatcher> {
             .temp_dir(temp_dir)
             .compose_on_initialisation(compose_on_initialisation)
             .output_target(output_target)
+            .federation_updater_config(FederationUpdaterConfig {
+                studio_client_config,
+                elv2_licence_accepter,
+                skip_update,
+            })
             .build();
         Runner {
             state: state::Run {

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -15,9 +15,8 @@ use crate::composition::watchers::composition::CompositionInputEvent::{
 };
 use crate::composition::{
     CompositionError, CompositionSubgraphAdded, CompositionSubgraphRemoved, CompositionSuccess,
+    FederationUpdaterConfig,
 };
-use crate::options::LicenseAccepter;
-use crate::utils::client::StudioClientConfig;
 use crate::utils::effect::install::InstallBinary;
 use crate::{
     composition::{
@@ -55,13 +54,6 @@ pub struct CompositionWatcher<ExecC, ReadF, WriteF> {
     temp_dir: Utf8PathBuf,
     compose_on_initialisation: bool,
     output_target: OutputTarget,
-}
-
-#[derive(Debug, Clone)]
-pub struct FederationUpdaterConfig {
-    pub(crate) studio_client_config: StudioClientConfig,
-    pub(crate) elv2_licence_accepter: LicenseAccepter,
-    pub(crate) skip_update: bool,
 }
 
 impl<ExecC, ReadF, WriteF> SubtaskHandleStream for CompositionWatcher<ExecC, ReadF, WriteF>
@@ -162,8 +154,9 @@ where
                                         continue;
                                     }
                                 }
+                            } else {
+                                tracing::warn!("Detected Federation Version change but due to overrides (CLI flags, ENV vars etc.) this was not actioned.")
                             }
-
                         }
                         Passthrough(ev) => {
                             let _ = sender.send(ev).tap_err(|err| error!("{:?}", err));

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -3,7 +3,7 @@ use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use futures::stream::BoxStream;
-use rover_std::{errln, infoln};
+use rover_std::{errln, infoln, warnln};
 use tap::TapFallible;
 use tokio::{sync::mpsc::UnboundedSender, task::AbortHandle};
 use tokio_stream::StreamExt;
@@ -139,6 +139,7 @@ where
                         Federation(fed_version) => {
                             if let Some(federation_updater_config) = self.federation_updater_config.clone() {
                                 tracing::info!("Attempting to change supergraph version to {:?}", fed_version);
+                                infoln!("Attempting to change supergraph version to {}", fed_version.get_exact().unwrap());
                                 let install_res =
                                     InstallSupergraph::new(fed_version, federation_updater_config.studio_client_config.clone())
                                         .install(None, federation_updater_config.elv2_licence_accepter, federation_updater_config.skip_update)
@@ -146,10 +147,12 @@ where
                                 match install_res {
                                     Ok(supergraph_binary) => {
                                         tracing::info!("Supergraph version changed to {:?}", supergraph_binary.version());
+                                        infoln!("Supergraph version changed to {}", supergraph_binary.version().to_string());
                                         self.supergraph_binary = supergraph_binary
                                     }
                                     Err(err) => {
                                         tracing::warn!("Failed to change supergraph version, current version has been retained...");
+                                        warnln!("Failed to change supergraph version, current version has been retained...");
                                         let _ = sender.send(CompositionEvent::Error(err.into())).tap_err(|err| error!("{:?}", err));
                                         continue;
                                     }

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -163,6 +163,7 @@ where
                         }
                         Passthrough(ev) => {
                             let _ = sender.send(ev).tap_err(|err| error!("{:?}", err));
+                            continue;
                         }
                     }
 

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -159,6 +159,7 @@ where
                                     Err(err) => {
                                         tracing::warn!("Failed to change supergraph version, current version has been retained...");
                                         let _ = sender.send(CompositionEvent::Error(err.into())).tap_err(|err| error!("{:?}", err));
+                                        continue;
                                     }
                                 }
                             }

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -6,6 +6,7 @@ use tokio::task::AbortHandle;
 use tracing::error;
 
 use crate::composition::events::CompositionEvent;
+use crate::composition::watchers::composition::CompositionInputEvent;
 use crate::composition::watchers::watcher::supergraph_config::{
     SupergraphConfigDiff, SupergraphConfigSerialisationError,
 };
@@ -17,7 +18,7 @@ pub struct FederationWatcher {}
 impl SubtaskHandleStream for FederationWatcher {
     type Input = Result<SupergraphConfigDiff, SupergraphConfigSerialisationError>;
 
-    type Output = CompositionEvent;
+    type Output = CompositionInputEvent;
 
     fn handle(
         self,
@@ -26,15 +27,24 @@ impl SubtaskHandleStream for FederationWatcher {
     ) -> AbortHandle {
         tokio::task::spawn(async move {
             while let Some(recv_res) = input.next().await {
-                if let Err(SupergraphConfigSerialisationError::DeserializingConfigError {
-                    source,
-                }) = recv_res
-                {
-                    let _ = sender
-                        .send(CompositionEvent::Error(
-                            CompositionError::InvalidSupergraphConfig(source.message()),
-                        ))
-                        .tap_err(|err| error!("{:?}", err));
+                match recv_res {
+                    Ok(diff) => {
+                        if let Some(fed_version) = diff.federation_version() {
+                            let _ = sender
+                                .send(CompositionInputEvent::Federation(fed_version.clone()))
+                                .tap_err(|err| error!("{:?}", err));
+                        }
+                    }
+                    Err(SupergraphConfigSerialisationError::DeserializingConfigError {
+                        source,
+                    }) => {
+                        let _ = sender
+                            .send(CompositionInputEvent::Passthrough(CompositionEvent::Error(
+                                CompositionError::InvalidSupergraphConfig(source.message()),
+                            )))
+                            .tap_err(|err| error!("{:?}", err));
+                    }
+                    Err(_) => {}
                 }
             }
         })

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -1,3 +1,4 @@
+use apollo_federation_types::config::FederationVersion::LatestFedTwo;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use tap::TapFallible;
@@ -31,7 +32,9 @@ impl SubtaskHandleStream for FederationWatcher {
                     Ok(diff) => {
                         if let Some(fed_version) = diff.federation_version() {
                             let _ = sender
-                                .send(CompositionInputEvent::Federation(fed_version.clone()))
+                                .send(CompositionInputEvent::Federation(
+                                    fed_version.clone().unwrap_or(LatestFedTwo),
+                                ))
                                 .tap_err(|err| error!("{:?}", err));
                         }
                     }

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -191,9 +191,8 @@ impl SupergraphConfigDiff {
             .collect::<Vec<_>>();
 
         let federation_version = if old.get_federation_version() != new.get_federation_version() {
-            debug!("Detected federation version change!");
             debug!(
-                "Old: {:?}, New: {:?}",
+                "Detected federation version change. Changing from {:?} to {:?}",
                 old.get_federation_version(),
                 new.get_federation_version()
             );


### PR DESCRIPTION
One of the key features that is required for the LSP is the ability to change the Federation Version specified in the `supergraph.yaml` and for it to then reload in the active session, rather than needing a restart. This is implemented as of this PR, and due to the nature of the previous refactor, has also been added to `rover dev` as well!

The way this has been done is to extend the FederationWatcher to track when a change of version occurs and then to get the CompositionWatcher to update its own internal state (downloading a new version when necessary). The outcome has been tested and performs w.r.t the LSP as we'd expect.  Below is an example of the logging with it working for `rover dev`:

![Screenshot 2025-01-09 at 12 06 16](https://github.com/user-attachments/assets/b961054f-6730-4770-a380-f25edeaacdaf)

I've also implemented a feature whereby we don't do the auto-updating behaviour if a user is specifically overriding the version of composition to be used via an environment variable, though for the moment this is only relevant to `rover dev`. 

There is an important open question here w.r.t behaviour:
- The original ticket mentioned a behaviour where if the change didn't work the router would shut down, but this seems a bit overmuch. A much better solution from a UX perspective, and the one implemented here, is to continue composing with the old version but raise an error so the user can correct it. I am happy to hear the counter argument on this though!