### PR TITLE
[BGS-153] [messages] when `APOLLO_GRAPH_REF` is set and the studio client could be loaded, but the whoami call failed, stderr should receive message.

### DIFF
--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -87,6 +87,9 @@ pub enum LoadRemoteSubgraphsError {
     /// Error captured by the underlying implementation of [`FetchRemoteSubgraphs`]
     #[error(transparent)]
     FetchRemoteSubgraphsError(Box<dyn std::error::Error + Send + Sync>),
+    /// Error captured when the `FetchRemoteSubgraphs` error includes a invalid credentials marker
+    #[error("Invalid credentials provided. Cannot connect to subgraph(s). See Authenticating with GraphOS [https://www.apollographql.com/docs/rover/configuring].")]
+    FetchRemoteSubgraphsAuthError(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
@@ -117,7 +120,21 @@ impl SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
                 .call(FetchRemoteSubgraphsRequest::new(graph_ref.clone()))
                 .await
                 .map_err(|err| {
-                    LoadRemoteSubgraphsError::FetchRemoteSubgraphsError(Box::new(err))
+
+                    // Q: Why choose map_err here instead of From?
+                    //
+                    // Q: How can I limit my match to only those which are "Invalid credentials
+                    // provided. Cannot connect to subgraphs."
+                    //match &err {
+                        //PartialError(_) => { println!("hahah") },
+                        //(la) => { println!("{}", la) },
+                    //}
+                    eprintln!("Error => \n {:?}", err);
+
+                    //Error =>
+ //Service { source: PartialError { data: ResponseData { variant: None }, errors: [Error { message: "406: Not Acceptable", locations: None, path: None, extensions: Some({"response": Object {"body": Object {"errors": Array [Object {"message": String("Invalid credentials provided")}]}, "status": Number(406), "statusText": String("Not Acceptable"), "url": String("http://engine-graphql.apollo-default.svc.prod.apollo-internal:8081/api/graphql")}, "code": String("INTERNAL_SERVER_ERROR")}) }] }, endpoint_kind: ApolloStudio }
+                    //LoadRemoteSubgraphsError::FetchRemoteSubgraphsError(Box::new(err))
+                    LoadRemoteSubgraphsError::FetchRemoteSubgraphsAuthError(Box::new(err))
                 })?;
             Ok(SupergraphConfigResolver {
                 state: state::LoadSupergraphConfig {


### PR DESCRIPTION
This PR improves the messaging when a user supplies a graphref and whoami fails during composition.

I've raised some questions in the PR itself.