### PR TITLE
ROVER-281 Add ability to start LSP with a broken `supergraph.yaml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-language-server"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e0b40ad3867c874a5b1bb243aab4ae8fda8efd1d1b14816a674202894ea066"
+checksum = "3aadcacf564bfe5c3a0e1444bd893942001e616e1d1e44670ddd04e50117af15"
 dependencies = [
  "apollo-compiler",
  "apollo-composition",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ apollo-encoder = "0.8"
 # https://github.com/apollographql/federation-rs
 apollo-federation-types = "0.14.1"
 
-apollo-language-server = { version = "0.3.4", default-features = false, features = ["tokio"] }
+apollo-language-server = { version = "0.3.5", default-features = false, features = ["tokio"] }
 
 # crates.io dependencies
 anyhow = "1"

--- a/src/command/dev/next/mod.rs
+++ b/src/command/dev/next/mod.rs
@@ -17,6 +17,7 @@ use tower::ServiceExt;
 
 use self::router::config::{RouterAddress, RunRouterConfig};
 use crate::composition::supergraph::binary::OutputTarget;
+use crate::composition::supergraph::config::resolver::SubgraphPrompt;
 use crate::composition::FederationUpdaterConfig;
 use crate::{
     command::{
@@ -129,6 +130,7 @@ impl Dev {
                 resolve_introspect_subgraph_factory.clone(),
                 fetch_remote_subgraph_factory.clone(),
                 federation_version,
+                Some(&SubgraphPrompt::default()),
             )
             .await?
             .install_supergraph_binary(
@@ -186,6 +188,7 @@ impl Dev {
                 OutputTarget::Stdout,
                 false,
                 federation_updater_config,
+                Some(&SubgraphPrompt::default()),
             )
             .await?;
 

--- a/src/command/lsp/errors.rs
+++ b/src/command/lsp/errors.rs
@@ -12,7 +12,7 @@ pub enum StartCompositionError {
     SupergraphYamlUrlConversionFailed(Utf8PathBuf),
     #[error("Could not create HTTP service")]
     HttpServiceCreationFailed(#[from] Error),
-    #[error("Could not initialise the composition pipeline")]
+    #[error("Could not initialise the composition pipeline: {}", .0)]
     InitialisingCompositionPipelineFailed(#[from] CompositionPipelineError),
     #[error("Could not run initial composition")]
     InitialCompositionFailed(#[from] CompositionError),

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -127,7 +127,7 @@ async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverR
                 Config {
                     root_uri: String::from(supergraph_yaml_url.clone()),
                     enable_auto_composition: false,
-                    force_federation: false,
+                    force_federation: true,
                     disable_telemetry: false,
                     max_spec_versions: MaxSpecVersions {
                         connect: None,

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -96,7 +96,7 @@ pub enum SupergraphConfigResolutionError {
     StudioClientInitialisationFailed(#[from] Error),
     #[error("Could not load remote subgraphs")]
     LoadRemoteSubgraphsFailed(#[from] LoadRemoteSubgraphsError),
-    #[error("Could not load supergraph config from local file")]
+    #[error("Could not load supergraph config from local file.\n{}", .0)]
     LoadLocalSupergraphConfigFailed(#[from] LoadSupergraphConfigError),
     #[error("Could not resolve local and remote elements into complete SupergraphConfig")]
     ResolveSupergraphConfigFailed(#[from] ResolveSupergraphConfigError),

--- a/src/composition/supergraph/config/error/subgraph.rs
+++ b/src/composition/supergraph/config/error/subgraph.rs
@@ -92,4 +92,7 @@ pub enum ResolveSubgraphError {
     /// Pass-through error for when a [`tower::Service`] fails to be ready
     #[error(transparent)]
     ServiceReady(#[from] Arc<Box<dyn std::error::Error + Send + Sync>>),
+    /// Error encountered if we can't parse a URL properly in the introspection case
+    #[error(transparent)]
+    ParsingSubgraphUrlError(#[from] url::ParseError),
 }

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -162,7 +162,9 @@ impl FederationVersionResolver<state::FromSubgraphs> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use apollo_federation_types::config::{FederationVersion, SubgraphConfig, SupergraphConfig};
+    use apollo_federation_types::config::{
+        FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
+    };
     use speculoos::prelude::*;
 
     use super::FederationVersionResolverFromSupergraphConfig;
@@ -192,8 +194,11 @@ mod tests {
             subgraph_name.to_string(),
             FullyResolvedSubgraph::builder()
                 .name(subgraph_name.to_string())
-                .schema(subgraph_scenario.sdl)
+                .schema(subgraph_scenario.sdl.clone())
                 .routing_url(subgraph_scenario.routing_url.to_string())
+                .schema_source(SchemaSource::Sdl {
+                    sdl: subgraph_scenario.sdl,
+                })
                 .build(),
         )];
         let federation_version = federation_version_resolver
@@ -226,9 +231,12 @@ mod tests {
         let resolved_subgraphs = [(
             subgraph_name.to_string(),
             FullyResolvedSubgraph::builder()
-                .schema(subgraph_scenario.sdl)
+                .schema(subgraph_scenario.sdl.clone())
                 .routing_url(subgraph_scenario.routing_url.to_string())
                 .name(subgraph_name.to_string())
+                .schema_source(SchemaSource::Sdl {
+                    sdl: subgraph_scenario.sdl,
+                })
                 .build(),
         )];
         let federation_version = federation_version_resolver
@@ -260,9 +268,12 @@ mod tests {
         let resolved_subgraphs = [(
             subgraph_name.to_string(),
             FullyResolvedSubgraph::builder()
-                .schema(subgraph_scenario.sdl)
+                .schema(subgraph_scenario.sdl.clone())
                 .routing_url(subgraph_scenario.routing_url.to_string())
                 .name(subgraph_name.to_string())
+                .schema_source(SchemaSource::Sdl {
+                    sdl: subgraph_scenario.sdl,
+                })
                 .build(),
         )];
         let federation_version = federation_version_resolver

--- a/src/composition/supergraph/config/full/subgraph/file.rs
+++ b/src/composition/supergraph/config/full/subgraph/file.rs
@@ -39,6 +39,7 @@ impl Service<()> for ResolveFileSubgraph {
         let supergraph_config_root = self.supergraph_config_root.clone();
         let path = self.path.clone();
         let subgraph_name = unresolved_subgraph.name().to_string();
+        let schema_source = self.unresolved_subgraph.schema().clone();
         let fut = async move {
             let file = unresolved_subgraph.resolve_file_path(&supergraph_config_root, &path)?;
             let schema = Fs::read_file(&file).map_err(|err| ResolveSubgraphError::Fs {
@@ -54,6 +55,7 @@ impl Service<()> for ResolveFileSubgraph {
                 .name(subgraph_name)
                 .routing_url(routing_url)
                 .schema(schema)
+                .schema_source(schema_source)
                 .build())
         };
         Box::pin(fut)

--- a/src/composition/supergraph/config/full/subgraph/mod.rs
+++ b/src/composition/supergraph/config/full/subgraph/mod.rs
@@ -33,6 +33,7 @@ pub struct FullyResolvedSubgraph {
     name: String,
     routing_url: String,
     schema: String,
+    schema_source: SchemaSource,
     pub(crate) is_fed_two: bool,
 }
 
@@ -40,13 +41,19 @@ pub struct FullyResolvedSubgraph {
 impl FullyResolvedSubgraph {
     /// Hook for [`buildstructor::buildstructor`]'s builder pattern to create a [`FullyResolvedSubgraph`]
     #[builder]
-    pub fn new(name: String, schema: String, routing_url: String) -> FullyResolvedSubgraph {
+    pub fn new(
+        name: String,
+        schema: String,
+        routing_url: String,
+        schema_source: SchemaSource,
+    ) -> FullyResolvedSubgraph {
         let is_fed_two = schema_contains_link_directive(&schema);
         FullyResolvedSubgraph {
             name,
             schema,
             routing_url,
             is_fed_two,
+            schema_source,
         }
     }
 
@@ -125,6 +132,7 @@ impl FullyResolvedSubgraph {
                             },
                         )?)
                         .schema(sdl.to_string())
+                        .schema_source(SchemaSource::Sdl { sdl })
                         .build())
                 }
             })

--- a/src/composition/supergraph/config/full/subgraph/remote.rs
+++ b/src/composition/supergraph/config/full/subgraph/remote.rs
@@ -3,6 +3,7 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
+use apollo_federation_types::config::SchemaSource;
 use buildstructor::Builder;
 use futures::Future;
 use rover_client::shared::GraphRef;
@@ -66,7 +67,7 @@ where
                 })?
                 .call(
                     FetchRemoteSubgraphRequest::builder()
-                        .graph_ref(graph_ref)
+                        .graph_ref(graph_ref.clone())
                         .subgraph_name(subgraph_name.to_string())
                         .build(),
                 )
@@ -79,9 +80,13 @@ where
             let routing_url =
                 routing_url.unwrap_or_else(|| remote_subgraph.routing_url().to_string());
             Ok(FullyResolvedSubgraph::builder()
-                .name(subgraph_name)
+                .name(subgraph_name.clone())
                 .routing_url(routing_url)
                 .schema(schema)
+                .schema_source(SchemaSource::Subgraph {
+                    graphref: graph_ref.to_string(),
+                    subgraph: subgraph_name,
+                })
                 .build())
         };
         Box::pin(fut)

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -267,7 +267,7 @@ mod tests {
     };
 
     use anyhow::Result;
-    use apollo_federation_types::config::FederationVersion;
+    use apollo_federation_types::config::{FederationVersion, SchemaSource};
     use camino::Utf8PathBuf;
     use futures::{
         stream::{once, BoxStream},
@@ -380,8 +380,9 @@ mod tests {
         let subgraph_change_events: BoxStream<CompositionInputEvent> = once(async {
             Subgraph(SubgraphEvent::SubgraphChanged(SubgraphSchemaChanged::new(
                 subgraph_name,
-                subgraph_sdl,
+                subgraph_sdl.clone(),
                 "https://example.com".to_string(),
+                SchemaSource::Sdl { sdl: subgraph_sdl },
             )))
         })
         .boxed();

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -1,4 +1,3 @@
-use apollo_federation_types::config::SchemaSource::Sdl;
 use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
@@ -105,7 +104,7 @@ where
                     match event {
                         Subgraph(SubgraphEvent::SubgraphChanged(subgraph_schema_changed)) => {
                             let name = subgraph_schema_changed.name().clone();
-                            let sdl = subgraph_schema_changed.sdl().clone();
+                            let schema_source = subgraph_schema_changed.schema_source().clone();
                             let message = format!("Schema change detected for subgraph: {}", &name);
                             infoln!("{}", message);
                             tracing::info!(message);
@@ -120,7 +119,7 @@ where
                                     .send(CompositionEvent::SubgraphAdded(
                                         CompositionSubgraphAdded {
                                             name,
-                                            schema_source: Sdl { sdl },
+                                            schema_source
                                         },
                                     ))
                                     .tap_err(|err| error!("{:?}", err));

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use apollo_federation_types::config::SubgraphConfig;
+use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
 use camino::Utf8PathBuf;
 use futures::stream::{self, BoxStream, StreamExt};
 use itertools::Itertools;
@@ -109,15 +109,23 @@ pub struct SubgraphSchemaChanged {
     /// SDL with changes
     sdl: String,
     routing_url: String,
+    /// Schema Source
+    schema_source: SchemaSource,
 }
 
 impl SubgraphSchemaChanged {
     #[cfg(test)]
-    pub fn new(name: String, sdl: String, routing_url: String) -> SubgraphSchemaChanged {
+    pub fn new(
+        name: String,
+        sdl: String,
+        routing_url: String,
+        schema_source: SchemaSource,
+    ) -> SubgraphSchemaChanged {
         SubgraphSchemaChanged {
             name,
             sdl,
             routing_url,
+            schema_source,
         }
     }
 }
@@ -128,6 +136,7 @@ impl From<SubgraphSchemaChanged> for FullyResolvedSubgraph {
             .name(value.name)
             .schema(value.sdl)
             .routing_url(value.routing_url)
+            .schema_source(value.schema_source)
             .build()
     }
 }
@@ -138,6 +147,7 @@ impl From<FullyResolvedSubgraph> for SubgraphSchemaChanged {
             name: value.name().to_string(),
             sdl: value.schema().to_string(),
             routing_url: value.routing_url().to_string(),
+            schema_source: value.schema_source().to_owned(),
         }
     }
 }

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -214,7 +214,7 @@ mod tests {
         let mut writeable_file = OpenOptions::new()
             .write(true)
             .truncate(true)
-            .open(path)
+            .open(path.clone())
             .expect("Cannot open file");
 
         let sdl = "type Query { test: String! }";
@@ -229,6 +229,7 @@ mod tests {
             .name(subgraph_name.to_string())
             .routing_url(routing_url.to_string())
             .schema(sdl.to_string())
+            .schema_source(SchemaSource::File { file: path })
             .build();
         assert_that!(&output)
             .is_ok()


### PR DESCRIPTION
As per title, one big problem with the original version of this change was that if the initial `supergraph.yaml` was broken the Language Server would stop. This is now fixed, so the event loop still starts, even if the `supergraph.yaml` is invalid. It can then be fixed by the user later on and from there the LSP will continue to behave as normal.