### PR TITLE
fix(dev): respect APOLLO_KEY-only uses

### DIFF
--- a/src/command/dev/next/router/binary.rs
+++ b/src/command/dev/next/router/binary.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fmt, process::Stdio};
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use futures::TryFutureExt;
+use houston::Credential;
 use rover_std::Style;
 use semver::Version;
 use tap::TapFallible;
@@ -107,6 +108,7 @@ pub struct RunRouterBinary<Spawn: Send> {
     config_path: Utf8PathBuf,
     supergraph_schema_path: Utf8PathBuf,
     remote_config: Option<RemoteRouterConfig>,
+    credential: Credential,
     spawn: Spawn,
 }
 
@@ -134,13 +136,27 @@ where
                 "info".to_string(),
                 "--dev".to_string(),
             ];
-            let mut env = HashMap::from_iter([("APOLLO_ROVER".to_string(), "true".to_string())]);
+
+            // We set the APOLLO_KEY here, but it might be overriden by RemoteRouterConfig. That
+            // struct takes the who_am_i service, gets an identity, and checks whether the
+            // associated API key (if present) is of a graph-level actor; if it is, we overwrite
+            // the env key with it because we know it's associated with the target graph_ref
+            let api_key =
+                if let Some(api_key) = remote_config.as_ref().and_then(|c| c.api_key().clone()) {
+                    api_key
+                } else {
+                    self.credential.api_key.clone()
+                };
+
+            let mut env = HashMap::from_iter([
+                ("APOLLO_ROVER".to_string(), "true".to_string()),
+                ("APOLLO_KEY".to_string(), api_key),
+            ]);
+
             if let Some(graph_ref) = remote_config.as_ref().map(|c| c.graph_ref().to_string()) {
                 env.insert("APOLLO_GRAPH_REF".to_string(), graph_ref);
             }
-            if let Some(api_key) = remote_config.and_then(|c| c.api_key().clone()) {
-                env.insert("APOLLO_KEY".to_string(), api_key);
-            }
+
             let child = spawn
                 .ready()
                 .and_then(|spawn| {

--- a/src/command/dev/next/router/run.rs
+++ b/src/command/dev/next/router/run.rs
@@ -141,6 +141,7 @@ impl RunRouter<state::Run> {
         temp_router_dir: &Utf8Path,
         studio_client_config: StudioClientConfig,
         supergraph_schema: &str,
+        credential: Credential,
     ) -> Result<RunRouter<state::Watch>, RunRouterBinaryError>
     where
         Spawn: Service<ExecCommandConfig, Response = Child> + Send + Clone + 'static,
@@ -195,6 +196,7 @@ impl RunRouter<state::Run> {
             .config_path(hot_reload_config_path.clone())
             .supergraph_schema_path(hot_reload_schema_path.clone())
             .and_remote_config(self.state.remote_config.clone())
+            .credential(credential)
             .spawn(spawn)
             .build();
 


### PR DESCRIPTION
  - we should be able to run rover dev without running rover config auth by setting APOLLO_KEY