### PR TITLE
ROVER-280 Fix Adding Subgraphs Semantics

### DIFF
--- a/crates/rover-std/src/fs.rs
+++ b/crates/rover-std/src/fs.rs
@@ -261,8 +261,9 @@ impl Fs {
     pub fn watch_file(
         path: PathBuf,
         tx: UnboundedSender<Result<(), RoverStdError>>,
+        cancellation_token: Option<CancellationToken>,
     ) -> CancellationToken {
-        let cancellation_token = CancellationToken::new();
+        let cancellation_token = cancellation_token.unwrap_or_default();
 
         let poll_watcher = PollWatcher::new(
             {
@@ -452,7 +453,7 @@ mod tests {
         let path = file.path().to_path_buf();
         let (tx, rx) = unbounded_channel();
         let rx = Arc::new(Mutex::new(rx));
-        let cancellation_token = Fs::watch_file(path.clone(), tx);
+        let cancellation_token = Fs::watch_file(path.clone(), tx, None);
 
         sleep(Duration::from_millis(1500)).await;
 
@@ -513,7 +514,7 @@ mod tests {
         let (tx, rx) = unbounded_channel();
         let rx = Arc::new(Mutex::new(rx));
 
-        let _cancellation_token = Fs::watch_file(path.clone(), tx);
+        let _cancellation_token = Fs::watch_file(path.clone(), tx, None);
 
         sleep(Duration::from_millis(1500)).await;
 

--- a/src/command/dev/router/hot_reload.rs
+++ b/src/command/dev/router/hot_reload.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 use rover_std::{debugln, errln, infoln};
 use serde_yaml::Value;
 use tap::TapFallible;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use super::config::{parser::RouterConfigParser, RouterConfig};
@@ -116,75 +117,101 @@ where
         self,
         sender: tokio::sync::mpsc::UnboundedSender<Self::Output>,
         mut input: futures::stream::BoxStream<'static, Self::Input>,
-    ) -> tokio::task::AbortHandle {
+        cancellation_token: Option<CancellationToken>,
+    ) {
         let write_file_impl = self.write_file_impl.clone();
+        let cancellation_token = cancellation_token.unwrap_or_default();
         tokio::task::spawn(async move {
-            while let Some(router_update_event) = input.next().await {
-                match router_update_event {
-                    RouterUpdateEvent::SchemaChanged { schema } => {
-                        match write_file_impl
-                            .write_file(&self.schema, schema.as_bytes())
-                            .await
-                        {
-                            Ok(_) => {
-                                let message = HotReloadEvent::SchemaWritten(Ok(()));
-                                let _ = sender.send(message).tap_err(|err| {
-                                    tracing::error!("Unable to send message. Error: {:?}", err)
-                                });
+            cancellation_token
+                .run_until_cancelled(async move {
+                    while let Some(router_update_event) = input.next().await {
+                        match router_update_event {
+                            RouterUpdateEvent::SchemaChanged { schema } => {
+                                match write_file_impl
+                                    .write_file(&self.schema, schema.as_bytes())
+                                    .await
+                                {
+                                    Ok(_) => {
+                                        let message = HotReloadEvent::SchemaWritten(Ok(()));
+                                        let _ = sender.send(message).tap_err(|err| {
+                                            tracing::error!(
+                                                "Unable to send message. Error: {:?}",
+                                                err
+                                            )
+                                        });
+                                    }
+                                    Err(err) => {
+                                        let message =
+                                            HotReloadEvent::SchemaWritten(Err(Box::new(err)));
+                                        let _ = sender.send(message).tap_err(|err| {
+                                            tracing::error!(
+                                                "Unable to send message. Error: {:?}",
+                                                err
+                                            )
+                                        });
+                                    }
+                                }
                             }
-                            Err(err) => {
-                                let message = HotReloadEvent::SchemaWritten(Err(Box::new(err)));
-                                let _ = sender.send(message).tap_err(|err| {
-                                    tracing::error!("Unable to send message. Error: {:?}", err)
-                                });
-                            }
-                        }
-                    }
-                    RouterUpdateEvent::ConfigChanged { config } => {
-                        let hot_reload_config = match HotReloadConfig::new(
-                            config.inner().to_string(),
-                            Some(self.overrides),
-                        ) {
-                            Ok(config) => config,
-                            Err(err) => {
-                                let error_message =
-                                    format!("Router config failed to update. {}", &err);
-                                let message = HotReloadEvent::ConfigWritten(Err(Box::new(err)));
-                                let _ = sender.send(message).tap_err(|err| {
-                                    tracing::error!("Unable to send message. Error: {:?}", err)
-                                });
-                                errln!("{}", error_message);
-                                break;
-                            }
-                        };
+                            RouterUpdateEvent::ConfigChanged { config } => {
+                                let hot_reload_config = match HotReloadConfig::new(
+                                    config.inner().to_string(),
+                                    Some(self.overrides),
+                                ) {
+                                    Ok(config) => config,
+                                    Err(err) => {
+                                        let error_message =
+                                            format!("Router config failed to update. {}", &err);
+                                        let message =
+                                            HotReloadEvent::ConfigWritten(Err(Box::new(err)));
+                                        let _ = sender.send(message).tap_err(|err| {
+                                            tracing::error!(
+                                                "Unable to send message. Error: {:?}",
+                                                err
+                                            )
+                                        });
+                                        errln!("{}", error_message);
+                                        break;
+                                    }
+                                };
 
-                        match write_file_impl
-                            .write_file(&self.config, hot_reload_config.to_string().as_bytes())
-                            .await
-                        {
-                            Ok(_) => {
-                                let message = HotReloadEvent::ConfigWritten(Ok(()));
-                                let _ = sender.send(message).tap_err(|err| {
-                                    tracing::error!("Unable to send message. Error: {:?}", err)
-                                });
-                                infoln!("Router config updated.");
-                                debugln!("{}", hot_reload_config);
-                            }
-                            Err(err) => {
-                                let error_message =
-                                    format!("Router config failed to update. {}", &err);
-                                let message = HotReloadEvent::ConfigWritten(Err(Box::new(err)));
-                                let _ = sender.send(message).tap_err(|err| {
-                                    tracing::error!("Unable to send message. Error: {:?}", err)
-                                });
-                                errln!("{}", error_message);
+                                match write_file_impl
+                                    .write_file(
+                                        &self.config,
+                                        hot_reload_config.to_string().as_bytes(),
+                                    )
+                                    .await
+                                {
+                                    Ok(_) => {
+                                        let message = HotReloadEvent::ConfigWritten(Ok(()));
+                                        let _ = sender.send(message).tap_err(|err| {
+                                            tracing::error!(
+                                                "Unable to send message. Error: {:?}",
+                                                err
+                                            )
+                                        });
+                                        infoln!("Router config updated.");
+                                        debugln!("{}", hot_reload_config);
+                                    }
+                                    Err(err) => {
+                                        let error_message =
+                                            format!("Router config failed to update. {}", &err);
+                                        let message =
+                                            HotReloadEvent::ConfigWritten(Err(Box::new(err)));
+                                        let _ = sender.send(message).tap_err(|err| {
+                                            tracing::error!(
+                                                "Unable to send message. Error: {:?}",
+                                                err
+                                            )
+                                        });
+                                        errln!("{}", error_message);
+                                    }
+                                }
                             }
                         }
                     }
-                }
-            }
-        })
-        .abort_handle()
+                })
+                .await;
+        });
     }
 }
 

--- a/src/command/dev/router/watchers/file.rs
+++ b/src/command/dev/router/watchers/file.rs
@@ -30,7 +30,7 @@ impl FileWatcher {
         let path = self.path;
         let (file_tx, file_rx) = unbounded_channel();
         let output = UnboundedReceiverStream::new(file_rx);
-        let cancellation_token = Fs::watch_file(path.as_path().into(), file_tx);
+        let cancellation_token = Fs::watch_file(path.as_path().into(), file_tx, None);
 
         output
             .filter_map(move |result| {

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -220,7 +220,10 @@ where
         // events in order to trigger recomposition.
         let (composition_messages, composition_subtask) =
             Subtask::new(self.state.composition_watcher);
-        composition_subtask.run(select(subgraph_change_stream, federation_watcher_stream).boxed());
+        composition_subtask.run(
+            select(subgraph_change_stream, federation_watcher_stream).boxed(),
+            None,
+        );
 
         // Start subgraph watchers, listening for events from the supergraph change stream.
         subgraph_watcher_subtask.run(
@@ -235,6 +238,7 @@ where
                     }
                 })
                 .boxed(),
+            None,
         );
 
         federation_watcher_subtask.run(
@@ -249,11 +253,12 @@ where
                     }
                 })
                 .boxed(),
+            None,
         );
 
         // Start the supergraph watcher subtask.
         if let Some(supergraph_config_subtask) = supergraph_config_subtask {
-            supergraph_config_subtask.run();
+            supergraph_config_subtask.run(None);
         }
 
         composition_messages.boxed()

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -3,7 +3,7 @@ use futures::stream::BoxStream;
 use futures::StreamExt;
 use tap::TapFallible;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::task::AbortHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::error;
 
 use crate::composition::events::CompositionEvent;
@@ -25,32 +25,42 @@ impl SubtaskHandleStream for FederationWatcher {
         self,
         sender: UnboundedSender<Self::Output>,
         mut input: BoxStream<'static, Self::Input>,
-    ) -> AbortHandle {
-        tokio::task::spawn(async move {
-            while let Some(recv_res) = input.next().await {
-                match recv_res {
-                    Ok(diff) => {
-                        if let Some(fed_version) = diff.federation_version() {
-                            let _ = sender
-                                .send(CompositionInputEvent::Federation(
-                                    fed_version.clone().unwrap_or(LatestFedTwo),
-                                ))
-                                .tap_err(|err| error!("{:?}", err));
+        cancellation_token: Option<CancellationToken>,
+    ) {
+        let cancellation_token = cancellation_token.unwrap_or_default();
+        tokio::spawn(async move {
+            let cancellation_token = cancellation_token.clone();
+            cancellation_token
+                .run_until_cancelled(async move {
+                    while let Some(recv_res) = input.next().await {
+                        match recv_res {
+                            Ok(diff) => {
+                                if let Some(fed_version) = diff.federation_version() {
+                                    let _ = sender
+                                        .send(CompositionInputEvent::Federation(
+                                            fed_version.clone().unwrap_or(LatestFedTwo),
+                                        ))
+                                        .tap_err(|err| error!("{:?}", err));
+                                }
+                            }
+                            Err(SupergraphConfigSerialisationError::DeserializingConfigError {
+                                source,
+                            }) => {
+                                let _ = sender
+                                    .send(CompositionInputEvent::Passthrough(
+                                        CompositionEvent::Error(
+                                            CompositionError::InvalidSupergraphConfig(
+                                                source.message(),
+                                            ),
+                                        ),
+                                    ))
+                                    .tap_err(|err| error!("{:?}", err));
+                            }
+                            Err(_) => {}
                         }
                     }
-                    Err(SupergraphConfigSerialisationError::DeserializingConfigError {
-                        source,
-                    }) => {
-                        let _ = sender
-                            .send(CompositionInputEvent::Passthrough(CompositionEvent::Error(
-                                CompositionError::InvalidSupergraphConfig(source.message()),
-                            )))
-                            .tap_err(|err| error!("{:?}", err));
-                    }
-                    Err(_) => {}
-                }
-            }
-        })
-        .abort_handle()
+                })
+                .await;
+        });
     }
 }

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -89,17 +89,12 @@ pub struct SubgraphFileWatcher {
     /// The filepath to watch
     path: Utf8PathBuf,
     resolver: FullyResolveSubgraphService,
-    drop_guard: Arc<Mutex<Option<DropGuard>>>,
 }
 
 impl SubgraphFileWatcher {
     /// Create a new filewatcher
     pub fn new(path: Utf8PathBuf, resolver: FullyResolveSubgraphService) -> Self {
-        Self {
-            path,
-            resolver,
-            drop_guard: Arc::new(Mutex::new(None)),
-        }
+        Self { path, resolver }
     }
 
     pub async fn fetch(mut self) -> Result<FullyResolvedSubgraph, ResolveSubgraphError> {
@@ -125,10 +120,6 @@ impl SubgraphFileWatcher {
             file_tx,
             Some(cancellation_token),
         );
-        {
-            let mut drop_guard = self.drop_guard.lock().await;
-            let _ = drop_guard.insert(cancellation_token.clone().drop_guard());
-        }
 
         output
             .filter_map({

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use buildstructor::Builder;
 use tap::TapFallible;
+use tokio_util::sync::CancellationToken;
 use tower::{Service, ServiceExt};
 
 use crate::subtask::SubtaskHandleUnit;
@@ -26,46 +27,53 @@ where
     fn handle(
         self,
         sender: tokio::sync::mpsc::UnboundedSender<Self::Output>,
-    ) -> tokio::task::AbortHandle {
+        cancellation_token: Option<CancellationToken>,
+    ) {
         let mut service = self.service.clone();
+        let cancellation_token = cancellation_token.unwrap_or_default();
         tokio::task::spawn(async move {
-            let service = service.ready().await.unwrap();
-            let mut last_result: Option<Result<S::Response, String>> = None;
-            loop {
-                match service.call(()).await {
-                    Ok(output) => {
-                        let mut was_updated = true;
-                        if let Some(Ok(last)) = last_result {
-                            if last == output {
-                                was_updated = false
+            let cancellation_token = cancellation_token.clone();
+            let mut interval = tokio::time::interval(self.polling_interval);
+            cancellation_token
+                .run_until_cancelled(async move {
+                    let service = service.ready().await.unwrap();
+                    let mut last_result: Option<Result<S::Response, String>> = None;
+                    loop {
+                        interval.tick().await;
+                        match service.call(()).await {
+                            Ok(output) => {
+                                let mut was_updated = true;
+                                if let Some(Ok(last)) = last_result {
+                                    if last == output {
+                                        was_updated = false
+                                    }
+                                }
+                                if was_updated {
+                                    let _ = sender
+                                        .send(Ok(output.clone()))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                }
+                                last_result = Some(Ok(output));
+                            }
+                            Err(error) => {
+                                let mut was_updated = true;
+                                let e = error.to_string();
+                                if let Some(Err(last)) = last_result {
+                                    if last == e {
+                                        was_updated = false;
+                                    }
+                                }
+                                if was_updated {
+                                    let _ = sender
+                                        .send(Err(error))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
+                                }
+                                last_result = Some(Err(e));
                             }
                         }
-                        if was_updated {
-                            let _ = sender
-                                .send(Ok(output.clone()))
-                                .tap_err(|err| tracing::error!("{:?}", err));
-                        }
-                        last_result = Some(Ok(output));
                     }
-                    Err(error) => {
-                        let mut was_updated = true;
-                        let e = error.to_string();
-                        if let Some(Err(last)) = last_result {
-                            if last == e {
-                                was_updated = false;
-                            }
-                        }
-                        if was_updated {
-                            let _ = sender
-                                .send(Err(error))
-                                .tap_err(|err| tracing::error!("{:?}", err));
-                        }
-                        last_result = Some(Err(e));
-                    }
-                }
-                tokio::time::sleep(self.polling_interval).await
-            }
-        })
-        .abort_handle()
+                })
+                .await;
+        });
     }
 }


### PR DESCRIPTION
In the original code even though we reported errors with and the subgraph was ostensibly "removed", it was retained inside an internal data structure within the SupergraphConfigWatcher and so when changes were made they were not seen properly and thus not acted on.

In addition there were issues with adding a subgraph where file watchers were getting dropped too early, because of the use of a DropGuard in one of the Watcher objects, I've removed this idiom and instead added a series of cancellation tokens throughout, rather than relying on abort handles. This has the added benefit that cancellation is much more controlled and cascades in a better way than consistently trying to ensure all the right abort handles get called.