### PR TITLE
ROVER-286 Removing `routing_url` gives correct error message

### DIFF
--- a/src/composition/supergraph/config/full/subgraph/mod.rs
+++ b/src/composition/supergraph/config/full/subgraph/mod.rs
@@ -31,7 +31,7 @@ pub type FullyResolveSubgraphService =
 #[derive(Clone, Debug, Eq, PartialEq, Getters)]
 pub struct FullyResolvedSubgraph {
     name: String,
-    routing_url: String,
+    routing_url: Option<String>,
     schema: String,
     schema_source: SchemaSource,
     pub(crate) is_fed_two: bool,
@@ -44,7 +44,7 @@ impl FullyResolvedSubgraph {
     pub fn new(
         name: String,
         schema: String,
-        routing_url: String,
+        routing_url: Option<String>,
         schema_source: SchemaSource,
     ) -> FullyResolvedSubgraph {
         let is_fed_two = schema_contains_link_directive(&schema);
@@ -124,16 +124,14 @@ impl FullyResolvedSubgraph {
                 let unresolved_subgraph = unresolved_subgraph.clone();
                 let sdl = sdl.to_string();
                 async move {
-                    Ok(FullyResolvedSubgraph::builder()
+                    let builder = FullyResolvedSubgraph::builder()
                         .name(unresolved_subgraph.name().to_string())
-                        .routing_url(unresolved_subgraph.routing_url().clone().ok_or_else(
-                            || ResolveSubgraphError::MissingRoutingUrl {
-                                subgraph: unresolved_subgraph.name().to_string(),
-                            },
-                        )?)
                         .schema(sdl.to_string())
-                        .schema_source(SchemaSource::Sdl { sdl })
-                        .build())
+                        .schema_source(SchemaSource::Sdl { sdl });
+                    Ok(match unresolved_subgraph.routing_url() {
+                        None => builder.build(),
+                        Some(routing_url) => builder.routing_url(routing_url).build(),
+                    })
                 }
             })
             .boxed_clone()),
@@ -149,7 +147,7 @@ impl FullyResolvedSubgraph {
 impl From<FullyResolvedSubgraph> for SubgraphConfig {
     fn from(value: FullyResolvedSubgraph) -> Self {
         SubgraphConfig {
-            routing_url: Some(value.routing_url),
+            routing_url: value.routing_url,
             schema: SchemaSource::Sdl { sdl: value.schema },
         }
     }

--- a/src/composition/supergraph/config/full/subgraph/mod.rs
+++ b/src/composition/supergraph/config/full/subgraph/mod.rs
@@ -31,7 +31,7 @@ pub type FullyResolveSubgraphService =
 #[derive(Clone, Debug, Eq, PartialEq, Getters)]
 pub struct FullyResolvedSubgraph {
     name: String,
-    routing_url: Option<String>,
+    pub(crate) routing_url: Option<String>,
     schema: String,
     schema_source: SchemaSource,
     pub(crate) is_fed_two: bool,

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -109,7 +109,7 @@ pub struct SubgraphSchemaChanged {
     name: String,
     /// SDL with changes
     sdl: String,
-    routing_url: String,
+    routing_url: Option<String>,
     /// Schema Source
     schema_source: SchemaSource,
 }
@@ -125,7 +125,7 @@ impl SubgraphSchemaChanged {
         SubgraphSchemaChanged {
             name,
             sdl,
-            routing_url,
+            routing_url: Some(routing_url),
             schema_source,
         }
     }
@@ -133,12 +133,14 @@ impl SubgraphSchemaChanged {
 
 impl From<SubgraphSchemaChanged> for FullyResolvedSubgraph {
     fn from(value: SubgraphSchemaChanged) -> Self {
-        FullyResolvedSubgraph::builder()
+        let builder = FullyResolvedSubgraph::builder()
             .name(value.name)
             .schema(value.sdl)
-            .routing_url(value.routing_url)
-            .schema_source(value.schema_source)
-            .build()
+            .schema_source(value.schema_source);
+        match value.routing_url {
+            None => builder.build(),
+            Some(routing_url) => builder.routing_url(routing_url).build(),
+        }
     }
 }
 
@@ -147,7 +149,7 @@ impl From<FullyResolvedSubgraph> for SubgraphSchemaChanged {
         SubgraphSchemaChanged {
             name: value.name().to_string(),
             sdl: value.schema().to_string(),
-            routing_url: value.routing_url().to_string(),
+            routing_url: value.routing_url().to_owned(),
             schema_source: value.schema_source().to_owned(),
         }
     }

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -97,7 +97,9 @@ impl SubgraphWatchers {
 /// name of the subgraph
 pub enum SubgraphEvent {
     /// A change to the watched subgraph
-    SubgraphChanged(SubgraphSchemaChanged),
+    SubgraphSchemaChanged(SubgraphSchemaChanged),
+    /// A change to the watched subgraph's routing URL
+    RoutingUrlChanged(SubgraphRoutingUrlChanged),
     /// The subgraph is no longer watched
     SubgraphRemoved(SubgraphSchemaRemoved),
 }
@@ -153,6 +155,12 @@ impl From<FullyResolvedSubgraph> for SubgraphSchemaChanged {
             schema_source: value.schema_source().to_owned(),
         }
     }
+}
+
+#[derive(derive_getters::Getters, Default)]
+pub struct SubgraphRoutingUrlChanged {
+    name: String,
+    routing_url: Option<String>,
 }
 
 /// The subgraph is no longer watched
@@ -260,7 +268,9 @@ impl SubgraphHandles {
                         while let Some(subgraph) = messages.next().await {
                             tracing::info!("Subgraph change detected: {:?}", subgraph);
                             let _ = sender
-                                .send(Subgraph(SubgraphEvent::SubgraphChanged(subgraph.into())))
+                                .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
+                                    subgraph.into(),
+                                )))
                                 .tap_err(|err| tracing::error!("{:?}", err));
                         }
                     })
@@ -339,7 +349,7 @@ impl SubgraphHandles {
         )
         .await?;
         let subgraph_watcher = SubgraphWatcher::new(
-            lazily_resolved_subgraph,
+            lazily_resolved_subgraph.clone(),
             resolver,
             introspection_polling_interval,
             subgraph.to_string(),
@@ -353,10 +363,23 @@ impl SubgraphHandles {
                 .map(|subgraph| {
                     let _ = self
                         .sender
-                        .send(Subgraph(SubgraphEvent::SubgraphChanged(subgraph.into())))
+                        .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
+                            subgraph.into(),
+                        )))
                         .tap_err(|err| tracing::error!("{:?}", err));
                 });
         }
+
+        // It's possible that the routing_url was updated at this point so we need to update that
+        // and propagate the update through by forcing a recomposition. This may be unnecessary,
+        // but we'll figure that out on the receiving end rather than passing around more
+        // context.
+        let _ = self.sender.send(Subgraph(SubgraphEvent::RoutingUrlChanged(
+            SubgraphRoutingUrlChanged {
+                name: subgraph.to_string(),
+                routing_url: lazily_resolved_subgraph.routing_url().clone(),
+            },
+        )));
         Ok(())
     }
 
@@ -388,7 +411,9 @@ impl SubgraphHandles {
             .map(|subgraph| {
                 let _ = self
                     .sender
-                    .send(Subgraph(SubgraphEvent::SubgraphChanged(subgraph.into())))
+                    .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
+                        subgraph.into(),
+                    )))
                     .tap_err(|err| tracing::error!("{:?}", err));
             });
     }
@@ -404,7 +429,7 @@ impl SubgraphHandles {
             Subtask::<SubgraphWatcher, FullyResolvedSubgraph>::new(subgraph_watcher);
         let _ = self
             .sender
-            .send(Subgraph(SubgraphEvent::SubgraphChanged(
+            .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
                 subgraph.clone().into(),
             )))
             .tap_err(|err| tracing::error!("{:?}", err));
@@ -416,9 +441,10 @@ impl SubgraphHandles {
                 cancellation_token
                     .run_until_cancelled(async move {
                         while let Some(subgraph) = messages.next().await {
-                            tracing::info!("Subgraph change detected: {:?}", subgraph);
                             let _ = sender
-                                .send(Subgraph(SubgraphEvent::SubgraphChanged(subgraph.into())))
+                                .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
+                                    subgraph.into(),
+                                )))
                                 .tap_err(|err| tracing::error!("{:?}", err));
                         }
                     })

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -206,7 +206,7 @@ impl SupergraphConfigDiff {
         let changed = old
             .clone()
             .into_iter()
-            .filter(|(old_name, _)| !removed.contains(&old_name))
+            .filter(|(old_name, _)| !removed.contains(old_name))
             .filter_map(|(old_name, old_subgraph)| {
                 new_subgraphs.get(&old_name).and_then(|new_subgraph| {
                     let new_subgraph = new_subgraph.clone();


### PR DESCRIPTION
As per title, due to some particularly inconvenient handling of federation resolution subgraphs losing a routing_url while the LSP was running, or not having one to start with were causing us many problems. This is now resolved and I've run over the test suite we have and all tests are passing (with the exception of the `--profile` ones, which are a known issue). 

Some comments are added throughout to explain the decisions taken.