### PR TITLE
[BGS-153] User who provides `APOLLO_GRAPH_REF` should see a helpful message printed to stderr if the `whoami` call fails.

### DIFF
--- a/crates/rover-client/src/operations/subgraph/fetch_all/service.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/service.rs
@@ -95,7 +95,10 @@ where
                 .map_err(|err| match err {
                     GraphQLServiceError::InvalidCredentials() => {
                         RoverClientError::PermissionError {
-                            msg: format!("attempting to fetch subgraphs for {}", req.graph_ref.to_string()),
+                            msg: format!(
+                                "attempting to fetch subgraphs for {}",
+                                req.graph_ref.to_string()
+                            ),
                         }
                     }
                     _ => RoverClientError::Service {

--- a/crates/rover-client/src/operations/subgraph/fetch_all/service.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/service.rs
@@ -92,9 +92,16 @@ where
             inner
                 .call(GraphQLRequest::<SubgraphFetchAllQuery>::new(variables))
                 .await
-                .map_err(|err| RoverClientError::Service {
-                    source: Box::new(err),
-                    endpoint_kind: EndpointKind::ApolloStudio,
+                .map_err(|err| match err {
+                    GraphQLServiceError::InvalidCredentials() => {
+                        RoverClientError::PermissionError {
+                            msg: format!("attempting to fetch subgraphs for {}", req.graph_ref.to_string()),
+                        }
+                    }
+                    _ => RoverClientError::Service {
+                        source: Box::new(err),
+                        endpoint_kind: EndpointKind::ApolloStudio,
+                    },
                 })
                 .and_then(|response_data| {
                     get_subgraphs_from_response_data(req.graph_ref, response_data)

--- a/crates/rover-client/src/operations/subgraph/fetch_all/service.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/service.rs
@@ -95,10 +95,7 @@ where
                 .map_err(|err| match err {
                     GraphQLServiceError::InvalidCredentials() => {
                         RoverClientError::PermissionError {
-                            msg: format!(
-                                "attempting to fetch subgraphs for {}",
-                                req.graph_ref.to_string()
-                            ),
+                            msg: format!("attempting to fetch subgraphs for {}", req.graph_ref),
                         }
                     }
                     _ => RoverClientError::Service {

--- a/crates/rover-graphql/Cargo.toml
+++ b/crates/rover-graphql/Cargo.toml
@@ -14,6 +14,7 @@ http-body = { workspace = true }
 http-body-util = { workspace = true }
 rover-http = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 tower = { workspace = true }
 url = { workspace = true }
@@ -22,7 +23,6 @@ url = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 rstest = { workspace = true }
-serde = { workspace = true }
 speculoos = { workspace = true }
 tower-test = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
was
```
~/src/fed-quickstart/retail-supergraph(main *=) ~/src/rover/target/debug/rover  dev  --graph-ref Retail-Supergraph-j5fgoc@prod --profile BAD_PROFILE
retrieving subgraphs remotely from Retail-Supergraph-j5fgoc@prod
merging supergraph schema files
error: Failed to load remote subgraphs.
Data was returned, but with errors

Caused by:
    0: Data was returned, but with errors
    1: Data was returned, but with errors
```

updated to:


```
~/src/fed-quickstart/retail-supergraph(nik/test-cases-for-manual-tests *) ~/src/rover/target/debug/rover  dev  --graph-ref Retail-Supergraph-j5fgoc@prod --profile BAD_PROFILE
retrieving subgraphs remotely from Retail-Supergraph-j5fgoc@prod
merging supergraph schema files
error: Failed to load remote subgraphs.
You don't have the required permissions to perform this operation: attempting to fetch subgraphs.

Caused by:
    You don't have the required permissions to perform this operation: attempting to fetch subgraphs.
  ```