### PR TITLE
ROVER-285 Allow LSP to start up with unresolvable `supergraph.yaml`

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -112,7 +112,7 @@ impl Dev {
                 federation_version,
                 Some(&SubgraphPrompt::default()),
             )
-            .await?
+            .await
             .install_supergraph_binary(
                 client_config.clone(),
                 override_install_path.clone(),

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -122,6 +122,7 @@ async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverR
                 .iter()
                 .map(|(name, subgraph)| (name.clone(), subgraph.schema().clone()))
                 .collect();
+            debug!("Initial Subgraphs are: {:?}", initial_subgraphs);
 
             // Generate the config needed to spin up the Language Server
             let (service, socket, _receiver) = ApolloLanguageServer::build_service(

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -188,6 +188,12 @@ async fn start_composition(
                         .publish_diagnostics(supergraph_yaml_url.clone(), vec![])
                         .await;
                     language_server
+                        .publish_diagnostics(
+                            supergraph_yaml_url.clone(),
+                            resolution_errors.values().cloned().collect(),
+                        )
+                        .await;
+                    language_server
                         .composition_did_update(
                             Some(supergraph_sdl),
                             hints.into_iter().map(Into::into).collect(),

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -115,7 +115,7 @@ impl Compose {
                 self.opts.federation_version.clone(),
                 None::<&SubgraphPrompt>,
             )
-            .await?
+            .await
             .install_supergraph_binary(
                 client_config.clone(),
                 override_install_path.clone(),

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::path::PathBuf;
 
 use anyhow::Error;
 use apollo_federation_types::config::SchemaSource;
@@ -77,6 +76,8 @@ pub enum CompositionError {
     InvalidSupergraphConfig(String),
     #[error("Error when updating Federation Version:\n{}", .0)]
     ErrorUpdatingFederationVersion(#[from] InstallSupergraphError),
+    #[error("Error resolving subgraphs:\n{}", .0)]
+    ResolvingSubgraphsError(#[from] ResolveSupergraphConfigError),
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -100,6 +101,4 @@ pub enum SupergraphConfigResolutionError {
     LoadLocalSupergraphConfigFailed(#[from] LoadSupergraphConfigError),
     #[error("Could not resolve local and remote elements into complete SupergraphConfig")]
     ResolveSupergraphConfigFailed(#[from] ResolveSupergraphConfigError),
-    #[error("Path `{0}` does not point to a file")]
-    PathDoesNotPointToAFile(PathBuf),
 }

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -9,6 +9,7 @@ use apollo_federation_types::{
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
 use crate::composition::supergraph::config::resolver::{
     LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
 };
@@ -86,9 +87,10 @@ pub struct CompositionSubgraphAdded {
     pub(crate) schema_source: SchemaSource,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct CompositionSubgraphRemoved {
     pub(crate) name: String,
+    pub(crate) resolution_error: Option<ResolveSubgraphError>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -357,7 +357,11 @@ impl CompositionPipeline<state::Run> {
             )
             .await
             .map_err(CompositionPipelineError::ResolveSubgraphs)?
-            .setup_supergraph_config_watcher(lazily_resolved_supergraph_config)
+            .setup_supergraph_config_watcher(
+                lazily_resolved_supergraph_config,
+                self.state.fetch_remote_subgraph_factory.clone(),
+                self.state.resolve_introspect_subgraph_factory.clone(),
+            )
             .setup_composition_watcher(
                 fully_resolved_supergraph_config,
                 resolution_errors,

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -29,6 +29,7 @@ use super::{
     FederationUpdaterConfig,
 };
 use crate::composition::supergraph::binary::OutputTarget;
+use crate::composition::supergraph::config::full::introspect::ResolveIntrospectSubgraphFactory;
 use crate::composition::watchers::federation::FederationWatcher;
 use crate::subtask::{BroadcastSubtask, SubtaskRunUnit};
 use crate::{
@@ -96,6 +97,8 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
     pub fn setup_supergraph_config_watcher(
         self,
         supergraph_config: LazilyResolvedSupergraphConfig,
+        fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
+        resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory,
     ) -> Runner<state::SetupCompositionWatcher> {
         // If the supergraph config was passed as a file, we can configure a watcher for change
         // events.
@@ -111,7 +114,12 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
         );
         let supergraph_config_watcher = if let Some(origin_path) = supergraph_config.origin_path() {
             let f = FileWatcher::new(origin_path.clone());
-            let watcher = SupergraphConfigWatcher::new(f, supergraph_config.clone());
+            let watcher = SupergraphConfigWatcher::new(
+                f,
+                supergraph_config.clone(),
+                fetch_remote_subgraph_factory,
+                resolve_introspect_subgraph_factory,
+            );
             Some(watcher)
         } else {
             None

--- a/src/composition/runner/state.rs
+++ b/src/composition/runner/state.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use crate::composition::supergraph::config::lazy::LazilyResolvedSupergraphConfig;
 use crate::composition::watchers::{
     composition::CompositionWatcher, subgraphs::SubgraphWatchers,
     watcher::supergraph_config::SupergraphConfigWatcher,
@@ -14,6 +15,7 @@ pub struct SetupSupergraphConfigWatcher {
 pub struct SetupCompositionWatcher {
     pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
     pub subgraph_watchers: SubgraphWatchers,
+    pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }
 
 pub struct Run<ReadF, ExecC, WriteF>
@@ -25,4 +27,5 @@ where
     pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
     pub subgraph_watchers: SubgraphWatchers,
     pub composition_watcher: CompositionWatcher<ReadF, ExecC, WriteF>,
+    pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -21,19 +21,6 @@ pub struct LazilyResolvedSupergraphConfig {
 }
 
 impl LazilyResolvedSupergraphConfig {
-    /// Builds a new config, with the given options
-    pub fn new(
-        origin_path: Option<Utf8PathBuf>,
-        subgraphs: BTreeMap<String, LazilyResolvedSubgraph>,
-        federation_version: Option<FederationVersion>,
-    ) -> Self {
-        LazilyResolvedSupergraphConfig {
-            origin_path,
-            subgraphs,
-            federation_version,
-        }
-    }
-
     /// Resolves an [`UnresolvedSupergraphConfig`] into a [`LazilyResolvedSupergraphConfig`] by
     /// making sure any internal file paths are correct
     pub async fn resolve(

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -7,9 +7,8 @@ use futures::{stream, StreamExt};
 use itertools::Itertools;
 
 use super::LazilyResolvedSubgraph;
-use crate::composition::supergraph::config::{
-    error::ResolveSubgraphError, unresolved::UnresolvedSupergraphConfig,
-};
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
+use crate::composition::supergraph::config::unresolved::UnresolvedSupergraphConfig;
 
 /// Represents a [`SupergraphConfig`] where all its [`SchemaSource::File`] subgraphs have
 /// known and valid file paths relative to a supergraph config file (or working directory of the
@@ -74,6 +73,13 @@ impl LazilyResolvedSupergraphConfig {
             },
             BTreeMap::from_iter(errors.into_iter()),
         )
+    }
+
+    /// Updates the internal structure of the SupergraphConfig by filtering out
+    /// any subgraphs that are included in the list of subgraphs to remove.
+    pub fn filter_subgraphs(&mut self, subgraphs_to_remove: Vec<String>) {
+        self.subgraphs
+            .retain(|name, _| !subgraphs_to_remove.contains(name));
     }
 }
 

--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -247,7 +247,13 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
         fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
         supergraph_config_root: &Utf8PathBuf,
         prompt: Option<&impl Prompt>,
-    ) -> Result<FullyResolvedSupergraphConfig, ResolveSupergraphConfigError> {
+    ) -> Result<
+        (
+            FullyResolvedSupergraphConfig,
+            BTreeMap<String, ResolveSubgraphError>,
+        ),
+        ResolveSupergraphConfigError,
+    > {
         match (prompt, self.state.subgraphs.is_empty()) {
             (Some(prompt), true) => {
                 let subgraph_url = prompt.prompt_for_subgraph_url().map_err(|err| {
@@ -315,7 +321,13 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
         &self,
         supergraph_config_root: &Utf8PathBuf,
         prompt: Option<&impl Prompt>,
-    ) -> Result<LazilyResolvedSupergraphConfig, ResolveSupergraphConfigError> {
+    ) -> Result<
+        (
+            LazilyResolvedSupergraphConfig,
+            BTreeMap<String, ResolveSubgraphError>,
+        ),
+        ResolveSupergraphConfigError,
+    > {
         match (prompt, self.state.subgraphs.is_empty()) {
             (Some(prompt), true) => {
                 let subgraph_url = prompt.prompt_for_subgraph_url().map_err(|err| {
@@ -353,8 +365,7 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
                     supergraph_config_root,
                     unresolved_supergraph_config,
                 )
-                .await
-                .map_err(ResolveSupergraphConfigError::ResolveSubgraphs)?;
+                .await;
                 Ok(resolved_supergraph_config)
             }
             _ => {
@@ -367,8 +378,7 @@ impl SupergraphConfigResolver<ResolveSubgraphs> {
                     supergraph_config_root,
                     unresolved_supergraph_config,
                 )
-                .await
-                .map_err(ResolveSupergraphConfigError::ResolveSubgraphs)?;
+                .await;
                 Ok(resolved_supergraph_config)
             }
         }
@@ -713,7 +723,7 @@ mod tests {
             );
 
         // fully resolve subgraphs into their SDLs
-        let fully_resolved_supergraph_config = resolver
+        let (fully_resolved_supergraph_config, _) = resolver
             .fully_resolve_subgraphs(
                 resolve_introspect_subgraph_factory,
                 fetch_remote_subgraph_factory,
@@ -946,7 +956,7 @@ mod tests {
             );
 
         // fully resolve subgraphs into their SDLs
-        let fully_resolved_supergraph_config = resolver
+        let (fully_resolved_supergraph_config, _) = resolver
             .fully_resolve_subgraphs(
                 resolve_introspect_subgraph_factory,
                 fetch_remote_subgraph_factory,
@@ -1179,7 +1189,7 @@ mod tests {
             );
 
         // fully resolve subgraphs into their SDLs
-        let fully_resolved_supergraph_config = resolver
+        let (fully_resolved_supergraph_config, _) = resolver
             .fully_resolve_subgraphs(
                 resolve_introspect_subgraph_factory,
                 fetch_remote_subgraph_factory,

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -162,17 +162,18 @@ where
                         }
                         Subgraph(SubgraphEvent::SubgraphRemoved(subgraph_removed)) => {
                             let name = subgraph_removed.name();
-                            tracing::info!("Subgraph removed: {}", name);
+                            let resolution_error = subgraph_removed.resolution_error().clone();
+                            info!("Subgraph removed: {}", name);
                             supergraph_config.remove_subgraph(name);
                             let _ = sender
                                 .send(CompositionEvent::SubgraphRemoved(
-                                    CompositionSubgraphRemoved { name: name.clone() },
+                                    CompositionSubgraphRemoved { name: name.clone(), resolution_error },
                                 ))
                                 .tap_err(|err| error!("{:?}", err));
                         }
                         Federation(fed_version) => {
                             if let Some(federation_updater_config) = self.federation_updater_config.clone() {
-                                tracing::info!("Attempting to change supergraph version to {:?}", fed_version);
+                                info!("Attempting to change supergraph version to {:?}", fed_version);
                                 infoln!("Attempting to change supergraph version to {}", fed_version.get_exact().unwrap());
                                 let install_res =
                                     InstallSupergraph::new(fed_version, federation_updater_config.studio_client_config.clone())

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
@@ -9,10 +11,13 @@ use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
+use crate::composition::supergraph::config::resolver::ResolveSupergraphConfigError;
 use crate::composition::supergraph::install::InstallSupergraph;
 use crate::composition::watchers::composition::CompositionInputEvent::{
     Federation, Passthrough, Recompose, Subgraph,
 };
+use crate::composition::CompositionError::ResolvingSubgraphsError;
 use crate::composition::{
     CompositionError, CompositionSubgraphAdded, CompositionSubgraphRemoved, CompositionSuccess,
     FederationUpdaterConfig,
@@ -47,7 +52,8 @@ pub enum CompositionInputEvent {
 
 #[derive(Builder, Debug)]
 pub struct CompositionWatcher<ExecC, ReadF, WriteF> {
-    supergraph_config: FullyResolvedSupergraphConfig,
+    initial_supergraph_config: FullyResolvedSupergraphConfig,
+    initial_resolution_errors: BTreeMap<String, ResolveSubgraphError>,
     federation_updater_config: Option<FederationUpdaterConfig>,
     supergraph_binary: SupergraphBinary,
     exec_command: ExecC,
@@ -74,34 +80,51 @@ where
         cancellation_token: Option<CancellationToken>,
     ) {
         tokio::task::spawn(async move {
-            let mut supergraph_config = self.supergraph_config.clone();
+            let mut supergraph_config = self.initial_supergraph_config.clone();
             let target_file = self.temp_dir.join("supergraph.yaml");
-            if self.compose_on_initialisation {
-                if let Err(err) = self
-                    .setup_temporary_supergraph_yaml(&supergraph_config, &target_file)
-                    .await
-                {
-                    error!("Could not setup initial supergraph schema: {}", err);
-                };
-                let _ = sender
-                    .send(CompositionEvent::Started)
-                    .tap_err(|err| error!("{:?}", err));
-                let output = self
-                    .run_composition(&target_file, &self.output_target)
-                    .await;
-                match output {
-                    Ok(success) => {
-                        let _ = sender
-                            .send(CompositionEvent::Success(success))
-                            .tap_err(|err| error!("{:?}", err));
-                    }
-                    Err(err) => {
-                        let _ = sender
-                            .send(CompositionEvent::Error(err))
-                            .tap_err(|err| error!("{:?}", err));
+
+            match (
+                self.initial_resolution_errors.is_empty(),
+                self.compose_on_initialisation,
+            ) {
+                (true, true) => {
+                    if let Err(err) = self
+                        .setup_temporary_supergraph_yaml(&supergraph_config, &target_file)
+                        .await
+                    {
+                        error!("Could not setup initial supergraph schema: {}", err);
+                    };
+                    let _ = sender
+                        .send(CompositionEvent::Started)
+                        .tap_err(|err| error!("{:?}", err));
+                    let output = self
+                        .run_composition(&target_file, &self.output_target)
+                        .await;
+                    match output {
+                        Ok(success) => {
+                            let _ = sender
+                                .send(CompositionEvent::Success(success))
+                                .tap_err(|err| error!("{:?}", err));
+                        }
+                        Err(err) => {
+                            let _ = sender
+                                .send(CompositionEvent::Error(err))
+                                .tap_err(|err| error!("{:?}", err));
+                        }
                     }
                 }
-            }
+                (false, _) => {
+                    let _ = sender
+                        .send(CompositionEvent::Error(ResolvingSubgraphsError(
+                            ResolveSupergraphConfigError::ResolveSubgraphs(
+                                self.initial_resolution_errors.clone(),
+                            ),
+                        )))
+                        .tap_err(|err| error!("{:?}", err));
+                }
+                (true, false) => {}
+            };
+
             let cancellation_token = cancellation_token.unwrap_or_default();
             cancellation_token.run_until_cancelled(async {
                 while let Some(event) = input.next().await {
@@ -297,6 +320,7 @@ mod tests {
     use crate::composition::supergraph::binary::OutputTarget;
     use crate::composition::watchers::composition::CompositionInputEvent::Subgraph;
     use crate::composition::CompositionSubgraphAdded;
+    use crate::subtask::SubtaskRunStream;
     use crate::{
         composition::{
             events::CompositionEvent,
@@ -307,7 +331,7 @@ mod tests {
             test::{default_composition_json, default_composition_success},
             watchers::subgraphs::{SubgraphEvent, SubgraphSchemaChanged},
         },
-        subtask::{Subtask, SubtaskRunStream},
+        subtask::Subtask,
         utils::effect::{
             exec::MockExecCommand, read_file::MockReadFile, write_file::MockWriteFile,
         },
@@ -381,7 +405,7 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let composition_handler = CompositionWatcher::builder()
-            .supergraph_config(subgraphs)
+            .initial_supergraph_config(subgraphs)
             .supergraph_binary(supergraph_binary)
             .exec_command(mock_exec)
             .read_file(mock_read_file)

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -56,7 +56,6 @@ impl SubtaskHandleStream for FederationWatcher {
                                     ))
                                     .tap_err(|err| error!("{:?}", err));
                             }
-                            Err(_) => {}
                         }
                     }
                 })

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -201,7 +201,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                                     subgraph_name,
                                     subgraph_config,
                                     self.introspection_polling_interval
-                                ).await.tap_err(|err| tracing::error!("{:?}", err));
+                                ).await.tap_err(|err| error!("{:?}", err));
                             }
 
                             for (subgraph_name, subgraph_config) in diff.changed() {
@@ -209,7 +209,7 @@ impl SubtaskHandleStream for SubgraphWatchers {
                                     subgraph_name,
                                     subgraph_config,
                                     self.introspection_polling_interval
-                                ).await.tap_err(|err| tracing::error!("{:?}", err));
+                                ).await.tap_err(|err| error!("{:?}", err));
                             }
 
                             // If we detect removal diffs, stop the subtask for the removed subgraph.

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -378,10 +378,21 @@ impl SubgraphHandles {
         // and propagate the update through by forcing a recomposition. This may be unnecessary,
         // but we'll figure that out on the receiving end rather than passing around more
         // context.
+        let routing_url = lazily_resolved_subgraph.routing_url().clone().or_else(|| {
+            if let SubgraphConfig {
+                schema: SchemaSource::SubgraphIntrospection { subgraph_url, .. },
+                ..
+            } = subgraph_config
+            {
+                Some(subgraph_url.to_string())
+            } else {
+                None
+            }
+        });
         let _ = self.sender.send(Subgraph(SubgraphEvent::RoutingUrlChanged(
             SubgraphRoutingUrlChanged {
                 name: subgraph.to_string(),
-                routing_url: lazily_resolved_subgraph.routing_url().clone(),
+                routing_url,
             },
         )));
         Ok(())


### PR DESCRIPTION
This PR takes in a few aspects, but the crucial point is that it is now possible for the LSP to start up, and enter the event loop, even if the `supergraph.yaml` is not properly resolvable down to a set of SDLs. This solves multiple bugs including issues with `--profile` not being correctly set, introspection potentially failing, incorrect GraphRefs not being reported and so on.

Have added tests where appropriate but a lot of this work is plumbing in order to move data around and so is somewhat challenging to test without working end-to-end, as I also have during the course of this work, see: https://docs.google.com/spreadsheets/d/1MXZzRDgxGMcEAtaguFnWAU0WW4-j6LRpdLCXz3Wv6YY/edit?gid=0#gid=0 for the E2E test cases considered.