### PR TITLE
ROVER-263 Enabling Remote Proxy Downloads (continuing #2254)

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -46,6 +46,32 @@ To install a **specific version** of Rover (recommended for CI environments to e
 iwr 'https://rover.apollo.dev/win/v0.26.3' | iex
 ```
 
+#### Installing from a binary mirror using the bash and PowerShell scripts
+
+Both the bash and powershell scripts support the `APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX` environment variable,
+which defaults to `https://github.com/apollographql/rover/releases/download`.
+
+This can be set in your environment to specify a remote mirror or proxy to a GitHub release download URL for the Apollo Rover GitHub repository.
+
+For example, if your remote host is `my-mirror-proxy.com/artifacts/github-com`:
+
+- From a bash shell:
+
+```bash
+# for bash (Mac/Linux)
+export APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX="https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
+```
+
+- From a PowerShell:
+
+```powershell
+# for PowerShell (Windows)
+$env:APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX = "https://my-mirror-proxy.com/artifacts/github-com/apollographql/rover/releases/download"
+```
+
+This variable also supports basic authentication.
+Set the format of the URL to `https://<username>:<password>@<remote-host>/apollographql/rover/releases/download`
+
 ### `npm` installer
 
 Rover is distributed on npm for integration with your JavaScript projects.
@@ -80,7 +106,7 @@ You can then call `rover <parameters>` directly in your `package.json` [scripts]
 
 <Note>
 
-When using `npx`, the `-p @apollo/rover` argument is necessary to specify that the `@apollo/rover` package provides the `rover` command.  See [`npx`'s documentation](https://www.npmjs.com/package/npx#description) for more information.
+When using `npx`, the `-p @apollo/rover` argument is necessary to specify that the `@apollo/rover` package provides the `rover` command. See [`npx`'s documentation](https://www.npmjs.com/package/npx#description) for more information.
 
 </Note>
 

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -15,7 +15,7 @@
 
 set -u
 
-BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/rover/releases/download"
+BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX:="https://github.com/apollographql/rover/releases/download"}"
 
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
@@ -63,13 +63,16 @@ download_binary_and_run_installer() {
     local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t rover)"
     local _file="$_dir/input.tar.gz"
     local _rover="$_dir/rover$_ext"
+    local _safe_url
 
-    say "downloading rover from $_url" 1>&2
+    # Remove credentials from the URL for logging
+    _safe_url=$(echo "$_url" | awk '{sub("https://[^@]+@","https://");}1')
+    say "downloading rover from $_safe_url" 1>&2
 
     ensure mkdir -p "$_dir"
     downloader "$_url" "$_file"
     if [ $? != 0 ]; then
-      say "failed to download $_url"
+      say "failed to download $_safe_url"
       say "this may be a standard network error, but it may also indicate"
       say "that rover's release process is not working. When in doubt"
       say "please feel free to open an issue!"

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -37,8 +37,16 @@ function Install-Binary($rover_install_args) {
 }
 
 function Download($version) {
-  $url = "https://github.com/apollographql/rover/releases/download/$version/rover-$version-x86_64-pc-windows-msvc.tar.gz"
-  "Downloading Rover from $url" | Out-Host
+  $binary_download_prefix = $env:APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX
+  if (-not $binary_download_prefix) {
+    $binary_download_prefix = "https://github.com/apollographql/rover/releases/download"
+  }
+  $url = "$binary_download_prefix/$version/rover-$version-x86_64-pc-windows-msvc.tar.gz"
+
+  # Remove credentials from the URL for logging
+  $safe_url = $url -replace "https://[^@]+@", "https://"
+
+  "Downloading Rover from $safe_url" | Out-Host
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\rover.tar.gz"
   $wc = New-Object Net.Webclient


### PR DESCRIPTION
Transfers over the work done by @LongLiveCHIEF, while updating to the new names `APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX` and using `awk` over `sed`. Corresponding router PR is here: #6667