### PR TITLE
ROVER-305 Update address precedence logic

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -257,7 +257,7 @@ impl Dev {
             "Do not run this command in production! It is intended for local development only."
         );
 
-        let pretty_router_addr_string = router_address.to_pretty_string();
+        let pretty_router_addr_string = router_address.pretty_string();
         infoln!("Your supergraph is running! head to {pretty_router_addr_string} to query your supergraph");
 
         loop {

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -12,7 +12,7 @@ use rover_std::{errln, infoln, warnln};
 use semver::Version;
 use tower::ServiceExt;
 
-use crate::command::dev::router::config::RouterAddress;
+use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort};
 use crate::command::dev::router::hot_reload::HotReloadConfigOverrides;
 use crate::command::dev::router::run::RunRouter;
 use crate::command::dev::{OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION};
@@ -204,8 +204,14 @@ impl Dev {
         // default, but we still have to reckon with the config-set address (if one exists). See
         // the reassignment of the variable below for details
         let router_address = RouterAddress::new(
-            self.opts.supergraph_opts.supergraph_address,
-            self.opts.supergraph_opts.supergraph_port,
+            self.opts
+                .supergraph_opts
+                .supergraph_address
+                .map(RouterHost::CliOption),
+            self.opts
+                .supergraph_opts
+                .supergraph_port
+                .map(RouterPort::CliOption),
         );
 
         let run_router = RunRouter::default()
@@ -251,7 +257,8 @@ impl Dev {
             "Do not run this command in production! It is intended for local development only."
         );
 
-        infoln!("Your supergraph is running! head to {router_address} to query your supergraph");
+        let pretty_router_addr_string = router_address.to_pretty_string();
+        infoln!("Your supergraph is running! head to {pretty_router_addr_string} to query your supergraph");
 
         loop {
             tokio::select! {

--- a/src/command/dev/router/config/mod.rs
+++ b/src/command/dev/router/config/mod.rs
@@ -100,7 +100,7 @@ impl RouterAddress {
 }
 
 impl RouterAddress {
-    pub(crate) fn to_pretty_string(&self) -> String {
+    pub(crate) fn pretty_string(&self) -> String {
         let host = self
             .host
             .to_string()
@@ -114,7 +114,7 @@ impl RouterAddress {
 
 impl Display for RouterAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.host.to_string(), self.port.to_string())
+        write!(f, "{}:{}", self.host, self.port)
     }
 }
 

--- a/src/command/dev/router/config/parser.rs
+++ b/src/command/dev/router/config/parser.rs
@@ -146,8 +146,6 @@ mod tests {
     #[rstest]
     #[case("127.0.0.1", RouterAddress::new(Some(RouterHost::ConfigFile("127.0.0.1".parse()?)), Some(RouterPort::ConfigFile(80))))]
     #[case("127.0.0.1:8000", RouterAddress::new(Some(RouterHost::ConfigFile("127.0.0.1".parse()?)), Some(RouterPort::ConfigFile(8000))))]
-    #[case("localhost", RouterAddress::new(Some(RouterHost::ConfigFile("::1".parse()?)), Some(RouterPort::ConfigFile(80))))]
-    #[case("localhost:8000", RouterAddress::new(Some(RouterHost::ConfigFile("::1".parse()?)), Some(RouterPort::ConfigFile(8000))))]
     fn test_get_address_from_router_config(
         #[case] socket_addr_str: &str,
         #[case] expected_router_address: RouterAddress,

--- a/src/command/dev/router/config/parser.rs
+++ b/src/command/dev/router/config/parser.rs
@@ -46,7 +46,7 @@ impl<'a> RouterConfigParser<'a> {
                 source: err,
             })?;
 
-        // Resolution precendence for addresses and ports:
+        // Resolution precedence for addresses and ports:
         // 1) CLI option
         // 2) Config
         // 3) Default

--- a/src/command/dev/router/config/parser.rs
+++ b/src/command/dev/router/config/parser.rs
@@ -1,12 +1,10 @@
-use std::{
-    io::Error,
-    net::{SocketAddr, SocketAddrV4, ToSocketAddrs},
-    str::FromStr,
-};
+use std::io::Error;
+use std::net::{SocketAddr, SocketAddrV4, ToSocketAddrs};
+use std::str::FromStr;
 
 use thiserror::Error;
 
-use super::RouterAddress;
+use super::{RouterAddress, RouterHost, RouterPort};
 
 #[derive(Error, Debug)]
 pub enum ParseRouterConfigError {
@@ -19,14 +17,14 @@ pub enum ParseRouterConfigError {
 
 pub struct RouterConfigParser<'a> {
     yaml: &'a serde_yaml::Value,
-    address: SocketAddr,
+    address: RouterAddress,
 }
 
 impl<'a> RouterConfigParser<'a> {
-    pub fn new(yaml: &'a serde_yaml::Value, address: SocketAddr) -> RouterConfigParser<'a> {
+    pub fn new(yaml: &'a serde_yaml::Value, address: RouterAddress) -> RouterConfigParser<'a> {
         RouterConfigParser { yaml, address }
     }
-    pub fn address(&self) -> Result<SocketAddr, ParseRouterConfigError> {
+    pub fn address(&self) -> Result<RouterAddress, ParseRouterConfigError> {
         let config_address = self
             .yaml
             .get("supergraph")
@@ -48,28 +46,27 @@ impl<'a> RouterConfigParser<'a> {
                 source: err,
             })?;
 
-        let default_address: SocketAddr = RouterAddress::default().into();
-        // Resolution precendence for addresses:
+        // Resolution precendence for addresses and ports:
         // 1) CLI option
         // 2) Config
-        // 4) Environment variable
         // 3) Default
-        //
-        // `self.address` gets set by first looking at the environment variable and then the CLI
-        // option; otherwise, we set it to the default
-        //
-        // If `self.address` doesn't match the default, we have either an environment variable or
-        // CLI option (and we rely on the proper handling of that elsewhere)
-        if self.address != default_address {
-            // So, send it back!
-            Ok(self.address)
-        } else if config_address.is_some() {
-            // Otherwise, if we have a config address, send it back
-            Ok(config_address.unwrap_or(default_address))
-        } else {
-            // Lastly, if no env var or config address are found, return the default
-            Ok(default_address)
-        }
+        let port = match (config_address, self.address.port) {
+            (Some(_), RouterPort::CliOption(port)) => RouterPort::CliOption(port),
+            (Some(addr), RouterPort::ConfigFile(..)) | (Some(addr), RouterPort::Default(..)) => {
+                RouterPort::ConfigFile(addr.port())
+            }
+            (None, port) => port,
+        };
+
+        let host = match (config_address, self.address.host) {
+            (Some(_), RouterHost::CliOption(addr)) => RouterHost::CliOption(addr),
+            (Some(addr), RouterHost::ConfigFile(..)) | (Some(addr), RouterHost::Default(..)) => {
+                RouterHost::ConfigFile(addr.ip())
+            }
+            (None, host) => host,
+        };
+
+        Ok(RouterAddress::new(Some(host), Some(port)))
     }
     pub fn health_check_enabled(&self) -> bool {
         self.yaml
@@ -137,23 +134,23 @@ impl<'a> RouterConfigParser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddr, str::FromStr};
-
     use anyhow::Result;
     use rstest::rstest;
     use speculoos::prelude::*;
 
     use super::RouterConfigParser;
-    use crate::command::dev::router::config::RouterAddress;
+    use crate::command::dev::router::config::{
+        RouterAddress, RouterHost, RouterPort, DEFAULT_ROUTER_IP_ADDR, DEFAULT_ROUTER_PORT,
+    };
 
     #[rstest]
-    #[case("127.0.0.1", SocketAddr::from_str("127.0.0.1:80").unwrap())]
-    #[case("127.0.0.1:8000", SocketAddr::from_str("127.0.0.1:8000").unwrap())]
-    #[case("localhost", SocketAddr::from_str("[::1]:80").unwrap())]
-    #[case("localhost:8000", SocketAddr::from_str("[::1]:8000").unwrap())]
+    #[case("127.0.0.1", RouterAddress::new(Some(RouterHost::ConfigFile("127.0.0.1".parse()?)), Some(RouterPort::ConfigFile(80))))]
+    #[case("127.0.0.1:8000", RouterAddress::new(Some(RouterHost::ConfigFile("127.0.0.1".parse()?)), Some(RouterPort::ConfigFile(8000))))]
+    #[case("localhost", RouterAddress::new(Some(RouterHost::ConfigFile("::1".parse()?)), Some(RouterPort::ConfigFile(80))))]
+    #[case("localhost:8000", RouterAddress::new(Some(RouterHost::ConfigFile("::1".parse()?)), Some(RouterPort::ConfigFile(8000))))]
     fn test_get_address_from_router_config(
         #[case] socket_addr_str: &str,
-        #[case] expected_socket_addr: SocketAddr,
+        #[case] expected_router_address: RouterAddress,
     ) -> Result<()> {
         let config_yaml_str = format!(
             indoc::indoc! {
@@ -167,42 +164,104 @@ supergraph:
         let config_yaml = serde_yaml::from_str(&config_yaml_str)?;
         let router_config = RouterConfigParser {
             yaml: &config_yaml,
-            address: expected_socket_addr,
+            address: expected_router_address,
         };
         let address = router_config.address();
         assert_that!(address)
             .is_ok()
-            .is_equal_to(expected_socket_addr);
+            .is_equal_to(expected_router_address);
         Ok(())
     }
 
     #[rstest]
-    #[case::cli_override_over_config(SocketAddr::from_str("127.0.0.1:8089").unwrap(), "127.0.0.1:4000", SocketAddr::from_str("127.0.0.1:8089").unwrap())]
-    // When the default is passed in, we use the config's address
-    #[case::config_over_default(Into::<SocketAddr>::into(RouterAddress::default()), "127.0.0.1:8089", SocketAddr::from_str("127.0.0.1:8089").unwrap())]
+    #[case::no_overrides_gives_default(
+        None,
+        None,
+        None,
+        RouterAddress::new(Some(DEFAULT_ROUTER_IP_ADDR), Some(DEFAULT_ROUTER_PORT))
+    )]
+    #[case::cli_host_overrides_default(
+        Some(RouterHost::CliOption("129.0.0.1".parse()?)),
+        None,
+        None,
+        RouterAddress::new(Some(RouterHost::CliOption("129.0.0.1".parse()?)), Some(DEFAULT_ROUTER_PORT))
+    )]
+    #[case::cli_port_overrides_default(
+        None,
+        Some(RouterPort::CliOption(9999)),
+        None,
+        RouterAddress::new(Some(DEFAULT_ROUTER_IP_ADDR), Some(RouterPort::CliOption(9999)))
+    )]
+    #[case::cli_host_and_port_overrides_default(
+        Some(RouterHost::CliOption("129.0.0.1".parse()?)),
+        Some(RouterPort::CliOption(9999)),
+        None,
+        RouterAddress::new(Some(RouterHost::CliOption("129.0.0.1".parse()?)), Some(RouterPort::CliOption(9999)))
+    )]
+    #[case::cli_host_and_port_overrides_even_config(
+        Some(RouterHost::CliOption("129.0.0.1".parse()?)),
+        Some(RouterPort::CliOption(9999)),
+        Some("127.0.0.1:1234"),
+        RouterAddress::new(Some(RouterHost::CliOption("129.0.0.1".parse()?)), Some(RouterPort::CliOption(9999)))
+    )]
+    #[case::config_overrides_default_but_only_for_address(
+        None,
+        Some(RouterPort::CliOption(9999)),
+        Some("127.0.0.1:1234"),
+        RouterAddress::new(Some(RouterHost::ConfigFile("127.0.0.1".parse()?)), Some(RouterPort::CliOption(9999)))
+    )]
+    #[case::config_overrides_default_but_only_for_port(
+        Some(RouterHost::CliOption("129.0.0.1".parse()?)),
+        None,
+        Some("127.0.0.1:1234"),
+        RouterAddress::new(Some(RouterHost::CliOption("129.0.0.1".parse()?)), Some(RouterPort::ConfigFile(1234)))
+    )]
+    #[case::config_overrides_default_no_cli_options(
+        None,
+        None,
+        Some("127.0.0.1:1234"),
+        RouterAddress::new(Some(RouterHost::ConfigFile("127.0.0.1".parse()?)), Some(RouterPort::ConfigFile(1234)))
+    )]
     fn test_get_address_from_router_config_with_override(
-        #[case] cli_override_addr: SocketAddr,
-        #[case] config_addr: &str,
-        #[case] expected_socket_addr: SocketAddr,
+        #[case] cli_override_host: Option<RouterHost>,
+        #[case] cli_override_port: Option<RouterPort>,
+        #[case] config_addr: Option<&str>,
+        #[case] expected_router_address: RouterAddress,
     ) -> Result<()> {
-        let config_yaml_str = format!(
-            indoc::indoc! {
-                r#"---
+        let config_yaml_str = match config_addr {
+            Some(config_addr) => {
+                format!(
+                    indoc::indoc! {
+                        r#"---
 supergraph:
   listen: {}
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
 "#
-            },
-            config_addr
-        );
+                    },
+                    config_addr
+                )
+            }
+            None => String::from(indoc::indoc! {
+                r#"---
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
+"#
+            }),
+        };
         let config_yaml = serde_yaml::from_str(&config_yaml_str)?;
         let router_config = RouterConfigParser {
             yaml: &config_yaml,
-            address: cli_override_addr,
+            address: RouterAddress::new(cli_override_host, cli_override_port),
         };
         let address = router_config.address();
         assert_that!(address)
             .is_ok()
-            .is_equal_to(expected_socket_addr);
+            .is_equal_to(expected_router_address);
         Ok(())
     }
 
@@ -220,7 +279,7 @@ health_check:
         let config_yaml = serde_yaml::from_str(&config_yaml_str)?;
         let router_config = RouterConfigParser {
             yaml: &config_yaml,
-            address: SocketAddr::from_str("127.0.0.1:80")?,
+            address: RouterAddress::new(None, None),
         };
         let health_check_enabled = router_config.health_check_enabled();
         assert_that!(health_check_enabled).is_equal_to(is_health_check_enabled);
@@ -236,7 +295,7 @@ health_check:
         let config_yaml = serde_yaml::from_str(config_yaml_str)?;
         let router_config = RouterConfigParser {
             yaml: &config_yaml,
-            address: SocketAddr::from_str("127.0.0.1:80")?,
+            address: RouterAddress::new(None, None),
         };
         let health_check = router_config.health_check_endpoint()?.unwrap().to_string();
 
@@ -253,7 +312,7 @@ health_check:
         let config_yaml = serde_yaml::from_str(config_yaml_str)?;
         let router_config = RouterConfigParser {
             yaml: &config_yaml,
-            address: SocketAddr::from_str("127.0.0.1:80")?,
+            address: RouterAddress::new(None, None),
         };
         assert_that!(router_config.listen_path()).is_none();
         Ok(())
@@ -271,7 +330,7 @@ supergraph:
         let router_config = RouterConfigParser {
             yaml: &config_yaml,
 
-            address: SocketAddr::from_str("127.0.0.1:80")?,
+            address: RouterAddress::new(None, None),
         };
         assert_that!(router_config.listen_path())
             .is_some()

--- a/src/command/dev/router/hot_reload.rs
+++ b/src/command/dev/router/hot_reload.rs
@@ -369,14 +369,13 @@ headers:
                 .as_str()
                 .unwrap()
                 == "127.0.0.1:8888"
-                && value
+                && !value
                     .get("supergraph")
                     .unwrap()
                     .get("generate_query_fragments")
                     .unwrap()
                     .as_bool()
                     .unwrap()
-                    == false
         });
     }
 }

--- a/src/command/dev/router/hot_reload.rs
+++ b/src/command/dev/router/hot_reload.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Formatter};
-use std::net::SocketAddr;
 
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
@@ -10,7 +9,7 @@ use tap::TapFallible;
 use tokio_util::sync::CancellationToken;
 
 use super::config::parser::RouterConfigParser;
-use super::config::RouterConfig;
+use super::config::{RouterAddress, RouterConfig};
 use crate::subtask::SubtaskHandleStream;
 use crate::utils::effect::write_file::WriteFile;
 use crate::utils::expansion::expand;
@@ -39,7 +38,7 @@ pub enum HotReloadError {
 
 #[derive(Builder, Debug, Copy, Clone)]
 pub struct HotReloadConfigOverrides {
-    pub address: SocketAddr,
+    pub address: RouterAddress,
 }
 
 #[derive(Builder)]
@@ -230,12 +229,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
 
     use rstest::{fixture, rstest};
     use speculoos::prelude::*;
 
     use super::*;
+    use crate::command::dev::router::config::{RouterHost, RouterPort};
 
     #[fixture]
     fn router_config() -> &'static str {
@@ -320,7 +319,10 @@ headers:
 
     #[rstest]
     fn overrides_apply(router_config: &'static str, router_config_expectation: &'static str) {
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+        let address = RouterAddress::new(
+            Some(RouterHost::CliOption("127.0.0.1".parse().unwrap())),
+            Some(RouterPort::CliOption(8888)),
+        );
         let overrides = HotReloadConfigOverrides::new(address);
         let hot_reload_config = HotReloadConfig::new(router_config.to_string(), Some(overrides));
         assert_that!(hot_reload_config).is_ok().matches(|config| {
@@ -333,7 +335,10 @@ headers:
 
     #[rstest]
     fn supergraph_stanza_not_required(router_config_no_supergraph: &'static str) {
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+        let address = RouterAddress::new(
+            Some(RouterHost::CliOption("127.0.0.1".parse().unwrap())),
+            Some(RouterPort::CliOption(8888)),
+        );
         let overrides = HotReloadConfigOverrides::new(address);
         let hot_reload_config =
             HotReloadConfig::new(router_config_no_supergraph.to_string(), Some(overrides));
@@ -346,7 +351,10 @@ headers:
 
     #[rstest]
     fn listen_key_not_required(router_config_no_listen: &'static str) {
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+        let address = RouterAddress::new(
+            Some(RouterHost::CliOption("127.0.0.1".parse().unwrap())),
+            Some(RouterPort::CliOption(8888)),
+        );
         let overrides = HotReloadConfigOverrides::new(address);
         let hot_reload_config =
             HotReloadConfig::new(router_config_no_listen.to_string(), Some(overrides));

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -2,46 +2,34 @@ use std::time::Duration;
 
 use apollo_federation_types::config::RouterVersion;
 use camino::{Utf8Path, Utf8PathBuf};
-use futures::{
-    stream::{self, BoxStream},
-    StreamExt,
-};
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
 use houston::Credential;
-use rover_client::{
-    operations::config::who_am_i::{RegistryIdentity, WhoAmIError, WhoAmIRequest},
-    shared::GraphRef,
-};
+use rover_client::operations::config::who_am_i::{RegistryIdentity, WhoAmIError, WhoAmIRequest};
+use rover_client::shared::GraphRef;
 use rover_std::{debugln, infoln, RoverStdError};
-use tokio::{process::Child, time::sleep};
+use tokio::process::Child;
+use tokio::time::sleep;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tower::{Service, ServiceExt};
 
-use super::{
-    binary::{RouterLog, RunRouterBinary, RunRouterBinaryError},
-    config::{remote::RemoteRouterConfig, ReadRouterConfigError, RouterAddress, RunRouterConfig},
-    hot_reload::{HotReloadEvent, HotReloadWatcher, RouterUpdateEvent},
-    install::{InstallRouter, InstallRouterError},
-    watchers::router_config::RouterConfigWatcher,
-};
-use crate::{
-    command::dev::{
-        router::hot_reload::{HotReloadConfig, HotReloadConfigOverrides},
-        router::watchers::file::FileWatcher,
-    },
-    composition::events::CompositionEvent,
-    options::LicenseAccepter,
-    subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit},
-    utils::{
-        client::StudioClientConfig,
-        effect::{
-            exec::ExecCommandConfig,
-            install::InstallBinary,
-            read_file::ReadFile,
-            write_file::{WriteFile, WriteFileRequest},
-        },
-    },
-};
+use super::binary::{RouterLog, RunRouterBinary, RunRouterBinaryError};
+use super::config::remote::RemoteRouterConfig;
+use super::config::{ReadRouterConfigError, RouterAddress, RunRouterConfig};
+use super::hot_reload::{HotReloadEvent, HotReloadWatcher, RouterUpdateEvent};
+use super::install::{InstallRouter, InstallRouterError};
+use super::watchers::router_config::RouterConfigWatcher;
+use crate::command::dev::router::hot_reload::{HotReloadConfig, HotReloadConfigOverrides};
+use crate::command::dev::router::watchers::file::FileWatcher;
+use crate::composition::events::CompositionEvent;
+use crate::options::LicenseAccepter;
+use crate::subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit};
+use crate::utils::client::StudioClientConfig;
+use crate::utils::effect::exec::ExecCommandConfig;
+use crate::utils::effect::install::InstallBinary;
+use crate::utils::effect::read_file::ReadFile;
+use crate::utils::effect::write_file::{WriteFile, WriteFileRequest};
 
 pub struct RunRouter<S> {
     pub(crate) state: S,
@@ -171,7 +159,7 @@ impl RunRouter<state::Run> {
             self.state.config.raw_config(),
             Some(
                 HotReloadConfigOverrides::builder()
-                    .address(self.state.config.address())
+                    .address(*self.state.config.address())
                     .build(),
             ),
         )
@@ -398,11 +386,10 @@ mod state {
     use tokio_stream::wrappers::UnboundedReceiverStream;
     use tokio_util::sync::CancellationToken;
 
-    use crate::command::dev::router::{
-        binary::{RouterBinary, RouterLog, RunRouterBinaryError},
-        config::{remote::RemoteRouterConfig, RouterConfigFinal},
-        hot_reload::HotReloadEvent,
-    };
+    use crate::command::dev::router::binary::{RouterBinary, RouterLog, RunRouterBinaryError};
+    use crate::command::dev::router::config::remote::RemoteRouterConfig;
+    use crate::command::dev::router::config::RouterConfigFinal;
+    use crate::command::dev::router::hot_reload::HotReloadEvent;
 
     #[derive(Default)]
     pub struct Install {}


### PR DESCRIPTION
The current address deciding logic, cannot differentiate between a value in the config that has been overriden by the config file or by another source. As such it's impossible to tell if it should update that value when the config file changes and so it makes the wrong choice.

This fixes that by expanding the expressiveness of the RouterAddress struct, and thus produces something that makes the correct choice in this and other situations.