### PR TITLE
[ROVER-301] Fixes => `rover dev` prematurely outputs that the supergraph is running.

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -39,6 +39,10 @@ impl Dev {
         override_install_path: Option<Utf8PathBuf>,
         client_config: StudioClientConfig,
     ) -> RoverResult<RoverOutput> {
+        warnln!(
+            "Do not run this command in production! It is intended for local development only.\n"
+        );
+
         let elv2_license_accepter = self.opts.plugin_opts.elv2_license_accepter;
         let skip_update = self.opts.plugin_opts.skip_update;
         let read_file_impl = FsReadFile::default();
@@ -240,6 +244,11 @@ impl Dev {
             .address(router_address)
             .build();
 
+        infoln!(
+            "Attempting to start router at {}.",
+            router_address.pretty_string()
+        );
+
         let mut run_router = run_router
             .run(
                 FsWriteFile::default(),
@@ -253,13 +262,6 @@ impl Dev {
             .watch_for_changes(write_file_impl, composition_messages, hot_reload_overrides)
             .await;
 
-        warnln!(
-            "Do not run this command in production! It is intended for local development only."
-        );
-
-        let pretty_router_addr_string = router_address.pretty_string();
-        infoln!("Your supergraph is running! head to {pretty_router_addr_string} to query your supergraph");
-
         loop {
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {
@@ -271,8 +273,8 @@ impl Dev {
                     match router_log {
                         Ok(router_log) => {
                             if !router_log.to_string().is_empty() {
-                        eprintln!("{}", router_log);
-                    }
+                                eprintln!("{}", router_log);
+                            }
                         }
                         Err(err) => {
                             tracing::error!("{:?}", err);


### PR DESCRIPTION
This PR makes 2 changes (and a trivial 3rd change) related to messaging the user as a router (attempts) to start up.

1. We were telling the user that their supergraph was running when we had only told router to start (and the router could fail to start or fail to host the supergraph after this line). This line has been changed to indicate we're starting the router up.
2. Instead of swallowing all the info messages from the router, I'm allowing messages that show the router has started to be emitted to stderr.
3. (trivial) I've moved the warning to not use this in production to the top of the logged output.

When the router starts up as expected, the user will see:
```
...
==> Watching router-config-dev.yaml for changes
==> Attempting to start router at http://localhost:4090.
INFO: Health check exposed at http://127.0.0.1:8088/health
INFO: GraphQL endpoint exposed at http://127.0.0.1:4090/ 🚀
```

when the router starts and the config file has an error, the user will see:

```
...
==> Watching router-config-dev-bad.yaml for changes
==> Attempting to start router at http://localhost:4000.
WARN: configuration could not be upgraded automatically as it had errors
ERROR: Failed to read configuration: configuration had errors: 
1. at line 3

  telemetry:
    instrumentation:
      spans: null
             ^----- null is not of type "object"

2. at line 6

    instrumentation:
      spans: null
  headers:
    all:
      request: null
               ^----- null is not of type "array"


ERROR: no valid configuration was supplied
ERROR: no valid configuration was supplied
```

and when the user fixes the config file, they will see:

```
...
==> Router config updated.
debug: supergraph:
  listen: 127.0.0.1:4090
telemetry:
  instrumentation:
    spans:
      mode: spec_compliant
headers:
  all:
    request:
    - propagate:
        matching: .*

```
