### PR TITLE
ROVER-311 Stop `rover dev` if the Router binary crashes

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -12,6 +12,7 @@ use rover_std::{errln, infoln, warnln};
 use semver::Version;
 use tower::ServiceExt;
 
+use crate::command::dev::router::binary::RunRouterBinaryError;
 use super::version_upgrade_message::VersionUpgradeMessage;
 use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort};
 use crate::command::dev::router::hot_reload::HotReloadConfigOverrides;
@@ -277,6 +278,26 @@ impl Dev {
                             if !router_log.to_string().is_empty() {
                                 eprintln!("{}", router_log);
                             }
+                        }
+                        Err(RunRouterBinaryError::BinaryExited(res)) => {
+                            match res {
+                                Ok(status) => {
+                                    match status.code() {
+                                        None => {
+                                            eprintln!("Router process terminal by signal");
+                                        }
+                                        Some(code) => {
+                                            eprintln!("Router process exited with status code: {code}");
+                                        }
+                                    }
+
+                                }
+                                Err(err) => {
+                                    tracing::error!("Router process exited without status code. Error: {err}")
+                                }
+                            }
+                            eprintln!("\nRouter binary exited, stopping `rover dev` processes...");
+                            break;
                         }
                         Err(err) => {
                             tracing::error!("{:?}", err);

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -12,8 +12,8 @@ use rover_std::{errln, infoln, warnln};
 use semver::Version;
 use tower::ServiceExt;
 
-use crate::command::dev::router::binary::RunRouterBinaryError;
 use super::version_upgrade_message::VersionUpgradeMessage;
+use crate::command::dev::router::binary::RunRouterBinaryError;
 use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort};
 use crate::command::dev::router::hot_reload::HotReloadConfigOverrides;
 use crate::command::dev::router::run::RunRouter;

--- a/src/command/dev/router/binary.rs
+++ b/src/command/dev/router/binary.rs
@@ -47,7 +47,7 @@ fn produce_special_message(raw_message: &str) {
     let starting_message_regex = Regex::new(r"^.*\s+.*://(.*:[0-9]+).*\s+.*").unwrap();
 
     let contents = match starting_message_regex.captures(raw_message) {
-        None => format!("{}", raw_message.to_string()),
+        None => raw_message.to_string(),
         Some(captures) => {
             let socket_address: Option<Result<SocketAddr, AddrParseError>> =
                 captures.get(1).map(|m| m.as_str().parse());
@@ -60,7 +60,7 @@ fn produce_special_message(raw_message: &str) {
                     .pretty_string();
                     format!("Your supergraph is running! head to {router_address} to query your supergraph")
                 }
-                _ => format!("{}", raw_message.to_string()),
+                _ => raw_message.to_string(),
             }
         }
     };
@@ -88,7 +88,7 @@ impl fmt::Display for RouterLog {
 
                     match level {
                         "INFO" if should_select_log_message(message) => {
-                            produce_special_message(&message);
+                            produce_special_message(message);
                         }
                         "INFO" => tracing::info!(%message),
                         "DEBUG" => tracing::debug!(%message),
@@ -337,6 +337,7 @@ where
                                         });
                                 }
                             })
+                            .await
                         })
                         .await;
                 }


### PR DESCRIPTION
At the moment (in Rover 0.26.3) if the Router fails to startup because of bad configuration `rover dev` doesn't respond to that event. It will sit there and still attempt to update the hot reloadable config, despite the fact that this won't have an impact as the binary is not monitoring the config once it has crashed.

This moves us to a much better situation where the error is printed to the user, and then `rover dev` shuts down, so they can retry it once they've fixed the config in question. 

This also includes a change to re-instate some logging that was previously removed.