### PR TITLE
ROVER-316 Upgrade to `apollo-language-server` 0.4.0 to resolve spurious EOF errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-composition"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d82be69fce8ac07544017fe8cd52befc61d4548d3233bd1757984d56c53804"
+checksum = "b04b21e3ad6f86c0eed95276e1f4f1e09da8e43d886abb57897037c633b51141"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -196,13 +196,14 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.0.0-preview.1"
+version = "2.0.0-preview.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87a5a622646520e2e7df15ed33de1558e9d6eaaa7834eeafd02a8378cd73d2"
+checksum = "e5b55660f21b078f44ff3cf3b149c6ea2fa94d7ea698e36caa3729d131c836d1"
 dependencies = [
  "apollo-compiler",
  "derive_more",
  "either",
+ "hashbrown 0.15.2",
  "http 0.2.12",
  "indexmap 2.7.1",
  "itertools 0.13.0",
@@ -227,11 +228,10 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e256949c5f8ebcb6aee00063cb56aaa89cbcfc29cd45fa83519eb9a3290cfe"
+checksum = "bc933111fa54f7fb3002c4833d766b4806ac017edf06d4be54b73b8d90d2141c"
 dependencies = [
- "camino",
  "log",
  "semver",
  "serde",
@@ -244,9 +244,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-language-server"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aadcacf564bfe5c3a0e1444bd893942001e616e1d1e44670ddd04e50117af15"
+version = "0.3.1"
 dependencies = [
  "apollo-compiler",
  "apollo-composition",
@@ -2032,6 +2030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2449,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,33 +155,21 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.24"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71153ad85c85f7aa63f0e0a5868912c220bb48e4c764556f5841d37fc17b0103"
+checksum = "615145d8c4b53ea4e6c15261adbb71cefad3a6834c4a12158f89a484f0769fb2"
 dependencies = [
  "ahash 0.8.11",
  "apollo-parser 0.8.4",
- "ariadne 0.4.1",
+ "ariadne",
  "indexmap 2.7.1",
- "rowan 0.15.16",
+ "rowan 0.16.1",
  "serde",
  "serde_json_bytes",
  "thiserror 1.0.69",
  "triomphe",
  "typed-arena",
  "uuid",
-]
-
-[[package]]
-name = "apollo-composition"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b21e3ad6f86c0eed95276e1f4f1e09da8e43d886abb57897037c633b51141"
-dependencies = [
- "apollo-compiler",
- "apollo-federation",
- "apollo-federation-types",
- "either",
 ]
 
 [[package]]
@@ -196,18 +184,17 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.0.0-preview.3"
+version = "2.0.0-preview.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b55660f21b078f44ff3cf3b149c6ea2fa94d7ea698e36caa3729d131c836d1"
+checksum = "0fb3caac3f7ca459562c22a95d9a880f45e1f73ecb50827215884cf814845dbb"
 dependencies = [
  "apollo-compiler",
  "derive_more",
  "either",
  "hashbrown 0.15.2",
- "http 0.2.12",
+ "http 1.2.0",
  "indexmap 2.7.1",
  "itertools 0.13.0",
- "lazy_static",
  "line-col",
  "multimap",
  "nom",
@@ -218,6 +205,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_bytes",
+ "shape",
  "strum",
  "strum_macros",
  "thiserror 1.0.69",
@@ -232,6 +220,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc933111fa54f7fb3002c4833d766b4806ac017edf06d4be54b73b8d90d2141c"
 dependencies = [
+ "apollo-compiler",
  "log",
  "semver",
  "serde",
@@ -244,10 +233,11 @@ dependencies = [
 
 [[package]]
 name = "apollo-language-server"
-version = "0.3.1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e6c00b39694b5f0a4cbdc913a0c1516571abe7f25315e03a315d229c378fd1"
 dependencies = [
  "apollo-compiler",
- "apollo-composition",
  "apollo-federation",
  "apollo-federation-types",
  "apollo-parser 0.8.4",
@@ -307,21 +297,11 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ariadne"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
-dependencies = [
- "concolor",
- "unicode-width 0.1.14",
- "yansi",
-]
-
-[[package]]
-name = "ariadne"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31beedec3ce83ae6da3a79592b3d8d7afd146a5b15bb9bb940279aced60faa89"
 dependencies = [
+ "concolor",
  "unicode-width 0.1.14",
  "yansi",
 ]
@@ -1150,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4939,7 +4919,7 @@ dependencies = [
  "apollo-encoder",
  "apollo-federation-types",
  "apollo-parser 0.8.4",
- "ariadne 0.5.0",
+ "ariadne",
  "backoff",
  "buildstructor",
  "camino",
@@ -5586,6 +5566,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shape"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e114fc498dd1dcc20b12a9571a7b9b78396760e44b7a9024afa3a04ce26763"
+dependencies = [
+ "apollo-compiler",
+ "indexmap 2.7.1",
+ "serde_json",
+ "serde_json_bytes",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5727,7 +5719,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -7006,7 +6998,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ apollo-encoder = "0.8"
 # https://github.com/apollographql/federation-rs
 apollo-federation-types = "0.15.2"
 
-apollo-language-server = { path = "../language-server/crates/language-server-core", default-features = false, features = ["tokio"] }
+apollo-language-server = { version = "0.4.0", default-features = false, features = ["tokio"] }
 
 # crates.io dependencies
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.14.1"
+apollo-federation-types = "0.15.2"
 
-apollo-language-server = { version = "0.3.5", default-features = false, features = ["tokio"] }
+apollo-language-server = { path = "../language-server/crates/language-server-core", default-features = false, features = ["tokio"] }
 
 # crates.io dependencies
 anyhow = "1"
@@ -88,7 +88,7 @@ buildstructor = "0.5.4"
 bytes = "1.8.0"
 cargo_metadata = "0.18"
 calm_io = "0.1"
-camino = "1"
+camino = { version = "1", features = ["serde1"] }
 clap = "4"
 chrono = "0.4"
 ci_info = "0.14"

--- a/deny.toml
+++ b/deny.toml
@@ -52,8 +52,8 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "Unicode-DFS-2016",
-    "Unicode-3.0"
+    "Unicode-3.0",
+    "Zlib"
 ]
 confidence-threshold = 0.8
 private = { ignore = true }
@@ -76,10 +76,6 @@ allow = ["Elastic-2.0"]
 
 [[licenses.exceptions]]
 name = "apollo-federation"
-allow = ["Elastic-2.0"]
-
-[[licenses.exceptions]]
-name = "apollo-composition"
 allow = ["Elastic-2.0"]
 
 # This section is considered when running `cargo deny check bans`.

--- a/src/composition/supergraph/config/error/subgraph.rs
+++ b/src/composition/supergraph/config/error/subgraph.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
+use camino::Utf8PathBuf;
 use http::header::{InvalidHeaderName, InvalidHeaderValue};
 
 /// Errors that may occur as a result of resolving subgraphs
@@ -13,11 +13,11 @@ pub enum ResolveSubgraphError {
         /// The subgraph name that failed to be resolved
         subgraph_name: String,
         /// Supplied path to the supergraph config file
-        supergraph_config_path: PathBuf,
+        supergraph_config_path: Utf8PathBuf,
         /// Supplied path to the subgraph schema file
-        path: PathBuf,
+        path: Utf8PathBuf,
         /// The result of joining the paths together, that caused the failure
-        joined_path: PathBuf,
+        joined_path: Utf8PathBuf,
         /// The source error
         source: Arc<std::io::Error>,
     },

--- a/src/composition/supergraph/config/error/subgraph.rs
+++ b/src/composition/supergraph/config/error/subgraph.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use camino::Utf8PathBuf;
 use http::header::{InvalidHeaderName, InvalidHeaderValue};
 
 /// Errors that may occur as a result of resolving subgraphs
@@ -14,7 +13,7 @@ pub enum ResolveSubgraphError {
         /// The subgraph name that failed to be resolved
         subgraph_name: String,
         /// Supplied path to the supergraph config file
-        supergraph_config_path: Utf8PathBuf,
+        supergraph_config_path: PathBuf,
         /// Supplied path to the subgraph schema file
         path: PathBuf,
         /// The result of joining the paths together, that caused the failure
@@ -95,4 +94,7 @@ pub enum ResolveSubgraphError {
     /// Error encountered if we can't parse a URL properly in the introspection case
     #[error(transparent)]
     ParsingSubgraphUrlError(#[from] url::ParseError),
+    /// Error encountered if we can't parse a PathBuf into a Utf8PathBuf
+    #[error(transparent)]
+    ParsingUt8FilePathError(#[from] camino::FromPathBufError),
 }

--- a/src/composition/supergraph/config/full/subgraph/file.rs
+++ b/src/composition/supergraph/config/full/subgraph/file.rs
@@ -35,14 +35,12 @@ impl Service<()> for ResolveFileSubgraph {
 
     fn call(&mut self, _req: ()) -> Self::Future {
         let unresolved_subgraph = self.unresolved_subgraph.clone();
-        let supergraph_config_root = self.supergraph_config_root.clone().into_std_path_buf();
-        let path = self.path.clone().into_std_path_buf();
+        let supergraph_config_root = self.supergraph_config_root.clone();
+        let path = self.path.clone();
         let subgraph_name = unresolved_subgraph.name().to_string();
         let schema_source = self.unresolved_subgraph.schema().clone();
         let fut = async move {
-            let file = Utf8PathBuf::try_from(
-                unresolved_subgraph.resolve_file_path(&supergraph_config_root, &path)?,
-            )?;
+            let file = unresolved_subgraph.resolve_file_path(&supergraph_config_root, &path)?;
             let schema = Fs::read_file(&file).map_err(|err| ResolveSubgraphError::Fs {
                 source: Arc::new(Box::new(err)),
             })?;

--- a/src/composition/supergraph/config/full/subgraph/mod.rs
+++ b/src/composition/supergraph/config/full/subgraph/mod.rs
@@ -7,21 +7,19 @@ use buildstructor::buildstructor;
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 use rover_client::shared::GraphRef;
-use tower::{service_fn, util::BoxCloneService, Service, ServiceExt};
+use tower::util::BoxCloneService;
+use tower::{service_fn, Service, ServiceExt};
 
 pub mod file;
 pub mod introspect;
 pub mod remote;
 
-use self::{
-    file::ResolveFileSubgraph,
-    introspect::{MakeResolveIntrospectSubgraphRequest, ResolveIntrospectSubgraphFactory},
-    remote::ResolveRemoteSubgraph,
-};
-use crate::composition::supergraph::config::{
-    error::ResolveSubgraphError, resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory,
-    unresolved::UnresolvedSubgraph,
-};
+use self::file::ResolveFileSubgraph;
+use self::introspect::{MakeResolveIntrospectSubgraphRequest, ResolveIntrospectSubgraphFactory};
+use self::remote::ResolveRemoteSubgraph;
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
+use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
+use crate::composition::supergraph::config::unresolved::UnresolvedSubgraph;
 
 /// Alias for a [`tower::Service`] that fully resolves a subgraph
 pub type FullyResolveSubgraphService =
@@ -70,7 +68,7 @@ impl FullyResolvedSubgraph {
             SchemaSource::File { file } => {
                 let service = ResolveFileSubgraph::builder()
                     .supergraph_config_root(supergraph_config_root)
-                    .path(file.clone())
+                    .path(Utf8PathBuf::try_from(file)?)
                     .unresolved_subgraph(unresolved_subgraph.clone())
                     .build();
                 Ok(service.boxed_clone())

--- a/src/composition/supergraph/config/lazy/subgraph.rs
+++ b/src/composition/supergraph/config/lazy/subgraph.rs
@@ -24,12 +24,16 @@ impl LazilyResolvedSubgraph {
     ) -> Result<LazilyResolvedSubgraph, ResolveSubgraphError> {
         match unresolved_subgraph.schema() {
             SchemaSource::File { file } => {
-                let file = unresolved_subgraph
-                    .resolve_file_path(&supergraph_config_root.clone().into_std_path_buf(), file)?;
+                let file = unresolved_subgraph.resolve_file_path(
+                    &supergraph_config_root.clone(),
+                    &Utf8PathBuf::try_from(file.clone())?,
+                )?;
                 Ok(LazilyResolvedSubgraph {
                     name: unresolved_subgraph.name().to_string(),
                     routing_url: unresolved_subgraph.routing_url().clone(),
-                    schema: SchemaSource::File { file },
+                    schema: SchemaSource::File {
+                        file: file.into_std_path_buf(),
+                    },
                 })
             }
             _ => Ok(LazilyResolvedSubgraph {

--- a/src/composition/supergraph/config/lazy/subgraph.rs
+++ b/src/composition/supergraph/config/lazy/subgraph.rs
@@ -3,9 +3,8 @@ use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 
-use crate::composition::supergraph::config::{
-    error::ResolveSubgraphError, unresolved::UnresolvedSubgraph,
-};
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
+use crate::composition::supergraph::config::unresolved::UnresolvedSubgraph;
 
 /// A subgraph config that has had its file paths validated and
 /// confirmed to be relative to a supergraph config file
@@ -25,7 +24,8 @@ impl LazilyResolvedSubgraph {
     ) -> Result<LazilyResolvedSubgraph, ResolveSubgraphError> {
         match unresolved_subgraph.schema() {
             SchemaSource::File { file } => {
-                let file = unresolved_subgraph.resolve_file_path(supergraph_config_root, file)?;
+                let file = unresolved_subgraph
+                    .resolve_file_path(&supergraph_config_root.clone().into_std_path_buf(), file)?;
                 Ok(LazilyResolvedSubgraph {
                     name: unresolved_subgraph.name().to_string(),
                     routing_url: unresolved_subgraph.routing_url().clone(),

--- a/src/composition/supergraph/config/scenario.rs
+++ b/src/composition/supergraph/config/scenario.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, io::Write, path::Path, str::FromStr};
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+use std::str::FromStr;
 
 use anyhow::Result;
 use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
@@ -234,7 +237,7 @@ pub fn file_subgraph_scenario(
             subgraph_name,
             SubgraphConfig {
                 schema: SchemaSource::File {
-                    file: schema_file_path,
+                    file: schema_file_path.into_std_path_buf(),
                 },
                 routing_url: Some(routing_url),
             },

--- a/src/composition/supergraph/config/unresolved/subgraph.rs
+++ b/src/composition/supergraph/config/unresolved/subgraph.rs
@@ -1,12 +1,11 @@
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
-use camino::Utf8PathBuf;
 use derive_getters::Getters;
 
-use crate::composition::supergraph::config::{
-    error::ResolveSubgraphError, lazy::LazilyResolvedSubgraph,
-};
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
+use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
 
 /// Represents a `SubgraphConfig` that needs to be resolved, either fully or lazily
 #[derive(Clone, Debug, Getters)]
@@ -29,18 +28,18 @@ impl UnresolvedSubgraph {
     /// Produces a canonical filepath as the path relates to the supplied root path
     pub fn resolve_file_path(
         &self,
-        root: &Utf8PathBuf,
-        path: &Utf8PathBuf,
-    ) -> Result<Utf8PathBuf, ResolveSubgraphError> {
+        root: &Path,
+        path: &Path,
+    ) -> Result<PathBuf, ResolveSubgraphError> {
         let joined_path = root.join(path);
-        let canonical_filename = joined_path.canonicalize_utf8();
+        let canonical_filename = joined_path.canonicalize();
         match canonical_filename {
             Ok(canonical_filename) => Ok(canonical_filename),
             Err(err) => Err(ResolveSubgraphError::FileNotFound {
                 subgraph_name: self.name.to_string(),
-                supergraph_config_path: root.clone(),
-                path: path.as_std_path().to_path_buf(),
-                joined_path: joined_path.as_std_path().to_path_buf(),
+                supergraph_config_path: root.to_path_buf(),
+                path: path.to_path_buf(),
+                joined_path,
                 source: Arc::new(err),
             }),
         }

--- a/src/composition/supergraph/config/unresolved/subgraph.rs
+++ b/src/composition/supergraph/config/unresolved/subgraph.rs
@@ -1,7 +1,7 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
+use camino::Utf8PathBuf;
 use derive_getters::Getters;
 
 use crate::composition::supergraph::config::error::ResolveSubgraphError;
@@ -28,17 +28,17 @@ impl UnresolvedSubgraph {
     /// Produces a canonical filepath as the path relates to the supplied root path
     pub fn resolve_file_path(
         &self,
-        root: &Path,
-        path: &Path,
-    ) -> Result<PathBuf, ResolveSubgraphError> {
+        root: &Utf8PathBuf,
+        path: &Utf8PathBuf,
+    ) -> Result<Utf8PathBuf, ResolveSubgraphError> {
         let joined_path = root.join(path);
-        let canonical_filename = joined_path.canonicalize();
+        let canonical_filename = joined_path.canonicalize_utf8();
         match canonical_filename {
             Ok(canonical_filename) => Ok(canonical_filename),
             Err(err) => Err(ResolveSubgraphError::FileNotFound {
                 subgraph_name: self.name.to_string(),
-                supergraph_config_path: root.to_path_buf(),
-                path: path.to_path_buf(),
+                supergraph_config_path: root.clone(),
+                path: path.clone(),
                 joined_path,
                 source: Arc::new(err),
             }),

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -507,7 +507,7 @@ mod tests {
                     .schema(file_subgraph_scenario.sdl.clone())
                     .name(file_subgraph_name.to_string())
                     .schema_source(SchemaSource::File {
-                        file: file_subgraph_scenario.schema_file_path.clone(),
+                        file: file_subgraph_scenario.schema_file_path.into_std_path_buf(),
                     })
                     .build(),
             ),
@@ -903,7 +903,7 @@ mod tests {
                     .schema(SchemaSource::File {
                         file: supergraph_config_root_dir_path
                             .join(file_subgraph_scenario.schema_file_path)
-                            .canonicalize_utf8()?,
+                            .canonicalize()?,
                     })
                     .name(file_subgraph_name.clone())
                     .routing_url(file_subgraph_scenario.routing_url)

--- a/src/composition/watchers/watcher/file.rs
+++ b/src/composition/watchers/watcher/file.rs
@@ -1,6 +1,7 @@
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
-use futures::{stream::BoxStream, StreamExt, TryFutureExt};
+use futures::stream::BoxStream;
+use futures::{StreamExt, TryFutureExt};
 use rover_std::{errln, Fs, RoverStdError};
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
@@ -8,9 +9,9 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tower::{Service, ServiceExt};
 
-use crate::composition::supergraph::config::{
-    error::ResolveSubgraphError,
-    full::{FullyResolveSubgraphService, FullyResolvedSubgraph},
+use crate::composition::supergraph::config::error::ResolveSubgraphError;
+use crate::composition::supergraph::config::full::{
+    FullyResolveSubgraphService, FullyResolvedSubgraph,
 };
 
 /// File watcher specifically for files related to composition
@@ -152,7 +153,9 @@ impl SubgraphFileWatcher {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, io::Write, time::Duration};
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::time::Duration;
 
     use apollo_federation_types::config::{SchemaSource, SubgraphConfig};
     use speculoos::prelude::*;
@@ -179,7 +182,9 @@ mod tests {
             .unresolved_subgraph(UnresolvedSubgraph::new(
                 subgraph_name.to_string(),
                 SubgraphConfig {
-                    schema: SchemaSource::File { file: path.clone() },
+                    schema: SchemaSource::File {
+                        file: path.clone().into_std_path_buf(),
+                    },
                     routing_url: Some(routing_url.to_string()),
                 },
             ))
@@ -220,7 +225,9 @@ mod tests {
             .name(subgraph_name.to_string())
             .routing_url(routing_url.to_string())
             .schema(sdl.to_string())
-            .schema_source(SchemaSource::File { file: path })
+            .schema_source(SchemaSource::File {
+                file: path.into_std_path_buf(),
+            })
             .build();
         assert_that!(&output)
             .is_ok()


### PR DESCRIPTION
As per title, this upgrades us to using `apollo-language-server` v0.4.0 (and by extension `apollo-federation-types` v0.15.2), to resolve the issues we see with EOF errors being thrown when we first open files.

This patches round the issues with the removal of Camino, by adding conversions where necessary.