### PR TITLE
release: v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,325 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.27.0] - 2025-02-10
+
+> Important: 3 potentially breaking changes below, indicated by **❗ BREAKING ❗**
+> 
+> **If using Rover with Connectors,** you will need to specify `APOLLO_ROVER_DEV_ROUTER_VERSION=2.0.0-preview.X` when using `rover dev`
+
+## ❗ BREAKING ❗
+
+- **Make paths in `supergraph.yaml` resolve relative to the location of the `supergraph.yaml` file - @jonathanrainer PR #2119**
+
+  To support the new Apollo Language Server it is now the case that any paths expressed in the `supergraph.yaml` file will
+  be resolved relative to the file's location on disk, **not** the location that Rover is running in, at the time.
+
+- **Remove `fed2` command - @aaronArinder PR #2222**
+
+  This was a deprecated, hidden, unused command that was for early Federation 2.0 testing. This command has not been
+  invoked for a very long time.
+
+- **Remove ability to start multiple `rover dev` sessions - @jonathanrainer PR #2352**
+
+  Now that Rover supports hot-reloading from `supergraph.yaml` files we've removed the ability to start multiple
+  `rover dev` sessions, in multiple terminal windows, and have them communicate with each other.
+
+## 🚀 Features
+
+- **Apollo Language Server - @jonathanrainer**
+
+  This brand-new feature aids in subgraph development and also supports connectors. It enhances Apollo tools such as the schema proposals editor and recent versions of IDE plugins and extensions by providing federation-aware syntax highlighting, validation, autocompletion, and more
+
+  <details open>
+  <summary>PRs Included</summary>
+    <ul>
+      <li>#2272</li>
+      <li>#2345</li>
+      <li>#2354</li>
+      <li>#2364</li>
+      <li>#2369</li>
+      <li>#2386</li>
+      <li>#2389</li>
+    </ul>
+  </details>
+
+- **New version of `rover dev` - @dotdat @aaronArinder @loshz @monkpow @jonathanrainer**
+
+  In this version of Rover there is a new version of `rover dev` built upon a completely new implementation of the
+  composition pipeline inside of Rover. This not only allows a better functioning `rover dev` with more features, but
+  it also supports the new Apollo Language Server, for use with Connectors!
+
+  In addition, it also supports hot-reloading of the `supergraph.yaml` file, subgraphs can be added, removed or edited,
+  and this will be all be reflected in the running `rover dev` session!
+
+  <details open>
+  <summary>PRs Included</summary>
+    <ul>
+      <li>#2118</li>
+      <li>#2127</li>
+      <li>#2130</li>
+      <li>#2131</li>
+      <li>#2132</li>
+      <li>#2138</li>
+      <li>#2141</li>
+      <li>#2142</li>
+      <li>#2144</li>
+      <li>#2145</li>
+      <li>#2146</li>
+      <li>#2147</li>
+      <li>#2149</li>
+      <li>#2150</li>
+      <li>#2152</li>
+      <li>#2154</li>
+      <li>#2156</li>
+      <li>#2157</li>
+      <li>#2158</li>
+      <li>#2159</li>
+      <li>#2160</li>
+      <li>#2163</li>
+      <li>#2166</li>
+      <li>#2167</li>
+      <li>#2171</li>
+      <li>#2172</li>
+      <li>#2177</li>
+      <li>#2178</li>
+      <li>#2179</li>
+      <li>#2184</li>
+      <li>#2189</li>
+      <li>#2204</li>
+      <li>#2205</li>
+      <li>#2207</li>
+      <li>#2208</li>
+      <li>#2209</li>
+      <li>#2210</li>
+      <li>#2211</li>
+      <li>#2214</li>
+      <li>#2223</li>
+      <li>#2228</li>
+      <li>#2229</li>
+      <li>#2251</li>
+      <li>#2253</li>
+      <li>#2257</li>
+      <li>#2267</li>
+      <li>#2268</li>
+      <li>#2274</li>
+      <li>#2282</li>
+      <li>#2283</li>
+      <li>#2285</li>
+      <li>#2288</li>
+      <li>#2289</li>
+      <li>#2305</li>
+      <li>#2308</li>
+      <li>#2309</li>
+      <li>#2310</li>
+      <li>#2311</li>
+      <li>#2312</li>
+      <li>#2314</li>
+      <li>#2316</li>
+      <li>#2318</li>
+      <li>#2319</li>
+      <li>#2320</li>
+      <li>#2321</li>
+      <li>#2322</li>
+      <li>#2326</li>
+      <li>#2327</li>
+      <li>#2328</li>
+      <li>#2329</li>
+      <li>#2330</li>
+      <li>#2331</li>
+      <li>#2332</li>
+      <li>#2334</li>
+      <li>#2335</li>
+      <li>#2336</li>
+      <li>#2338</li>
+      <li>#2339</li>
+      <li>#2340</li>
+      <li>#2341</li>
+      <li>#2342</li>
+      <li>#2343</li>
+      <li>#2344</li>
+      <li>#2355</li>
+      <li>#2356</li>
+      <li>#2357</li>
+      <li>#2358</li>
+      <li>#2360</li>
+      <li>#2361</li>
+      <li>#2362</li>
+      <li>#2365</li>
+      <li>#2370</li>
+      <li>#2371</li>
+      <li>#2374</li>
+      <li>#2379</li>
+      <li>#2383</li>
+      <li>#2384</li>
+    </ul>
+  </details>
+
+- **Add ability to hot-reload `federation_version` in `supergraph.yaml` - @jonathanrainer PR #2347**
+
+  Rover now has the ability to account for changes in the `federation_version` field of the `supergraph.yaml` file,
+  while it is running.
+
+- **Enabling Remote Proxy Downloads - @LongLiveCHIEF @jonathanrainer PR #2254 #2372**
+
+  Rover now has the ability to be installed from a remote proxy, via the use of environment variables.
+
+- **Display the results of custom check tasks - @swcollard PR #2087**
+
+  Rover now has the ability to print out results of CustomCheckTasks from the Platform API
+
+## 🐛 Fixes
+
+- **Stop Running Router with logs at TRACE level - @nmoutschen PR #2143**
+
+  We were running the Router at TRACE level logging, which was causing queries to not complete in some cases
+
+- **Stop `rover dev` session if router binary crashes - @jonathanrainer PR #2382**
+
+  In the past we let the `rover dev` session continue if the router binary crashed, which led to a misleading state
+  of affairs, this has now been fixed.
+
+## 🛠 Maintenance
+
+- **Consolidate Rover Tests - @jonathanrainer PR #2095**
+
+  Removes old tests now that the E2E tests are more mature and consolidates our examples to clean up the codebase
+
+- **Implement breaking changes for `apollo-federation-types` 0.14 - @dylan-apollo PR #2104**
+- **Update `apollographql/router` to v1.55.0 - @jonathanrainer PR #2123**
+- **Update rust crates - @jonathanrainer PR #2129**
+
+  Includes `octocrab` to v0.41.0, `rstest` to v0.23.0 and `tower-http` to v0.6.0
+
+- **Update rust crates - @jonathanrainer PR #2136**
+
+  Includes `git-url-parse` to v0.4.5 and `tower` to v0.5.1
+
+- **Update node.js packages - @jonathanrainer PR #2137**
+
+  Includes `concurrently` to v9.0.1, `eslint` to v9.11.1 and `nodemon` to 3.1.7
+
+- **Update `apollo-federation-types` to v0.14.1 - @loshz PR #2161**
+- **Downgrade `openssl-src` to v300.3.1+3.3.1 - @aaronArinder PR #2174**
+- **Fix integration tests against the `supergraph-demo` repo - @dotdat PR #2175**
+- **Refactor `Fs::watch_file` to be more async - @dotdat PR #2176**
+- **Fix Windows tests for `rover_std` - @aaronArinder PR #2180**
+- **Cleanup `Fs` tests - @dotdat PR #2182**
+- **Strip ANSI codes from lint/custom validations tests - @dotdat PR #2183**
+- **Update `apollographql/router` to v1.56.0 - @jonathanrainer PR #2123**
+- **Fix Smoke Test Payload to be valid JSON and add test timeout - @jonathanrainer PR #2191**
+- **Fix Dependabot Alerts in `/examples` - @jonathanrainer PR #2192**
+- **Switch to a timeout of 15 minutes per matrix job in Smoke Tests - @jonathanrainer PR #2193**
+- **Add ability to skip linting check where no `.md` files have changed - @jonathanrainer PR #2194**
+- **Update links after docs re-write has launched - @jonathanrainer PR #2195**
+- **Ensure we catch all semver pre-release versions - @jonathanrainer PR #2196**
+- **Update `tower-http` to v0.6.1 - @jonathanrainer PR #2197**
+- **Update node.js packages - @jonathanrainer PR #2137**
+
+  Includes `@eslint/compat` to v1.2.0, `eslint` to v9.12.0, `node` to v20.18.0 and `npm` to 10.9.0
+
+- **Update CI node Docker Image to v20.18.0 - @jonathanrainer PR #2199**
+- **Update `lychee-lib` to v0.16.0 - @jonathanrainer PR #2200**
+- **Let lint tests to message Slack if linting check fails - @jonathanrainer PR #2201**
+- **Move Smoke Tests away from macOS 12 - @jonathanrainer PR #2202**
+- **Remove comma such that `payload` becomes valid JSON - @jonathanrainer #2212**
+- **Update `async-trait` to v0.1.83 - @jonathanrainer PR #2216**
+- **Update `axios-mock-adapter` to v2.1.0 - @jonathanrainer PR #2217**
+- **Update `gh` CircleCI orb to v2.5.0 - @jonathanrainer PR #2218**
+- **Update `node` CircleCI orb to v6.2.0 - @jonathanrainer PR #2219**
+- **Update `slack` CircleCI orb to v5.0.0 - @jonathanrainer PR #2221**
+- **Update `package-lock.json` across repo to resolve security vulnerabilities - @jonathanrainer PR #2226**
+- **Ignore links in CHANGELOG when linting - @aaronArinder PR #2227**
+- **Update node.js packages - @jonathanrainer PR #2230**
+
+  Includes `@eslint/compat` to v1.2.1 and `eslint` to v9.13.0
+
+- **Update `node` CircleCI orb to v6.3.0 - @jonathanrainer PR #2231**
+- **Update Rust to v1.82.0 - @jonathanrainer PR #2232**
+- **Update `apollographql/router` to v1.57.0 - @jonathanrainer PR #2235**
+- **Delete vestigial `last_run.uuid` file - @glasser PR #2236**
+- **Bump macOS CI such that we're using support OpenSSL - @jonathanrainer PR #2238**
+- **Update `bytes` to v1.8.0 - @jonathanrainer PR #2240**
+- **Update `notify` to v7.0.0 - @jonathanrainer PR #2241**
+- **Update `termimad` to v0.31.0 - @jonathanrainer PR #2242**
+- **Increase robustness of Smoke Tests - @jonathanrainer PR #2243**
+- **Update `--timeout` for delete commands in line with other tests - @jonathanrainer PR #2244**
+- **Update node.js packages - @jonathanrainer PR #2245**
+
+  Includes `@eslint/compat` to v1.2.2 and `eslint` to v9.14.0
+
+- **Update `ariadne` to v0.5.0 - @jonathanrainer PR #2246**
+- **Update `which` to v7.0.0 - @jonathanrainer PR #2248**
+- **Update `apollographql/router` to v1.57.1 - @jonathanrainer PR #2249**
+- **Fix up Clippy warnings throughout tests - @jonathanrainer PR #2250**
+- **Remove `netlify.toml` after new Documentation Platform Launch - @Meschreiber PR #2258**
+- **Update node.js packages - @jonathanrainer PR #2259**
+
+  Includes `@eslint/compat` to v1.2.3, `eslint` to v9.15.0 and `concurrenctly` to v9.1.0
+
+- **Update `slack` CircleCI orb to v5.1.1 - @jonathanrainer PR #2260**
+- **Update `slack-github-action` GitHub Action to v1.27.1 - @jonathanrainer PR #2264**
+- **Update `slack-github-action` GitHub Action to v2.0.0 - @jonathanrainer PR #2265**
+- **Fix `cargo-deny` errors blocking CI - @jonathanrainer PR #2266**
+- **Update node.js packages - @jonathanrainer PR #2259**
+
+  Includes `node` to v20.18.1 and `npm` to v10.9.1
+
+- **Update `apollographql/router` to v1.58.0 - @jonathanrainer PR #2249**
+- **Update node.js packages - @jonathanrainer PR #2278**
+
+  Includes `eslint` to v9.16.0 and `prettier` to v3.4.1
+
+- **Update `gh` CircleCI orb to v2.6.0 - @jonathanrainer PR #2279**
+- **Update `@graphql-eslint/eslint-plugin` to v4.0.0 - @jonathanrainer PR #2281**
+- **Update `apollographql/federation-rs` to v2.9.3 - @jonathanrainer PR #2287**
+- **Update `apollographql/router` to v1.58.1 - @jonathanrainer PR #2290**
+- **Update node.js packages - @jonathanrainer PR #2291**
+
+  Includes `@eslint/compat` to v1.2.4, `@graphql-eslint/eslint-plugin` to v4.3.0, `npm` to v10.9.2 and `prettier` to v3.4.2
+
+- **Update `node` CircleCI orb to v7.0.0 - @jonathanrainer PR #2292**
+- **Update `url` package - @dotdat PR #2296**
+- **Fix `xtask lint` to support contributions from forked repositories - @dotdat PR #2298**
+- **Update node.js packages - @jonathanrainer PR #2302**
+
+  Includes `concurrently` to v9.1.2, `eslint` to v9.17.0, `graphql` to v16.10.0 and `nodemon` to v3.1.9
+
+- **Remove old security scanning infrastructure - @peakematt PR #2303**
+- **Update `apollographql/router` to v1.59.0 - @jonathanrainer PR #2307**
+- **Update `gh` CircleCI orb to v2.6.2 - @jonathanrainer PR #2324**
+- **Update `npm` to v11 - @jonathanrainer PR #2324**
+- **Update `apollographql/router` to v1.59.1 - @jonathanrainer PR #2290**
+- **Update node.js packages - @jonathanrainer PR #2350**
+
+  Includes `compat` to v1.2.5, `eslint` to v9.18.0
+
+- **Update `notify` to v8 - @jonathanrainer PR #2351**
+- **Update `node` Docker CI Image to v20.18.2 - @jonathanrainer PR #2366**
+- **Update node.js packages - @jonathanrainer PR #2367**
+
+  Includes `eslint` to v9.19.0, `node` to v20.18.2
+
+- **Update `apollographql/router` to v1.59.2 - @jonathanrainer PR #2375**
+- **Update package docs - @dotdat PR #2376**
+- **Update CODEOWNERS - @dotdat PR #2377**
+- **Update node.js packages - @jonathanrainer PR #2380**
+
+  Includes `compat` to v1.2.6, `npm` to v11.1.0
+- **Update to latest `openssl` to resolve security vulnerability - @jonathanrainer PR #2381**
+
+## 📚 Documentation
+
+- **Add Documentation for Subtasks and all associated traits - @aaronArinder PR #2162**
+- **Document the new CompositionRunner struct - @loshz PR #2181**
+- **Update docs pages for the new Documentation Platform - @Meschreiber PR #2224**
+- **Remove Summit Callout - @shorgi PR #2236**
+- **Update links to `apollosolutions` organisation - @Meschreiber PR #2269**
+- **Fix typo - @Meschreiber PR #2284**
+- **Remove internal redirects - @shorgi PR #2294**
+- **Replace Discord links with Discourse links - @shorgi PR #2315**
+- **Update docs post `rover dev` re-write - @aaronArinder PR #2333**
+
 # [0.26.3] - 2024-12-16
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "dbus"
@@ -3176,11 +3176,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -4022,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "opener"
@@ -4100,9 +4100,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.9.2"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6520c8cc998c5741ee68ec1dc369fc47e5f0ea5320018ecf2a1ccd6328f48b"
+checksum = "2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5"
 dependencies = [
  "log",
  "serde",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.27.0-rc.4"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "apollo-federation-types",
@@ -5251,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
 dependencies = [
  "sdd",
 ]
@@ -5275,9 +5275,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "3.0.5"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "secrecy"
@@ -6308,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6770,11 +6770,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
+ "js-sys",
  "serde",
  "wasm-bindgen",
 ]
@@ -6960,9 +6961,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
@@ -7369,7 +7370,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
- "which 7.0.1",
+ "which 7.0.2",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.27.0-rc.4"
+version = "0.27.0"
 default-run = "rover"
 
 publish = false

--- a/crates/rover-client/package-lock.json
+++ b/crates/rover-client/package-lock.json
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -58,22 +58,23 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.8.tgz",
+      "integrity": "sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
+        "@babel/generator": "^7.26.8",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
         "@babel/helpers": "^7.26.7",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.26.7",
-        "@babel/types": "^7.26.7",
+        "@babel/parser": "^7.26.8",
+        "@babel/template": "^7.26.8",
+        "@babel/traverse": "^7.26.8",
+        "@babel/types": "^7.26.8",
+        "@types/gensync": "^1.0.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -89,14 +90,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.8.tgz",
+      "integrity": "sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.5",
-        "@babel/types": "^7.26.5",
+        "@babel/parser": "^7.26.8",
+        "@babel/types": "^7.26.8",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -209,13 +210,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
+      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.7"
+        "@babel/types": "^7.26.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -241,32 +242,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
+      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.8",
+        "@babel/types": "^7.26.8"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.8.tgz",
+      "integrity": "sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7",
+        "@babel/generator": "^7.26.8",
+        "@babel/parser": "^7.26.8",
+        "@babel/template": "^7.26.8",
+        "@babel/types": "^7.26.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -275,9 +276,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
+      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -508,23 +509,6 @@
         }
       }
     },
-    "node_modules/@graphql-hive/gateway-abort-signal-any": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway-abort-signal-any/-/gateway-abort-signal-any-0.0.3.tgz",
-      "integrity": "sha512-TLYXRiK1DxkGXEdVrwbEtQ4JrsxJ4d/zXBeTzNzvuU+doTzot0wreFgrmmOq+bvqg/E6yMs1kOvBYz477gyMjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.7.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.0.0 || ^16.9.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/batch-execute": {
       "version": "9.0.11",
       "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.11.tgz",
@@ -544,14 +528,14 @@
       }
     },
     "node_modules/@graphql-tools/code-file-loader": {
-      "version": "8.1.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.13.tgz",
-      "integrity": "sha512-zEj+DJhZ8vInnCDeEcyim+LJiROPERqTCZdwHGQXKZXqab1dpyqTiIU+rjWmNUJFrqrLY15gLzrhNSLmDGDdUA==",
+      "version": "8.1.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.14.tgz",
+      "integrity": "sha512-vNm67L1Xnxbg+TGls/X3LNMlNxzslXQ2cRJZVCFPtWeu8NMXRDBPA8+vH+3gVtpjlF5FJ/3+Q6rTuJxAjo/TPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "8.3.12",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/graphql-tag-pluck": "8.3.13",
+        "@graphql-tools/utils": "^10.8.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -587,13 +571,13 @@
       }
     },
     "node_modules/@graphql-tools/executor": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.3.12.tgz",
-      "integrity": "sha512-FzLXZQJOZHB75SecYFOIEEHw/qcxkRFViw0lVqHpaL07c+GqDxv6VOto0FZCIiV9RgGdyRj3O8lXDCp9Cw1MbA==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.3.13.tgz",
+      "integrity": "sha512-4aRat1dUv3jQIhRRXPQwnyVFaCNsDjnYV/JhxgUjhvk1Eo3cyW0sNKgERvMNzo6/v0OPGDpNAPdTD8Alv7p9qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.0",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@repeaterjs/repeater": "^3.0.4",
         "@whatwg-node/disposablestack": "^0.0.5",
@@ -625,16 +609,16 @@
       }
     },
     "node_modules/@graphql-tools/executor-graphql-ws": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.3.7.tgz",
-      "integrity": "sha512-9KUrlpil5nBgcb+XRUIxNQGI+c237LAfDBqYCdLGuYT+/oZz1b4rRIe6HuRk09vuxrbaMTzm7xHhn/iuwWW4eg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.1.tgz",
+      "integrity": "sha512-TqdNLuDuLgaB8xOe+H4+3Sx9jyhRMpEwJTA+5MOvrMRPIPYW4P7w4KYouClS1zAmn4193pNRSt11lZptjIoLPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/executor-common": "^0.0.1",
         "@graphql-tools/utils": "^10.7.0",
         "@whatwg-node/disposablestack": "^0.0.5",
-        "graphql-ws": "^5.14.0",
+        "graphql-ws": "^6.0.3",
         "isomorphic-ws": "^5.0.0",
         "tslib": "^2.8.1",
         "ws": "^8.17.1"
@@ -647,13 +631,12 @@
       }
     },
     "node_modules/@graphql-tools/executor-http": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.2.5.tgz",
-      "integrity": "sha512-pG5YXsF2EhKS4JMhwFwI+0S5RGhPuJ3j3Dg1vWItzeBFiTzr2+VO8yyyahHIncLx7OzSYP/6pBDFp76FC55e+g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.2.6.tgz",
+      "integrity": "sha512-D+gcyDlqKFiwVEubf9HxNijG7LAck0ApXypv/oBzBIOt7avy+PkNopcjSikxy0BvxkIfyjaAtnYlmgf4kC6Y8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-hive/gateway-abort-signal-any": "^0.0.3",
         "@graphql-tools/executor-common": "^0.0.1",
         "@graphql-tools/utils": "^10.7.0",
         "@repeaterjs/repeater": "^3.0.4",
@@ -672,13 +655,13 @@
       }
     },
     "node_modules/@graphql-tools/executor-legacy-ws": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.10.tgz",
-      "integrity": "sha512-ENyCAky0PrcP0dR5ZNIsCTww3CdOECBor/VuRtxAA+BffFhofNiOKcgR6MEsAOH2jHh0K2wwK38sgrW+D3GX3w==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.11.tgz",
+      "integrity": "sha512-Iiy34ZSdqn2XCPwcopCXxs1MrpJvsZkPlEdGs2/kyhwDmKCsc50cGmXaktyvfVvOhJWdMzePBtXyOFfhlf7g7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.0",
         "@types/ws": "^8.0.0",
         "isomorphic-ws": "^5.0.0",
         "tslib": "^2.4.0",
@@ -692,14 +675,14 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.12.tgz",
-      "integrity": "sha512-fhn6IFAgj/LOM3zlr0KDtcYDZnkWacalHOouNVDat4wzpcD4AWyvlh7PoGx3EaDtnwGqmy/l/FMjwWPTjqd9zw==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.13.tgz",
+      "integrity": "sha512-eJJsYld43I6XYTLzGvHVIVg7w3yx3oPcbG3oq5mZdZnARQ12FSgWgqUKqVOdEbVK74Kw4BG/CpVOLcTD/nUKxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/import": "7.0.11",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/import": "7.0.12",
+        "@graphql-tools/utils": "^10.8.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -712,9 +695,9 @@
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "8.3.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.12.tgz",
-      "integrity": "sha512-C6Ddg5RTz1WM96LYBtMuSEwN4QHfivK/vtbiAq9Soo6SoW1vGE4gzt0QS2FDVnDeB16er3h8YQZJ0xwm4pLnfA==",
+      "version": "8.3.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.13.tgz",
+      "integrity": "sha512-U9rd24TAMjz37siV8mSgiOYqxCrX2u6v1wkrZII/+hDiL7BoawHC7Xz2Q+72mAeZTYdsqLJQ4LzjsiB2faoFGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -723,7 +706,7 @@
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/traverse": "^7.16.8",
         "@babel/types": "^7.16.8",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -734,13 +717,13 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.11.tgz",
-      "integrity": "sha512-zUru+YhjLUpdyNnTKHXLBjV6bh+CpxVhxJr5mgsFT/Lk6fdpjkEyk+hzdgINuo5GbIulFa6KpLZUBoZsDARBpQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.12.tgz",
+      "integrity": "sha512-vnvrCFyPtccNQujftnsfTLV0JFJhLKSpEi1+xkYiXp/DJxh1ua06sw2+/o+0trmxtoWDJviv21cnNpyskWXx0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.0",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
       },
@@ -752,13 +735,13 @@
       }
     },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.11.tgz",
-      "integrity": "sha512-xsfIbPyxyXWnu+GSC5HCw945Gt++b+5NeEvpunw2cK9myGhF2Bkb8N4QTNwWy+7kvOAKzNopBGqGV+x3uaQAZA==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.12.tgz",
+      "integrity": "sha512-1p9db6p0Fs0bJoWM9Pn/G6BCDxJ1eiqTOe+B0O/49+7dpcx8GEQ0m+R6k2OSG5PD1g9+3+nKT9gKHVB/S6sDYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.0",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -771,14 +754,14 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.12.tgz",
-      "integrity": "sha512-ZFqerNO7at64N4GHT76k0AkwToHNHVkpAh1iFDRHvvFpESpZ3LDz9Y6cs54Sf6zhATecDuUSwbWZoEE2WIDExA==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.13.tgz",
+      "integrity": "sha512-gWn2tiyF/LU53aeLvJbuYHjZpExaDnj7PEuwE415x/Rzgjsa415c6p0xHhagHdlNF3oq5B67FKCvdbOtmoPQNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/schema": "^10.0.16",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/schema": "^10.0.17",
+        "@graphql-tools/utils": "^10.8.0",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       },
@@ -790,13 +773,13 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.0.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.17.tgz",
-      "integrity": "sha512-3K4g8KKbIqfdmK0L5+VtZsqwAeElPkvT5ejiH+KEhn2wyKNCi4HYHxpQk8xbu+dSwLlm9Lhet1hylpo/mWCkuQ==",
+      "version": "9.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.18.tgz",
+      "integrity": "sha512-KFUj976w2egCM1huOstonTCnyeFwvPEK9jeIgDRawKF9Um0VO6E1jdfVry3lbP71hT5i9LMbRRhN/UPI0ZGoQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -807,16 +790,15 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.16.tgz",
-      "integrity": "sha512-G2zgb8hNg9Sx6Z2FSXm57ToNcwMls9A9cUm+EsCrnGGDsryzN5cONYePUpSGj5NCFivVp3o1FT5dg19P/1qeqQ==",
+      "version": "10.0.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.17.tgz",
+      "integrity": "sha512-7WIKZvhuELcgEk+Gv+jVPVOqkeFYTQ1tgfdldzu1kBXVK/uAtil3Xt6EoPYgLBpI0QIY7801nubvW7N78wcjMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.17",
-        "@graphql-tools/utils": "^10.7.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/merge": "^9.0.18",
+        "@graphql-tools/utils": "^10.8.0",
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -826,23 +808,22 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "8.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.24.tgz",
-      "integrity": "sha512-f+Yt6sswiEPrcWsInMbmf+3HNENV2IZK1z3IiGMHuyqb+QsMbJLxzDPHnxMtF2QGJOiRjBQy2sF2en7DPG+jSw==",
+      "version": "8.0.25",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.25.tgz",
+      "integrity": "sha512-8SstnWQCN3gXfsX5z8bZtLXElZm55e84hzaJxB+iJCz8Q8jt+cikHlBXc7y0buG5t/fPeaGht2X5QsBMMEi73w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/executor-graphql-ws": "^1.3.2",
+        "@graphql-tools/executor-graphql-ws": "^2.0.1",
         "@graphql-tools/executor-http": "^1.1.9",
-        "@graphql-tools/executor-legacy-ws": "^1.1.10",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/executor-legacy-ws": "^1.1.11",
+        "@graphql-tools/utils": "^10.8.0",
         "@graphql-tools/wrap": "^10.0.16",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.10.0",
         "isomorphic-ws": "^5.0.0",
         "sync-fetch": "0.6.0-2",
         "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.11",
         "ws": "^8.17.1"
       },
       "engines": {
@@ -853,9 +834,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.7.2.tgz",
-      "integrity": "sha512-Wn85S+hfkzfVFpXVrQ0hjnePa3p28aB6IdAGCiD1SqBCSMDRzL+OFEtyAyb30nV9Mqflqs9lCqjqlR2puG857Q==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.0.tgz",
+      "integrity": "sha512-c773cf9g3aLWWc8BjZs0VacBVjpq9kINpT0pxv9OvuxoxZVpgUSHnOCaJyTihs2AdR14fcKC9GjseEogUvgmvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1071,6 +1052,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.4.tgz",
+      "integrity": "sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1126,9 +1114,9 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.7.tgz",
-      "integrity": "sha512-BDbIMOenThOTFDBLh1WscgBNAxfDAdAdd9sMG8Ff83hYxApJVbqEct38bUAj+zn8bTsfBx/lyfnVOTyq5xUlvg==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.8.tgz",
+      "integrity": "sha512-Pbv72nbu3AgL9ZaAwdzYcqoMhYGhSBxo49CC+Nt+tlhdDuMZXcf3+41qGghsGJykkxhgfgFcPLwtt2HPEjk57w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1310,9 +1298,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
+      "version": "1.0.30001699",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
       "dev": true,
       "funding": [
         {
@@ -1502,9 +1490,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+      "version": "1.5.96",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
+      "integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
       "dev": true,
       "license": "ISC"
     },
@@ -2009,16 +1997,30 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
-      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.3.tgz",
+      "integrity": "sha512-mvLRHihMg0llF74vo16063HufZHMGaiMxAjzyj0ARYueIikGzj1khlbPNl7vUc2h9rxbq9pGpQYbqypgq1fAXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": ">=0.11 <=16"
+        "@fastify/websocket": "^10 || ^11",
+        "graphql": "^15.10.1 || ^16",
+        "uWebSockets.js": "^20",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "uWebSockets.js": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/has-flag": {

--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -51,7 +51,7 @@ jobs:
           name: Install
           command: |
             # download and install Rover
-            curl -sSL https://rover.apollo.dev/nix/v0.26.3 | sh
+            curl -sSL https://rover.apollo.dev/nix/v0.27.0 | sh
 
             # This allows the PATH changes to persist to the next `run` step
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
@@ -125,7 +125,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.26.3 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.27.0 | sh
 
           # Add Rover to the $GITHUB_PATH so it can be used in another step
           # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
@@ -216,10 +216,10 @@ Normally when installing, Rover adds the path of its executable to your `$PATH`.
 
 To avoid this issue, do one of the following:
 - Use the script, but reference `rover` by its full path (`$HOME/.rover/bin/rover`)
-- Download the latest release via cURL and extract the binary like so (this downloads Rover `0.23.0` for Linux x86 architectures):
+- Download the latest release via cURL and extract the binary like so (this downloads Rover `0.27.0` for Linux x86 architectures):
 
     ```
-    curl -L https://github.com/apollographql/rover/releases/download/v0.26.3/rover-v0.26.3-x86_64-unknown-linux-gnu.tar.gz | tar --strip-components=1 -zxv
+    curl -L https://github.com/apollographql/rover/releases/download/v0.27.0/rover-v0.27.0-x86_64-unknown-linux-gnu.tar.gz | tar --strip-components=1 -zxv
     ```
 
 #### Permission issues

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -20,7 +20,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.26.3 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.27.0 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -43,7 +43,7 @@ To install a **specific version** of Rover (recommended for CI environments to e
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.26.3' | iex
+iwr 'https://rover.apollo.dev/win/v0.27.0' | iex
 ```
 
 #### Installing from a binary mirror using the bash and PowerShell scripts

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX:="https://github.c
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.27.0-rc.4"
+PACKAGE_VERSION="v0.27.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.27.0-rc.4'
+$package_version = 'v0.27.0'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/rover",
-  "version": "0.27.0-rc.4",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/rover",
-      "version": "0.27.0-rc.4",
+      "version": "0.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -70,22 +70,23 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.8.tgz",
+      "integrity": "sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
+        "@babel/generator": "^7.26.8",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
         "@babel/helpers": "^7.26.7",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.26.7",
-        "@babel/types": "^7.26.7",
+        "@babel/parser": "^7.26.8",
+        "@babel/template": "^7.26.8",
+        "@babel/traverse": "^7.26.8",
+        "@babel/types": "^7.26.8",
+        "@types/gensync": "^1.0.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -101,14 +102,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.8.tgz",
+      "integrity": "sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.5",
-        "@babel/types": "^7.26.5",
+        "@babel/parser": "^7.26.8",
+        "@babel/types": "^7.26.8",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -221,13 +222,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
+      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.7"
+        "@babel/types": "^7.26.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -476,32 +477,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
+      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.8",
+        "@babel/types": "^7.26.8"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.8.tgz",
+      "integrity": "sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7",
+        "@babel/generator": "^7.26.8",
+        "@babel/parser": "^7.26.8",
+        "@babel/template": "^7.26.8",
+        "@babel/types": "^7.26.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -510,9 +511,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
+      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1092,6 +1093,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.4.tgz",
+      "integrity": "sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1484,9 +1492,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
+      "version": "1.0.30001699",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
       "dev": true,
       "funding": [
         {
@@ -1808,9 +1816,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+      "version": "1.5.96",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
+      "integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
       "dev": true,
       "license": "ISC"
     },

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/rover",
-  "version": "0.27.0-rc.4",
+  "version": "0.27.0",
   "description": "The new Apollo CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
# [0.27.0] - 2025-02-10

> Important: 3 potentially breaking changes below, indicated by **❗ BREAKING ❗**
> 
> **If using Rover with Connectors,** you will need to specify `APOLLO_ROVER_DEV_ROUTER_VERSION=2.0.0-preview.X` when using `rover dev`

## ❗ BREAKING ❗

- **Make paths in `supergraph.yaml` resolve relative to the location of the `supergraph.yaml` file - @jonathanrainer PR #2119**

  To support the new Apollo Language Server it is now the case that any paths expressed in the `supergraph.yaml` file will
  be resolved relative to the file's location on disk, **not** the location that Rover is running in, at the time.

- **Remove `fed2` command - @aaronArinder PR #2222**

  This was a deprecated, hidden, unused command that was for early Federation 2.0 testing. This command has not been
  invoked for a very long time.

- **Remove ability to start multiple `rover dev` sessions - @jonathanrainer PR #2352**

  Now that Rover supports hot-reloading from `supergraph.yaml` files we've removed the ability to start multiple
  `rover dev` sessions, in multiple terminal windows, and have them communicate with each other.

## 🚀 Features

- **Apollo Language Server - @jonathanrainer**

  This brand-new feature aids in subgraph development and also supports connectors. It enhances Apollo tools such as the schema proposals editor and recent versions of IDE plugins and extensions by providing federation-aware syntax highlighting, validation, autocompletion, and more

  <details open>
  <summary>PRs Included</summary>
    <ul>
      <li>#2272</li>
      <li>#2345</li>
      <li>#2354</li>
      <li>#2364</li>
      <li>#2369</li>
      <li>#2386</li>
      <li>#2389</li>
    </ul>
  </details>

- **New version of `rover dev` - @dotdat @aaronArinder @loshz @monkpow @jonathanrainer**

  In this version of Rover there is a new version of `rover dev` built upon a completely new implementation of the
  composition pipeline inside of Rover. This not only allows a better functioning `rover dev` with more features, but
  it also supports the new Apollo Language Server, for use with Connectors!

  In addition, it also supports hot-reloading of the `supergraph.yaml` file, subgraphs can be added, removed or edited,
  and this will be all be reflected in the running `rover dev` session!

  <details open>
  <summary>PRs Included</summary>
    <ul>
      <li>#2118</li>
      <li>#2127</li>
      <li>#2130</li>
      <li>#2131</li>
      <li>#2132</li>
      <li>#2138</li>
      <li>#2141</li>
      <li>#2142</li>
      <li>#2144</li>
      <li>#2145</li>
      <li>#2146</li>
      <li>#2147</li>
      <li>#2149</li>
      <li>#2150</li>
      <li>#2152</li>
      <li>#2154</li>
      <li>#2156</li>
      <li>#2157</li>
      <li>#2158</li>
      <li>#2159</li>
      <li>#2160</li>
      <li>#2163</li>
      <li>#2166</li>
      <li>#2167</li>
      <li>#2171</li>
      <li>#2172</li>
      <li>#2177</li>
      <li>#2178</li>
      <li>#2179</li>
      <li>#2184</li>
      <li>#2189</li>
      <li>#2204</li>
      <li>#2205</li>
      <li>#2207</li>
      <li>#2208</li>
      <li>#2209</li>
      <li>#2210</li>
      <li>#2211</li>
      <li>#2214</li>
      <li>#2223</li>
      <li>#2228</li>
      <li>#2229</li>
      <li>#2251</li>
      <li>#2253</li>
      <li>#2257</li>
      <li>#2267</li>
      <li>#2268</li>
      <li>#2274</li>
      <li>#2282</li>
      <li>#2283</li>
      <li>#2285</li>
      <li>#2288</li>
      <li>#2289</li>
      <li>#2305</li>
      <li>#2308</li>
      <li>#2309</li>
      <li>#2310</li>
      <li>#2311</li>
      <li>#2312</li>
      <li>#2314</li>
      <li>#2316</li>
      <li>#2318</li>
      <li>#2319</li>
      <li>#2320</li>
      <li>#2321</li>
      <li>#2322</li>
      <li>#2326</li>
      <li>#2327</li>
      <li>#2328</li>
      <li>#2329</li>
      <li>#2330</li>
      <li>#2331</li>
      <li>#2332</li>
      <li>#2334</li>
      <li>#2335</li>
      <li>#2336</li>
      <li>#2338</li>
      <li>#2339</li>
      <li>#2340</li>
      <li>#2341</li>
      <li>#2342</li>
      <li>#2343</li>
      <li>#2344</li>
      <li>#2355</li>
      <li>#2356</li>
      <li>#2357</li>
      <li>#2358</li>
      <li>#2360</li>
      <li>#2361</li>
      <li>#2362</li>
      <li>#2365</li>
      <li>#2370</li>
      <li>#2371</li>
      <li>#2374</li>
      <li>#2379</li>
      <li>#2383</li>
      <li>#2384</li>
    </ul>
  </details>

- **Add ability to hot-reload `federation_version` in `supergraph.yaml` - @jonathanrainer PR #2347**

  Rover now has the ability to account for changes in the `federation_version` field of the `supergraph.yaml` file,
  while it is running.

- **Enabling Remote Proxy Downloads - @LongLiveCHIEF @jonathanrainer PR #2254 #2372**

  Rover now has the ability to be installed from a remote proxy, via the use of environment variables.

- **Display the results of custom check tasks - @swcollard PR #2087**

  Rover now has the ability to print out results of CustomCheckTasks from the Platform API

## 🐛 Fixes

- **Stop Running Router with logs at TRACE level - @nmoutschen PR #2143**

  We were running the Router at TRACE level logging, which was causing queries to not complete in some cases

- **Stop `rover dev` session if router binary crashes - @jonathanrainer PR #2382**

  In the past we let the `rover dev` session continue if the router binary crashed, which led to a misleading state
  of affairs, this has now been fixed.

## 🛠 Maintenance

- **Consolidate Rover Tests - @jonathanrainer PR #2095**

  Removes old tests now that the E2E tests are more mature and consolidates our examples to clean up the codebase

- **Implement breaking changes for `apollo-federation-types` 0.14 - @dylan-apollo PR #2104**
- **Update `apollographql/router` to v1.55.0 - @jonathanrainer PR #2123**
- **Update rust crates - @jonathanrainer PR #2129**

  Includes `octocrab` to v0.41.0, `rstest` to v0.23.0 and `tower-http` to v0.6.0

- **Update rust crates - @jonathanrainer PR #2136**

  Includes `git-url-parse` to v0.4.5 and `tower` to v0.5.1

- **Update node.js packages - @jonathanrainer PR #2137**

  Includes `concurrently` to v9.0.1, `eslint` to v9.11.1 and `nodemon` to 3.1.7

- **Update `apollo-federation-types` to v0.14.1 - @loshz PR #2161**
- **Downgrade `openssl-src` to v300.3.1+3.3.1 - @aaronArinder PR #2174**
- **Fix integration tests against the `supergraph-demo` repo - @dotdat PR #2175**
- **Refactor `Fs::watch_file` to be more async - @dotdat PR #2176**
- **Fix Windows tests for `rover_std` - @aaronArinder PR #2180**
- **Cleanup `Fs` tests - @dotdat PR #2182**
- **Strip ANSI codes from lint/custom validations tests - @dotdat PR #2183**
- **Update `apollographql/router` to v1.56.0 - @jonathanrainer PR #2123**
- **Fix Smoke Test Payload to be valid JSON and add test timeout - @jonathanrainer PR #2191**
- **Fix Dependabot Alerts in `/examples` - @jonathanrainer PR #2192**
- **Switch to a timeout of 15 minutes per matrix job in Smoke Tests - @jonathanrainer PR #2193**
- **Add ability to skip linting check where no `.md` files have changed - @jonathanrainer PR #2194**
- **Update links after docs re-write has launched - @jonathanrainer PR #2195**
- **Ensure we catch all semver pre-release versions - @jonathanrainer PR #2196**
- **Update `tower-http` to v0.6.1 - @jonathanrainer PR #2197**
- **Update node.js packages - @jonathanrainer PR #2137**

  Includes `@eslint/compat` to v1.2.0, `eslint` to v9.12.0, `node` to v20.18.0 and `npm` to 10.9.0

- **Update CI node Docker Image to v20.18.0 - @jonathanrainer PR #2199**
- **Update `lychee-lib` to v0.16.0 - @jonathanrainer PR #2200**
- **Let lint tests to message Slack if linting check fails - @jonathanrainer PR #2201**
- **Move Smoke Tests away from macOS 12 - @jonathanrainer PR #2202**
- **Remove comma such that `payload` becomes valid JSON - @jonathanrainer #2212**
- **Update `async-trait` to v0.1.83 - @jonathanrainer PR #2216**
- **Update `axios-mock-adapter` to v2.1.0 - @jonathanrainer PR #2217**
- **Update `gh` CircleCI orb to v2.5.0 - @jonathanrainer PR #2218**
- **Update `node` CircleCI orb to v6.2.0 - @jonathanrainer PR #2219**
- **Update `slack` CircleCI orb to v5.0.0 - @jonathanrainer PR #2221**
- **Update `package-lock.json` across repo to resolve security vulnerabilities - @jonathanrainer PR #2226**
- **Ignore links in CHANGELOG when linting - @aaronArinder PR #2227**
- **Update node.js packages - @jonathanrainer PR #2230**

  Includes `@eslint/compat` to v1.2.1 and `eslint` to v9.13.0

- **Update `node` CircleCI orb to v6.3.0 - @jonathanrainer PR #2231**
- **Update Rust to v1.82.0 - @jonathanrainer PR #2232**
- **Update `apollographql/router` to v1.57.0 - @jonathanrainer PR #2235**
- **Delete vestigial `last_run.uuid` file - @glasser PR #2236**
- **Bump macOS CI such that we're using support OpenSSL - @jonathanrainer PR #2238**
- **Update `bytes` to v1.8.0 - @jonathanrainer PR #2240**
- **Update `notify` to v7.0.0 - @jonathanrainer PR #2241**
- **Update `termimad` to v0.31.0 - @jonathanrainer PR #2242**
- **Increase robustness of Smoke Tests - @jonathanrainer PR #2243**
- **Update `--timeout` for delete commands in line with other tests - @jonathanrainer PR #2244**
- **Update node.js packages - @jonathanrainer PR #2245**

  Includes `@eslint/compat` to v1.2.2 and `eslint` to v9.14.0

- **Update `ariadne` to v0.5.0 - @jonathanrainer PR #2246**
- **Update `which` to v7.0.0 - @jonathanrainer PR #2248**
- **Update `apollographql/router` to v1.57.1 - @jonathanrainer PR #2249**
- **Fix up Clippy warnings throughout tests - @jonathanrainer PR #2250**
- **Remove `netlify.toml` after new Documentation Platform Launch - @Meschreiber PR #2258**
- **Update node.js packages - @jonathanrainer PR #2259**

  Includes `@eslint/compat` to v1.2.3, `eslint` to v9.15.0 and `concurrenctly` to v9.1.0

- **Update `slack` CircleCI orb to v5.1.1 - @jonathanrainer PR #2260**
- **Update `slack-github-action` GitHub Action to v1.27.1 - @jonathanrainer PR #2264**
- **Update `slack-github-action` GitHub Action to v2.0.0 - @jonathanrainer PR #2265**
- **Fix `cargo-deny` errors blocking CI - @jonathanrainer PR #2266**
- **Update node.js packages - @jonathanrainer PR #2259**

  Includes `node` to v20.18.1 and `npm` to v10.9.1

- **Update `apollographql/router` to v1.58.0 - @jonathanrainer PR #2249**
- **Update node.js packages - @jonathanrainer PR #2278**

  Includes `eslint` to v9.16.0 and `prettier` to v3.4.1

- **Update `gh` CircleCI orb to v2.6.0 - @jonathanrainer PR #2279**
- **Update `@graphql-eslint/eslint-plugin` to v4.0.0 - @jonathanrainer PR #2281**
- **Update `apollographql/federation-rs` to v2.9.3 - @jonathanrainer PR #2287**
- **Update `apollographql/router` to v1.58.1 - @jonathanrainer PR #2290**
- **Update node.js packages - @jonathanrainer PR #2291**

  Includes `@eslint/compat` to v1.2.4, `@graphql-eslint/eslint-plugin` to v4.3.0, `npm` to v10.9.2 and `prettier` to v3.4.2

- **Update `node` CircleCI orb to v7.0.0 - @jonathanrainer PR #2292**
- **Update `url` package - @dotdat PR #2296**
- **Fix `xtask lint` to support contributions from forked repositories - @dotdat PR #2298**
- **Update node.js packages - @jonathanrainer PR #2302**

  Includes `concurrently` to v9.1.2, `eslint` to v9.17.0, `graphql` to v16.10.0 and `nodemon` to v3.1.9

- **Remove old security scanning infrastructure - @peakematt PR #2303**
- **Update `apollographql/router` to v1.59.0 - @jonathanrainer PR #2307**
- **Update `gh` CircleCI orb to v2.6.2 - @jonathanrainer PR #2324**
- **Update `npm` to v11 - @jonathanrainer PR #2324**
- **Update `apollographql/router` to v1.59.1 - @jonathanrainer PR #2290**
- **Update node.js packages - @jonathanrainer PR #2350**

  Includes `compat` to v1.2.5, `eslint` to v9.18.0

- **Update `notify` to v8 - @jonathanrainer PR #2351**
- **Update `node` Docker CI Image to v20.18.2 - @jonathanrainer PR #2366**
- **Update node.js packages - @jonathanrainer PR #2367**

  Includes `eslint` to v9.19.0, `node` to v20.18.2

- **Update `apollographql/router` to v1.59.2 - @jonathanrainer PR #2375**
- **Update package docs - @dotdat PR #2376**
- **Update CODEOWNERS - @dotdat PR #2377**
- **Update node.js packages - @jonathanrainer PR #2380**

  Includes `compat` to v1.2.6, `npm` to v11.1.0
- **Update to latest `openssl` to resolve security vulnerability - @jonathanrainer PR #2381**

## 📚 Documentation

- **Add Documentation for Subtasks and all associated traits - @aaronArinder PR #2162**
- **Document the new CompositionRunner struct - @loshz PR #2181**
- **Update docs pages for the new Documentation Platform - @Meschreiber PR #2224**
- **Remove Summit Callout - @shorgi PR #2236**
- **Update links to `apollosolutions` organisation - @Meschreiber PR #2269**
- **Fix typo - @Meschreiber PR #2284**
- **Remove internal redirects - @shorgi PR #2294**
- **Replace Discord links with Discourse links - @shorgi PR #2315**
- **Update docs post `rover dev` re-write - @aaronArinder PR #2333**