### PR TITLE
Remove obsolete language from `rover dev --help`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -363,8 +363,6 @@ pub enum Command {
     /// Contract configuration commands
     Contract(command::Contract),
 
-    /// Combine multiple subgraphs into a local supergraph
-    ///
     /// This command starts a local router that can query across one or more
     /// running GraphQL APIs (subgraphs) through one endpoint (supergraph).
     /// As you add, edit, and remove subgraphs, `rover dev` automatically
@@ -374,26 +372,8 @@ pub enum Command {
     /// ⚠️ Do not run this command in production!
     /// ⚠️ It is intended for local development.
     ///
-    /// The first time you run `rover dev`, a supergraph is created from the
-    /// GraphQL API you provide. This GraphQL API is the first subgraph
-    /// inside of the larger supergraph. As you make changes to the subgraph
-    /// schema, the supergraph schema will be re-composed and the router will
-    /// reload.
-    ///
     /// You can navigate to the supergraph endpoint in your browser
     /// to execute operations and see query plans using Apollo Sandbox.
-    ///
-    /// You can add more subgraphs by running `rover dev` again in a new
-    /// terminal. Subsequent subgraphs are composed into the supergraph and
-    /// can be queried alongside all other subgraphs from the original endpoint.
-    /// Changes to these schemas will also cause the supergraph schema to be
-    /// re-composed and the router to reload.
-    ///
-    /// Terminating the first `rover dev` process terminates the entire supergraph.
-    /// Terminating one of the subsequent `rover dev` processes (i.e. your second
-    /// or third subgraph) will decompose that subgraph from your supergraph.
-    ///
-    /// Think plug-n-play USB devices but with your GraphQL APIs!
     Dev(command::Dev),
 
     /// Supergraph schema commands


### PR DESCRIPTION
Now that there is no multi-terminal mode, I removed the language in `rover dev --help` that referred to it. I also cleaned up some other bits that seemed redundant.