### PR TITLE
Refine how composition produces artifacts for its targets

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -21,7 +21,6 @@ use crate::command::dev::{OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_
 use crate::command::Dev;
 use crate::composition::events::CompositionEvent;
 use crate::composition::pipeline::CompositionPipeline;
-use crate::composition::supergraph::binary::OutputTarget;
 use crate::composition::supergraph::config::full::introspect::MakeResolveIntrospectSubgraph;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::MakeFetchRemoteSubgraph;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraphs::MakeFetchRemoteSubgraphs;
@@ -183,13 +182,11 @@ impl Dev {
         let composition_runner = composition_pipeline
             .runner(
                 exec_command_impl,
-                read_file_impl.clone(),
                 write_file_impl.clone(),
                 client_config.service()?,
                 fetch_remote_subgraph_factory.boxed_clone(),
                 self.opts.subgraph_opts.subgraph_polling_interval,
                 tmp_config_dir_path.clone(),
-                OutputTarget::Stdout,
                 true,
                 federation_updater_config,
             )

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -22,7 +22,6 @@ use crate::command::lsp::errors::StartCompositionError::SupergraphYamlUrlConvers
 use crate::composition::events::CompositionEvent;
 use crate::composition::pipeline::CompositionPipeline;
 use crate::composition::runner::CompositionRunner;
-use crate::composition::supergraph::binary::OutputTarget;
 use crate::composition::supergraph::config::error::ResolveSubgraphError;
 use crate::composition::supergraph::config::full::introspect::MakeResolveIntrospectSubgraph;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::MakeFetchRemoteSubgraph;
@@ -36,7 +35,6 @@ use crate::composition::{
 use crate::options::PluginOpts;
 use crate::utils::client::StudioClientConfig;
 use crate::utils::effect::exec::TokioCommand;
-use crate::utils::effect::read_file::FsReadFile;
 use crate::utils::effect::write_file::FsWriteFile;
 use crate::utils::parsers::FileDescriptorType;
 use crate::{RoverOutput, RoverResult};
@@ -161,7 +159,7 @@ async fn run_lsp(client_config: StudioClientConfig, lsp_opts: LspOpts) -> RoverR
 }
 
 async fn start_composition(
-    runner: CompositionRunner<TokioCommand, FsReadFile, FsWriteFile>,
+    runner: CompositionRunner<TokioCommand, FsWriteFile>,
     language_server: ApolloLanguageServer,
     supergraph_yaml_url: Url,
 ) -> Result<(), StartCompositionError> {
@@ -320,7 +318,7 @@ async fn create_composition_runner(
     federation_version: Option<FederationVersion>,
     client_config: StudioClientConfig,
     lsp_opts: LspOpts,
-) -> Result<CompositionRunner<TokioCommand, FsReadFile, FsWriteFile>, StartCompositionError> {
+) -> Result<CompositionRunner<TokioCommand, FsWriteFile>, StartCompositionError> {
     let fetch_remote_subgraphs_factory = MakeFetchRemoteSubgraphs::builder()
         .studio_client_config(client_config.clone())
         .profile(lsp_opts.plugin_opts.profile.clone())
@@ -360,13 +358,11 @@ async fn create_composition_runner(
     Ok(composition_pipeline
         .runner(
             TokioCommand::default(),
-            FsReadFile::default(),
             FsWriteFile::default(),
             client_config.service()?,
             fetch_remote_subgraph_factory.boxed_clone(),
             lsp_opts.introspection_polling_interval,
             Utf8PathBuf::try_from(temp_dir())?,
-            OutputTarget::InMemory,
             true,
             Some(FederationUpdaterConfig {
                 studio_client_config: client_config,

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -1,4 +1,4 @@
-use std::io::stdin;
+use std::{fs, io::stdin};
 
 use apollo_federation_types::config::FederationVersion;
 use camino::Utf8PathBuf;
@@ -125,6 +125,12 @@ impl Compose {
             .await?;
 
         if let Some(output_file) = output_file {
+            let parent = output_file.parent();
+            if let Some(parent) = parent {
+                if !parent.exists() {
+                    fs::create_dir_all(parent)?;
+                }
+            }
             write_file_impl
                 .write_file(&output_file, composition_success.supergraph_sdl.as_bytes())
                 .await?;

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -49,9 +49,9 @@ pub enum CompositionError {
         stdout: String,
         stderr: String,
     },
-    #[error("Failed to parse output of `{binary} compose`")]
+    #[error("Failed to parse output of `{binary} compose`\n{error}")]
     InvalidOutput { binary: Utf8PathBuf, error: String },
-    #[error("Invalid input for `{binary} compose`")]
+    #[error("Invalid input for `{binary} compose`\n{error}")]
     InvalidInput { binary: Utf8PathBuf, error: String },
     #[error("Failed to read the file at: {path}.\n{error}")]
     ReadFile {

--- a/src/composition/runner/state.rs
+++ b/src/composition/runner/state.rs
@@ -18,14 +18,13 @@ pub struct SetupCompositionWatcher {
     pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }
 
-pub struct Run<ReadF, ExecC, WriteF>
+pub struct Run<ExecC, WriteF>
 where
-    ReadF: Eq + PartialEq + Debug,
     ExecC: Eq + PartialEq + Debug,
     WriteF: Eq + PartialEq + Debug,
 {
     pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
     pub subgraph_watchers: SubgraphWatchers,
-    pub composition_watcher: CompositionWatcher<ReadF, ExecC, WriteF>,
+    pub composition_watcher: CompositionWatcher<ExecC, WriteF>,
     pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }


### PR DESCRIPTION
# Background
When testing the rover dev rewrite, we were largely testing against [supergraph v2.9.3](https://github.com/apollographql/federation-rs/releases/tag/supergraph%40v2.9.3). This binary comes with the ability to write its output to a file, where previous versions did not. This ability has confused the nature of writing to a file as it relates to composition. We incorrectly assumed that the supergraph binary would handle writing a composed supergraph sdl to a file. The file that it writes has more information that just an SDL, and is only supported in versions greater than 2.9.0.

# Requirements
With this in mind, our supergraph pipeline needs to be the utility in charge of reading the output of the supergraph binary and producing the output that is desired by the calling command. These cases follow:

`rover supergraph compose --config {supergraph config}`
This writes the supergraph sdl to stdout

`rover supergraph compose --config {supergraph config} -o {target path}`
This writes the supergraph sdl to the path defined in `{target path}`

`rover dev ...`
This spins up a watcher utility that writes the supergraph sdl to a temporary location that is used to hot-reload the router as the sdl changes.

`rover lsp ...`
This spins up a watcher utility that passes the supergraph sdl to a tokio channel as an in-memory event

# Implementation Details
Since the supergraph binary only outputs to a file in versions >2.9.0 and in a format that is more than just an sdl, there is no real use case to be calling the supergraph binary with this option, over just reading its stdout output. It also turns out that only `rover supergraph compose` would need to pipe output from the binary to the user, and there is already a utility to do that as a function of [RoverOutput](https://github.com/apollographql/rover/blob/185630ba85752f7ce662c31e1d7a9c9e79c168d2/src/command/output.rs#L42). Ultimately, this means we could remove `OutputTarget`s since `InMemory` was the only target left.

This pushed the requirements described above to two places: the internals of the `supergraph compose` command and `CompositionPipeline` used by `dev` and `lsp`.

# Issues
This should fix #2393 as it handles the scenario where the supergraph binary does not produce a readable artifact, resulting in the error shown in that report.