### PR TITLE
ROVER-325 Ensure credentials are checked when needed and not before

### DIFF
--- a/src/command/dev/router/config/remote.rs
+++ b/src/command/dev/router/config/remote.rs
@@ -30,7 +30,7 @@ impl RemoteRouterConfig {
                 Ok(client) => match client.studio_graphql_service() {
                     Ok(service) => WhoAmI::new(service),
                     Err(err) => {
-                        warnln!("APOLLO_GRAPH_REF but could not initialise Studio service. Router may fail to start if Enterprise features are enabled: {err}");
+                        warnln!("APOLLO_GRAPH_REF is set, but could not communicate with Studio. Router may fail to start if Enterprise features are enabled: {err}");
                         return RemoteRouterConfig {
                             graph_ref,
                             api_key: None,
@@ -38,7 +38,7 @@ impl RemoteRouterConfig {
                     }
                 },
                 Err(e) => {
-                    warnln!("APOLLO_GRAPH_REF but could not authenticate with Studio. Router may fail to start if Enterprise features are enabled: {e}");
+                    warnln!("APOLLO_GRAPH_REF is set, but could not authenticate with Studio. Router may fail to start if Enterprise features are enabled: {e}");
                     return RemoteRouterConfig {
                         graph_ref,
                         api_key: None,

--- a/src/command/dev/router/config/remote.rs
+++ b/src/command/dev/router/config/remote.rs
@@ -1,12 +1,13 @@
 use derive_getters::Getters;
 use futures::TryFutureExt;
-use houston::Credential;
-use rover_client::{
-    operations::config::who_am_i::{Actor, RegistryIdentity, WhoAmIError, WhoAmIRequest},
-    shared::GraphRef,
-};
+use houston::{Config, Credential, HoustonProblem, Profile};
+use rover_client::operations::config::who_am_i::{Actor, WhoAmI, WhoAmIRequest};
+use rover_client::shared::GraphRef;
 use rover_std::warnln;
 use tower::{Service, ServiceExt};
+
+use crate::options::ProfileOpt;
+use crate::utils::client::StudioClientConfig;
 
 #[derive(Clone, Getters)]
 pub struct RemoteRouterConfig {
@@ -15,15 +16,35 @@ pub struct RemoteRouterConfig {
 }
 
 impl RemoteRouterConfig {
-    pub async fn load<S>(
-        mut who_am_i: S,
+    pub async fn load(
+        client_config: StudioClientConfig,
+        profile: ProfileOpt,
         graph_ref: GraphRef,
-        credential: Option<Credential>,
-    ) -> RemoteRouterConfig
-    where
-        S: Service<WhoAmIRequest, Response = RegistryIdentity, Error = WhoAmIError>,
-    {
-        if let Some(credential) = credential {
+        home_override: Option<String>,
+        api_key_override: Option<String>,
+    ) -> RemoteRouterConfig {
+        if let Ok(credential) =
+            Self::establish_credentials(&profile, home_override, api_key_override)
+        {
+            let mut who_am_i = match client_config.get_authenticated_client(&profile) {
+                Ok(client) => match client.studio_graphql_service() {
+                    Ok(service) => WhoAmI::new(service),
+                    Err(err) => {
+                        warnln!("APOLLO_GRAPH_REF but could not initialise Studio service. Router may fail to start if Enterprise features are enabled: {err}");
+                        return RemoteRouterConfig {
+                            graph_ref,
+                            api_key: None,
+                        };
+                    }
+                },
+                Err(e) => {
+                    warnln!("APOLLO_GRAPH_REF but could not authenticate with Studio. Router may fail to start if Enterprise features are enabled: {e}");
+                    return RemoteRouterConfig {
+                        graph_ref,
+                        api_key: None,
+                    };
+                }
+            };
             let identity = who_am_i
                 .ready()
                 .and_then(|who_am_i| who_am_i.call(WhoAmIRequest::new(credential.origin)))
@@ -59,5 +80,16 @@ impl RemoteRouterConfig {
             api_key: None,
             graph_ref,
         }
+    }
+
+    fn establish_credentials(
+        profile: &ProfileOpt,
+        home_override: Option<String>,
+        api_key_override: Option<String>,
+    ) -> Result<Credential, HoustonProblem> {
+        Profile::get_credential(
+            &profile.profile_name,
+            &Config::new(home_override.as_ref(), api_key_override)?,
+        )
     }
 }

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -4,8 +4,6 @@ use apollo_federation_types::config::RouterVersion;
 use camino::{Utf8Path, Utf8PathBuf};
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
-use houston::Credential;
-use rover_client::operations::config::who_am_i::{RegistryIdentity, WhoAmIError, WhoAmIRequest};
 use rover_client::shared::GraphRef;
 use rover_client::RoverClientError;
 use rover_std::{debugln, errln, infoln, RoverStdError};
@@ -25,7 +23,7 @@ use crate::command::dev::router::hot_reload::{HotReloadConfig, HotReloadConfigOv
 use crate::command::dev::router::watchers::file::FileWatcher;
 use crate::composition::events::CompositionEvent;
 use crate::composition::CompositionError;
-use crate::options::LicenseAccepter;
+use crate::options::{LicenseAccepter, ProfileOpt};
 use crate::subtask::{Subtask, SubtaskRunStream, SubtaskRunUnit};
 use crate::utils::client::StudioClientConfig;
 use crate::utils::effect::exec::ExecCommandConfig;
@@ -99,19 +97,24 @@ impl RunRouter<state::LoadLocalConfig> {
 }
 
 impl RunRouter<state::LoadRemoteConfig> {
-    pub async fn load_remote_config<S>(
+    pub async fn load_remote_config(
         self,
-        who_am_i: S,
+        client_config: StudioClientConfig,
+        profile: ProfileOpt,
         graph_ref: Option<GraphRef>,
-        credential: Option<Credential>,
-    ) -> RunRouter<state::Run>
-    where
-        S: Service<WhoAmIRequest, Response = RegistryIdentity, Error = WhoAmIError>,
-    {
+        home_override: Option<String>,
+        api_key_override: Option<String>,
+    ) -> RunRouter<state::Run> {
         let state = match graph_ref {
             Some(graph_ref) => {
-                let remote_config =
-                    RemoteRouterConfig::load(who_am_i, graph_ref.clone(), credential).await;
+                let remote_config = RemoteRouterConfig::load(
+                    client_config,
+                    profile,
+                    graph_ref.clone(),
+                    home_override,
+                    api_key_override,
+                )
+                .await;
                 state::Run {
                     binary: self.state.binary,
                     config: self.state.config,
@@ -131,6 +134,7 @@ impl RunRouter<state::LoadRemoteConfig> {
 }
 
 impl RunRouter<state::Run> {
+    #[allow(clippy::too_many_arguments)]
     pub async fn run<Spawn, WriteFile>(
         self,
         mut write_file: WriteFile,
@@ -138,7 +142,9 @@ impl RunRouter<state::Run> {
         temp_router_dir: &Utf8Path,
         studio_client_config: StudioClientConfig,
         supergraph_schema: &str,
-        credential: Credential,
+        profile: ProfileOpt,
+        home_override: Option<String>,
+        api_key_override: Option<String>,
     ) -> Result<RunRouter<state::Watch>, RunRouterBinaryError>
     where
         Spawn: Service<ExecCommandConfig, Response = Child> + Send + Clone + 'static,
@@ -205,7 +211,9 @@ impl RunRouter<state::Run> {
             .config_path(hot_reload_config_path.clone())
             .supergraph_schema_path(hot_reload_schema_path.clone())
             .and_remote_config(self.state.remote_config.clone())
-            .credential(credential)
+            .and_home_override(home_override)
+            .and_api_key_override(api_key_override)
+            .profile(profile)
             .spawn(spawn)
             .build();
 

--- a/src/options/profile.rs
+++ b/src/options/profile.rs
@@ -1,12 +1,15 @@
+use std::fmt::Display;
+
 use clap::Parser;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+
+pub const DEFAULT_PROFILE: &str = "default";
 
 #[cfg_attr(test, derive(Default))]
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct ProfileOpt {
     /// Name of configuration profile to use
-    #[arg(long = "profile", default_value = "default")]
+    #[arg(long = "profile", default_value = DEFAULT_PROFILE)]
     #[serde(skip_serializing)]
     pub profile_name: String,
 }


### PR DESCRIPTION
Fixes: #2399 

As per title, in the current version of `rover dev` we're trying to establish credentials very early, when we might not actually need them at all. This PR moves the establishment of credentials closer to where we actually need them, and doesn't stop `rover dev` starting if they're not present as happens at the moment.

Have tested this in the multiple configurations required, particularly around the reported case and we see the following behaviour now:

No profile provided, no profiles exist
![Screenshot 2025-02-14 at 08 50 58](https://github.com/user-attachments/assets/cde7ba00-991a-4869-81ac-ea26eff096d6)

Profile provided, no profiles exist
![Screenshot 2025-02-14 at 08 51 41](https://github.com/user-attachments/assets/88ed26c5-2a19-4809-88d6-79e919544100)

Profile provided, the profile doesn't exist
![Screenshot 2025-02-14 at 08 52 22](https://github.com/user-attachments/assets/62ea0bae-cf1c-4f22-a3ae-c4e7b7d0bb8a)

No profile provided (customer use case)
![Screenshot 2025-02-14 at 08 53 05](https://github.com/user-attachments/assets/abe665e3-6e29-4126-a819-762de42709a9)

Profile provided, it exists
![Screenshot 2025-02-14 at 08 53 32](https://github.com/user-attachments/assets/2e091a6f-4e7a-49de-873e-ed7860443ee6)

Graph Ref behaviour is dealt with similarly
