### PR TITLE
Replace prettytable-rs with comfy-table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [0.28.0] (unreleased) - 2025-mm-dd
+
+## 🐛 Fixes
+
+- **Fix formatting of table output by `rover config whoami` - @pubmodmatt PR #2413**
+
 # [0.27.2] - 2025-02-19
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom",
+ "vte",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +324,12 @@ dependencies = [
  "unicode-width 0.1.14",
  "yansi",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
@@ -1142,6 +1167,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "ansi-str",
+ "console",
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "concolor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,27 +1457,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4448,20 +4465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4841,6 +4844,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
+ "comfy-table",
  "console",
  "derive-getters",
  "dialoguer",
@@ -4865,7 +4869,6 @@ dependencies = [
  "os_info",
  "portpicker",
  "predicates",
- "prettytable-rs",
  "rand",
  "rand_regex",
  "regex",
@@ -4921,6 +4924,7 @@ dependencies = [
  "buildstructor",
  "camino",
  "chrono",
+ "comfy-table",
  "derive-getters",
  "git-url-parse",
  "git2",
@@ -4933,7 +4937,6 @@ dependencies = [
  "indoc",
  "itertools 0.13.0",
  "pretty_assertions",
- "prettytable-rs",
  "regex",
  "reqwest 0.12.12",
  "rover-graphql",
@@ -6700,6 +6703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6807,6 +6816,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
+ "arrayvec",
  "memchr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ camino = { version = "1", features = ["serde1"] }
 clap = "4"
 chrono = "0.4"
 ci_info = "0.14"
+comfy-table = {  version = "7.1.4", features = ["custom_styling"] }
 console = "0.15"
 derive-getters = "0.5.0"
 dialoguer = "0.11"
@@ -118,7 +119,6 @@ os_info = "3.7"
 os_type = "2.6"
 predicates = "3"
 pretty_assertions = "1"
-prettytable-rs = "0.10"
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
 rstest = "0.23.0"
@@ -185,7 +185,6 @@ heck = { workspace = true }
 http = { workspace = true }
 houston = { workspace = true }
 itertools = { workspace = true }
-prettytable-rs = { workspace = true }
 lazycell = { workspace = true }
 lazy_static = { workspace = true }
 opener = { workspace = true }
@@ -222,6 +221,7 @@ tower-lsp = { version = "0.20.0" }
 tracing = { workspace = true }
 uuid = { workspace = true }
 url = { workspace = true, features = ["serde"] }
+comfy-table = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -15,6 +15,7 @@ apollo-encoder = { workspace = true }
 backoff = { workspace = true, features = ["tokio", "futures"] }
 buildstructor = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+comfy-table = { workspace = true, features = ["custom_styling"]}
 derive-getters = { workspace = true }
 git-url-parse = { workspace = true }
 git2 = { workspace = true, features = [
@@ -26,7 +27,6 @@ http = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
-prettytable-rs = { workspace = true }
 reqwest = { workspace = true, features = [
     "blocking",
     "brotli",

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -1,14 +1,14 @@
+use crate::{shared::lint_response::Diagnostic, RoverClientError};
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::Attribute::Bold;
+use comfy_table::CellAlignment::Center;
+use comfy_table::{Cell, Table};
+use rover_std::Style;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use crate::{shared::lint_response::Diagnostic, RoverClientError};
-
-use rover_std::Style;
-
-use prettytable::format::consts::FORMAT_BOX_CHARS;
 use serde::{Deserialize, Serialize};
 
-use prettytable::{row, Table};
 use serde_json::{json, Value};
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
@@ -174,13 +174,19 @@ impl OperationCheckResponse {
 
     pub fn get_table(&self) -> String {
         let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
 
-        table.set_format(*FORMAT_BOX_CHARS);
-
-        // bc => sets top row to be bold and center
-        table.add_row(row![bc => "Change", "Code", "Description"]);
+        table.set_header(
+            vec!["Change", "Code", "Description"]
+                .into_iter()
+                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+        );
         for check in &self.changes {
-            table.add_row(row![check.severity, check.code, check.description]);
+            table.add_row(vec![
+                &check.severity.to_string(),
+                &check.code,
+                &check.description,
+            ]);
         }
 
         table.to_string()
@@ -224,18 +230,20 @@ pub struct LintCheckResponse {
 impl LintCheckResponse {
     pub fn get_table(&self) -> String {
         let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
 
-        table.set_format(*FORMAT_BOX_CHARS);
-
-        // bc => sets top row to be bold and center
-        table.add_row(row![bc =>  "Level", "Coordinate", "Line", "Description"]);
+        table.set_header(
+            vec!["Level", "Coordinate", "Line", "Description"]
+                .into_iter()
+                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+        );
 
         for diagnostic in &self.diagnostics {
-            table.add_row(row![
-                diagnostic.level,
-                diagnostic.coordinate,
-                diagnostic.start_line,
-                diagnostic.message
+            table.add_row(vec![
+                &diagnostic.level,
+                &diagnostic.coordinate,
+                &diagnostic.start_line.to_string(),
+                &diagnostic.message,
             ]);
         }
 
@@ -322,14 +330,16 @@ pub struct ProposalsCheckResponse {
 impl ProposalsCheckResponse {
     pub fn get_table(&self) -> String {
         let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
 
-        table.set_format(*FORMAT_BOX_CHARS);
-
-        // bc => sets top row to be bold and center
-        table.add_row(row![bc =>  "Status", "Proposal Name"]);
+        table.set_header(
+            vec!["Status", "Proposal Name"]
+                .into_iter()
+                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+        );
 
         for proposal in &self.related_proposals {
-            table.add_row(row![proposal.status, proposal.display_name,]);
+            table.add_row(vec![&proposal.status, &proposal.display_name]);
         }
 
         table.to_string()
@@ -391,22 +401,24 @@ pub struct CustomCheckResponse {
 impl CustomCheckResponse {
     pub fn get_table(&self) -> String {
         let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
 
-        table.set_format(*FORMAT_BOX_CHARS);
-
-        // bc => sets top row to be bold and center
-        table.add_row(row![bc =>  "Level", "Rule", "Line", "Message"]);
+        table.set_header(
+            vec!["Level", "Rule", "Line", "Message"]
+                .into_iter()
+                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+        );
 
         for violation in &self.violations {
             let coordinate = match &violation.start_line {
                 Some(message) => message.to_string(),
                 None => "".to_string(),
             };
-            table.add_row(row![
-                violation.level,
-                violation.rule,
-                coordinate,
-                violation.message,
+            table.add_row(vec![
+                &violation.level,
+                &violation.rule,
+                &coordinate,
+                &violation.message,
             ]);
         }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -6,6 +6,9 @@ use std::{
 
 use calm_io::{stderr, stderrln};
 use camino::Utf8PathBuf;
+use comfy_table::Attribute::Bold;
+use comfy_table::Cell;
+use comfy_table::CellAlignment::Center;
 use serde_json::{json, Value};
 use termimad::{crossterm::style::Attribute::Underlined, MadSkin};
 
@@ -27,7 +30,7 @@ use crate::command::supergraph::compose::CompositionOutput;
 use crate::command::template::queries::list_templates_for_language::ListTemplatesForLanguageTemplates;
 use crate::options::JsonVersion;
 use crate::options::ProjectLanguage;
-use crate::utils::table::{self, row};
+use crate::utils::table;
 use crate::RoverError;
 
 /// RoverOutput defines all of the different types of data that are printed
@@ -118,24 +121,24 @@ impl RoverOutput {
             } => {
                 let mut table = table::get_table();
 
-                table.add_row(row![Style::WhoAmIKey.paint("Key Type"), key_type]);
+                table.add_row(vec![&Style::WhoAmIKey.paint("Key Type"), key_type]);
 
                 if let Some(graph_id) = graph_id {
-                    table.add_row(row![Style::WhoAmIKey.paint("Graph ID"), graph_id]);
+                    table.add_row(vec![&Style::WhoAmIKey.paint("Graph ID"), graph_id]);
                 }
 
                 if let Some(graph_title) = graph_title {
-                    table.add_row(row![Style::WhoAmIKey.paint("Graph Title"), graph_title]);
+                    table.add_row(vec![&Style::WhoAmIKey.paint("Graph Title"), graph_title]);
                 }
 
                 if let Some(user_id) = user_id {
-                    table.add_row(row![Style::WhoAmIKey.paint("User ID"), user_id]);
+                    table.add_row(vec![&Style::WhoAmIKey.paint("User ID"), user_id]);
                 }
 
-                table.add_row(row![Style::WhoAmIKey.paint("Origin"), origin]);
-                table.add_row(row![Style::WhoAmIKey.paint("API Key"), api_key]);
+                table.add_row(vec![&Style::WhoAmIKey.paint("Origin"), origin]);
+                table.add_row(vec![&Style::WhoAmIKey.paint("API Key"), api_key]);
 
-                Some(format!("{}", table))
+                Some(format!("{table}"))
             }
             RoverOutput::ContractDescribe(describe_response) => Some(format!(
                 "{description}\nView the variant's full configuration at {variant_config}",
@@ -164,12 +167,15 @@ impl RoverOutput {
                 )?;
                 let mut table = table::get_table();
 
-                // bc => sets top row to be bold and center
-                table.add_row(row![bc => "Slug", "Description"]);
+                table.set_header(
+                    vec!["Slug", "Description"]
+                        .into_iter()
+                        .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+                );
                 for (shortlink_slug, shortlink_description) in shortlinks {
-                    table.add_row(row![shortlink_slug, shortlink_description]);
+                    table.add_row(vec![shortlink_slug, shortlink_description]);
                 }
-                Some(format!("{}", table))
+                Some(format!("{table}"))
             }
             RoverOutput::FetchResponse(fetch_response) => {
                 Some((fetch_response.sdl.contents).to_string())
@@ -297,8 +303,11 @@ impl RoverOutput {
             RoverOutput::SubgraphList(details) => {
                 let mut table = table::get_table();
 
-                // bc => sets top row to be bold and center
-                table.add_row(row![bc => "Name", "Routing Url", "Last Updated"]);
+                table.set_header(
+                    vec!["Name", "Routing Url", "Last Updated"]
+                        .into_iter()
+                        .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+                );
 
                 for subgraph in &details.subgraphs {
                     // Default to "unspecified" if the url is None or empty.
@@ -317,7 +326,7 @@ impl RoverOutput {
                         "N/A".to_string()
                     };
 
-                    table.add_row(row![subgraph.name, url, formatted_updated_at]);
+                    table.add_row(vec![subgraph.name.clone(), url, formatted_updated_at]);
                 }
                 Some(format!(
                     "{}\n View full details at {}/graph/{}/service-list",
@@ -327,20 +336,23 @@ impl RoverOutput {
             RoverOutput::TemplateList(templates) => {
                 let mut table = table::get_table();
 
-                // bc => sets top row to be bold and center
-                table.add_row(row![bc => "Name", "ID", "Language", "Repo URL"]);
+                table.set_header(
+                    vec!["Name", "ID", "Language", "Repo URL"]
+                        .into_iter()
+                        .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+                );
 
                 for template in templates {
                     let language: ProjectLanguage = template.language.clone().into();
-                    table.add_row(row![
-                        template.name,
-                        template.id,
-                        language,
-                        template.repo_url,
+                    table.add_row(vec![
+                        template.name.clone(),
+                        template.id.clone(),
+                        language.to_string(),
+                        template.repo_url.to_string(),
                     ]);
                 }
 
-                Some(format!("{}", table))
+                Some(format!("{table}"))
             }
             RoverOutput::TemplateUseSuccess { template_id, path } => {
                 let template_id = Style::Command.paint(template_id);

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,16 +1,7 @@
-use prettytable::{
-    format::{consts::FORMAT_BOX_CHARS, TableFormat},
-    Table,
-};
-
-pub use prettytable::{cell, row};
+use comfy_table::Table;
 
 pub fn get_table() -> Table {
     let mut table = Table::new();
-    table.set_format(get_table_format());
+    table.load_preset(comfy_table::presets::UTF8_FULL);
     table
-}
-
-pub fn get_table_format() -> TableFormat {
-    *FORMAT_BOX_CHARS
 }


### PR DESCRIPTION
Replace the [`prettytable-rs`](https://crates.io/crates/prettytable-rs/) dependency with [`comfy-table`](https://crates.io/crates/comfy-table/).

# Motivation

The table output by `rover config whoami` was misalgined, due to [this issue](https://github.com/phsym/prettytable-rs/issues/165) in `prettytable-rs`:

```
┌───────────────┬────────────────────────────────────────────┐
│ Key Type    │ Graph                                      │
├───────────────┼────────────────────────────────────────────┤
│ Graph ID    │ SpaceOrbit3                                │
├───────────────┼────────────────────────────────────────────┤
│ Graph Title │ SpaceOrbit                                 │
├───────────────┼────────────────────────────────────────────┤
│ Origin      │ $APOLLO_KEY                                │
├───────────────┼────────────────────────────────────────────┤
│ API Key     │ ****************************************** │
└───────────────┴────────────────────────────────────────────┘
```

As pointed out in the [comparison with other libraries](https://docs.rs/comfy-table/7.1.4/comfy_table/#comparison-with-other-libraries) in the `comfy-table` docs, it appears that `prettytable-rs` may be abandoned. The fix for the above issue has had an open PR for several months, but it has not been merged and released. `comfy-table` appears to be actively developed, and had a new version release 12 days ago.

# Differences

Dropping in `comfy-table` is almost seamless. There are a few very slight differences in the output, in addition to fixing the above alignment issue:

* The bold headers were not working with `prettytable-rs`, but they do work with `comfy-table`
* `comfy-table` uses a double line between the header row and the next row, more clearly delineating the headers
* The `comfy-table` preset uses dashed lines inside the table, and solid lines for the table border, provding a nice visual separation. `prettytable-rs` used solid lines everywhere.

# Comparison

Note that the examples below do not show bold fonts or colors that would appear in the terminal.

## `rover config whoami`

### `prettytable-rs`

```
┌───────────────┬────────────────────────────────────────────┐
│ Key Type    │ Graph                                      │
├───────────────┼────────────────────────────────────────────┤
│ Graph ID    │ SpaceOrbit3                                │
├───────────────┼────────────────────────────────────────────┤
│ Graph Title │ SpaceOrbit                                 │
├───────────────┼────────────────────────────────────────────┤
│ Origin      │ $APOLLO_KEY                                │
├───────────────┼────────────────────────────────────────────┤
│ API Key     │ ****************************************** │
└───────────────┴────────────────────────────────────────────┘
```

### `comfy-table`

```
┌─────────────┬────────────────────────────────────────────┐
│ Key Type    ┆ Graph                                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Graph ID    ┆ SpaceOrbit3                                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Graph Title ┆ SpaceOrbit                                 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin      ┆ $APOLLO_KEY                                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key     ┆ ****************************************** │
└─────────────┴────────────────────────────────────────────┘
```

## `rover docs list`

### `prettytable-rs`

```
┌──────────────┬──────────────────────────────────────┐
│     Slug     │             Description              │
├──────────────┼──────────────────────────────────────┤
│ api-keys     │ Understanding Apollo's API Keys      │
├──────────────┼──────────────────────────────────────┤
│ contributing │ Contributing to Rover                │
├──────────────┼──────────────────────────────────────┤
│ docs         │ Rover's Documentation Homepage       │
├──────────────┼──────────────────────────────────────┤
│ migration    │ Migrate from the Apollo CLI to Rover │
├──────────────┼──────────────────────────────────────┤
│ start        │ Getting Started with Rover           │
└──────────────┴──────────────────────────────────────┘
```

### `comfy-table`

```
┌──────────────┬──────────────────────────────────────┐
│     Slug     ┆              Description             │
╞══════════════╪══════════════════════════════════════╡
│ api-keys     ┆ Understanding Apollo's API Keys      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ contributing ┆ Contributing to Rover                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ docs         ┆ Rover's Documentation Homepage       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ migration    ┆ Migrate from the Apollo CLI to Rover │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ start        ┆ Getting Started with Rover           │
└──────────────┴──────────────────────────────────────┘
```

## `rover subgraph list`

### `prettytable-rs`

```
┌───────┬───────────────────────┬────────────────────────────┐
│ Name  │      Routing Url      │        Last Updated        │
├───────┼───────────────────────┼────────────────────────────┤
│ posts │ http://localhost:4000 │ 2025-02-19 12:04:01 -07:00 │
└───────┴───────────────────────┴────────────────────────────┘
```

### `comfy-table`

```
┌───────┬───────────────────────┬────────────────────────────┐
│  Name ┆      Routing Url      ┆        Last Updated        │
╞═══════╪═══════════════════════╪════════════════════════════╡
│ posts ┆ http://localhost:4000 ┆ 2025-02-19 12:04:01 -07:00 │
└───────┴───────────────────────┴────────────────────────────┘
```