### PR TITLE
Implement `supergraph config schema` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,8 +48,9 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "once_cell",
+ "serde",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -225,8 +226,8 @@ dependencies = [
  "serde_json",
  "serde_json_bytes",
  "shape",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
+ "strum_macros",
  "thiserror 1.0.69",
  "time",
  "tracing",
@@ -241,6 +242,7 @@ checksum = "bc933111fa54f7fb3002c4833d766b4806ac017edf06d4be54b73b8d90d2141c"
 dependencies = [
  "apollo-compiler",
  "log",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -700,7 +702,7 @@ dependencies = [
  "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -793,7 +795,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -801,6 +812,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -835,6 +852,12 @@ dependencies = [
  "futures-lite",
  "piper",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
 
 [[package]]
 name = "brotli"
@@ -1010,16 +1033,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1056,7 +1079,7 @@ dependencies = [
  "mailchecker",
  "md5",
  "pwned",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest 0.11.27",
  "serde",
@@ -1817,6 +1840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +1956,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "fast-socks5"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2046,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2252,16 +2313,16 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d7ff03a34ea818a59cf30c0d7aa55354925484fa30bcc4cb96d784ff07578f"
 dependencies = [
- "strum 0.26.3",
+ "strum",
  "thiserror 1.0.69",
  "url",
 ]
 
 [[package]]
 name = "git2"
-version = "0.20.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
@@ -3127,15 +3188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3229,31 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c59cb1733c34377b6067a0419befd7f25073c5249ec3b0614a482bf499e1df5"
+dependencies = [
+ "ahash 0.8.11",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna 1.0.3",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax 0.8.5",
+ "reqwest 0.12.12",
+ "serde",
+ "serde_json",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -3240,7 +3317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
@@ -3323,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.0+1.9.0"
+version = "0.17.0+1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",
@@ -3721,7 +3798,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -3864,6 +3941,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -4137,6 +4220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,7 +4394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4393,7 +4482,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4408,7 +4497,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4547,19 +4636,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.2",
- "zerocopy 0.8.20",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -4569,17 +4647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -4592,22 +4660,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
-dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.20",
-]
-
-[[package]]
 name = "rand_regex"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb7969b106060de455cbdb979d3d84c84ffec7b9fa6fa5c56343df409e1614a"
+checksum = "4bfbd599a8c757f89100e3ae559fb1ef9efa1cfd9276136862e3089dec627b31"
 dependencies = [
- "rand 0.9.0",
+ "rand",
  "regex-syntax 0.8.5",
 ]
 
@@ -4649,6 +4707,40 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "referencing"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce52678d53e5ee37e4af0a9036ca834d0cd34b33c82457c6b06a24f8d783344"
+dependencies = [
+ "ahash 0.8.11",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4886,7 +4978,8 @@ dependencies = [
  "http 1.2.0",
  "httpmock",
  "indoc",
- "itertools 0.14.0",
+ "itertools 0.13.0",
+ "jsonschema",
  "lazy_static",
  "lazycell",
  "mime",
@@ -4895,7 +4988,7 @@ dependencies = [
  "os_info",
  "portpicker",
  "predicates",
- "rand 0.9.0",
+ "rand",
  "rand_regex",
  "regex",
  "reqwest 0.12.12",
@@ -4906,6 +4999,7 @@ dependencies = [
  "rover-std",
  "rover-studio",
  "rstest",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -4915,8 +5009,8 @@ dependencies = [
  "speculoos",
  "sputnik",
  "strsim 0.11.1",
- "strum 0.27.1",
- "strum_macros 0.27.1",
+ "strum",
+ "strum_macros",
  "tap",
  "tar",
  "temp-env",
@@ -4961,7 +5055,7 @@ dependencies = [
  "humantime",
  "hyper 1.6.0",
  "indoc",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "pretty_assertions",
  "regex",
  "reqwest 0.12.12",
@@ -5267,6 +5361,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,6 +5465,17 @@ name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5859,33 +5989,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
+ "strum_macros",
 ]
-
-[[package]]
-name = "strum"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 
 [[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6559,7 +6670,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "thiserror 1.0.69",
  "tinyvec",
@@ -6762,6 +6873,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6784,6 +6906,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -7403,16 +7531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
-dependencies = [
- "zerocopy-derive 0.8.20",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -7420,17 +7539,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7520,7 +7628,7 @@ dependencies = [
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "rand 0.8.5",
+ "rand",
  "sha1 0.10.6",
  "thiserror 2.0.11",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ git2 = { workspace = true, features = ["https"] }
 graphql-schema-diff = "=0.2.0"
 httpmock = { workspace = true }
 indoc = { workspace = true }
+jsonschema = "0.29.0"
 mime = "=0.3.17"
 mockall = "=0.13.1"
 portpicker = "=0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = "0.15.2"
+apollo-federation-types = { version = "0.15.2", features = ["json_schema"] }
 
 apollo-language-server = { version = "0.4.0", default-features = false, features = ["tokio"] }
 
@@ -86,7 +86,7 @@ base64 = "0.22"
 billboard = "0.2"
 buildstructor = "0.6.0"
 bytes = "1.8.0"
-cargo_metadata = "0.19"
+cargo_metadata = "0.18"
 calm_io = "0.1"
 camino = { version = "1", features = ["serde1"] }
 clap = "4"
@@ -100,7 +100,7 @@ directories-next = "2.0"
 flate2 = "1"
 futures = "0.3"
 git-url-parse = "0.4.5"
-git2 = { version = "0.20", default-features = false }
+git2 = { version = "0.19", default-features = false }
 graphql_client = "0.14"
 heck = "0.5"
 humantime = "2.1.0"
@@ -110,7 +110,7 @@ http-body-util = "0.1.2"
 httpmock = "0.7"
 hyper = "1.0"
 indoc = "2"
-itertools = "0.14.0"
+itertools = "0.13.0"
 lazycell = "1"
 lazy_static = "1.4"
 notify = { version = "8" }
@@ -122,6 +122,7 @@ pretty_assertions = "1"
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
 rstest = "0.24.0"
+schemars = "0.8.21"
 semver = "1"
 serial_test = "3"
 serde = "1.0"
@@ -132,8 +133,8 @@ shell-candy = "0.4"
 speculoos = "0.11.0"
 strip-ansi-escapes = "0.2"
 strsim = "0.11"
-strum = "0.27"
-strum_macros = "0.27"
+strum = "0.26"
+strum_macros = "0.26"
 sha2 = "0.10"
 shellexpand = "3.1"
 termcolor = "1.3"
@@ -197,6 +198,7 @@ rover-graphql = { workspace = true }
 rover-http = { workspace = true }
 rover-std = { workspace = true }
 rover-studio = { workspace = true }
+schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -237,8 +239,8 @@ mime = "=0.3.17"
 mockall = "=0.13.1"
 portpicker = "=0.1.1"
 predicates = { workspace = true }
-rand = "=0.9.0"
-rand_regex = "=0.18.0"
+rand = "=0.8.5"
+rand_regex = "=0.17.0"
 reqwest = { workspace = true, features = ["native-tls-vendored"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }

--- a/docs/source/commands/supergraphs.mdx
+++ b/docs/source/commands/supergraphs.mdx
@@ -229,3 +229,23 @@ We recommend updating to the latest version of Rover as soon as possible. If you
 |---|---|
 |&lt;= v0.2.x|&lt;= v0.38.x|
 |&gt;= v0.3.x|&gt;= v0.39.x|
+
+## Configuration awareness in your text editor
+
+### `supergraph config schema`
+
+You can use Rover to generate a JSON schema for config validation in your text editor. This schema helps you format the YAML file correctly and also provides content assist.
+
+Generate the schema with the following command:
+
+```bash
+rover supergraph config schema
+```
+
+After you generate the schema, configure your text editor. Here are the instructions for some commonly used editors:
+
+- [Visual Studio Code](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings)
+- [Emacs](https://emacs-lsp.github.io/lsp-mode/page/lsp-yaml)
+- [IntelliJ](https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas)
+- [Sublime](https://github.com/sublimelsp/LSP-yaml)
+- [Vim](https://github.com/Quramy/vison)

--- a/src/command/supergraph/config/mod.rs
+++ b/src/command/supergraph/config/mod.rs
@@ -1,0 +1,26 @@
+mod schema;
+
+use clap::Parser;
+use serde::Serialize;
+
+use crate::{RoverOutput, RoverResult};
+
+#[derive(Debug, Serialize, Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Serialize, Parser)]
+pub enum Command {
+    /// Print the Schema associated with the `supergraph.yaml` file for use in editors
+    Schema(schema::Schema),
+}
+
+impl Config {
+    pub fn run(&self) -> RoverResult<RoverOutput> {
+        match &self.command {
+            Command::Schema(command) => command.run(),
+        }
+    }
+}

--- a/src/command/supergraph/config/schema.rs
+++ b/src/command/supergraph/config/schema.rs
@@ -1,0 +1,18 @@
+use apollo_federation_types::config::SupergraphConfig;
+use clap::Parser;
+use schemars::schema_for;
+use serde::Serialize;
+
+use crate::{RoverOutput, RoverResult};
+
+#[derive(Debug, Serialize, Parser)]
+pub struct Schema {}
+
+impl Schema {
+    pub fn run(&self) -> RoverResult<RoverOutput> {
+        let schema = schema_for!(SupergraphConfig);
+        Ok(RoverOutput::JsonSchema(
+            serde_json::to_string_pretty(&schema).unwrap(),
+        ))
+    }
+}

--- a/src/command/supergraph/mod.rs
+++ b/src/command/supergraph/mod.rs
@@ -6,6 +6,7 @@ use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
 pub(crate) mod compose;
+mod config;
 mod fetch;
 
 #[derive(Debug, Serialize, Parser)]
@@ -18,6 +19,9 @@ pub struct Supergraph {
 pub enum Command {
     /// Locally compose supergraph SDL from a set of subgraph schemas
     Compose(compose::Compose),
+
+    /// Supergraph Config Schema commands
+    Config(config::Config),
 
     /// Fetch supergraph SDL from the graph registry
     Fetch(fetch::Fetch),
@@ -37,6 +41,7 @@ impl Supergraph {
                     .run(override_install_path, client_config, output_file)
                     .await
             }
+            Command::Config(command) => command.run(),
         }
     }
 }

--- a/tests/e2e/supergraph/config.rs
+++ b/tests/e2e/supergraph/config.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+use assert_cmd::cargo::CommandCargoExt;
+use rstest::rstest;
+use tracing::error;
+use tracing_test::traced_test;
+
+#[rstest]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+async fn e2e_test_rover_supergraph_config_schema() {
+    let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
+    cmd.args(["supergraph", "config", "schema"]);
+
+    let output = cmd.output().expect("Could not run command");
+    if !output.status.success() {
+        error!("{}", String::from_utf8(output.stderr).unwrap());
+        panic!("Command did not complete successfully");
+    }
+
+    let output = String::from_utf8(output.stdout).unwrap();
+    let json_schema = serde_json::from_str(&output).unwrap();
+    if !jsonschema::meta::is_valid(&json_schema) {
+        error!("{}", output);
+        panic!("Could not validate JSON Schema, incorrect schema printed above");
+    }
+}

--- a/tests/e2e/supergraph/mod.rs
+++ b/tests/e2e/supergraph/mod.rs
@@ -1,2 +1,3 @@
 mod compose;
+mod config;
 mod fetch;

--- a/tests/e2e/supergraph/print_json_schema.rs
+++ b/tests/e2e/supergraph/print_json_schema.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+use assert_cmd::cargo::CommandCargoExt;
+use rstest::rstest;
+use tracing::error;
+use tracing_test::traced_test;
+
+#[rstest]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+async fn e2e_test_rover_supergraph_print_json_schema() {
+    let mut cmd = Command::cargo_bin("rover").expect("Could not find necessary binary");
+    cmd.args(["supergraph", "print-json-schema"]);
+
+    let output = cmd.output().expect("Could not run command");
+    if !output.status.success() {
+        error!("{}", String::from_utf8(output.stderr).unwrap());
+        panic!("Command did not complete successfully");
+    }
+
+    let output = String::from_utf8(output.stdout).unwrap();
+    let json_schema = serde_json::from_str(&output).unwrap();
+    if !jsonschema::meta::is_valid(&json_schema) {
+        error!("{}", output);
+        panic!("Could not validate JSON Schema, incorrect schema printed above");
+    }
+}


### PR DESCRIPTION
This takes Dylan's work from #2139 and makes it work with the latest work in Rover

Essentially this allows us to take the work done in `apollo-federation-types` and expose it for others to consume in other IDEs etc.
