### PR TITLE
adds docs on using the native GitHub actions

### DIFF
--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -65,11 +65,61 @@ jobs:
 
 ### Displaying schema check results on GitHub pull requests
 
-If you use GitHub Actions to automatically run [schema checks](/graphos/delivery/schema-checks/) on every pull request ([as shown below](#full-example-1)), you can install the [Apollo Studio GitHub app](https://github.com/marketplace/apollo-studio) to provide links to the results of those checks alongside your other pull request checks:
+If you use GitHub Actions to automatically run [schema checks](/graphos/delivery/schema-checks/) on every pull request (as shown below), you can install the [Apollo Studio GitHub app](https://github.com/marketplace/apollo-studio) to provide links to the results of those checks alongside your other pull request checks:
 
 <img class="screenshot" src="./assets/checks-result.jpg" width="550"/>
 
 <SetApolloVCSCommit />
+
+### Apollo-provided GitHub Actions
+
+Apollo provides a GitHub Action to run Rover commands for all CI/CID-relevant commands. For full documentation of the parameters of the GitHub Action, see the [README within the repository](https://github.com/apollographql/rover-actions).
+
+#### Full example using the Apollo-provided GitHub Actions
+
+```yaml
+# .github/workflows/check.yml
+
+name: Check Schema
+
+# Controls when the action will run. Triggers the workflow on push or pull request events
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # https://docs.github.com/en/actions/reference/environments
+    environment: apollo
+
+    # https://docs.github.com/en/actions/reference/encrypted-secrets
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsenv
+    env:
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+      APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Installs Rover into $PATH for use with subsequent steps
+      - uses: apollographql/rover-actions/install-rover-cli@v1
+
+      # Only run this command with the `background` setting if you have the Apollo Studio GitHub integration enabled on your repository
+      - uses: apollographql/rover-actions/subgraph-check@v1
+        with:
+          apollo-key: ${{ secrets.APOLLO_KEY }}
+          # This could also be provided via an environment variable or GitHub Action variable
+          graph-ref: ${{ secrets.APOLLO_GRAPH_REF }}
+          name: subgraph-name
+          # If you use a code-first subgraph, you can generate the schema in another step for use with this action
+          schema: ./path/to/schema.graphql
+
+```
 
 ### Linux/MacOS jobs using the `curl` installer
 
@@ -85,12 +135,9 @@ echo "$HOME/.rover/bin" >> $GITHUB_PATH
 
 Because the `rover config auth` command is interactive, you need to [authenticate using an environment variable](./configuring#with-an-environment-variable) in your project settings.
 
-GitHub actions uses [project environments](https://docs.github.com/en/actions/reference/environments) to set up secret environment variables. In your action, you choose a `build.environment` by name and set `build.env` variables using the saved secrets.
+GitHub Actions uses [project environments](https://docs.github.com/en/actions/reference/environments) to set up secret environment variables. In your action, you choose a `build.environment` by name and set `build.env` variables using the saved secrets.
 
 </Note>
-
-The following is a full example script, showing how to choose an `apollo` environment and set an `APOLLO_KEY` variable:
-
 
 #### Full example
 
@@ -136,11 +183,6 @@ jobs:
           rover graph check my-graph@prod --schema ./test.graphql --background
 
 ```
-
-You can also use this [Apollo Solutions repository](https://github.com/apollosolutions/rover-actions) install Rover on GitHub action runners.
-Once installed, `rover` is added to `PATH`, so it can be used in subsequent steps.
-
-<SolutionsNote />
 
 ## Bitbucket Pipelines
 

--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -65,7 +65,7 @@ jobs:
 
 ### Displaying schema check results on GitHub pull requests
 
-If you use GitHub Actions to automatically run [schema checks](/graphos/delivery/schema-checks/) on every pull request (as shown below), you can install the [Apollo Studio GitHub app](https://github.com/marketplace/apollo-studio) to provide links to the results of those checks alongside your other pull request checks:
+If you use GitHub Actions to automatically run schema checks on every pull request as shown below, you can install the [Apollo Studio GitHub app](https://github.com/marketplace/apollo-studio) to provide links to the results of those checks alongside your other pull request checks:
 
 <img class="screenshot" src="./assets/checks-result.jpg" width="550"/>
 
@@ -73,7 +73,7 @@ If you use GitHub Actions to automatically run [schema checks](/graphos/delivery
 
 ### Apollo-provided GitHub Actions
 
-Apollo provides a GitHub Action to run Rover commands for all CI/CID-relevant commands. For full documentation of the parameters of the GitHub Action, see the [README within the repository](https://github.com/apollographql/rover-actions).
+Apollo provides a GitHub Action to run Rover commands for all CI/CD-relevant commands. For full documentation of the parameters of the GitHub Action, see the [README within the repository](https://github.com/apollographql/rover-actions).
 
 #### Full example using the Apollo-provided GitHub Actions
 


### PR DESCRIPTION
As we've moved the GitHub Actions into a more formally supported repo ([https://github.com/apollographql/rover-actions](https://github.com/apollographql/rover-actions)), this just updates the docs to point folks there vs. just the cURL example. 
