### PR TITLE
[ROVER-332] Patch => Rover does not pass `--log` level as indended to Router.

### DIFF
--- a/src/command/dev/router/binary.rs
+++ b/src/command/dev/router/binary.rs
@@ -200,7 +200,7 @@ where
                 "--config".to_string(),
                 self.config_path.to_string(),
                 "--log".to_string(),
-                "info".to_string(),
+                "trace".to_string(),
                 "--dev".to_string(),
             ];
 


### PR DESCRIPTION
This PR contains a simple patch that will repair the issue.  This solution will trigger verbose logging between Router and Rover; existing Rover functionality filters output to messages matching the user's `--log` level.

A more robust and efficient solution would set this value dynamically based on the current Rover log level, but I'm leaving that for a second iteration so we have a patch now if we want it.
