### PR TITLE
ROVER-332 Pass log_level through to Router binary

### DIFF
--- a/crates/timber/src/lib.rs
+++ b/crates/timber/src/lib.rs
@@ -3,18 +3,25 @@
 //! Defines the output format of traces, events, and spans produced
 //! by `env_logger`, `log`, and/or `tracing`.
 
-use clap::ValueEnum;
 use std::io;
+
+use clap::ValueEnum;
+pub use tracing_core::Level;
 use tracing_subscriber::fmt;
 
-pub use tracing_core::Level;
-
 #[derive(Clone, ValueEnum)]
-pub(crate) enum RoverLogLevel {
+/// Enum to describe the log levels that can be utilised by Rover, and by extension the Router
+/// binary run as part of rover dev
+pub enum RoverLogLevel {
+    /// Highest level logging, emits very large amounts of logs and may inhibit router performance
     Trace,
+    /// Emits many logs, which are useful for debugging
     Debug,
+    /// Default log level, emits useful user messages
     Info,
+    /// Only emits warning logs
     Warn,
+    /// Lowest log level, only emits error logs
     Error,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,27 +1,24 @@
+use std::fmt::Display;
+use std::{io, process};
+
 use camino::Utf8PathBuf;
 use clap::{Parser, ValueEnum};
-use lazycell::{AtomicLazyCell, LazyCell};
-use reqwest::Client;
-use serde::Serialize;
-
-use crate::command::{self, RoverOutput};
-use crate::options::OutputOpts;
-use crate::utils::{
-    client::{ClientBuilder, ClientTimeout, StudioClientConfig},
-    env::{RoverEnv, RoverEnvKey},
-    stringify::option_from_display,
-    version,
-};
-use crate::RoverResult;
-
 use config::Config;
 use houston as config;
+use lazycell::{AtomicLazyCell, LazyCell};
+use reqwest::Client;
 use rover_client::shared::GitContext;
+use serde::Serialize;
 use sputnik::Session;
 use timber::Level;
 
-use std::fmt::Display;
-use std::{io, process};
+use crate::command::{self, RoverOutput};
+use crate::options::OutputOpts;
+use crate::utils::client::{ClientBuilder, ClientTimeout, StudioClientConfig};
+use crate::utils::env::{RoverEnv, RoverEnvKey};
+use crate::utils::stringify::option_from_display;
+use crate::utils::version;
+use crate::RoverResult;
 
 #[derive(Debug, Serialize, Parser)]
 #[command(
@@ -185,7 +182,11 @@ impl Rover {
             Command::Contract(command) => command.run(self.get_client_config()?).await,
             Command::Dev(command) => {
                 command
-                    .run(self.get_install_override_path()?, self.get_client_config()?)
+                    .run(
+                        self.get_install_override_path()?,
+                        self.get_client_config()?,
+                        self.log_level,
+                    )
                     .await
             }
             Command::Supergraph(command) => {

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -8,6 +8,7 @@ use futures::StreamExt;
 use rover_client::RoverClientError;
 use rover_std::{errln, infoln, warnln};
 use semver::Version;
+use timber::Level;
 use tower::ServiceExt;
 
 use super::version_upgrade_message::VersionUpgradeMessage;
@@ -37,6 +38,7 @@ impl Dev {
         &self,
         override_install_path: Option<Utf8PathBuf>,
         client_config: StudioClientConfig,
+        log_level: Option<Level>,
     ) -> RoverResult<RoverOutput> {
         VersionUpgradeMessage::print();
         warnln!(
@@ -269,6 +271,7 @@ impl Dev {
                 self.opts.plugin_opts.profile.clone(),
                 home_override,
                 api_key_override,
+                log_level,
             )
             .await?
             .watch_for_changes(write_file_impl, composition_messages, hot_reload_overrides)

--- a/src/command/dev/no_dev.rs
+++ b/src/command/dev/no_dev.rs
@@ -1,15 +1,17 @@
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
+use timber::Level;
 
-use crate::{
-    command::dev::Dev, utils::client::StudioClientConfig, RoverError, RoverOutput, RoverResult,
-};
+use crate::command::dev::Dev;
+use crate::utils::client::StudioClientConfig;
+use crate::{RoverError, RoverOutput, RoverResult};
 
 impl Dev {
     pub async fn run(
         &self,
         _override_install_path: Option<Utf8PathBuf>,
         _client_config: StudioClientConfig,
+        _log_level: Option<Level>,
     ) -> RoverResult<RoverOutput> {
         Err(RoverError::new(anyhow!(
             "rover dev is not supported on this platform"

--- a/src/command/dev/router/binary.rs
+++ b/src/command/dev/router/binary.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use rover_std::{infoln, warnln, Style};
 use semver::Version;
 use tap::TapFallible;
+use timber::Level;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Child;
 use tokio_util::sync::CancellationToken;
@@ -175,6 +176,7 @@ pub struct RunRouterBinary<Spawn: Send> {
     home_override: Option<String>,
     api_key_override: Option<String>,
     spawn: Spawn,
+    log_level: Option<Level>,
 }
 
 impl<Spawn> SubtaskHandleUnit for RunRouterBinary<Spawn>
@@ -200,7 +202,7 @@ where
                 "--config".to_string(),
                 self.config_path.to_string(),
                 "--log".to_string(),
-                "info".to_string(),
+                self.log_level.unwrap_or(Level::INFO).to_string(),
                 "--dev".to_string(),
             ];
 

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -7,6 +7,7 @@ use futures::StreamExt;
 use rover_client::shared::GraphRef;
 use rover_client::RoverClientError;
 use rover_std::{debugln, errln, infoln, RoverStdError};
+use timber::Level;
 use tokio::process::Child;
 use tokio::time::sleep;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -145,6 +146,7 @@ impl RunRouter<state::Run> {
         profile: ProfileOpt,
         home_override: Option<String>,
         api_key_override: Option<String>,
+        log_level: Option<Level>,
     ) -> Result<RunRouter<state::Watch>, RunRouterBinaryError>
     where
         Spawn: Service<ExecCommandConfig, Response = Child> + Send + Clone + 'static,
@@ -214,6 +216,7 @@ impl RunRouter<state::Run> {
             .and_home_override(home_override)
             .and_api_key_override(api_key_override)
             .profile(profile)
+            .and_log_level(log_level)
             .spawn(spawn)
             .build();
 


### PR DESCRIPTION
We already capture the log level as a CLI argument, so pass this through to the Router so we can control logs there too.