### PR TITLE
Add Apollo Router 2.x dependency to renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,8 +47,9 @@
       "automerge": false
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "^latest_plugin_versions\\.json$"
       ],
@@ -59,6 +60,18 @@
       "datasourceTemplate": "github-releases",
     },
     {
+      "customType": "regex",
+      "fileMatch": [
+        "^latest_plugin_versions\\.json$"
+      ],
+      "matchStrings": [
+        "\"router\"(.|\\s)*?\"latest-2\": \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "apollographql/router",
+      "datasourceTemplate": "github-releases",
+    },
+    {
+      "customType": "regex",
       "fileMatch": ["^latest_plugin_versions\\.json$"],
       "matchStrings": [
         "\"supergraph\"(.|\\s)*?\"latest-2\": \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Fix formatting of table output by `rover config whoami` - @pubmodmatt PR #2413**
 
+## 🛠 Maintenance
+
+- **Add Apollo Router 2.x dependency to renovate - @pubmodmatt PR #2430**
+
+  Migrate renovate configuration from `regexManagers` to `customManagers`. Add a custom regex manager for Router 2.x.
+
 # [0.27.2] - 2025-02-19
 
 ## 🐛 Fixes

--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -9,7 +9,8 @@
   "router": {
     "repository": "https://github.com/apollographql/router",
     "versions": {
-      "latest-1": "v1.61.0"
+      "latest-1": "v1.61.0",
+      "latest-2": "v2.0.0"
     }
   }
 }

--- a/tests/integration/installers/mod.rs
+++ b/tests/integration/installers/mod.rs
@@ -106,15 +106,25 @@ fn latest_plugins_are_valid_versions() {
         .get("versions")
         .expect("JSON malformed: `router.versions` did not exist");
 
-    let latest_router = router_versions
+    let latest_router_one = router_versions
         .get("latest-1")
         .expect("JSON malformed: `router.versions.latest-1` did not exist")
         .as_str()
         .expect("JSON malformed: `router.versions.latest-1` was not a string");
 
-    assert!(latest_router.starts_with('v'));
-    Version::parse(&latest_router.to_string()[1..])
+    assert!(latest_router_one.starts_with('v'));
+    Version::parse(&latest_router_one.to_string()[1..])
         .expect("JSON malformed: `router.versions.latest-1 was not valid semver");
+
+    let latest_router_two = router_versions
+        .get("latest-2")
+        .expect("JSON malformed: `router.versions.latest-2` did not exist")
+        .as_str()
+        .expect("JSON malformed: `router.versions.latest-2` was not a string");
+
+    assert!(latest_router_two.starts_with('v'));
+    Version::parse(&latest_router_two.to_string()[1..])
+        .expect("JSON malformed: `router.versions.latest-2 was not valid semver");
 
     let router_repository = Url::parse(
         router
@@ -146,10 +156,15 @@ fn latest_plugins_are_valid_versions() {
         url = &supergraph_release_url,
         version = &latest_federation_two
     );
-    let latest_router = format!(
+    let latest_router_one = format!(
         "{url}{version}/router-{version}-{arch}.tar.gz",
         url = &router_release_url,
-        version = &latest_router
+        version = &latest_router_one
+    );
+    let latest_router_two = format!(
+        "{url}{version}/router-{version}-{arch}.tar.gz",
+        url = &router_release_url,
+        version = &latest_router_two
     );
 
     let client = Client::new();
@@ -186,14 +201,25 @@ fn latest_plugins_are_valid_versions() {
             )
         });
     client
-        .get(&latest_router)
+        .get(&latest_router_one)
         .send()
-        .unwrap_or_else(|e| panic!("could not send HEAD request to {}: {}", &latest_router, e))
+        .unwrap_or_else(|e| panic!("could not send HEAD request to {}: {}", &latest_router_one, e))
         .error_for_status()
         .unwrap_or_else(|e| {
             panic!(
                 "HEAD request to {} failed with a status code: {}",
-                &latest_router, e
+                &latest_router_one, e
+            )
+        });
+    client
+        .get(&latest_router_two)
+        .send()
+        .unwrap_or_else(|e| panic!("could not send HEAD request to {}: {}", &latest_router_two, e))
+        .error_for_status()
+        .unwrap_or_else(|e| {
+            panic!(
+                "HEAD request to {} failed with a status code: {}",
+                &latest_router_two, e
             )
         });
 }

--- a/tests/integration/installers/mod.rs
+++ b/tests/integration/installers/mod.rs
@@ -203,7 +203,12 @@ fn latest_plugins_are_valid_versions() {
     client
         .get(&latest_router_one)
         .send()
-        .unwrap_or_else(|e| panic!("could not send HEAD request to {}: {}", &latest_router_one, e))
+        .unwrap_or_else(|e| {
+            panic!(
+                "could not send HEAD request to {}: {}",
+                &latest_router_one, e
+            )
+        })
         .error_for_status()
         .unwrap_or_else(|e| {
             panic!(
@@ -214,7 +219,12 @@ fn latest_plugins_are_valid_versions() {
     client
         .get(&latest_router_two)
         .send()
-        .unwrap_or_else(|e| panic!("could not send HEAD request to {}: {}", &latest_router_two, e))
+        .unwrap_or_else(|e| {
+            panic!(
+                "could not send HEAD request to {}: {}",
+                &latest_router_two, e
+            )
+        })
         .error_for_status()
         .unwrap_or_else(|e| {
             panic!(


### PR DESCRIPTION
* Add Apollo Router 2.x to `latest_plugin_versions.json`
* Migrate from `regexManagers` to `customManagers` in `renovate.json5`
* Add a custom `regex` manager for Apollo Router 2.x
* Add tests for Router 2.x

<!-- [ROVER-306] -->

[ROVER-306]: https://apollographql.atlassian.net/browse/ROVER-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ