### PR TITLE
Fix CI post update to Rustup 1.28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,7 @@ commands:
                   exit $LASTEXITCODE
             - run:
                 name: Configure rustup
-                command: rustup show active-toolchain || rustup toolchain install
+                command: rustup show active-toolchain; if ($LASTEXITCODE -ne 0) { rustup toolchain install }
             - run:
                 name: Configure cargo for Windows
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,6 +563,9 @@ commands:
                   & $installer_dir\rustup-init.exe --profile minimal -y
                   exit $LASTEXITCODE
             - run:
+                name: Configure rustup
+                command: rustup show active-toolchain || rustup toolchain install
+            - run:
                 name: Configure cargo for Windows
                 command: |
                   Set-Content -path "${Env:USERPROFILE}\.cargo\config.toml" @"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -537,7 +537,10 @@ commands:
                 version: << parameters.rust_channel >>
             - run:
                 name: Install specific rust toolchain
-                command: rustup target add $XTASK_TARGET
+                command: |
+                  rustup show active-toolchain || rustup toolchain install
+                  rustup target add $XTASK_TARGET
+
             - run:
                 name: Unset rustup override
                 command: rustup override unset

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -48,6 +48,7 @@ jobs:
       - if: ${{ matrix.compile_target.container == '' }}
         name: "Build binaries on host"
         run: |
+          rustup show active-toolchain || rustup toolchain install
           rustup target add ${{ matrix.compile_target.target }}
           cargo build --target ${{ matrix.compile_target.target }} --test e2e
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,6 +44,7 @@ jobs:
             yum -y install perl-core gcc openssl-devel openssl git
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             . "$HOME/.cargo/env"
+            rustup show active-toolchain || rustup toolchain install
             cargo build --target ${{ matrix.compile_target.target }} --test e2e
       - if: ${{ matrix.compile_target.container == '' }}
         name: "Build binaries on host"


### PR DESCRIPTION
As per https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html, rustup now won't automatically install the active toolchain if it's not installed. So we have to force it manually.
