### PR TITLE
Use Apollo Router 2.x by default

### DIFF
--- a/.github/workflows/run-smokes-on-pr.yml
+++ b/.github/workflows/run-smokes-on-pr.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ".github/scripts"
         run: |
           ls -al
-          JSON=$(source get_latest_x_versions.sh 1 apollographql router router latest-1 1)
+          JSON=$(source get_latest_x_versions.sh 1 apollographql router router latest-2 2)
           echo "router_versions=$JSON" >> "$GITHUB_OUTPUT"
       - name: "Get latest Supergraph Plugin versions"
         id: "supergraph-versions"

--- a/.github/workflows/run-smokes-scheduled.yml
+++ b/.github/workflows/run-smokes-scheduled.yml
@@ -18,7 +18,9 @@ jobs:
         name: "Install `semver` cli"
       - run: |
           ls -al
-          JSON=$(source get_latest_x_versions.sh 3 apollographql router router latest-1 1)
+          ROUTER1_VERSIONS=$(source get_latest_x_versions.sh 3 apollographql router router latest-1 1)
+          ROUTER2_VERSIONS=$(source get_latest_x_versions.sh 3 apollographql router router latest-2 2)
+          JSON=$(echo "$ROUTER1_VERSIONS $ROUTER2_VERSIONS" | jq -cs 'add')
           echo "router_versions=$JSON" >> "$GITHUB_OUTPUT"
         id: "router-versions"
         working-directory: ".github/scripts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [0.28.0] (unreleased) - 2025-mm-dd
 
+## 🚀 Features
+
+- **Default to Apollo Router 2.x for `rover dev` - @pubmodmatt PR #2433**
+
+  The default version of Apollo Router used by `rover dev` is now 2.x instead of 1.x. The default can be overridden by
+  setting `APOLLO_ROVER_DEV_ROUTER_VERSION`, for example `APOLLO_ROVER_DEV_ROUTER_VERSION=1.61.0`.
+
 ## 🐛 Fixes
 
 - **Fix formatting of table output by `rover config whoami` - @pubmodmatt PR #2413**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc933111fa54f7fb3002c4833d766b4806ac017edf06d4be54b73b8d90d2141c"
+checksum = "45af2904c14573bc1f44f346e3acabae1d6128ad249fda57673864d149d315fb"
 dependencies = [
  "apollo-compiler",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = { version = "0.15.2", features = ["json_schema"] }
+apollo-federation-types = { version = "0.15.3", features = ["json_schema"] }
 
 apollo-language-server = { version = "0.4.0", default-features = false, features = ["tokio"] }
 

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -146,7 +146,7 @@ impl Dev {
 
         let router_version = match &*OVERRIDE_DEV_ROUTER_VERSION {
             Some(version) => RouterVersion::Exact(Version::parse(version)?),
-            None => RouterVersion::Latest,
+            None => RouterVersion::LatestTwo,
         };
 
         let api_key_override = match std::env::var(RoverEnvKey::Key.to_string()) {

--- a/src/command/dev/router/install.rs
+++ b/src/command/dev/router/install.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[fixture]
     fn router_version() -> RouterVersion {
-        RouterVersion::Latest
+        RouterVersion::LatestTwo
     }
 
     #[fixture]


### PR DESCRIPTION
* Rover will use Apollo Router 2.x by default for `rover dev`
* Smoke tests will now run against the latest Router 2.x version on each PR
* Nightly smoke tests will now run against the latest 3 versions of Router 1.x and Router 2.x