### PR TITLE
Replace backoff with backon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,16 +693,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
 dependencies = [
- "futures-core",
- "getrandom 0.2.15",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
+ "fastrand",
+ "gloo-timers",
  "tokio",
 ]
 
@@ -3110,15 +3107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5079,7 +5067,7 @@ dependencies = [
  "apollo-federation-types",
  "apollo-parser 0.8.4",
  "ariadne",
- "backoff",
+ "backon",
  "buildstructor",
  "camino",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ assert_cmd = "2"
 assert-json-diff = "2"
 async-trait = "0.1.83"
 backtrace = "0.3"
-backoff = { version = "0.4", features = ["tokio"] }
+backon = { version = "1.4.0", features = ["std", "tokio-sleep"] }
 base64 = "0.22"
 billboard = "0.2"
 buildstructor = "0.6.0"

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -12,7 +12,7 @@ ariadne = { workspace = true }
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
 apollo-encoder = { workspace = true }
-backoff = { workspace = true, features = ["tokio", "futures"] }
+backon = { workspace = true }
 buildstructor = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 comfy-table = { workspace = true, features = ["custom_styling"]}

--- a/crates/rover-client/readme.md
+++ b/crates/rover-client/readme.md
@@ -21,11 +21,11 @@ Retries can happen for two broad reasons: either the client failed or the server
 
 Retries are also only part of the story. The interval of time you place between retries matters. If you retry all at once, you might get rate-limited or otherwise fail. It's best to spread them out exponentially, adding big chunks of time so that the server can complete its work and get ready for more work. Spreading out retries is a good idea, but if you have multiple calls happening at the same time with the same spread, they might fail if the server is overloaded. It's better to spread them out with some added noise, meaning that you spread them out with some randomly generated bit of time added or subtracted so that calls are received by the server in a somewhat distributed fashion.
 
-#### `backoff` crate
+#### `backon` crate
 
-We use the [backoff](https://docs.rs/backoff/latest/backoff/) crate for retries. It builds in both the spreading-out of retries in an exponential way, but also the little bit of jitter that helps the server handle many requests.
+We use the [backon](https://crates.io/crates/backon) crate for retries with exponential backoff and jitter.
 
-The crate is interesting in handling retries not by a total amount of retries, but total amount of time. The `MAX_ELAPSED_TIME` in the client file sets this value and defaults to 10s.
+Retries are limited based on the total duration of the retries. The `MAX_ELAPSED_TIME` in the client file sets this value and defaults to 10s.
 
 #### Client failures
 

--- a/deny.toml
+++ b/deny.toml
@@ -26,12 +26,7 @@ ignore = [
     # `yaml-rust`, a dependency of `apollo-federation-types` via `serde_yaml`, is unmaintained. Represents no
     # security risk to us at present, and when/if `apollo-federation-types` decides to move their YAML
     # library else where we can remove this.
-    "RUSTSEC-2024-0320",
-    # `instant` is now unmaintained. We depend on this in two ways, once via notify and then also via backoff.
-    # Notify have already merged a PR to produce a version that does not contain this vulnerability, but
-    # we need to wait till this is released before we can upgrade. Until then we can safely ignore
-    # this.
-    "RUSTSEC-2024-0384"
+    "RUSTSEC-2024-0320"
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Replace [backoff](https://docs.rs/backoff/latest/backoff) with [backon](https://docs.rs/backoff/latest/backon). This resolves two security advisories for unmaintained dependency crates:

* [RUSTSEC-2025-0012](https://rustsec.org/advisories/RUSTSEC-2025-0012) - `backoff`
* [RUSTSEC-2024-0384](https://rustsec.org/advisories/RUSTSEC-2024-0384) - `instant` (was only used through `backoff`)
