### PR TITLE
Fix telemetry reporting for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,3 +249,8 @@ speculoos = { workspace = true }
 tower-test = { workspace = true }
 tracing-test = { workspace = true }
 temp-env = { version = "=0.3.6", features = ["async_closure"] }
+
+# For sputnik, run tests with debug_assertions disabled. This is necessary because telemetry is not sent if
+# debug_assertions is enabled, and the tests rely on telemetry being sent to mock APIs.
+[profile.test.package.sputnik]
+debug-assertions = false

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -17,8 +17,9 @@ use std::time::Duration;
 
 use crate::{Report, SputnikError};
 
-// set timeout to 100 ms to prevent blocking for too long on reporting; 30ms p99
-const REPORT_TIMEOUT: Duration = Duration::from_millis(100);
+/// Timeout for reporting telemetry. Note that this includes the entire time to make the request
+/// and receive the response, including on the client side. This is not just the server latency.
+const REPORT_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// The Session represents a usage of the CLI analogous to a web session
 /// It contains the "url" (command path + flags) but doesn't contain any
@@ -141,8 +142,9 @@ impl Session {
     /// sends anonymous usage data to the endpoint defined in ReportingInfo.
     pub async fn report(&self) -> Result<(), SputnikError> {
         // TODO: consider whether we want to disable non-production telemetry or at least document
-        // the reasoning for not using it
-        if !cfg!(debug_assertions) && !cfg!(test) {
+        //  the reasoning for not using it
+        if cfg!(debug_assertions) || cfg!(test) {
+            tracing::debug!("Skipping telemetry reporting");
             return Ok(());
         }
         if self.reporting_info.is_telemetry_enabled {

--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -143,7 +143,7 @@ impl Session {
     pub async fn report(&self) -> Result<(), SputnikError> {
         // TODO: consider whether we want to disable non-production telemetry or at least document
         //  the reasoning for not using it
-        if cfg!(debug_assertions) || cfg!(test) {
+        if cfg!(debug_assertions) {
             tracing::debug!("Skipping telemetry reporting");
             return Ok(());
         }


### PR DESCRIPTION
Surprisingly, it appears that rover telemetry reporting has been broken since July 2024 with #1947 and version [v0.24.0](https://github.com/apollographql/rover/releases/tag/v0.24.0).

Due to a logic error, **it was only reporting telemetry for debug builds**. Release builds were skipping the telemetry reporting.

Metrics back this up - we see a high volume of usage of versions 0.23.0 and earlier, but metrics from later releases show far lower usage (just debug builds, presumably).

Additionally, when telemetry *was* enabled (previously only in debug builds), the timeout was too low, causing it to fail much of the time. #1947 lowered this timeout from 4 seconds to 100ms. Since telemetry is best effort, this silently failed unless debug logging was enabled.

The logic error has been fixed, a new debug message is emitted if telemetry is skipped (allowing verification that this now only occurs in debug builds), and the timeout has been increased to 500ms.

Verification of fix:

```console
cargo run -- config whoami -l DEBUG
...
DEBUG sputnik::session: Skipping telemetry reporting
```

```console
cargo run --release -- config whoami -l DEBUG
...
DEBUG sputnik::session: POSTing to https://rover.apollo.dev/telemetry
```