### PR TITLE
Remove redundant CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @apollographql/betelgeuse
-/docs/ @apollographql/docs @apollographql/betelgeuse
+* @apollographql/graph-tooling
+docs @apollographql/docs @apollographql/graph-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-* @apollographql/graph-tooling
-docs @apollographql/docs @apollographql/graph-tooling


### PR DESCRIPTION
#1965 introduced a duplicate CODEOWNERS file. Remove the duplicate file and update the remaining one with Graph Tooling ownership.