### PR TITLE
Fix curl installer anonymized usage collection message

### DIFF
--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -83,10 +83,10 @@ impl Install {
                     }
                 }
 
-                // these messages are duplicated in `installers/npm/install.js`
+                // these messages are duplicated in `installers/npm/binary.js`
                 // for the npm installer.
                 eprintln!(
-                        "If you would like to disable Rover's anonymized usage collection, you can set {}=1", RoverEnvKey::TelemetryDisabled
+                        "If you would like to disable Rover's anonymized usage collection, you can set {}=true", RoverEnvKey::TelemetryDisabled
                     );
                 eprintln!(
                     "You can check out our documentation at {}.",


### PR DESCRIPTION
Changes from #1873. The E2E tests in this repo are not currently configured to allow PRs from forks, due to the way they use secrets. For now, creating a new PR for these changes.