### PR TITLE
docs: update broken anchor to Gitlab CI/CD section

### DIFF
--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -12,7 +12,7 @@ Rover's installation is similar to many other CLI tools, but the recommended met
 * [GitHub](#github)
 * [Bitbucket Pipelines](#bitbucket-pipelines)
 * [Jenkins](#jenkins)
-* [Gitlab CI/CD](#gitlab-cicd)
+* [Gitlab CI/CD](#gitlab)
 
 If you're using Rover with a CI/CD provider not listed here, we'd love for you to share the steps by opening an [issue](https://github.com/apollographql/rover/issues/new/choose) or [pull request](https://github.com/apollographql/rover/compare).
 


### PR DESCRIPTION
takes from the fork in this PR so that CI can pass
https://github.com/apollographql/rover/pull/2458

This PR updates and corrects a broken anchor navigating to the Gitlab section of the CI/CD docs.