### PR TITLE
Adding prompt for project use case to init command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [features]
-default = ["composition-js", "init"]
+default = ["composition-js"]
 
 # this feature exists to enable composition
 # notably, it is disabled for x86_64-unknown-linux-musl builds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [features]
-default = ["composition-js"]
+default = ["composition-js", "init"]
 
 # this feature exists to enable composition
 # notably, it is disabled for x86_64-unknown-linux-musl builds

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -1,14 +1,19 @@
 use clap::Parser;
 use serde::Serialize;
-
-use crate::{RoverOutput, RoverResult};
+use crate::options::ProjectUseCaseOpt;
+use crate::{RoverResult, RoverOutput};
 
 #[derive(Debug, Serialize, Parser)]
-pub struct Init {}
+pub struct Init {
+    #[clap(flatten)]
+    use_case_options: ProjectUseCaseOpt,
+}
 
 impl Init {
     pub async fn run(&self) -> RoverResult<RoverOutput> {
         println!("\nWelcome! This command helps you initialize a new GraphQL API project using Apollo Federation with Apollo Router.\n");
+
+        let _ = self.use_case_options.get_or_prompt_use_case()?;
 
         Ok(RoverOutput::EmptySuccess)
     }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -18,11 +18,6 @@ impl Init {
         match use_case {
             ProjectUseCase::Connectors => println!("\nComing soon!\n"),
             ProjectUseCase::GraphQLTemplate => println!("\nComing soon!\n"),
-            _ => {
-                return Err(RoverError::new(anyhow!(
-                    "Unknown project use case selected."
-                )))
-            }
         }
 
         Ok(RoverOutput::EmptySuccess)

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -1,8 +1,8 @@
+use crate::options::{ProjectUseCase, ProjectUseCaseOpt};
+use crate::{RoverError, RoverOutput, RoverResult};
 use anyhow::anyhow;
 use clap::Parser;
 use serde::Serialize;
-use crate::options::{ProjectUseCaseOpt, ProjectUseCase};
-use crate::{RoverResult, RoverOutput, RoverError};
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Init {
@@ -17,9 +17,11 @@ impl Init {
         let use_case = self.use_case_options.get_or_prompt_use_case()?;
         match use_case {
             ProjectUseCase::Connectors => println!("\nComing soon!\n"),
-            ProjectUseCase::GraphQLTemplate =>  println!("\nComing soon!\n"),
+            ProjectUseCase::GraphQLTemplate => println!("\nComing soon!\n"),
             _ => {
-                return Err(RoverError::new(anyhow!("Unknown project use case selected.")))
+                return Err(RoverError::new(anyhow!(
+                    "Unknown project use case selected."
+                )))
             }
         }
 

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -1,7 +1,8 @@
+use anyhow::anyhow;
 use clap::Parser;
 use serde::Serialize;
-use crate::options::ProjectUseCaseOpt;
-use crate::{RoverResult, RoverOutput};
+use crate::options::{ProjectUseCaseOpt, ProjectUseCase};
+use crate::{RoverResult, RoverOutput, RoverError};
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Init {
@@ -13,7 +14,14 @@ impl Init {
     pub async fn run(&self) -> RoverResult<RoverOutput> {
         println!("\nWelcome! This command helps you initialize a new GraphQL API project using Apollo Federation with Apollo Router.\n");
 
-        let _ = self.use_case_options.get_or_prompt_use_case()?;
+        let use_case = self.use_case_options.get_or_prompt_use_case()?;
+        match use_case {
+            ProjectUseCase::Connectors => println!("\nComing soon!\n"),
+            ProjectUseCase::GraphQLTemplate =>  println!("\nComing soon!\n"),
+            _ => {
+                return Err(RoverError::new(anyhow!("Unknown project use case selected.")))
+            }
+        }
 
         Ok(RoverOutput::EmptySuccess)
     }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -1,6 +1,5 @@
 use crate::options::{ProjectUseCase, ProjectUseCaseOpt};
-use crate::{RoverError, RoverOutput, RoverResult};
-use anyhow::anyhow;
+use crate::{RoverOutput, RoverResult};
 use clap::Parser;
 use serde::Serialize;
 

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -11,6 +11,8 @@ mod profile;
 mod schema;
 mod subgraph;
 mod template;
+#[cfg(feature = "init")]
+mod project_use_case;
 
 pub(crate) use check::*;
 pub(crate) use compose::*;
@@ -25,3 +27,5 @@ pub(crate) use profile::*;
 pub(crate) use schema::*;
 pub(crate) use subgraph::*;
 pub(crate) use template::*;
+#[cfg(feature = "init")]
+pub(crate) use project_use_case::*;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -8,11 +8,11 @@ mod lint;
 mod output;
 mod persisted_queries;
 mod profile;
+#[cfg(feature = "init")]
+mod project_use_case;
 mod schema;
 mod subgraph;
 mod template;
-#[cfg(feature = "init")]
-mod project_use_case;
 
 pub(crate) use check::*;
 pub(crate) use compose::*;
@@ -24,8 +24,8 @@ pub(crate) use lint::*;
 pub(crate) use output::*;
 pub(crate) use persisted_queries::*;
 pub(crate) use profile::*;
+#[cfg(feature = "init")]
+pub(crate) use project_use_case::*;
 pub(crate) use schema::*;
 pub(crate) use subgraph::*;
 pub(crate) use template::*;
-#[cfg(feature = "init")]
-pub(crate) use project_use_case::*;

--- a/src/options/project_use_case.rs
+++ b/src/options/project_use_case.rs
@@ -29,7 +29,11 @@ impl ProjectUseCaseOpt {
         }
     }
 
-    pub fn handle_use_case_selection(&self, use_cases: &[ProjectUseCase], selection: Option<usize>) -> RoverResult<ProjectUseCase> {
+    pub fn handle_use_case_selection(
+        &self,
+        use_cases: &[ProjectUseCase],
+        selection: Option<usize>,
+    ) -> RoverResult<ProjectUseCase> {
         match selection {
             Some(index) => Ok(use_cases[index].clone()),
             None => Err(RoverError::new(anyhow!("No use case selected"))),

--- a/src/options/project_use_case.rs
+++ b/src/options/project_use_case.rs
@@ -9,7 +9,6 @@ use crate::{RoverResult, RoverError};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct ProjectUseCaseOpt {
-    /// Filter templates by the available use case
     #[arg(long = "project-use-case", value_enum)]
     pub project_use_case: Option<ProjectUseCase>,
 }

--- a/src/options/project_use_case.rs
+++ b/src/options/project_use_case.rs
@@ -1,0 +1,53 @@
+use clap::{Parser, ValueEnum};
+use std::fmt::{self, Display};
+use anyhow::anyhow;
+use console::Term;
+use dialoguer::Select;
+use serde::{Deserialize, Serialize};
+
+use crate::{RoverResult, RoverError};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Parser)]
+pub struct ProjectUseCaseOpt {
+    /// Filter templates by the available use case
+    #[arg(long = "project_use_case", value_enum)]
+    pub project_use_case: Option<ProjectUseCase>,
+}
+
+impl ProjectUseCaseOpt {
+    pub fn get_or_prompt_use_case(&self) -> RoverResult<ProjectUseCase> {
+        if let Some(project_use_case) = &self.project_use_case {
+            Ok(project_use_case.clone())
+        } else {
+            let use_cases = <ProjectUseCase as ValueEnum>::value_variants();
+
+            let selection = Select::new()
+                .with_prompt("? Select use case")
+                .items(use_cases)
+                .default(0)
+                .interact_on_opt(&Term::stderr())?;
+
+            match selection {
+                Some(index) => Ok(use_cases[index].clone()),
+                None => Err(RoverError::new(anyhow!("No use case selected"))),
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, clap::ValueEnum)]
+pub enum ProjectUseCase {
+    Connectors,
+    GraphQLTemplate,
+}
+
+impl Display for ProjectUseCase {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ProjectUseCase::*;
+        let readable = match self {
+            Connectors => "Connect one or more REST APIs",
+            GraphQLTemplate => "Start a GraphQL API with recommended libraries",
+        };
+        write!(f, "{}", readable)
+    }
+}

--- a/src/options/project_use_case.rs
+++ b/src/options/project_use_case.rs
@@ -25,10 +25,14 @@ impl ProjectUseCaseOpt {
                 .default(0)
                 .interact_on_opt(&Term::stderr())?;
 
-            match selection {
-                Some(index) => Ok(use_cases[index].clone()),
-                None => Err(RoverError::new(anyhow!("No use case selected"))),
-            }
+            self.handle_use_case_selection(use_cases, selection)
+        }
+    }
+
+    pub fn handle_use_case_selection(&self, use_cases: &[ProjectUseCase], selection: Option<usize>) -> RoverResult<ProjectUseCase> {
+        match selection {
+            Some(index) => Ok(use_cases[index].clone()),
+            None => Err(RoverError::new(anyhow!("No use case selected"))),
         }
     }
 }
@@ -65,5 +69,32 @@ mod tests {
         assert!(result.is_ok());
         let use_case = result.unwrap();
         assert_eq!(use_case, ProjectUseCase::Connectors);
+    }
+
+    #[test]
+    fn test_handle_use_case_selection_returns_use_case_with_some_selection() {
+        let instance = ProjectUseCaseOpt {
+            project_use_case: None,
+        };
+
+        let use_cases = <ProjectUseCase as ValueEnum>::value_variants();
+        let selection: usize = 0;
+        let result = instance.handle_use_case_selection(use_cases, Some(selection));
+
+        assert!(result.is_ok());
+        let use_case = result.unwrap();
+        assert_eq!(use_case, use_cases[selection].clone());
+    }
+
+    #[test]
+    fn test_handle_use_case_selection_returns_error_with_none_selection() {
+        let instance = ProjectUseCaseOpt {
+            project_use_case: None,
+        };
+
+        let use_cases = <ProjectUseCase as ValueEnum>::value_variants();
+        let result = instance.handle_use_case_selection(use_cases, None);
+
+        assert!(result.is_err());
     }
 }

--- a/src/options/project_use_case.rs
+++ b/src/options/project_use_case.rs
@@ -1,11 +1,10 @@
-use clap::{Parser, ValueEnum};
-use std::fmt::{self, Display};
+use crate::{RoverError, RoverResult};
 use anyhow::anyhow;
+use clap::{Parser, ValueEnum};
 use console::Term;
 use dialoguer::Select;
 use serde::{Deserialize, Serialize};
-
-use crate::{RoverResult, RoverError};
+use std::fmt::{self, Display};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct ProjectUseCaseOpt {

--- a/src/options/project_use_case.rs
+++ b/src/options/project_use_case.rs
@@ -10,7 +10,7 @@ use crate::{RoverResult, RoverError};
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct ProjectUseCaseOpt {
     /// Filter templates by the available use case
-    #[arg(long = "project_use_case", value_enum)]
+    #[arg(long = "project-use-case", value_enum)]
     pub project_use_case: Option<ProjectUseCase>,
 }
 
@@ -49,5 +49,23 @@ impl Display for ProjectUseCase {
             GraphQLTemplate => "Start a GraphQL API with recommended libraries",
         };
         write!(f, "{}", readable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_use_case_with_some_project_use_case() {
+        let instance = ProjectUseCaseOpt {
+            project_use_case: Some(ProjectUseCase::Connectors),
+        };
+
+        let result = instance.get_or_prompt_use_case();
+
+        assert!(result.is_ok());
+        let use_case = result.unwrap();
+        assert_eq!(use_case, ProjectUseCase::Connectors);
     }
 }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
Adding a select prompt to the `init` command that allows the user to select between connecting a REST API or starting with recommended GraphQL libraries.

Currently, selection is a no-op