### PR TITLE
Separating Fetching from writing templates to support confirmation of files before writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5012,6 +5012,7 @@ dependencies = [
  "heck 0.5.0",
  "houston",
  "http 1.3.1",
+ "http-body-util",
  "httpmock",
  "indoc",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ futures = { workspace = true }
 graphql_client = { workspace = true }
 heck = { workspace = true }
 http = { workspace = true }
+http-body-util = { workspace = true }
 houston = { workspace = true }
 itertools = { workspace = true }
 lazycell = { workspace = true }

--- a/crates/rover-http/src/lib.rs
+++ b/crates/rover-http/src/lib.rs
@@ -7,7 +7,8 @@ use std::{fmt::Debug, str::Utf8Error, time::Duration};
 use buildstructor::Builder;
 use bytes::Bytes;
 use derive_getters::Getters;
-use http_body_util::Full;
+
+pub use http_body_util::{Empty, Full};
 
 use tower::{timeout::error::Elapsed, util::BoxCloneService};
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,7 +211,7 @@ impl Rover {
                     )
                     .await
             }
-            Command::Template(command) => command.run(self.get_client_config()?).await,
+            Command::Template(command) => command.run().await,
             Command::Readme(command) => command.run(self.get_client_config()?).await,
             Command::Subgraph(command) => {
                 command

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -1,7 +1,14 @@
-use crate::options::{ProjectUseCase, ProjectUseCaseOpt};
+use crate::options::{ProjectUseCase, ProjectUseCaseOpt, TemplateFetcher};
 use crate::{RoverOutput, RoverResult};
+use camino::Utf8PathBuf;
 use clap::Parser;
+use itertools::Itertools;
+use rover_http::ReqwestService;
+use rover_std::infoln;
+use rover_std::prompt::prompt_confirm_default_yes;
 use serde::Serialize;
+use std::collections::HashSet;
+use std::env;
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Init {
@@ -13,12 +20,60 @@ impl Init {
     pub async fn run(&self) -> RoverResult<RoverOutput> {
         println!("\nWelcome! This command helps you initialize a new GraphQL API project using Apollo Federation with Apollo Router.\n");
 
+        let request_service = ReqwestService::builder().build()?;
+
         let use_case = self.use_case_options.get_or_prompt_use_case()?;
         match use_case {
-            ProjectUseCase::Connectors => println!("\nComing soon!\n"),
+            ProjectUseCase::Connectors => {
+                let repo_url = "https://github.com/apollographql/rover-connectors-starter/archive/refs/heads/main.tar.gz";
+                self.init_project(repo_url, request_service).await?;
+            }
             ProjectUseCase::GraphQLTemplate => println!("\nComing soon!\n"),
         }
 
         Ok(RoverOutput::EmptySuccess)
+    }
+
+    fn prompt_creation(&self, artifacts: Vec<String>) -> std::io::Result<bool> {
+        infoln!("The following files will be created:");
+        let mut top_level_artifacts = HashSet::new();
+        artifacts
+            .iter()
+            .filter(|path| path.matches('/').count() == 1 || path.matches('/').count() == 0)
+            .sorted()
+            .for_each(|path| {
+                top_level_artifacts.insert(path.clone());
+            });
+
+        for artifact in top_level_artifacts {
+            infoln!("{}", artifact);
+        }
+        println!();
+
+        prompt_confirm_default_yes("Proceed with creation?")
+    }
+
+    async fn init_project(&self, repo_url: &str, http_service: ReqwestService) -> RoverResult<()> {
+        let fetcher = TemplateFetcher::new(repo_url.parse()?, http_service).await?;
+        let current_dir = env::current_dir()?;
+        let current_dir = Utf8PathBuf::from_path_buf(current_dir)
+            .map_err(|_| anyhow::anyhow!("Failed to parse current directory"))?;
+
+        //at this point, we have the compressed bytes in the fetcher
+        // we can do here other prep work below
+
+        // once all the work is ready, confirm with user:
+        match self.prompt_creation(fetcher.list_files()?) {
+            Ok(result) => {
+                if result {
+                    fetcher.write_template(&current_dir)?;
+                } else {
+                    println!("Project creation canceled. You can run this command again anytime.");
+                }
+            }
+            Err(_) => Err(anyhow::anyhow!("Failed to prompt user for confirmation"))?,
+        }
+
+        Ok(())
     }
 }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -61,8 +61,8 @@ impl Init {
             .map_err(|_| anyhow::anyhow!("Failed to parse current directory"))?;
 
         let output_path = match env::var("INIT_OUTPUT_DIR") {
-            Ok(value) => { Utf8PathBuf::from(value)}
-            Err(_) => {current_dir}
+            Ok(value) => Utf8PathBuf::from(value),
+            Err(_) => current_dir,
         };
 
         //at this point, we have the compressed bytes in the fetcher

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -9,7 +9,6 @@ use rover_std::prompt::prompt_confirm_default_yes;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::env;
-use std::env::VarError;
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Init {

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -56,7 +56,9 @@ impl Init {
     }
 
     async fn init_project(&self, repo_url: &str, http_service: ReqwestService) -> RoverResult<()> {
-        let fetcher = TemplateFetcher::new(repo_url.parse()?, http_service).await?;
+        let template = TemplateFetcher::new(http_service)
+            .call(repo_url.parse()?)
+            .await?;
         let current_dir = env::current_dir()?;
         let current_dir = Utf8PathBuf::from_path_buf(current_dir)
             .map_err(|_| anyhow::anyhow!("Failed to parse current directory"))?;
@@ -87,10 +89,10 @@ impl Init {
         // we can do here other prep work below
 
         // once all the work is ready, confirm with user:
-        match self.prompt_creation(fetcher.list_files()?) {
+        match self.prompt_creation(template.list_files()?) {
             Ok(result) => {
                 if result {
-                    fetcher.write_template(&output_path)?;
+                    template.write_template(&output_path)?;
                 } else {
                     println!("Project creation canceled. You can run this command again anytime.");
                 }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -8,14 +8,16 @@ use rover_http::ReqwestService;
 use rover_std::infoln;
 use rover_std::prompt::prompt_confirm_default_yes;
 use serde::Serialize;
-use std::collections::HashSet;
-use std::env;
 use std::fs::read_dir;
+use std::{env, io};
 
 #[derive(Debug, Serialize, Parser)]
 pub struct Init {
     #[clap(flatten)]
     use_case_options: ProjectUseCaseOpt,
+
+    #[clap(long, hide(true))]
+    path: Option<Utf8PathBuf>,
 }
 
 impl Init {
@@ -28,7 +30,8 @@ impl Init {
         match use_case {
             ProjectUseCase::Connectors => {
                 let repo_url = "https://github.com/apollographql/rover-connectors-starter/archive/refs/heads/main.tar.gz";
-                self.init_project(repo_url, request_service).await?;
+                self.init_project(repo_url, request_service, self.path.clone())
+                    .await?;
             }
             ProjectUseCase::GraphQLTemplate => println!("\nComing soon!\n"),
         }
@@ -36,37 +39,41 @@ impl Init {
         Ok(RoverOutput::EmptySuccess)
     }
 
-    fn prompt_creation(&self, artifacts: Vec<String>) -> std::io::Result<bool> {
-        infoln!("The following files will be created:");
-        let mut top_level_artifacts = HashSet::new();
-        artifacts
-            .iter()
-            .filter(|path| path.matches('/').count() == 1 || path.matches('/').count() == 0)
-            .sorted()
-            .for_each(|path| {
-                top_level_artifacts.insert(path.clone());
-            });
+    fn prompt_creation(&self, artifacts: Vec<Utf8PathBuf>) -> io::Result<bool> {
+        println!("The following files will be created:");
+        let mut artifacts_sorted = artifacts;
+        artifacts_sorted.sort();
 
-        for artifact in top_level_artifacts {
-            infoln!("{}", artifact);
-        }
+        self.print_grouped_files(artifacts_sorted);
+
         println!();
-
         prompt_confirm_default_yes("Proceed with creation?")
     }
 
-    async fn init_project(&self, repo_url: &str, http_service: ReqwestService) -> RoverResult<()> {
-        let template = TemplateFetcher::new(http_service)
-            .call(repo_url.parse()?)
-            .await?;
+    fn print_grouped_files(&self, artifacts: Vec<Utf8PathBuf>) {
+        for (_, files) in &artifacts
+            .into_iter()
+            .chunk_by(|artifact| artifact.parent().map(|p| p.to_owned()))
+        {
+            for file in files {
+                if file.file_name().is_some() {
+                    infoln!("{}", file);
+                }
+            }
+        }
+    }
+
+    async fn init_project(
+        &self,
+        repo_url: &str,
+        http_service: ReqwestService,
+        output_path: Option<Utf8PathBuf>,
+    ) -> RoverResult<()> {
         let current_dir = env::current_dir()?;
         let current_dir = Utf8PathBuf::from_path_buf(current_dir)
             .map_err(|_| anyhow::anyhow!("Failed to parse current directory"))?;
 
-        let output_path = match env::var("INIT_OUTPUT_DIR") {
-            Ok(value) => Utf8PathBuf::from(value),
-            Err(_) => current_dir,
-        };
+        let output_path = output_path.unwrap_or(current_dir);
 
         //TODO: move this in favor of the template command handling
         match read_dir(&output_path) {
@@ -75,7 +82,8 @@ impl Init {
                     return Err(RoverError::new(anyhow!(
                         "Cannot initialize the project because the '{}' directory is not empty.",
                         &output_path
-                    )).with_suggestion(RoverErrorSuggestion::Adhoc(
+                    ))
+                    .with_suggestion(RoverErrorSuggestion::Adhoc(
                         "Please run Init on an empty directory".to_string(),
                     )));
                 }
@@ -83,8 +91,9 @@ impl Init {
             _ => {} // we could handle not found here but for init is unlikely. Also, this block will be removed once we start using the template code
         }
 
-        //at this point, we have the compressed bytes in the fetcher
-        // we can do here other prep work below
+        let template = TemplateFetcher::new(http_service)
+            .call(repo_url.parse()?)
+            .await?;
 
         // once all the work is ready, confirm with user:
         match self.prompt_creation(template.list_files()?) {

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -72,14 +72,12 @@ impl Init {
         match read_dir(&output_path) {
             Ok(mut dir) => {
                 if dir.next().is_some() {
-                    let mut err = RoverError::new(anyhow!(
+                    return Err(RoverError::new(anyhow!(
                         "Cannot initialize the project because the '{}' directory is not empty.",
                         &output_path
-                    ));
-                    err.set_suggestion(RoverErrorSuggestion::Adhoc(
+                    )).with_suggestion(RoverErrorSuggestion::Adhoc(
                         "Please run Init on an empty directory".to_string(),
-                    ));
-                    return Err(err);
+                    )));
                 }
             }
             _ => {} // we could handle not found here but for init is unlikely. Also, this block will be removed once we start using the template code

--- a/src/command/template/mod.rs
+++ b/src/command/template/mod.rs
@@ -9,7 +9,7 @@ pub use r#use::Use;
 
 use clap::Parser;
 use serde::Serialize;
-
+use rover_http::ReqwestService;
 use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
 
@@ -30,8 +30,11 @@ enum Command {
 
 impl Template {
     pub(crate) async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+
+        let request_service = ReqwestService::builder().build()?;
+        
         match &self.command {
-            Command::Use(use_template) => use_template.run(client_config).await,
+            Command::Use(use_template) => use_template.run(request_service).await,
             Command::List(list) => list.run().await,
         }
     }

--- a/src/command/template/mod.rs
+++ b/src/command/template/mod.rs
@@ -7,11 +7,10 @@ mod r#use;
 pub use list::List;
 pub use r#use::Use;
 
-use clap::Parser;
-use serde::Serialize;
-use rover_http::ReqwestService;
-use crate::utils::client::StudioClientConfig;
 use crate::{RoverOutput, RoverResult};
+use clap::Parser;
+use rover_http::ReqwestService;
+use serde::Serialize;
 
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct Template {
@@ -29,10 +28,9 @@ enum Command {
 }
 
 impl Template {
-    pub(crate) async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
-
+    pub(crate) async fn run(&self) -> RoverResult<RoverOutput> {
         let request_service = ReqwestService::builder().build()?;
-        
+
         match &self.command {
             Command::Use(use_template) => use_template.run(request_service).await,
             Command::List(list) => list.run().await,

--- a/src/command/template/use.rs
+++ b/src/command/template/use.rs
@@ -32,9 +32,6 @@ pub struct Use {
     path: Option<Utf8PathBuf>,
 }
 
-// Steps:
-// 1. Download the template from repo
-
 impl Use {
     pub async fn run(&self, request_service: ReqwestService) -> RoverResult<RoverOutput> {
         // find the template to extract

--- a/src/command/template/use.rs
+++ b/src/command/template/use.rs
@@ -62,8 +62,10 @@ impl Use {
         let path = self.get_or_prompt_path()?;
 
         // download and extract a tarball from github
-        let fetcher = TemplateFetcher::new(download_url.as_str().parse()?, request_service).await?;
-        fetcher.write_template(&path)?;
+        let template = TemplateFetcher::new(request_service)
+            .call(download_url.as_str().parse()?)
+            .await?;
+        template.write_template(&path)?;
         Ok(RoverOutput::TemplateUseSuccess { template_id, path })
     }
 

--- a/src/command/template/use.rs
+++ b/src/command/template/use.rs
@@ -3,15 +3,15 @@ use std::{
     io::{self, IsTerminal},
 };
 
+use crate::cli::Rover;
+use crate::options::{TemplateFetcher, TemplateOpt};
+use crate::{RoverError, RoverErrorSuggestion, RoverOutput, RoverResult};
 use anyhow::{anyhow, Context};
 use camino::Utf8PathBuf;
 use clap::{error::ErrorKind as ClapErrorKind, CommandFactory, Parser};
 use dialoguer::Input;
-use serde::Serialize;
 use rover_http::ReqwestService;
-use crate::cli::Rover;
-use crate::options::{extract_tarball, TemplateOpt};
-use crate::{RoverError, RoverErrorSuggestion, RoverOutput, RoverResult};
+use serde::Serialize;
 
 use super::templates::{get_template, get_templates_for_language, selection_prompt};
 
@@ -62,8 +62,8 @@ impl Use {
         let path = self.get_or_prompt_path()?;
 
         // download and extract a tarball from github
-        extract_tarball(download_url.as_str().parse()?, &path, request_service).await?;
-
+        let fetcher = TemplateFetcher::new(download_url.as_str().parse()?, request_service).await?;
+        fetcher.write_template(&path)?;
         Ok(RoverOutput::TemplateUseSuccess { template_id, path })
     }
 

--- a/src/options/template.rs
+++ b/src/options/template.rs
@@ -87,6 +87,8 @@ impl TemplateFetcher {
         Ok(())
     }
 
+    // this is only used by init behind feature flag
+    #[allow(dead_code)]
     pub fn list_files(&self) -> RoverResult<Vec<String>> {
         let cursor = Cursor::new(&self.contents);
         let tar = flate2::read::GzDecoder::new(cursor);

--- a/src/options/template.rs
+++ b/src/options/template.rs
@@ -99,7 +99,7 @@ impl TemplateProject {
     }
 
     // this is only used by init behind feature flag
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "init"), allow(dead_code))]
     pub fn list_files(&self) -> RoverResult<Vec<String>> {
         let cursor = Cursor::new(&self.contents);
         let tar = flate2::read::GzDecoder::new(cursor);


### PR DESCRIPTION
### Summary
The PR introduces functionality for downloading and extracting template files and modifies several commands to integrate with this feature.

The main motivation for the separation of fetching vs writing the contents is to allow an additional feature to display the files for those commands where the user needs to confirm the operations to execute, including what files will be written. This is also a stepping stone to move parts of rover template to a common place so that they can be used by both commands.

### Main Changes

- Updated rover-http to export additional utilities (Empty, Full) from http-body-util. 
- Modified the CLI and Template commands to utilize a new ReqwestService for HTTP requests.
- Implemented a new TemplateFetcher utility for handling template file downloads and extraction.
- Refactored Init and Template commands to use the new TemplateFetcher
- Introduced a new environment variable INIT_OUTPUT_DIR to control when testing where is the init project created. Since init will be forced to be created in the current_dir when running through cargo this is not possible as the directory will never be empty. Having an env variable feels much simpler. 

Thanks to @aaronArinder and @dotdat  for the help

### Testing
I executed the following test scenarios:
| Scenario                                                         | 
|------------------------------------------------------------------|
| rover template use (with no args)                                | 
| rover template use <path>                                        | 
| rover template use --template                                    |   
| rover template use --template <id> <path>                        |  
| rover init (with connectors and saying no to creation)           |    
| INIT_OUTPUT_DIR=<path> rover init (with connectors and saying Y) | 

### Next steps:
- I'm working on adding proper unit testing to the new logic since all testing was done manually.
- Extract the template selection logic from the template command to a shared location to be used by both init and template. 