### PR TITLE
generating supergraph.yaml

### DIFF
--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -14,9 +14,6 @@ use clap::Parser;
 use rover_http::ReqwestService;
 use serde::Serialize;
 
-#[cfg(test)]
-pub mod tests;
-
 #[derive(Debug, Parser, Clone, Serialize)]
 #[clap(about = "Initialize a new GraphQL API project")]
 pub struct Init {

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -1,5 +1,6 @@
 use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
-use crate::RoverResult;
+use crate::{RoverError, RoverResult};
+use anyhow::format_err;
 use apollo_federation_types::config::{
     FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
 };
@@ -7,10 +8,10 @@ use camino::Utf8PathBuf;
 use itertools::Itertools;
 use rover_std::infoln;
 use rover_std::prompt::prompt_confirm_default_yes;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
-use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
 
 pub struct TemplateOperations;
 
@@ -38,91 +39,292 @@ impl TemplateOperations {
             }
         }
     }
+}
 
-    pub fn generate_supergraph(
-        output_dir: Utf8PathBuf,
-        subgraph: LazilyResolvedSubgraph,
+pub struct SupergraphBuilder {
+    directory: Utf8PathBuf,
+    max_depth: usize,
+}
+
+impl SupergraphBuilder {
+    pub fn new(directory: Utf8PathBuf, max_depth: usize) -> Self {
+        Self {
+            directory,
+            max_depth,
+        }
+    }
+
+    /*
+       In this fn we collect all graphql schemas found in the directory,
+       also try to disambiguate names in case that they end up being duplicate
+       by counting all resolved names to make sure there are no duplicates,
+       depending on the structure of the project, there is a chance that if we only use
+       the parent for naming, there might be duplicates. for example
+       /root
+         /products
+           /model
+             /schema.graphql
+         /services
+           /model
+             /schema.graphql
+    */
+    fn generate_subgraphs(&self) -> RoverResult<BTreeMap<String, SubgraphConfig>> {
+        let mut subgraphs = BTreeMap::new();
+        let mut name_counts = HashMap::new();
+
+        // Collect all graphql schemas
+        let graphql_files = self.find_graphql_files(&self.directory, self.max_depth)?;
+
+        if graphql_files.is_empty() {
+            return Err(RoverError::from(format_err!(
+                "No graphql files found in the directory"
+            )));
+        }
+
+        for file_path in &graphql_files {
+            let name = self.determine_subgraph_name(file_path)?;
+            *name_counts.entry(name).or_insert(0) += 1;
+        }
+
+        // create subgraphs with disambiguated names if needed
+        for file_path in graphql_files {
+            let basic_name = self.determine_subgraph_name(&file_path)?;
+
+            let name = if name_counts.get(&basic_name).unwrap_or(&0) > &1 {
+                self.disambiguate_name(&file_path, &basic_name)?
+            } else {
+                basic_name
+            };
+
+            // hardcoding for now, we need to find a
+            // way to resolve this for template based projects
+            let url = "http://ignore".to_string();
+
+            let subgraph = LazilyResolvedSubgraph::builder()
+                .name(name.clone())
+                .routing_url(url.clone())
+                .schema(SchemaSource::File {
+                    file: file_path.clone(),
+                })
+                .build();
+
+            subgraphs.insert(name, SubgraphConfig::from(subgraph));
+        }
+
+        Ok(subgraphs)
+    }
+
+    fn find_graphql_files(&self, dir: &Utf8PathBuf, max_depth: usize) -> RoverResult<Vec<PathBuf>> {
+        let mut graphql_files = Vec::new();
+        self.visit_dirs(dir.as_std_path(), 0, max_depth, &mut graphql_files)?;
+        Ok(graphql_files)
+    }
+
+    fn visit_dirs(
+        &self,
+        dir: &Path,
+        current_depth: usize,
+        max_depth: usize,
+        result: &mut Vec<PathBuf>,
     ) -> RoverResult<()> {
-        let mut subgraph_map = BTreeMap::new();
-        subgraph_map.insert(subgraph.name().clone(), SubgraphConfig::from(subgraph));
+        if current_depth > max_depth {
+            return Ok(());
+        }
 
-        let supergraph = SupergraphConfig::new(subgraph_map, Some(FederationVersion::LatestFedTwo));
+        if dir.is_dir() {
+            for entry in fs::read_dir(dir)? {
+                let entry = entry?;
+                let path = entry.path();
 
-        let file_writer = File::create(output_dir.join("supergraph.yaml"))?;
-        serde_yaml::to_writer(file_writer, &supergraph)?;
+                if path.is_dir() {
+                    self.visit_dirs(&path, current_depth + 1, max_depth, result)?;
+                } else if self.is_graphql_file(&path) {
+                    let path =
+                        Self::strip_base_prefix(path.as_path(), self.directory.as_std_path());
+                    result.push(path);
+                }
+            }
+        }
+
         Ok(())
     }
 
-    pub fn create_subgraph_config(
-        url: String,
-        schema_file_path: String,
-        subgraph_name: String,
-    ) -> RoverResult<LazilyResolvedSubgraph> {
-        let schema_source = SchemaSource::File {
-            file: PathBuf::from(schema_file_path),
-        };
+    fn strip_base_prefix(path: &Path, base_prefix: &Path) -> PathBuf {
+        path.strip_prefix(base_prefix).unwrap().to_owned()
+    }
 
-        let subgraph = LazilyResolvedSubgraph::builder()
-            .routing_url(url)
-            .schema(schema_source)
-            .name(subgraph_name)
-            .build();
+    fn is_graphql_file(&self, path: &Path) -> bool {
+        if let Some(ext) = path.extension() {
+            ext == "graphql" || ext == "graphqls"
+        } else {
+            false
+        }
+    }
 
-        Ok(subgraph)
+    // If the file is named "schema", use parent directory name
+    fn determine_subgraph_name(&self, file_path: &Path) -> RoverResult<String> {
+        let file_stem = file_path.file_stem().unwrap().to_string_lossy();
+        if file_stem == "schema" {
+            let parent = file_path.parent().unwrap();
+            let parent_name = parent.file_name().unwrap().to_string_lossy();
+            Ok(parent_name.to_string())
+        } else {
+            Ok(file_stem.to_string())
+        }
+    }
+
+    // Use parent's parent directory name for disambiguation
+    fn disambiguate_name(&self, file_path: &Path, base_name: &str) -> RoverResult<String> {
+        let parent_parent = file_path.parent().and_then(|p| p.parent()).unwrap();
+        let parent_parent_name = parent_parent.file_name().unwrap().to_string_lossy();
+        Ok(format!("{}_{}", parent_parent_name, base_name))
+    }
+
+    pub fn build_supergraph(&self) -> RoverResult<SupergraphConfig> {
+        let subgraphs = self.generate_subgraphs()?;
+        Ok(SupergraphConfig::new(
+            subgraphs,
+            Some(FederationVersion::LatestFedTwo),
+        ))
+    }
+
+    pub fn build_and_write(&self) -> RoverResult<()> {
+        let supergraph = self.build_supergraph()?;
+        let output_path = self.directory.join("supergraph.yaml");
+        let mut file = File::create(output_path)?;
+        serde_yaml::to_writer(&mut file, &supergraph)?;
+
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use tempfile::tempdir;
 
-    #[test]
-    pub fn test_writing_supergraph_yaml_new() {
-        let subgraph = TemplateOperations::create_subgraph_config(
-            "http://localhost:4000".to_string(),
-            "test.graphql".to_string(),
-            "test".to_string(),
-        )
-        .unwrap();
+    // Helper function to create a GraphQL file in a temp directory
+    fn create_graphql_file(base_dir: &Path, rel_path: &str, content: &str) -> io::Result<()> {
+        let file_path = base_dir.join(rel_path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut file = File::create(file_path)?;
+        file.write_all(content.as_bytes())?;
 
-        let temp_dir = TempDir::new().unwrap();
-        let output_dir = Utf8PathBuf::from_path_buf(temp_dir.into_path()).unwrap();
-        let expected_path = output_dir.join("supergraph.yaml");
-
-        TemplateOperations::generate_supergraph(output_dir, subgraph).unwrap();
-
-        let supergraph_yaml_content = fs::read_to_string(expected_path).unwrap();
-        assert_eq!(
-            supergraph_yaml_content,
-            "subgraphs:\n  test:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n"
-        );
+        Ok(())
     }
 
     #[test]
-    pub fn test_writing_supergraph_yaml_replace_existing() {
-        let temp_dir = TempDir::new().unwrap();
-        let output_dir = Utf8PathBuf::from_path_buf(temp_dir.into_path()).unwrap();
-        let original_path = output_dir.join("supergraph.yaml");
-        let expected_path = original_path.clone();
+    fn test_root_level_files() -> io::Result<()> {
+        let temp_dir = tempdir()?;
+        let path = Utf8PathBuf::from_path_buf(temp_dir.path().to_owned()).unwrap();
 
-        let original = "subgraphs:\n  should_be_replaced:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n";
-        fs::write(original_path, original).unwrap();
+        // Create a single root level GraphQL file
+        create_graphql_file(
+            temp_dir.path(),
+            "services.graphql",
+            "type Service { id: ID! }",
+        )?;
 
-        let subgraph = TemplateOperations::create_subgraph_config(
-            "http://localhost:4000".to_string(),
-            "test.graphql".to_string(),
-            "test".to_string(),
-        )
-        .unwrap();
+        let supergraph_builder = SupergraphBuilder::new(path, 5);
 
-        TemplateOperations::generate_supergraph(output_dir, subgraph).unwrap();
+        supergraph_builder.build_and_write().unwrap();
+        let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let supergraph_yaml_content = fs::read_to_string(expected_path).unwrap();
-        assert_eq!(
-            supergraph_yaml_content,
-            "subgraphs:\n  test:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n"
-        );
+        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deep_nested_file() -> io::Result<()> {
+        let temp_dir = tempdir()?;
+        let path = Utf8PathBuf::from_path_buf(temp_dir.path().to_owned()).unwrap();
+
+        create_graphql_file(
+            temp_dir.path(),
+            "products/schema.graphql",
+            "type Product { id: ID! }",
+        )?;
+
+        let supergraph_builder = SupergraphBuilder::new(path, 5);
+
+        supergraph_builder.build_and_write().unwrap();
+        let expected = supergraph_builder.build_supergraph().unwrap();
+
+        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_deep_nested_file() -> io::Result<()> {
+        let temp_dir = tempdir()?;
+        let path = Utf8PathBuf::from_path_buf(temp_dir.path().to_owned()).unwrap();
+
+        create_graphql_file(
+            temp_dir.path(),
+            "products/schema.graphql",
+            "type Product { id: ID! }",
+        )?;
+
+        create_graphql_file(
+            temp_dir.path(),
+            "services/schema.graphql",
+            "type Service { id: ID! }",
+        )?;
+
+        let supergraph_builder = SupergraphBuilder::new(path, 5);
+
+        supergraph_builder.build_and_write().unwrap();
+        let expected = supergraph_builder.build_supergraph().unwrap();
+
+        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_disambiguation() -> io::Result<()> {
+        let temp_dir = tempdir()?;
+        let path = Utf8PathBuf::from_path_buf(temp_dir.path().to_owned()).unwrap();
+
+        create_graphql_file(
+            temp_dir.path(),
+            "products/model/schema.graphql",
+            "type Product { id: ID! }",
+        )?;
+
+        create_graphql_file(
+            temp_dir.path(),
+            "services/model/schema.graphql",
+            "type Service { id: ID! }",
+        )?;
+
+        create_graphql_file(
+            temp_dir.path(),
+            "billing/billing.graphql",
+            "type Billing { id: ID! }",
+        )?;
+
+        let supergraph_builder = SupergraphBuilder::new(path, 5);
+
+        supergraph_builder.build_and_write().unwrap();
+        let expected = supergraph_builder.build_supergraph().unwrap();
+
+        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        assert_eq!(actual, expected);
+
+        Ok(())
     }
 }

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -75,7 +75,8 @@ impl TemplateOperations {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, fs};
+    use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     pub fn test_writing_supergraph_yaml_new() {
@@ -86,13 +87,13 @@ mod tests {
         )
         .unwrap();
 
-        let temp_dir = env::temp_dir();
-        let output_dir = Utf8PathBuf::from_path_buf(temp_dir).unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = Utf8PathBuf::from_path_buf(temp_dir.into_path()).unwrap();
         let expected_path = output_dir.join("supergraph.yaml");
 
         TemplateOperations::generate_supergraph(output_dir, subgraph).unwrap();
 
-        let supergraph_yaml_content = std::fs::read_to_string(expected_path).unwrap();
+        let supergraph_yaml_content = fs::read_to_string(expected_path).unwrap();
         assert_eq!(
             supergraph_yaml_content,
             "subgraphs:\n  test:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n"
@@ -101,8 +102,8 @@ mod tests {
 
     #[test]
     pub fn test_writing_supergraph_yaml_replace_existing() {
-        let temp_dir = env::temp_dir();
-        let output_dir = Utf8PathBuf::from_path_buf(temp_dir).unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = Utf8PathBuf::from_path_buf(temp_dir.into_path()).unwrap();
         let original_path = output_dir.join("supergraph.yaml");
         let expected_path = original_path.clone();
 
@@ -118,7 +119,7 @@ mod tests {
 
         TemplateOperations::generate_supergraph(output_dir, subgraph).unwrap();
 
-        let supergraph_yaml_content = std::fs::read_to_string(expected_path).unwrap();
+        let supergraph_yaml_content = fs::read_to_string(expected_path).unwrap();
         assert_eq!(
             supergraph_yaml_content,
             "subgraphs:\n  test:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n"

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -1,8 +1,16 @@
+use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
+use crate::RoverResult;
+use apollo_federation_types::config::{
+    FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
+};
 use camino::Utf8PathBuf;
 use itertools::Itertools;
 use rover_std::infoln;
 use rover_std::prompt::prompt_confirm_default_yes;
+use std::collections::BTreeMap;
+use std::fs::File;
 use std::io;
+use std::path::PathBuf;
 
 pub struct TemplateOperations;
 
@@ -29,5 +37,91 @@ impl TemplateOperations {
                 }
             }
         }
+    }
+
+    pub fn generate_supergraph(
+        output_dir: Utf8PathBuf,
+        subgraph: LazilyResolvedSubgraph,
+    ) -> RoverResult<()> {
+        let mut subgraph_map = BTreeMap::new();
+        subgraph_map.insert(subgraph.name().clone(), SubgraphConfig::from(subgraph));
+
+        let supergraph = SupergraphConfig::new(subgraph_map, Some(FederationVersion::LatestFedTwo));
+
+        let file_writer = File::create(output_dir.join("supergraph.yaml"))?;
+        serde_yaml::to_writer(file_writer, &supergraph)?;
+        Ok(())
+    }
+
+    pub fn create_subgraph_config(
+        url: String,
+        schema_file_path: String,
+        subgraph_name: String,
+    ) -> RoverResult<LazilyResolvedSubgraph> {
+        let schema_source = SchemaSource::File {
+            file: PathBuf::from(schema_file_path),
+        };
+
+        let subgraph = LazilyResolvedSubgraph::builder()
+            .routing_url(url)
+            .schema(schema_source)
+            .name(subgraph_name)
+            .build();
+
+        Ok(subgraph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{env, fs};
+
+    #[test]
+    pub fn test_writing_supergraph_yaml_new() {
+        let subgraph = TemplateOperations::create_subgraph_config(
+            "http://localhost:4000".to_string(),
+            "test.graphql".to_string(),
+            "test".to_string(),
+        )
+        .unwrap();
+
+        let temp_dir = env::temp_dir();
+        let output_dir = Utf8PathBuf::from_path_buf(temp_dir).unwrap();
+        let expected_path = output_dir.join("supergraph.yaml");
+
+        TemplateOperations::generate_supergraph(output_dir, subgraph).unwrap();
+
+        let supergraph_yaml_content = std::fs::read_to_string(expected_path).unwrap();
+        assert_eq!(
+            supergraph_yaml_content,
+            "subgraphs:\n  test:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n"
+        );
+    }
+
+    #[test]
+    pub fn test_writing_supergraph_yaml_replace_existing() {
+        let temp_dir = env::temp_dir();
+        let output_dir = Utf8PathBuf::from_path_buf(temp_dir).unwrap();
+        let original_path = output_dir.join("supergraph.yaml");
+        let expected_path = original_path.clone();
+
+        let original = "subgraphs:\n  should_be_replaced:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n";
+        fs::write(original_path, original).unwrap();
+
+        let subgraph = TemplateOperations::create_subgraph_config(
+            "http://localhost:4000".to_string(),
+            "test.graphql".to_string(),
+            "test".to_string(),
+        )
+        .unwrap();
+
+        TemplateOperations::generate_supergraph(output_dir, subgraph).unwrap();
+
+        let supergraph_yaml_content = std::fs::read_to_string(expected_path).unwrap();
+        assert_eq!(
+            supergraph_yaml_content,
+            "subgraphs:\n  test:\n    routing_url: http://localhost:4000\n    schema:\n      file: test.graphql\nfederation_version: '2'\n"
+        );
     }
 }

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -231,7 +231,18 @@ impl CreationConfirmed {
         // (confirmation was done in the previous state)
         self.template.write_template(&self.output_path)?;
 
-        // Get the list of created files
+        let subgraph = match self.config.use_case {
+            ProjectUseCase::Connectors => TemplateOperations::create_subgraph_config(
+                String::from("http://ignore"),
+                String::from("products.graphql"),
+                String::from("schema"),
+            ),
+            ProjectUseCase::GraphQLTemplate => {
+                Err(anyhow!("GraphQL Template is coming soon!").into())
+            }
+        };
+        TemplateOperations::generate_supergraph(self.output_path, subgraph.unwrap())?;
+
         let artifacts = self.template.list_files()?;
 
         // TODO: Implement API key creation -- generate_api_key() is not implemented
@@ -244,6 +255,8 @@ impl CreationConfirmed {
                 .into())
             }
         };
+
+        // write supergraph.yaml
 
         Ok(ProjectCreated {
             config: self.config,

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -8,7 +8,7 @@ use rover_http::ReqwestService;
 use crate::command::init::config::ProjectConfig;
 use crate::command::init::helpers::*;
 use crate::command::init::states::*;
-use crate::command::init::template_operations::TemplateOperations;
+use crate::command::init::template_operations::{SupergraphBuilder, TemplateOperations};
 use crate::options::GraphIdOpt;
 use crate::options::ProjectNameOpt;
 use crate::options::ProjectUseCase;
@@ -231,17 +231,7 @@ impl CreationConfirmed {
         // (confirmation was done in the previous state)
         self.template.write_template(&self.output_path)?;
 
-        let subgraph = match self.config.use_case {
-            ProjectUseCase::Connectors => TemplateOperations::create_subgraph_config(
-                String::from("http://ignore"),
-                String::from("products.graphql"),
-                String::from("schema"),
-            ),
-            ProjectUseCase::GraphQLTemplate => {
-                Err(anyhow!("GraphQL Template is coming soon!").into())
-            }
-        };
-        TemplateOperations::generate_supergraph(self.output_path, subgraph.unwrap())?;
+        SupergraphBuilder::new(self.output_path, 5).build_and_write()?;
 
         let artifacts = self.template.list_files()?;
 
@@ -255,8 +245,6 @@ impl CreationConfirmed {
                 .into())
             }
         };
-
-        // write supergraph.yaml
 
         Ok(ProjectCreated {
             config: self.config,


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

## Summary

- Adding supergraph.yaml generation for local composition when using connectors template
- the generation works by scanning the output directory with the template and finding all files ending in graphql | graphqls and creating them as subgraphs in the supergraph up to a configurable level.
