### PR TITLE
Update openssl and tokio dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,7 +2749,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4137,9 +4137,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -4178,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -6387,9 +6387,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -26,11 +26,7 @@ ignore = [
     # `yaml-rust`, a dependency of `apollo-federation-types` via `serde_yaml`, is unmaintained. Represents no
     # security risk to us at present, and when/if `apollo-federation-types` decides to move their YAML
     # library else where we can remove this.
-    "RUSTSEC-2024-0320",
-    # `humantime` appears to be unmaintained. It is only used by the `graph check` and `subgraph check` commands to
-    # parse the `--validation-period` option. The format is highly specific, so switching to a different dependency
-    # could cause breaking changes.
-    "RUSTSEC-2025-0014"
+    "RUSTSEC-2024-0320"
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
* Update the `openssl` and `tokio` dependencies to resolve deny check failures
* Remove unneeded exemption for [RUSTSEC-2025-0014](https://rustsec.org/advisories/RUSTSEC-2025-0014), which was withdrawn