### PR TITLE
Fixing stripping of prefix on relative path

### DIFF
--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -55,18 +55,12 @@ impl SupergraphBuilder {
     }
 
     fn strip_base_prefix(&self, path: &Path, base_prefix: &Path) -> PathBuf {
-        if let Ok(stripped) = path.strip_prefix(base_prefix) {
-            stripped.to_owned()
-        } else {
-            let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-            let canonical_base = base_prefix
-                .canonicalize()
-                .unwrap_or_else(|_| base_prefix.to_path_buf());
-            canonical_path
-                .strip_prefix(canonical_base)
-                .unwrap()
-                .to_owned()
-        }
+        let canonical_base = base_prefix.canonicalize().unwrap();
+        let canonical_path = path.canonicalize().unwrap();
+        canonical_path
+            .strip_prefix(canonical_base.clone())
+            .unwrap()
+            .to_owned()
     }
 
     /*


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

When testing, we discovered that when providing a relative path (./) the base path will not be stripped and absolute path will be used. In this PR we fix it by canonicalize and removing the base path after.