### PR TITLE
bugfix(init): handle errors gracefully during graph creation

### DIFF
--- a/crates/rover-client/src/operations/init/create_graph/runner.rs
+++ b/crates/rover-client/src/operations/init/create_graph/runner.rs
@@ -29,18 +29,22 @@ pub async fn run(
 }
 
 fn build_response(data: ResponseData) -> Result<CreateGraphResponse, RoverClientError> {
-    let graph_response = data
-        .organization
-        .ok_or_else(|| RoverClientError::MalformedResponse {
-            null_field: "organization".to_string(),
-        })?
-        .create_graph;
+    let organization = data.organization.ok_or_else(|| RoverClientError::MalformedResponse {
+        null_field: "organization".to_string(),
+    })?;
+
+    let graph_response = organization.create_graph;
+
     match graph_response {
-        CreateGraphMutationOrganizationCreateGraph::Graph(graph) => Ok(CreateGraphResponse::from(
-            CreateGraphMutationOrganizationCreateGraph::Graph(graph),
-        )),
+        CreateGraphMutationOrganizationCreateGraph::Graph(graph) => {
+            Ok(CreateGraphResponse::from(
+                CreateGraphMutationOrganizationCreateGraph::Graph(graph),
+            ))
+        }
         CreateGraphMutationOrganizationCreateGraph::GraphCreationError(error) => {
-            Err(RoverClientError::GraphCreationError { msg: error.message })
+            Err(RoverClientError::GraphCreationError { 
+                msg: format!("Failed to create graph: {}", error.message)
+            })
         }
     }
 }

--- a/crates/rover-client/src/operations/init/create_graph/runner.rs
+++ b/crates/rover-client/src/operations/init/create_graph/runner.rs
@@ -29,21 +29,21 @@ pub async fn run(
 }
 
 fn build_response(data: ResponseData) -> Result<CreateGraphResponse, RoverClientError> {
-    let organization = data.organization.ok_or_else(|| RoverClientError::MalformedResponse {
-        null_field: "organization".to_string(),
-    })?;
+    let organization = data
+        .organization
+        .ok_or_else(|| RoverClientError::MalformedResponse {
+            null_field: "organization".to_string(),
+        })?;
 
     let graph_response = organization.create_graph;
 
     match graph_response {
-        CreateGraphMutationOrganizationCreateGraph::Graph(graph) => {
-            Ok(CreateGraphResponse::from(
-                CreateGraphMutationOrganizationCreateGraph::Graph(graph),
-            ))
-        }
+        CreateGraphMutationOrganizationCreateGraph::Graph(graph) => Ok(CreateGraphResponse::from(
+            CreateGraphMutationOrganizationCreateGraph::Graph(graph),
+        )),
         CreateGraphMutationOrganizationCreateGraph::GraphCreationError(error) => {
-            Err(RoverClientError::GraphCreationError { 
-                msg: format!("Failed to create graph: {}", error.message)
+            Err(RoverClientError::GraphCreationError {
+                msg: format!("Failed to create graph: {}", error.message),
             })
         }
     }

--- a/crates/rover-client/src/operations/init/create_graph/types.rs
+++ b/crates/rover-client/src/operations/init/create_graph/types.rs
@@ -34,7 +34,7 @@ impl From<create_graph_mutation::CreateGraphMutationOrganizationCreateGraph>
         match graph {
             create_graph_mutation::CreateGraphMutationOrganizationCreateGraph::Graph(graph) => Self { id: graph.id },
             create_graph_mutation::CreateGraphMutationOrganizationCreateGraph::GraphCreationError(error) => {
-                panic!("Graph creation failed: {}", error.message)
+                Self { id: String::new() }
             }
         }
     }

--- a/crates/rover-client/src/operations/init/create_graph/types.rs
+++ b/crates/rover-client/src/operations/init/create_graph/types.rs
@@ -33,7 +33,7 @@ impl From<create_graph_mutation::CreateGraphMutationOrganizationCreateGraph>
     fn from(graph: create_graph_mutation::CreateGraphMutationOrganizationCreateGraph) -> Self {
         match graph {
             create_graph_mutation::CreateGraphMutationOrganizationCreateGraph::Graph(graph) => Self { id: graph.id },
-            create_graph_mutation::CreateGraphMutationOrganizationCreateGraph::GraphCreationError(error) => {
+            create_graph_mutation::CreateGraphMutationOrganizationCreateGraph::GraphCreationError(_error) => {
                 Self { id: String::new() }
             }
         }

--- a/src/command/init/spinner.rs
+++ b/src/command/init/spinner.rs
@@ -3,10 +3,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use termimad::crossterm::{
-    cursor::{Hide, MoveTo, Show},
+    cursor::{Hide, MoveTo, Show, position},
     execute,
     style::{Color, Print, ResetColor, SetForegroundColor},
-    terminal::{size, Clear, ClearType},
+    terminal::{Clear, ClearType},
 };
 
 /// A simple command line spinner component
@@ -29,7 +29,7 @@ impl Spinner {
 
         // Get initial cursor position
         let mut stdout = io::stdout();
-        let initial_position = if let Ok((_, row)) = size() {
+        let initial_position = if let Ok((_, row)) = position() {
             execute!(stdout, MoveTo(0, row + 1)).unwrap();
             (0, row + 1)
         } else {

--- a/src/command/init/spinner.rs
+++ b/src/command/init/spinner.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use termimad::crossterm::{
-    cursor::{Hide, MoveTo, Show, position},
+    cursor::{position, Hide, MoveTo, Show},
     execute,
     style::{Color, Print, ResetColor, SetForegroundColor},
     terminal::{Clear, ClearType},

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -345,7 +345,6 @@ impl CreationConfirmed {
         client_config: &StudioClientConfig,
         profile: &ProfileOpt,
     ) -> RoverResult<ProjectCreated> {
-        println!();
         let spinner = Spinner::new(
             "Creating files and generating GraphOS credentials...",
             vec!['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'],


### PR DESCRIPTION
## Description
This PR improves error handling during the graph creation step of `rover init`. When users select "Create a graph" during the `rover init` flow, some error cases were previously throwing unhelpful errors or causing panics.

## Changes
- Modified `crates/rover-client/src/operations/init/create_graph/runner.rs` to properly extract organization data and provide more descriptive error messages for GraphQL mutation error responses
- Updated `crates/rover-client/src/operations/init/create_graph/types.rs` to handle error cases gracefully in the `From` implementation (returning an empty string ID instead of panicking)
- Updated cursor position detection in `src/command/init/spinner.rs` by using `position()` instead of `size()`
- Removed `newline` in `src/command/init/transitions.rs`