### PR TITLE
bugfix(init): Update code snippet to run rover dev

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -55,7 +55,7 @@ pub fn display_project_created_message(
     println!(
         "{}",
         Style::Command.paint(format!(
-            "$ APOLLO_KEY={} rover dev --graph-ref {} --supergraph-config supergraph.yaml",
+            "APOLLO_KEY={} rover dev --graph-ref {} --supergraph-config supergraph.yaml",
             api_key, graph_ref
         ))
     );


### PR DESCRIPTION
This PR fixes a bug in the `rover init` command by removing the `$` prefix from the displayed code snippet. 

This change prevents users from accidentally copying the entire line including the `$` symbol, which would result in a command not found error when run. 

The code snippet now shows the exact command to run without any decorative prefix.