### PR TITLE
fix(init): Exit immediately when GraphQL Template is selected

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -5,7 +5,7 @@ use rover_std::{hyperlink, successln, Style};
 pub fn display_welcome_message() {
     println!();
     println!(
-        "Welcome! This command helps you initialize a federated Graph in your current directory."
+        "Welcome! This command helps you initialize a federated graph in your current directory."
     );
     println!();
     println!(

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -57,21 +57,28 @@ impl Init {
 
         match project_type_selected.project_type {
             crate::options::ProjectType::CreateNew => {
-                let creation_confirmed_option = project_type_selected
+                let use_case_selected_option = project_type_selected
                     .select_organization(&self.organization, &self.profile, &client_config)
                     .await?
-                    .select_use_case(&self.project_use_case)?
-                    .enter_project_name(&self.project_name)?
-                    .confirm_graph_id(&self.graph_id)?
-                    .preview_and_confirm_creation(http_service)
-                    .await?;
+                    .select_use_case(&self.project_use_case)?;
 
-                match creation_confirmed_option {
-                    Some(creation_confirmed) => {
-                        let project_created = creation_confirmed
-                            .create_project(&client_config, &self.profile)
+                match use_case_selected_option {
+                    Some(use_case_selected) => {
+                        let creation_confirmed_option = use_case_selected
+                            .enter_project_name(&self.project_name)?
+                            .confirm_graph_id(&self.graph_id)?
+                            .preview_and_confirm_creation(http_service)
                             .await?;
-                        Ok(project_created.complete().success())
+
+                        match creation_confirmed_option {
+                            Some(creation_confirmed) => {
+                                let project_created = creation_confirmed
+                                    .create_project(&client_config, &self.profile)
+                                    .await?;
+                                Ok(project_created.complete().success())
+                            }
+                            None => Ok(RoverOutput::EmptySuccess),
+                        }
                     }
                     None => Ok(RoverOutput::EmptySuccess),
                 }

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -202,7 +202,7 @@ impl OrganizationSelected {
 
         if use_case == ProjectUseCase::GraphQLTemplate {
             println!();
-            println!("GraphQL Template is coming soon!");
+            println!("This feature is coming soon!");
             println!();
             return Ok(None);
         }

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -56,7 +56,6 @@ impl UserAuthenticated {
         match client_config.get_authenticated_client(profile) {
             Ok(_) => {
                 let is_user_api_key = self.check_is_user_api_key(client_config, profile)?;
-                println!("is_user_api_key: {}", is_user_api_key);
                 if !is_user_api_key {
                     return Err(RoverError::new(anyhow!(
                         "Invalid API key found."
@@ -195,15 +194,22 @@ impl ProjectTypeSelected {
 /// > Start a graph with one or more REST APIs
 /// > Start a graph with recommended libraries
 impl OrganizationSelected {
-    pub fn select_use_case(self, options: &ProjectUseCaseOpt) -> RoverResult<UseCaseSelected> {
+    pub fn select_use_case(self, options: &ProjectUseCaseOpt) -> RoverResult<Option<UseCaseSelected>> {
         let use_case = options.get_or_prompt_use_case()?;
 
-        Ok(UseCaseSelected {
+        if use_case == ProjectUseCase::GraphQLTemplate {
+            println!();
+            println!("GraphQL Template is coming soon!");
+            println!();
+            return Ok(None);
+        }
+
+        Ok(Some(UseCaseSelected {
             output_path: self.output_path,
             project_type: self.project_type,
             organization: self.organization,
             use_case,
-        })
+        }))
     }
 }
 
@@ -272,19 +278,19 @@ impl GraphIdConfirmed {
         self,
         http_service: ReqwestService,
     ) -> RoverResult<Option<CreationConfirmed>> {
+        // If this is a GraphQL Template, we've already shown the message and can exit
+        if self.use_case == ProjectUseCase::GraphQLTemplate {
+            return Ok(None);
+        }
+
         // Create the configuration
         let config = self.create_config();
 
         // Determine the repository URL based on the use case
         let repo_url = match self.use_case {
-          ProjectUseCase::Connectors => "https://github.com/apollographql/rover-init-starters/archive/78e96e5a0c3f2023d8862a2572dd4da44cac726f.tar.gz",
-          ProjectUseCase::GraphQLTemplate => {
-              println!();
-              println!("GraphQL Template is coming soon!");
-              println!();
-              return Ok(None); // Early return if template not available
-          },
-      };
+            ProjectUseCase::Connectors => "https://github.com/apollographql/rover-init-starters/archive/78e96e5a0c3f2023d8862a2572dd4da44cac726f.tar.gz",
+            ProjectUseCase::GraphQLTemplate => unreachable!(), // This case is handled above
+        };
 
         // Fetch the template to get the list of files
         let template_fetcher = TemplateFetcher::new(http_service)

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -194,7 +194,10 @@ impl ProjectTypeSelected {
 /// > Start a graph with one or more REST APIs
 /// > Start a graph with recommended libraries
 impl OrganizationSelected {
-    pub fn select_use_case(self, options: &ProjectUseCaseOpt) -> RoverResult<Option<UseCaseSelected>> {
+    pub fn select_use_case(
+        self,
+        options: &ProjectUseCaseOpt,
+    ) -> RoverResult<Option<UseCaseSelected>> {
         let use_case = options.get_or_prompt_use_case()?;
 
         if use_case == ProjectUseCase::GraphQLTemplate {


### PR DESCRIPTION
When a user selects `Start a graph with recommended libraries - coming soon` in the `init` flow, we now show the `GraphQL Template is coming soon!` message and exit immediately without prompting for project name or graph ID. Previously, the flow would continue to the next steps before exiting.