### PR TITLE
fix(init): Gracefully exit `init` flow when duplicate graph ID is provided

### DIFF
--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -352,7 +352,9 @@ impl CreationConfirmed {
         .await
         {
             Ok(response) => response,
-            Err(RoverClientError::GraphCreationError { msg }) if msg.contains("Service already exists") => {
+            Err(RoverClientError::GraphCreationError { msg })
+                if msg.contains("Service already exists") =>
+            {
                 return Err(RoverError::new(anyhow!(
                     "Graph ID is already in use. Run {} again with a different graph ID.",
                     Style::Command.paint("`rover init`")

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -348,10 +348,14 @@ impl CreationConfirmed {
             },
             &client,
         )
-        .await {
+        .await
+        {
             Ok(response) => response,
             Err(_) => {
-                return Err(RoverError::new(anyhow!("Graph ID is already in use. Run {} again with a different graph ID.", Style::Command.paint("`rover init`"))));
+                return Err(RoverError::new(anyhow!(
+                    "Graph ID is already in use. Run {} again with a different graph ID.",
+                    Style::Command.paint("`rover init`")
+                )));
             }
         };
 

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -7,6 +7,7 @@ use rover_client::operations::init::create_graph;
 use rover_client::operations::init::create_graph::*;
 use rover_client::operations::init::memberships;
 use rover_client::shared::GraphRef;
+use rover_client::RoverClientError;
 use rover_http::ReqwestService;
 use rover_std::Style;
 
@@ -351,12 +352,13 @@ impl CreationConfirmed {
         .await
         {
             Ok(response) => response,
-            Err(_) => {
+            Err(RoverClientError::GraphCreationError { msg }) if msg.contains("Service already exists") => {
                 return Err(RoverError::new(anyhow!(
                     "Graph ID is already in use. Run {} again with a different graph ID.",
                     Style::Command.paint("`rover init`")
                 )));
             }
+            Err(e) => return Err(e.into()),
         };
 
         // Write the template files without asking for confirmation again

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -339,16 +339,7 @@ impl CreationConfirmed {
         );
         let client = client_config.get_authenticated_client(profile)?;
 
-        // Write the template files without asking for confirmation again
-        // (confirmation was done in the previous state)
-        self.template.write_template(&self.output_path)?;
-
-        let supergraph = SupergraphBuilder::new(self.output_path.clone(), 5);
-        supergraph.build_and_write()?;
-
-        let artifacts = self.template.list_files()?;
-
-        let create_graph_response = create_graph::run(
+        let create_graph_response = match create_graph::run(
             CreateGraphInput {
                 hidden_from_uninvited_non_admin: false,
                 create_graph_id: self.config.graph_id.to_string(),
@@ -357,7 +348,21 @@ impl CreationConfirmed {
             },
             &client,
         )
-        .await?;
+        .await {
+            Ok(response) => response,
+            Err(_) => {
+                return Err(RoverError::new(anyhow!("Graph ID is already in use. Run {} again with a different graph ID.", Style::Command.paint("`rover init`"))));
+            }
+        };
+
+        // Write the template files without asking for confirmation again
+        // (confirmation was done in the previous state)
+        self.template.write_template(&self.output_path)?;
+
+        let supergraph = SupergraphBuilder::new(self.output_path.clone(), 5);
+        supergraph.build_and_write()?;
+
+        let artifacts = self.template.list_files()?;
 
         let subgraphs = supergraph.generate_subgraphs()?;
         let graph_ref = GraphRef {


### PR DESCRIPTION
This PR improves the user experience when initializing a new graph with an ID that already exists. Instead of proceeding with the file creation and then failing, we now check for ID conflicts earlier in the process and provide a clear error message prompting the user to try again with a different ID.

Changes:
- Handles the error case from `create_graph::run()` by checking if the graph ID already exists
- Returns an error message with instructions to run `rover init` again
- Rearranges the code flow to check for ID conflicts before writing template files