### PR TITLE
docs: add graph ref environment variable info

### DIFF
--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -191,20 +191,20 @@ To configure advanced router functionality like CORS settings or header passthro
 
 If you want to use [GraphOS Router features](/graphos/routing/graphos-features#graphos-router-features), you must provide both:
 
-1 A [**graph** API key](/graphos/api-keys/#graph-api-keys) either via the `APOLLO_KEY` environment or by [configuring credentials](./config#creating-configuration-profiles) in Rover.
-1. A graph ref via the `APOLLO_GRAPH_REF` environment variable or the `--graph-ref` option. Learn about the difference between these in the section below.
+1 A [**graph** API key](/graphos/api-keys/#graph-api-keys) either via the `APOLLO_KEY` environment variable or by [configuring credentials](./config#creating-configuration-profiles) in Rover.
+1. A graph ref either via the `APOLLO_GRAPH_REF` environment variable or the `--graph-ref` option. Learn about the difference between these in the section below.
 
-#### Understanding `--graph-ref` vs `APOLLO_GRAPH_REF`
+#### Understanding `APOLLO_GRAPH_REF` vs `--graph-ref` 
 
-While both the `--graph-ref` option and `APOLLO_GRAPH_REF` environment variables provide a graph ref to `rover dev`, they work slightly differently:
+While both the `APOLLO_GRAPH_REF` environment variable and `--graph-ref` option provide a graph ref to `rover dev`, they work slightly differently:
 
 | Method | Purpose |
 |-----------|---------|
+| `APOLLO_GRAPH_REF` environment variable | Passed directly to the router that `rover dev` spins up in order to enable [GraphOS Router features](/graphos/routing/graphos-features#graphos-router-features). This environment variable is used only by the router and not by Rover for schema retrieval. |
 | `--graph-ref` option | Tells Rover to pull the supergraph schema from GraphOS, allowing you to [use a published variant](#starting-a-session-from-a-graphos-studio-variant) as the foundation for your local development. |
-| `APOLLO_GRAPH_REF` environment variable | Passed directly to the router that `rover dev` spins up to enable GraphOS features. This environment variable is only used by the router component, not by Rover for schema retrieval. |
 
 This means you should:
-- Use `APOLLO_GRAPH_REF` environment variable when you are using local schema files for development and need to enable [GraphOS Router features](/graphos/routing/graphos-features#graphos-router-features).
+- Use `APOLLO_GRAPH_REF` environment variable when you are using local schema files for development and need to enable GraphOS Router features.
 - Use the `--graph-ref` option when you want to develop against a published graph variant, pulling its schema from GraphOS. This option also enables GraphOS Router features if the referenced graph has access to them.
 
 ## Federation 2 ELv2 license

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -187,12 +187,25 @@ By default, the router's health check endpoint is disabled in `rover dev`. You c
 
 To configure advanced router functionality like CORS settings or header passthrough for subgraphs, you can pass a valid [router configuration YAML file](/router/configuration/overview#yaml-config-file) to `rover dev` via the `--router-config <ROUTER_CONFIG_PATH>` argument.
 
-### Enterprise features
+### GraphOS Router features
 
-If you want to use [enterprise router features](/router/enterprise-features/), you must provide both:
+If you want to use [GraphOS Router features](/graphos/routing/graphos-features#graphos-router-features), you must provide both:
 
-1. A graph ref via the `APOLLO_GRAPH_REF` environment variable or the `--graph-ref` option.
-2. A [**graph** API key](/graphos/api-keys/#graph-api-keys) either via the `APOLLO_KEY` environment or by [configuring credentials](./config#creating-configuration-profiles) in Rover.
+1 A [**graph** API key](/graphos/api-keys/#graph-api-keys) either via the `APOLLO_KEY` environment or by [configuring credentials](./config#creating-configuration-profiles) in Rover.
+1. A graph ref via the `APOLLO_GRAPH_REF` environment variable or the `--graph-ref` option. Learn about the difference between these in the section below.
+
+#### Understanding `--graph-ref` vs `APOLLO_GRAPH_REF`
+
+While both the `--graph-ref` option and `APOLLO_GRAPH_REF` environment variables provide a graph ref to `rover dev`, they work slightly differently:
+
+| Method | Purpose |
+|-----------|---------|
+| `--graph-ref` option | Tells Rover to pull the supergraph schema from GraphOS, allowing you to [use a published variant](#starting-a-session-from-a-graphos-studio-variant) as the foundation for your local development. |
+| `APOLLO_GRAPH_REF` environment variable | Passed directly to the router that `rover dev` spins up to enable GraphOS features. This environment variable is only used by the router component, not by Rover for schema retrieval. |
+
+This means you should:
+- Use `APOLLO_GRAPH_REF` environment variable when you are using local schema files for development and need to enable [GraphOS Router features](/graphos/routing/graphos-features#graphos-router-features).
+- Use the `--graph-ref` option when you want to develop against a published graph variant, pulling its schema from GraphOS. This option also enables GraphOS Router features if the referenced graph has access to them.
 
 ## Federation 2 ELv2 license
 

--- a/docs/source/configuring.mdx
+++ b/docs/source/configuring.mdx
@@ -394,6 +394,7 @@ If present, an environment variable's value takes precedence over all other meth
 |-----------------------------|----------------|
 | `APOLLO_HOME` | The path to the parent directory of Rover's binary. The default value is your operating system's default home directory. Rover will install itself in a folder called `.rover` inside the directory specified. |
 | `APOLLO_CONFIG_HOME` | The path where Rover's configuration is stored. The default value is your operating system's default configuration directory. |
+| `APOLLO_GRAPH_REF` | A graph ref passed to `rover dev` command. [Learn more](./commands/dev#understanding---graph-ref-vs-apollo_graph_ref) |
 | `APOLLO_KEY` | The API key that Rover should use to authenticate with GraphOS Studio. |
 | `APOLLO_TELEMETRY_DISABLED` | Set to `true` if you don't want Rover to collect anonymous usage data. |
 | `APOLLO_VCS_REMOTE_URL` | The URL of your project's remote repository. See [Git context](#git-context). |


### PR DESCRIPTION
Differentiate `--graph-ref` and `APOLLO_GRAPH_REF` env variable usage.