### PR TITLE
Increase telemetry timeout

### DIFF
--- a/crates/sputnik/src/session.rs
+++ b/crates/sputnik/src/session.rs
@@ -19,7 +19,7 @@ use crate::{Report, SputnikError};
 
 /// Timeout for reporting telemetry. Note that this includes the entire time to make the request
 /// and receive the response, including on the client side. This is not just the server latency.
-const REPORT_TIMEOUT: Duration = Duration::from_millis(500);
+const REPORT_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// The Session represents a usage of the CLI analogous to a web session
 /// It contains the "url" (command path + flags) but doesn't contain any


### PR DESCRIPTION
I've observed that telemetry frequently times out when running `rover` commands on my machine. This is likely resulting in missed telemetry data.

```console
DEBUG rover::cli: telemetry_error: HttpError(reqwest::Error { kind: Request, url: "https://rover.apollo.dev/telemetry", source: TimedOut })
    at src/cli.rs:135
```