### PR TITLE
refactor(init): Improve error handling for `graphId` step, improve and code structure of `rover init`

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -203,7 +203,7 @@ pub enum RoverClientError {
     PermissionError { msg: String },
 
     #[error("Failed to create project after {max_retries} retries. Please try again.")]
-    MaxRetriesExceeded { max_retries: u32 },
+    MaxRetriesExceeded { max_retries: u8 },
 
     #[error(
         "You cannot perform this operation due to a limit imposed by your current billing plan"

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -249,6 +249,9 @@ pub enum RoverClientError {
     #[error("Cannot operate on a non-cloud graph ref {graph_ref}")]
     NonCloudGraphRef { graph_ref: GraphRef },
 
+    #[error("Something went wrong on our end. This isn't your fault! Please try again.")]
+    GraphProjectInitError,
+
     #[error("Service failed to become ready")]
     ServiceReady(Box<dyn std::error::Error + Send + Sync>),
 

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -202,6 +202,9 @@ pub enum RoverClientError {
     #[error("You don't have the required permissions to perform this operation: {msg}.")]
     PermissionError { msg: String },
 
+    #[error("Failed to create project after {max_retries} retries. Please try again.")]
+    MaxRetriesExceeded { max_retries: u32 },
+
     #[error(
         "You cannot perform this operation due to a limit imposed by your current billing plan"
     )]

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -202,7 +202,7 @@ pub enum RoverClientError {
     #[error("You don't have the required permissions to perform this operation: {msg}.")]
     PermissionError { msg: String },
 
-    #[error("Failed to create project after {max_retries} retries. Please try again.")]
+    #[error("Failed to create graph after {max_retries} retries. Please try again.")]
     MaxRetriesExceeded { max_retries: u8 },
 
     #[error(

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -334,6 +334,6 @@ Offline enterprise license support for Apollo is available on an as-needed basis
 
 ### E045
 
-This error occurs when Rover tries to create a project but creating the project fails.
+This error occurs when Rover tries to [create a graph](/rover/commands/init) but fails.
 
 This is likely a temporary issue and you can try again. If the problem persists, please contact [Apollo Support](https://support.apollographql.com).

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -332,4 +332,8 @@ Please view the check in [Apollo Studio](https://studio.apollographql.com/) at t
 
 Offline enterprise license support for Apollo is available on an as-needed basis. It must be enabled on your Studio organization. For access, send a request to your Apollo contact.
 
+### E045
 
+This error occurs when Rover tries to create a project but creating the project fails.
+
+This is likely a temporary issue and you can try again. If the problem persists, please contact [Apollo Support](https://support.apollographql.com).

--- a/docs/source/errors.md
+++ b/docs/source/errors.md
@@ -336,4 +336,4 @@ Offline enterprise license support for Apollo is available on an as-needed basis
 
 This error occurs when Rover tries to [create a graph](/rover/commands/init) but fails.
 
-This is likely a temporary issue and you can try again. If the problem persists, please contact [Apollo Support](https://support.apollographql.com).
+This is likely temporary. Please try again or contact [Apollo Support](https://support.apollographql.com) if the issue persists.

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -33,6 +33,7 @@ use crate::{RoverOutput, RoverResult};
 use clap::Parser;
 use serde::Serialize;
 use std::path::PathBuf;
+#[cfg(feature = "composition-js")]
 use transitions::CreateProjectResult;
 
 #[derive(Debug, Parser, Clone, Serialize)]
@@ -71,6 +72,7 @@ impl Init {
     pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
         use helpers::display_use_template_message;
         use rover_http::ReqwestService;
+        use crate::command::init::states::UserAuthenticated;
 
         let http_service = ReqwestService::new(None, None)?;
 
@@ -162,5 +164,3 @@ impl Init {
         Err(err)
     }
 }
-
-use states::UserAuthenticated;

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -121,11 +121,10 @@ impl Init {
 
         // Handle restart loop
         if let CreateProjectResult::Restart(mut current_project) = project_created {
-            const MAX_RETRIES: u32 = 3;
-            let mut retry_count = 0;
+            const MAX_RETRIES: u8 = 3;
 
-            loop {
-                if retry_count >= MAX_RETRIES {
+            for attempt in 0..MAX_RETRIES {
+                if attempt >= MAX_RETRIES {
                     let suggestion = RoverErrorSuggestion::Adhoc(
                         format!(
                             "If the error persists, please contact the Apollo team at {}.",
@@ -156,7 +155,6 @@ impl Init {
                     }
                     CreateProjectResult::Restart(project_named) => {
                         current_project = project_named;
-                        retry_count += 1;
                         continue;
                     }
                 }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -120,7 +120,11 @@ impl Init {
         }
 
         // Handle restart loop
-        if let CreateProjectResult::Restart { state: mut current_project, reason } = project_created {
+        if let CreateProjectResult::Restart {
+            state: mut current_project,
+            reason,
+        } = project_created
+        {
             const MAX_RETRIES: u8 = 3;
 
             for attempt in 0..MAX_RETRIES {
@@ -158,21 +162,22 @@ impl Init {
                     CreateProjectResult::Created(project) => {
                         return Ok(project.complete().success())
                     }
-                    CreateProjectResult::Restart { state: project_named, reason } => {
-                        match reason {
-                            RestartReason::FullRestart => {
-                                let welcome = UserAuthenticated::new()
-                                    .check_authentication(&client_config, &self.profile)
-                                    .await?;
-                                welcome.select_project_type(&self.project_type, &self.path)?;
-                                return Ok(RoverOutput::EmptySuccess);
-                            }
-                            _ => {
-                                current_project = project_named;
-                                continue;
-                            }
+                    CreateProjectResult::Restart {
+                        state: project_named,
+                        reason,
+                    } => match reason {
+                        RestartReason::FullRestart => {
+                            let welcome = UserAuthenticated::new()
+                                .check_authentication(&client_config, &self.profile)
+                                .await?;
+                            welcome.select_project_type(&self.project_type, &self.path)?;
+                            return Ok(RoverOutput::EmptySuccess);
                         }
-                    }
+                        _ => {
+                            current_project = project_named;
+                            continue;
+                        }
+                    },
                 }
             }
         }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -22,17 +22,21 @@ pub mod transitions;
 
 #[cfg(feature = "composition-js")]
 use crate::command::init::options::{
-    GraphIdOpt, ProjectNameOpt, ProjectOrganizationOpt, ProjectType, ProjectTypeOpt, ProjectUseCaseOpt,
+    GraphIdOpt, ProjectNameOpt, ProjectOrganizationOpt, ProjectType, ProjectTypeOpt,
+    ProjectUseCaseOpt,
 };
 #[cfg(feature = "composition-js")]
 use crate::options::ProfileOpt;
 use crate::utils::client::StudioClientConfig;
-use crate::{RoverOutput, RoverResult};
+use crate::{RoverError, RoverOutput, RoverResult};
 use clap::Parser;
+use rover_client::RoverClientError;
+use rover_std::hyperlink;
 use serde::Serialize;
 use std::path::PathBuf;
 #[cfg(feature = "composition-js")]
 use transitions::CreateProjectResult;
+use crate::error::RoverErrorSuggestion;
 
 #[derive(Debug, Parser, Clone, Serialize)]
 #[clap(about = "Initialize a new graph")]
@@ -117,7 +121,21 @@ impl Init {
 
         // Handle restart loop
         if let CreateProjectResult::Restart(mut current_project) = project_created {
+            const MAX_RETRIES: u32 = 3;
+            let mut retry_count = 0;
+            
             loop {
+                if retry_count >= MAX_RETRIES {
+                    let suggestion = RoverErrorSuggestion::Adhoc(
+                        format!(
+                            "If the error persists, please contact the Apollo team at {}.",
+                            hyperlink("https://support.apollographql.com/?createRequest=true&portalId=1023&requestTypeId=1230")
+                        ).to_string()
+                    );
+                    return Err(RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: MAX_RETRIES })
+                        .with_suggestion(suggestion));
+                }
+                
                 let graph_id_confirmed = current_project.confirm_graph_id(&self.graph_id)?;
                 let creation_confirmed = match graph_id_confirmed
                     .preview_and_confirm_creation(http_service.clone())
@@ -136,6 +154,7 @@ impl Init {
                     }
                     CreateProjectResult::Restart(project_named) => {
                         current_project = project_named;
+                        retry_count += 1;
                         continue;
                     }
                 }

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -130,8 +130,8 @@ impl Init {
             for attempt in 0..MAX_RETRIES {
                 if attempt >= MAX_RETRIES {
                     let suggestion = RoverErrorSuggestion::Adhoc(format!("If the issue persists, please contact support at {}.", hyperlink("https://support.apollographql.com")).to_string());
-
-                    return Err(RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: MAX_RETRIES }).with_suggestion(suggestion));
+                    let error = RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: MAX_RETRIES }).with_suggestion(suggestion);
+                    return Err(error);
                 }
 
                 let graph_id_confirmed = current_project.confirm_graph_id(&self.graph_id)?;

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -122,28 +122,16 @@ impl Init {
         // Handle restart loop
         if let CreateProjectResult::Restart {
             state: mut current_project,
-            reason,
+            reason: _,
         } = project_created
         {
             const MAX_RETRIES: u8 = 3;
 
             for attempt in 0..MAX_RETRIES {
                 if attempt >= MAX_RETRIES {
-                    let suggestion = match reason {
-                        RestartReason::GraphIdExists => RoverErrorSuggestion::Adhoc(
-                            format!(
-                                "If the error persists, please contact the Apollo team at {}.",
-                                hyperlink("https://support.apollographql.com/?createRequest=true&portalId=1023&requestTypeId=1230")
-                            ).to_string()
-                        ),
-                        RestartReason::FullRestart => RoverErrorSuggestion::Adhoc(
-                            "Please try the operation again from the beginning.".to_string()
-                        ),
-                    };
-                    return Err(RoverError::from(RoverClientError::MaxRetriesExceeded {
-                        max_retries: MAX_RETRIES,
-                    })
-                    .with_suggestion(suggestion));
+                    let suggestion = RoverErrorSuggestion::Adhoc(format!("If the issue persists, please contact support at {}.", hyperlink("https://support.apollographql.com")).to_string());
+
+                    return Err(RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: MAX_RETRIES }).with_suggestion(suggestion));
                 }
 
                 let graph_id_confirmed = current_project.confirm_graph_id(&self.graph_id)?;

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -95,7 +95,9 @@ impl Init {
                     .create_project(&client_config, &self.profile)
                     .await?
                 {
-                    CreateProjectResult::Created(project) => return Ok(project.complete().success()),
+                    CreateProjectResult::Created(project) => {
+                        return Ok(project.complete().success())
+                    }
                     CreateProjectResult::Restart(project_named) => {
                         current_project = project_named;
                         continue;

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -21,6 +21,8 @@ pub mod tests;
 pub mod transitions;
 
 #[cfg(feature = "composition-js")]
+use crate::command::init::options::ProjectType;
+#[cfg(feature = "composition-js")]
 use crate::command::init::options::{
     GraphIdOpt, ProjectNameOpt, ProjectOrganizationOpt, ProjectTypeOpt, ProjectUseCaseOpt,
 };
@@ -32,8 +34,6 @@ use clap::Parser;
 use serde::Serialize;
 use std::path::PathBuf;
 use transitions::CreateProjectResult;
-#[cfg(feature = "composition-js")]
-use crate::command::init::options::ProjectType;
 
 #[derive(Debug, Parser, Clone, Serialize)]
 #[clap(about = "Initialize a new graph")]

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -70,9 +70,9 @@ pub struct Init {
 impl Init {
     #[cfg(feature = "composition-js")]
     pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        use crate::command::init::states::UserAuthenticated;
         use helpers::display_use_template_message;
         use rover_http::ReqwestService;
-        use crate::command::init::states::UserAuthenticated;
 
         let http_service = ReqwestService::new(None, None)?;
 

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -21,10 +21,8 @@ pub mod tests;
 pub mod transitions;
 
 #[cfg(feature = "composition-js")]
-use crate::command::init::options::ProjectType;
-#[cfg(feature = "composition-js")]
 use crate::command::init::options::{
-    GraphIdOpt, ProjectNameOpt, ProjectOrganizationOpt, ProjectTypeOpt, ProjectUseCaseOpt,
+    GraphIdOpt, ProjectNameOpt, ProjectOrganizationOpt, ProjectType, ProjectTypeOpt, ProjectUseCaseOpt,
 };
 #[cfg(feature = "composition-js")]
 use crate::options::ProfileOpt;

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -129,8 +129,17 @@ impl Init {
 
             for attempt in 0..MAX_RETRIES {
                 if attempt >= MAX_RETRIES {
-                    let suggestion = RoverErrorSuggestion::Adhoc(format!("If the issue persists, please contact support at {}.", hyperlink("https://support.apollographql.com")).to_string());
-                    let error = RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: MAX_RETRIES }).with_suggestion(suggestion);
+                    let suggestion = RoverErrorSuggestion::Adhoc(
+                        format!(
+                            "If the issue persists, please contact support at {}.",
+                            hyperlink("https://support.apollographql.com")
+                        )
+                        .to_string(),
+                    );
+                    let error = RoverError::from(RoverClientError::MaxRetriesExceeded {
+                        max_retries: MAX_RETRIES,
+                    })
+                    .with_suggestion(suggestion);
                     return Err(error);
                 }
 

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -10,8 +10,6 @@ mod tests {
     use crate::{RoverError, RoverResult};
     use anyhow::anyhow;
     use camino::Utf8PathBuf;
-    use rover_client::RoverClientError;
-    use super::super::transitions::{CreateProjectResult, RestartReason};
 
     mod mock {
         use super::*;
@@ -19,6 +17,7 @@ mod tests {
         #[derive(Clone, Default)]
         pub struct MockHttpService {}
 
+        #[derive(Clone)]
         pub struct MockTemplateFetcher {
             pub files: Vec<String>,
         }
@@ -44,7 +43,6 @@ mod tests {
 
         impl MockTemplateOperations {
             pub fn prompt_creation(_artifacts: Vec<String>) -> RoverResult<bool> {
-                // For testing, we'll return true always as if the user always confirmed
                 Ok(true)
             }
         }
@@ -344,60 +342,5 @@ mod tests {
             options_with_value.get_project_type(),
             Some(ProjectType::CreateNew)
         );
-    #[tokio::test]
-    async fn test_max_retries_error() {
-        let project_named = ProjectNamed {
-            output_path: ".".into(),
-            project_type: ProjectType::CreateNew,
-            organization: "test-org".parse::<OrganizationId>().unwrap(),
-            use_case: ProjectUseCase::Connectors,
-            project_name: "test-graph".parse().unwrap(),
-        };
-
-        let graph_id_confirmed = GraphIdConfirmed {
-            output_path: ".".into(),
-            project_type: project_named.project_type.clone(),
-            organization: project_named.organization.clone(),
-            use_case: project_named.use_case.clone(),
-            project_name: project_named.project_name.clone(),
-            graph_id: "test-graph-id".parse::<GraphId>().unwrap(),
-        };
-
-        let http_service = mock::MockHttpService::default();
-        let template_fetcher = mock::MockTemplateFetcher::new(http_service.clone());
-
-        // Create a mock that will always return Restart
-        let mut retry_count = 0;
-        let result = loop {
-            if retry_count >= 3 {
-                let suggestion = RoverErrorSuggestion::Adhoc("If the issue persists, please contact support at https://support.apollographql.com.".to_string());
-                break Err(RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: 3 }).with_suggestion(suggestion);
-            }
-            retry_count += 1;
-            let config = ProjectConfig {
-                project_type: graph_id_confirmed.project_type.clone(),
-                organization: graph_id_confirmed.organization.clone(),
-                use_case: graph_id_confirmed.use_case.clone(),
-                project_name: graph_id_confirmed.project_name.clone(),
-                graph_id: graph_id_confirmed.graph_id.clone(),
-            };
-            let creation_confirmed = CreationConfirmed {
-                output_path: ".".into(),
-                config,
-                template: TemplateProject::new(template_fetcher.clone()),
-            };
-            break Ok(CreateProjectResult::Restart {
-                state: project_named.clone(),
-                reason: RestartReason::GraphIdExists,
-            });
-        };
-
-        assert!(result.is_err());
-        let error = result.unwrap_err();
-        assert!(matches!(
-            error.downcast_ref::<RoverClientError>(),
-            Some(RoverClientError::MaxRetriesExceeded { max_retries: 3 })
-        ));
-        assert!(!error.suggestions().is_empty());
     }
-    }}
+}

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -11,6 +11,7 @@ mod tests {
     use anyhow::anyhow;
     use camino::Utf8PathBuf;
     use rover_client::RoverClientError;
+    use super::super::transitions::{CreateProjectResult, RestartReason};
 
     mod mock {
         use super::*;
@@ -384,7 +385,10 @@ mod tests {
                 config,
                 template: TemplateProject::new(template_fetcher.clone()),
             };
-            break Ok(CreateProjectResult::Restart(project_named.clone()));
+            break Ok(CreateProjectResult::Restart {
+                state: project_named.clone(),
+                reason: RestartReason::GraphIdExists,
+            });
         };
 
         assert!(result.is_err());

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -370,7 +370,8 @@ mod tests {
         let mut retry_count = 0;
         let result = loop {
             if retry_count >= 3 {
-                break Err(RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: 3 }));
+                let suggestion = RoverErrorSuggestion::Adhoc("If the issue persists, please contact support at https://support.apollographql.com.".to_string());
+                break Err(RoverError::from(RoverClientError::MaxRetriesExceeded { max_retries: 3 }).with_suggestion(suggestion);
             }
             retry_count += 1;
             let config = ProjectConfig {
@@ -397,5 +398,6 @@ mod tests {
             error.downcast_ref::<RoverClientError>(),
             Some(RoverClientError::MaxRetriesExceeded { max_retries: 3 })
         ));
+        assert!(!error.suggestions().is_empty());
     }
     }}

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -364,7 +364,10 @@ impl CreationConfirmed {
             {
                 println!();
                 println!();
-                println!("{} Graph ID is already in use. Please try again with a different graph ID.", Style::Failure.paint("Error:"));
+                println!(
+                    "{} Graph ID is already in use. Please try again with a different graph ID.",
+                    Style::Failure.paint("Error:")
+                );
                 return Ok(CreateProjectResult::Restart(ProjectNamed {
                     output_path: self.output_path,
                     project_type: self.config.project_type,

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -412,9 +412,11 @@ impl CreationConfirmed {
                     .to_string(),
                 );
                 let error = RoverError::from(RoverClientError::ClientError {
-                    msg: "Something went wrong on our end. This isn't your fault! Please try again.".to_string(),
+                    msg:
+                        "Something went wrong on our end. This isn't your fault! Please try again."
+                            .to_string(),
                 })
-                    .with_suggestion(suggestion);
+                .with_suggestion(suggestion);
                 return Err(error);
             }
         };

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -359,9 +359,8 @@ impl CreationConfirmed {
             Ok(client) => client,
             Err(_) => {
                 println!();
-                println!(
-                    "{} Invalid API key. Please authenticate again.",
-                    Style::Failure.paint("Error:")
+                errln!(
+                    "Invalid API key. Please authenticate again."
                 );
                 return Ok(CreateProjectResult::Restart {
                     state: ProjectNamed {

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -412,8 +412,8 @@ impl CreationConfirmed {
                 let suggestion = RoverErrorSuggestion::Adhoc(
                     format!("If the issue persists, please contact support at {}.", hyperlink("https://support.apollographql.com")).to_string()
                 );
-                return Err(RoverClientError::GraphProjectInitError.into())
-                .with_suggestion(suggestion);
+                let error = RoverError::from(RoverClientError::GraphProjectInitError).with_suggestion(suggestion);
+                return Err(error);
             }
         };
 

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -393,9 +393,8 @@ impl CreationConfirmed {
             {
                 println!();
                 println!();
-                println!(
-                    "{} Graph ID is already in use. Please try again with a different graph ID.",
-                    Style::Failure.paint("Error:")
+                errln!(
+                    "Graph ID is already in use. Please try again with a different graph ID."
                 );
                 return Ok(CreateProjectResult::Restart {
                     state: ProjectNamed {

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -9,6 +9,7 @@ use rover_client::operations::init::memberships;
 use rover_client::shared::GraphRef;
 use rover_client::RoverClientError;
 use rover_http::ReqwestService;
+use rover_std::errln;
 use rover_std::hyperlink;
 use rover_std::Style;
 
@@ -359,9 +360,7 @@ impl CreationConfirmed {
             Ok(client) => client,
             Err(_) => {
                 println!();
-                errln!(
-                    "Invalid API key. Please authenticate again."
-                );
+                errln!("Invalid API key. Please authenticate again.");
                 return Ok(CreateProjectResult::Restart {
                     state: ProjectNamed {
                         output_path: self.output_path,
@@ -392,9 +391,7 @@ impl CreationConfirmed {
             {
                 println!();
                 println!();
-                errln!(
-                    "Graph ID is already in use. Please try again with a different graph ID."
-                );
+                errln!("Graph ID is already in use. Please try again with a different graph ID.");
                 return Ok(CreateProjectResult::Restart {
                     state: ProjectNamed {
                         output_path: self.output_path,
@@ -414,7 +411,9 @@ impl CreationConfirmed {
                     )
                     .to_string(),
                 );
-                let error = RoverError::from(RoverClientError::GraphProjectInitError)
+                let error = RoverError::from(RoverClientError::ClientError {
+                    msg: "Something went wrong on our end. This isn't your fault! Please try again.".to_string(),
+                })
                     .with_suggestion(suggestion);
                 return Err(error);
             }

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -410,9 +410,14 @@ impl CreationConfirmed {
             }
             Err(_) => {
                 let suggestion = RoverErrorSuggestion::Adhoc(
-                    format!("If the issue persists, please contact support at {}.", hyperlink("https://support.apollographql.com")).to_string()
+                    format!(
+                        "If the issue persists, please contact support at {}.",
+                        hyperlink("https://support.apollographql.com")
+                    )
+                    .to_string(),
                 );
-                let error = RoverError::from(RoverClientError::GraphProjectInitError).with_suggestion(suggestion);
+                let error = RoverError::from(RoverClientError::GraphProjectInitError)
+                    .with_suggestion(suggestion);
                 return Err(error);
             }
         };

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -31,7 +31,7 @@ use crate::RoverResult;
 #[derive(Debug)]
 pub enum CreateProjectResult {
     Created(ProjectCreated),
-    Restart(ProjectNamed)
+    Restart(ProjectNamed),
 }
 
 const DEFAULT_VARIANT: &str = "current";

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -9,6 +9,7 @@ use rover_client::operations::init::memberships;
 use rover_client::shared::GraphRef;
 use rover_client::RoverClientError;
 use rover_http::ReqwestService;
+use rover_std::hyperlink;
 use rover_std::Style;
 
 use crate::command::init::authentication::{auth_error_to_rover_error, AuthenticationError};
@@ -407,7 +408,13 @@ impl CreationConfirmed {
                     reason: RestartReason::GraphIdExists,
                 });
             }
-            Err(e) => return Err(e.into()),
+            Err(_) => {
+                let suggestion = RoverErrorSuggestion::Adhoc(
+                    format!("If the issue persists, please contact support at {}.", hyperlink("https://support.apollographql.com")).to_string()
+                );
+                return Err(RoverClientError::GraphProjectInitError.into())
+                .with_suggestion(suggestion);
+            }
         };
 
         // Write the template files without asking for confirmation again

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -356,7 +356,7 @@ impl CreationConfirmed {
         );
         let client = match client_config.get_authenticated_client(profile) {
             Ok(client) => client,
-            Err(e) => {
+            Err(_) => {
                 println!();
                 println!(
                     "{} Invalid API key. Please authenticate again.",

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -362,7 +362,9 @@ impl CreationConfirmed {
             Err(RoverClientError::GraphCreationError { msg })
                 if msg.contains("Service already exists") =>
             {
-                println!("\n\n{} Graph ID is already in use. Please try again with a different graph ID.", Style::Failure.paint("Error:"));
+                println!();
+                println!();
+                println!("{} Graph ID is already in use. Please try again with a different graph ID.", Style::Failure.paint("Error:"));
                 return Ok(CreateProjectResult::Restart(ProjectNamed {
                     output_path: self.output_path,
                     project_type: self.config.project_type,

--- a/src/error/metadata/code.rs
+++ b/src/error/metadata/code.rs
@@ -50,6 +50,7 @@ pub enum RoverErrorCode {
     E042,
     E043,
     E044,
+    E045,
 }
 
 impl Display for RoverErrorCode {
@@ -238,6 +239,10 @@ impl RoverErrorCode {
             (
                 RoverErrorCode::E044,
                 include_str!("./codes/E044.md").to_string(),
+            ),
+            (
+                RoverErrorCode::E045,
+                include_str!("./codes/E045.md").to_string(),
             ),
         ];
         contents.into_iter().collect()

--- a/src/error/metadata/codes/E045.md
+++ b/src/error/metadata/codes/E045.md
@@ -1,0 +1,1 @@
+The operation failed after reaching the maximum number of retries. This usually indicates a temporary issue with the service. Please try again later, and if the issue persists, contact Apollo support. 

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -3,7 +3,6 @@ use std::env;
 pub use code::RoverErrorCode;
 use houston::HoustonProblem;
 use rover_client::{EndpointKind, RoverClientError};
-use rover_std::hyperlink;
 use serde::Serialize;
 pub use suggestion::RoverErrorSuggestion;
 

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -3,6 +3,7 @@ use std::env;
 pub use code::RoverErrorCode;
 use houston::HoustonProblem;
 use rover_client::{EndpointKind, RoverClientError};
+use rover_std::hyperlink;
 use serde::Serialize;
 pub use suggestion::RoverErrorSuggestion;
 
@@ -320,6 +321,10 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                 RoverClientError::ServiceReady(_) => (None, None),
                 RoverClientError::Service { .. } => (None, None),
                 RoverClientError::GraphCreationError { .. } => (None, None),
+                RoverClientError::MaxRetriesExceeded { .. } => (
+                    Some(RoverErrorSuggestion::ContactApolloSupport),
+                    Some(RoverErrorCode::E045),
+                ),
             };
             return RoverErrorMetadata {
                 json_version: JsonVersion::default(),

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -39,7 +39,11 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
         let mut skip_printing_cause = false;
         if let Some(rover_client_error) = error.downcast_ref::<RoverClientError>() {
             let (suggestion, code) = match rover_client_error {
-                RoverClientError::InvalidJson(_) => (
+                &RoverClientError::InvalidJson(_) => (
+                    Some(RoverErrorSuggestion::SubmitIssue),
+                    Some(RoverErrorCode::E001),
+                ),
+                &RoverClientError::GraphProjectInitError => (
                     Some(RoverErrorSuggestion::SubmitIssue),
                     Some(RoverErrorCode::E001),
                 ),

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -92,6 +92,7 @@ pub enum RoverErrorSuggestion {
     AllowInvalidRoutingUrlOrSpecifyValidUrl,
     ContactApolloAccountManager,
     TryAgainLater,
+    ContactApolloSupport,
 }
 
 impl Display for RoverErrorSuggestion {
@@ -132,29 +133,29 @@ impl Display for RoverErrorSuggestion {
                     Style::Command.paint("`--profile`")
                 )
             }
-RunComposition => {
+            RunComposition => {
                 format!("Try resolving the build errors in your subgraph(s), and publish them with the {} command.", Style::Command.paint("`rover subgraph publish`"))
             }
-UseFederatedGraph => {
+            UseFederatedGraph => {
                 "Try running the command on a valid federated graph, or use the appropriate `rover graph` command instead of `rover subgraph`.".to_string()
             }
             UseContractVariant => {
                 "Try running the command on a valid contract variant.".to_string()
             }
-CheckGraphNameAndAuth => {
+            CheckGraphNameAndAuth => {
                 format!(
                     "Make sure your graph name is typed correctly, and that your API key is valid.\n        You can run {} to check if you are authenticated.\n        If you are trying to create a new graph, you must do so online at {}, by clicking \"New Graph\".",
                     Style::Command.paint("`rover config whoami`"),
                     Style::Link.paint("https://studio.apollographql.com")
                 )
             }
-ProvideValidSubgraph(valid_subgraphs) => {
+            ProvideValidSubgraph(valid_subgraphs) => {
                 format!(
                     "Try running this command with one of the following valid subgraphs: [{}]",
                     valid_subgraphs.join(", ")
                 )
             }
-ProvideValidVariant { graph_ref, valid_variants, frontend_url_root} => {
+            ProvideValidVariant { graph_ref, valid_variants, frontend_url_root} => {
                 if let Some(maybe_variant) = did_you_mean(&graph_ref.variant, valid_variants).pop()  {
                     format!("Did you mean \"{}@{}\"?", graph_ref.name, maybe_variant)
                 } else {
@@ -184,46 +185,46 @@ ProvideValidVariant { graph_ref, valid_variants, frontend_url_root} => {
                     }
                 }
             }
-CheckKey => {
+            CheckKey => {
                 "Check your API key to make sure it's valid (are you using the right profile?).".to_string()
             }
-TryUnsetKey => {
+            TryUnsetKey => {
                 format!(
                     "Try to unset your {} key if you want to use {}.",
                     Style::Command.paint(format!("`${}`", RoverEnvKey::Key)),
                     Style::Command.paint("`--profile default`")
                 )
             }
-ProperKey => {
+            ProperKey => {
                 format!("Try running {} for more details on Apollo's API keys.", Style::Command.paint("`rover docs open api-keys`"))
             }
-ValidComposeFile => {
+            ValidComposeFile => {
                 "Make sure supergraph compose config YAML points to a valid schema file.".to_string()
             }
-ValidComposeRoutingUrl=> {
+            ValidComposeRoutingUrl=> {
                 "When trying to compose with a local .graphql file, make sure you supply a `routing_url` in your config YAML.".to_string()
             }
-NewUserNoProfiles => {
+            NewUserNoProfiles => {
                 format!("It looks like you may be new here. Welcome! To authenticate with Apollo Studio, run {}, or set {} to a valid Apollo Studio API key.",
                     Style::Command.paint("`rover config auth`"), Style::Command.paint(format!("`${}`", RoverEnvKey::Key))
                 )
             }
-Adhoc(msg) => msg.to_string(),
-CheckServerConnection => "Make sure the endpoint is accepting connections and is spelled correctly".to_string(),
-CheckResponseType => "Make sure the endpoint you specified is returning JSON data as its response".to_string(),
-ConvertGraphToSubgraph => "If you are sure you want to convert a non-federated graph to a subgraph, you can re-run the same command with a `--convert` flag.".to_string(),
-CheckGnuVersion => {
+            Adhoc(msg) => msg.to_string(),
+            CheckServerConnection => "Make sure the endpoint is accepting connections and is spelled correctly".to_string(),
+            CheckResponseType => "Make sure the endpoint you specified is returning JSON data as its response".to_string(),
+            ConvertGraphToSubgraph => "If you are sure you want to convert a non-federated graph to a subgraph, you can re-run the same command with a `--convert` flag.".to_string(),
+            CheckGnuVersion => {
                 let mut suggestion = "It looks like you are running a Rover binary that does not have the ability to run composition, please try re-installing.";
                 if cfg!(target_env = "musl") {
                     suggestion = "Unfortunately, Deno does not currently support musl architectures, and as of yet, there is no native composition implementation in Rust. You can follow along with this issue for updates on musl support: https://github.com/denoland/deno/issues/3711, for now you will need to switch to a Linux distribution (like Ubuntu or CentOS) that can run Rover's prebuilt binaries.";
                 }
                 suggestion.to_string()
             },
-FixSubgraphSchema { graph_ref, subgraph } => format!("The changes in the schema you proposed for subgraph {} are incompatible with supergraph {}. See {} for more information on resolving build errors.", Style::Link.paint(subgraph), Style::Link.paint(graph_ref.to_string()), Style::Link.paint("https://www.apollographql.com/docs/federation/errors/")),
-FixSupergraphConfigErrors => {
+            FixSubgraphSchema { graph_ref, subgraph } => format!("The changes in the schema you proposed for subgraph {} are incompatible with supergraph {}. See {} for more information on resolving build errors.", Style::Link.paint(subgraph), Style::Link.paint(graph_ref.to_string()), Style::Link.paint("https://www.apollographql.com/docs/federation/errors/")),
+            FixSupergraphConfigErrors => {
                 format!("See {} for information on the config format.", Style::Link.paint("https://www.apollographql.com/docs/rover/commands/supergraphs#yaml-configuration-file"))
             }
-FixCompositionErrors { num_subgraphs } => {
+            FixCompositionErrors { num_subgraphs } => {
                 let prefix = match num_subgraphs {
                     1 => "The subgraph schema you provided is invalid.".to_string(),
                     _ => "The subgraph schemas you provided are incompatible with each other.".to_string()
@@ -237,14 +238,14 @@ FixCompositionErrors { num_subgraphs } => {
                 "See {} for more information on resolving check errors.",
                     Style::Link.paint("https://www.apollographql.com/docs/graphos/delivery/schema-checks")
                 ),
-FixOperationsInSchema { graph_ref } => format!("The changes in the schema you proposed are incompatible with graph {}. See {} for more information on resolving operation check errors.", Style::Link.paint(graph_ref.to_string()), Style::Link.paint("https://www.apollographql.com/docs/studio/schema-checks/")),
-FixDownstreamCheckFailure { target_url } => format!("The changes in the schema you proposed cause checks to fail for blocking downstream variants. See {} to view the failure reasons for these downstream checks.", Style::Link.paint(target_url)),
-FixOtherCheckTaskFailure { target_url } => format!("See {} to view the failure reason for the check.", Style::Link.paint(target_url)),
-FixLintFailure => "The schema you submitted contains lint violations. Please address the violations and resubmit the schema.".to_string(),
-IncreaseClientTimeout => "You can try increasing the timeout value by passing a higher value to the --client-timeout option.".to_string(),
-IncreaseChecksTimeout {url} => format!("You can try increasing the timeout value by setting APOLLO_CHECKS_TIMEOUT_SECONDS to a higher value in your env. The default value is 300 seconds. You can also view the live check progress by visiting {}.", Style::Link.paint(url.clone().unwrap_or_else(|| "https://studio.apollographql.com".to_string()))),
-FixChecksInput { graph_ref } => format!("Graph {} has no published schema or is not a composition variant. Please publish a schema or use a different variant.", Style::Link.paint(graph_ref.to_string())),
-UpgradePlan => "Rover has likely reached rate limits while running graph or subgraph checks. Please try again later or contact your graph admin about upgrading your billing plan.".to_string(),
+            FixOperationsInSchema { graph_ref } => format!("The changes in the schema you proposed are incompatible with graph {}. See {} for more information on resolving operation check errors.", Style::Link.paint(graph_ref.to_string()), Style::Link.paint("https://www.apollographql.com/docs/studio/schema-checks/")),
+            FixDownstreamCheckFailure { target_url } => format!("The changes in the schema you proposed cause checks to fail for blocking downstream variants. See {} to view the failure reasons for these downstream checks.", Style::Link.paint(target_url)),
+            FixOtherCheckTaskFailure { target_url } => format!("See {} to view the failure reason for the check.", Style::Link.paint(target_url)),
+            FixLintFailure => "The schema you submitted contains lint violations. Please address the violations and resubmit the schema.".to_string(),
+            IncreaseClientTimeout => "You can try increasing the timeout value by passing a higher value to the --client-timeout option.".to_string(),
+            IncreaseChecksTimeout {url} => format!("You can try increasing the timeout value by setting APOLLO_CHECKS_TIMEOUT_SECONDS to a higher value in your env. The default value is 300 seconds. You can also view the live check progress by visiting {}.", Style::Link.paint(url.clone().unwrap_or_else(|| "https://studio.apollographql.com".to_string()))),
+            FixChecksInput { graph_ref } => format!("Graph {} has no published schema or is not a composition variant. Please publish a schema or use a different variant.", Style::Link.paint(graph_ref.to_string())),
+            UpgradePlan => "Rover has likely reached rate limits while running graph or subgraph checks. Please try again later or contact your graph admin about upgrading your billing plan.".to_string(),
             ProvideRoutingUrl { subgraph_name, graph_ref } => {
                 format!("The subgraph {} does not exist for {}. You cannot add a subgraph to a supergraph without a routing URL.
                 Try re-running this command with a `--routing-url` argument.", subgraph_name, Style::Link.paint(graph_ref.to_string()))
@@ -264,6 +265,10 @@ UpgradePlan => "Rover has likely reached rate limits while running graph or subg
             AllowInvalidRoutingUrlOrSpecifyValidUrl => format!("Try publishing the subgraph with a valid routing URL. If you are sure you want to publish an invalid routing URL, re-run this command with the {} option.", Style::Command.paint("`--allow-invalid-routing-url`")),
             ContactApolloAccountManager => {"Discuss your requirements with your Apollo point of contact.".to_string()},
             TryAgainLater => {"Please try again later.".to_string()},
+            ContactApolloSupport => format!(
+                "Please try again later. If the error persists, please contact the Apollo team at {}.",
+                Style::Link.paint("https://support.apollographql.com/?createRequest=true&portalId=1023&requestTypeId=1230")
+            ),
             InvalidSupergraphYamlSubgraphSchemaPath {
                 subgraph_name, supergraph_yaml_path
             } => format!("Make sure the specified path for subgraph '{}' is relative to the location of the supergraph schema file ({})", subgraph_name, Style::Path.paint(supergraph_yaml_path))


### PR DESCRIPTION
This PR makes two improvements to the `init` command:

1. **Graceful error handling for graph ID unavailability**
   - Added a restart flow when a graph ID is already in use instead of terminating with an error
   - Users can now try a different graph ID without restarting the entire `init` process
   - Introduced a `CreateProjectResult` enum to properly handle different outcomes (`Created`, `Restart`)
   - Improved error messaging to provide clearer guidance to users

2. **Flattened Nested Control Flow**
   - Refactored deeply nested match expressions into a flatter, more maintainable structure
   - Simplified the project creation flow with early returns for clearer control paths
   - Extracted the restart logic into a dedicated loop for better readability
   - Maintained our typestate pattern while reducing excessive nesting

## Why These Changes?

### Error Handling Improvements
Previously, when a user attempted to create a project with a graph ID that was already in use, the command would fail with an error message that required them to restart the entire `rover init` process. This was frustrating for users who had already gone through several steps of configuration.

Now, the command gracefully handles this case by allowing users to retry with a different graph ID while preserving all their previous selections.

### Code Structure Improvements
While implementing the typestate is ideal for this use case, I noticed the previous implementation had become overly nested with multiple layers of match expressions and option handling. This made the code harder to read, maintain, and extend.

The new implementation flattens these nested structures without sacrificing type safety, making the code more maintainable for future contributors while preserving the benefits of our typestate approach.

## Testing
Tested the following scenarios:
- Creating a new project with a unique graph ID
- Attempting to create a project with an already used graph ID and then successfully retrying with a different ID
- Adding a subgraph (early return path)
- Cancellation at various points in the flow