### PR TITLE
use actions/checkout@v4 in GitHub Actions example workflows

### DIFF
--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -101,7 +101,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Installs Rover into $PATH for use with subsequent steps
       - uses: apollographql-gh-actions/install-rover@v1
@@ -195,7 +195,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Rover
         run: |


### PR DESCRIPTION
GitHub has released newer versions of [actions/checkout](https://github.com/marketplace/actions/checkout). We should guide users to stop using the outdated version of it in the [docs](https://www.apollographql.com/docs/rover/ci-cd). This PR updates the example workflows to use `actions/checkout@v4` instead of `actions/checkout@v2`.

I tested that the latest version of `actions/checkout` works well with rover actions with on a personal repository:

![Shot 2025-04-24 at 10 51 18](https://github.com/user-attachments/assets/3beffeac-f909-41fa-847c-da2d59c72b36)
