### PR TITLE
Update doc about key used with graph ref

### DIFF
--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -111,7 +111,7 @@ rover dev --graph-ref docs-example-graph@current
 
 <Note>
 
-To pass a graph ref, you need a personal API key or graph API key configured in Rover.
+To pass a graph ref, you need a graph API key configured in Rover.
 
 </Note>
 


### PR DESCRIPTION
We've had multiple reports from customers that using a personal API key with a graph ref does not work. The [uplink code](https://github.com/mdg-private/monorepo/blob/c148b1dd10a039b735c3bfe186ab143f8801a42c/mdg/uplink/reader/src/main/kotlin/mdg/uplink/reader/GQLQuery.kt#L78) throws an error for anything but a graph key. Updating the doc to remove the reference to personal API keys to prevent confusion here.