### PR TITLE
fix(init): properly handle default graph ID acceptance

### DIFF
--- a/src/command/init/options/project_graphid.rs
+++ b/src/command/init/options/project_graphid.rs
@@ -48,7 +48,7 @@ impl GraphIdOpt {
                     return Ok(graph_id);
                 },
                 Err(e) => {
-                    self.handle_validation_error(e, attempt)?;
+                    let _ = self.handle_validation_error(e, attempt);
                 }
             }
 

--- a/src/command/init/options/project_graphid.rs
+++ b/src/command/init/options/project_graphid.rs
@@ -46,7 +46,7 @@ impl GraphIdOpt {
             match GraphId::from_str(input_to_validate) {
                 Ok(graph_id) => {
                     return Ok(graph_id);
-                },
+                }
                 Err(e) => {
                     let _ = self.handle_validation_error(e, attempt);
                 }

--- a/src/command/init/options/project_graphid.rs
+++ b/src/command/init/options/project_graphid.rs
@@ -36,9 +36,20 @@ impl GraphIdOpt {
         loop {
             let input = self.prompt_for_input(&suggested_id)?;
 
-            match GraphId::from_str(&input) {
-                Ok(graph_id) => return Ok(graph_id),
-                Err(e) => self.handle_validation_error(e, attempt)?,
+            // If the user just pressed Enter (empty input), use the suggested ID
+            let input_to_validate = if input.is_empty() {
+                &suggested_id
+            } else {
+                &input
+            };
+
+            match GraphId::from_str(input_to_validate) {
+                Ok(graph_id) => {
+                    return Ok(graph_id);
+                },
+                Err(e) => {
+                    self.handle_validation_error(e, attempt)?;
+                }
             }
 
             attempt += 1;
@@ -49,10 +60,14 @@ impl GraphIdOpt {
         let input = Input::<String>::new()
             .with_prompt(Style::Prompt.paint("Confirm or modify graph ID (start with a letter and use only letters, numbers, and dashes)"))
             .with_initial_text(suggested_id.to_string())
-            .allow_empty(false)
+            .allow_empty(true)
             .interact_text()?;
 
-        Ok(input)
+        if input.is_empty() {
+            Ok(suggested_id.to_string())
+        } else {
+            Ok(input)
+        }
     }
 
     fn handle_validation_error(


### PR DESCRIPTION
## Problem
When running `rover init` and selecting the `Connectors` use case, if a user accepts the default generated graph ID by pressing Enter, the graph ID prompt appears again. This occurs intermittently. 

## Possible Root Cause
1. The `prompt_for_input` method in `src/command/init/options/project_graphid.rs` was configured with `allow_empty(false)`, which meant that when a user pressed Enter to accept the default value, the input was considered invalid and the prompt would recycle. This would happen consistently whenever a user tried to accept the default by pressing Enter, regardless of what the generated graph ID was.
2. The error handling in the validation loop was using the `?` operator on `handle_validation_error`, causing the function to exit prematurely on validation errors instead of continuing the loop.

Note that this solution is based on the understanding the business logic of prompt, which would automatically return the same message on Enter because of the `allow_empty` configuration. 