### PR TITLE
feat(rover): Display template commands during `init` flow if one exists

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -83,7 +83,7 @@ pub fn generate_project_created_message(
     };
     if let Some(command) = command {
         output.push_str(&format!(
-            "1) Start the project: {}\n",
+            "1) Start the service: {}\n",
             Style::Command.paint(command)
         ));
         output.push_str(&format!(

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -21,6 +21,7 @@ pub fn display_project_created_message(
     artifacts: &[Utf8PathBuf],
     graph_ref: &GraphRef,
     api_key: &str,
+    command: Option<&str>,
 ) {
     println!();
     infoln!("All set! Your graph '{}' has been created. Please review details below to see what was generated.",Style::File.paint(project_name));
@@ -50,15 +51,17 @@ pub fn display_project_created_message(
     println!("- Store your graph API key securely, you won’t be able to access it again!");
     println!();
     println!("{}", Style::Heading.paint("Next steps"));
-    println!("Run the following command to start a local development session:");
-    println!();
-    println!(
-        "{}",
-        Style::Command.paint(format!(
-            "APOLLO_KEY={} rover dev --graph-ref {} --supergraph-config supergraph.yaml",
-            api_key, graph_ref
-        ))
+    let dev_command = format!(
+        "APOLLO_KEY={} rover dev --graph-ref {} --supergraph-config supergraph.yaml",
+        api_key, graph_ref
     );
+    if let Some(command) = command {
+        println!("1) Start the project: {}", Style::Command.paint(command));
+        println!("2) Start a local development session: {}", Style::Command.paint(dev_command));
+    } else {
+        println!("Start a local development session:");
+        println!("{}", Style::Command.paint(dev_command));
+    }
     println!();
     println!("For more information, check out 'getting-started.md'.");
     println!();

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -57,7 +57,10 @@ pub fn display_project_created_message(
     );
     if let Some(command) = command {
         println!("1) Start the project: {}", Style::Command.paint(command));
-        println!("2) Start a local development session: {}", Style::Command.paint(dev_command));
+        println!(
+            "2) Start a local development session: {}",
+            Style::Command.paint(dev_command)
+        );
     } else {
         println!("Start a local development session:");
         println!("{}", Style::Command.paint(dev_command));

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -24,24 +24,27 @@ pub fn generate_project_created_message(
     command: Option<&str>,
 ) -> String {
     let mut output = String::new();
-    
+
     // Add welcome message
     output.push_str(&format!(
         "\nAll set! Your graph '{}' has been created. Please review details below to see what was generated.\n\n",
         Style::File.paint(project_name)
     ));
-    
+
     // Add files section only if there are artifacts
     if !artifacts.is_empty() {
         output.push_str(&format!("{}\n", Style::Heading.paint("Files created:")));
         for artifact in artifacts.iter().filter(|a| !a.as_str().is_empty()) {
-            output.push_str(&format!("{}\n", Style::Success.paint(artifact.to_string())));
+            output.push_str(&format!("{}\n", Style::Success.paint(artifact)));
         }
         output.push('\n');
     }
-    
+
     // Add credentials section
-    output.push_str(&format!("{}\n", Style::Heading.paint("GraphOS credentials for your graph")));
+    output.push_str(&format!(
+        "{}\n",
+        Style::Heading.paint("GraphOS credentials for your graph")
+    ));
     output.push_str(&format!(
         "{}\n",
         Style::Success.paint(format!(
@@ -59,11 +62,15 @@ pub fn generate_project_created_message(
         ))
     ));
     output.push('\n');
-    
+
     // Add warning section
-    output.push_str(&format!("{}\n", Style::WarningHeading.paint("️▲ Before you proceed:")));
-    output.push_str("- Store your graph API key securely, you won't be able to access it again!\n\n");
-    
+    output.push_str(&format!(
+        "{}\n",
+        Style::WarningHeading.paint("️▲ Before you proceed:")
+    ));
+    output
+        .push_str("- Store your graph API key securely, you won't be able to access it again!\n\n");
+
     // Add next steps section
     output.push_str(&format!("{}\n", Style::Heading.paint("Next steps")));
     let dev_command = if !artifacts.is_empty() {
@@ -72,13 +79,13 @@ pub fn generate_project_created_message(
             api_key, graph_ref
         )
     } else {
-        format!(
-            "APOLLO_KEY={} rover dev --graph-ref {}",
-            api_key, graph_ref
-        )
+        format!("APOLLO_KEY={} rover dev --graph-ref {}", api_key, graph_ref)
     };
     if let Some(command) = command {
-        output.push_str(&format!("1) Start the project: {}\n", Style::Command.paint(command)));
+        output.push_str(&format!(
+            "1) Start the project: {}\n",
+            Style::Command.paint(command)
+        ));
         output.push_str(&format!(
             "2) Start a local development session: {}\n",
             Style::Command.paint(dev_command)
@@ -88,7 +95,7 @@ pub fn generate_project_created_message(
         output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
     }
     output.push_str("\nFor more information, check out 'getting-started.md'.\n\n");
-    
+
     output
 }
 
@@ -99,13 +106,8 @@ pub fn display_project_created_message(
     api_key: &str,
     command: Option<&str>,
 ) {
-    let message = generate_project_created_message(
-        project_name,
-        artifacts,
-        graph_ref,
-        api_key,
-        command,
-    );
+    let message =
+        generate_project_created_message(project_name, artifacts, graph_ref, api_key, command);
     println!("{}", message);
 }
 

--- a/src/command/init/states.rs
+++ b/src/command/init/states.rs
@@ -4,7 +4,7 @@ use crate::command::init::options::{OrganizationId, ProjectName, ProjectType, Pr
 #[cfg(feature = "init")]
 use crate::command::init::template_fetcher::Template;
 #[cfg(not(feature = "init"))]
-use crate::options::TemplateProject;
+use crate::options::template::TemplateProject;
 use camino::Utf8PathBuf;
 use rover_client::shared::GraphRef;
 #[cfg(feature = "init")]
@@ -91,6 +91,8 @@ pub struct ProjectCreated {
     pub artifacts: Vec<Utf8PathBuf>,
     pub api_key: String,
     pub graph_ref: GraphRef,
+    #[cfg(feature = "init")]
+    pub template: Option<Template>,
 }
 
 #[derive(Debug)]

--- a/src/command/init/tests/authentication_tests.rs
+++ b/src/command/init/tests/authentication_tests.rs
@@ -76,7 +76,6 @@ mod tests {
     // TYPE-BASED AUTHENTICATION TESTS
 
     struct ApiKey {
-        key: String,
         key_type: KeyType,
     }
 
@@ -91,24 +90,20 @@ mod tests {
         fn parse(key: &str) -> Self {
             if key.is_empty() {
                 return ApiKey {
-                    key: key.to_string(),
                     key_type: KeyType::Invalid,
                 };
             }
 
             if key.starts_with("user:") {
                 ApiKey {
-                    key: key.to_string(),
                     key_type: KeyType::User,
                 }
             } else if key.starts_with("graph:") {
                 ApiKey {
-                    key: key.to_string(),
                     key_type: KeyType::Graph,
                 }
             } else {
                 ApiKey {
-                    key: key.to_string(),
                     key_type: KeyType::Invalid,
                 }
             }

--- a/src/command/init/tests/mod.rs
+++ b/src/command/init/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod authentication_tests;
 pub mod project_authentication_tests;
+pub mod project_created_message_tests;
 pub mod transitions_tests;

--- a/src/command/init/tests/project_authentication_tests.rs
+++ b/src/command/init/tests/project_authentication_tests.rs
@@ -12,16 +12,14 @@ mod tests {
     // AUTHENTICATION WORKFLOW SIMULATION
 
     struct AuthWorkflowSimulation {
-        initial_key: Option<String>,
         entered_key: Option<String>,
         authenticated: bool,
         error: Option<AuthenticationError>,
     }
 
     impl AuthWorkflowSimulation {
-        fn new(initial_key: Option<String>) -> Self {
+        fn new() -> Self {
             AuthWorkflowSimulation {
-                initial_key,
                 entered_key: None,
                 authenticated: false,
                 error: None,
@@ -92,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_successful_authentication_flow() {
-        let mut workflow = AuthWorkflowSimulation::new(None);
+        let mut workflow = AuthWorkflowSimulation::new();
 
         workflow.enter_key("user:valid_key");
 
@@ -105,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_empty_key_authentication_flow() {
-        let mut workflow = AuthWorkflowSimulation::new(None);
+        let mut workflow = AuthWorkflowSimulation::new();
 
         workflow.enter_key("");
 
@@ -118,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_invalid_format_authentication_flow() {
-        let mut workflow = AuthWorkflowSimulation::new(None);
+        let mut workflow = AuthWorkflowSimulation::new();
 
         workflow.enter_key("invalid_format");
 
@@ -131,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_graph_key_authentication_flow() {
-        let mut workflow = AuthWorkflowSimulation::new(None);
+        let mut workflow = AuthWorkflowSimulation::new();
 
         workflow.enter_key("user:graph_mistake");
 
@@ -144,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_invalid_credentials_authentication_flow() {
-        let mut workflow = AuthWorkflowSimulation::new(None);
+        let mut workflow = AuthWorkflowSimulation::new();
 
         workflow.enter_key("user:invalid_credentials");
 
@@ -160,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_system_error_authentication_flow() {
-        let mut workflow = AuthWorkflowSimulation::new(None);
+        let mut workflow = AuthWorkflowSimulation::new();
 
         workflow.enter_key("user:system_error_key");
 

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -70,7 +70,7 @@ fn test_display_project_created_message_without_command() {
     assert!(plain_output.contains("Store your graph API key securely"));
     assert!(plain_output.contains("rover dev"));
     // Should not contain any command-specific text
-    assert!(!plain_output.contains("Start the project"));
+    assert!(!plain_output.contains("Start the service"));
 }
 
 #[test]

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -1,0 +1,105 @@
+use camino::Utf8PathBuf;
+use rover_client::shared::GraphRef;
+use std::string::String;
+
+use crate::command::init::helpers::generate_project_created_message;
+
+// Helper function to strip ANSI color codes
+fn strip_ansi_codes(s: &str) -> String {
+    s.replace("\x1b[0m", "")
+        .replace("\x1b[1m", "")
+        .replace("\x1b[32m", "")
+        .replace("\x1b[33m", "")
+        .replace("\x1b[34m", "")
+        .replace("\x1b[35m", "")
+        .replace("\x1b[36m", "")
+        .replace("\x1b[37m", "")
+        .replace("\x1b[38;5;", "")
+        .replace("\x1b[39m", "")
+}
+
+#[test]
+fn test_display_project_created_message_with_command() {
+    let project_name = "my-graph";
+    let artifacts = vec![
+        Utf8PathBuf::from("supergraph.yaml"),
+        Utf8PathBuf::from("getting-started.md"),
+    ];
+    let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
+    let api_key = "test-api-key";
+    let command = Some("npm start");
+
+    let output = generate_project_created_message(
+        project_name,
+        &artifacts,
+        &graph_ref,
+        api_key,
+        command,
+    );
+    let plain_output = strip_ansi_codes(&output);
+
+    // Test that the output contains expected content
+    assert!(plain_output.contains(&format!("All set! Your graph '{}' has been created", project_name)));
+    assert!(plain_output.contains("supergraph.yaml"));
+    assert!(plain_output.contains("getting-started.md"));
+    assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
+    assert!(plain_output.contains(&format!("APOLLO_KEY={}", api_key)));
+    assert!(plain_output.contains("Store your graph API key securely"));
+    assert!(plain_output.contains("npm start"));
+    assert!(plain_output.contains("rover dev"));
+}
+
+#[test]
+fn test_display_project_created_message_without_command() {
+    let project_name = "my-graph";
+    let artifacts = vec![Utf8PathBuf::from("supergraph.yaml")];
+    let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
+    let api_key = "test-api-key";
+    let command = None;
+
+    let output = generate_project_created_message(
+        project_name,
+        &artifacts,
+        &graph_ref,
+        api_key,
+        command,
+    );
+    let plain_output = strip_ansi_codes(&output);
+
+    // Test that the output contains expected content
+    assert!(plain_output.contains(&format!("All set! Your graph '{}' has been created", project_name)));
+    assert!(plain_output.contains("supergraph.yaml"));
+    assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
+    assert!(plain_output.contains(&format!("APOLLO_KEY={}", api_key)));
+    assert!(plain_output.contains("Store your graph API key securely"));
+    assert!(plain_output.contains("rover dev"));
+    // Should not contain any command-specific text
+    assert!(!plain_output.contains("Start the project"));
+}
+
+#[test]
+fn test_display_project_created_message_with_empty_artifacts() {
+    let project_name = "my-graph";
+    let artifacts: Vec<Utf8PathBuf> = vec![];
+    let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
+    let api_key = "test-api-key";
+    let command = None;
+
+    let output = generate_project_created_message(
+        project_name,
+        &artifacts,
+        &graph_ref,
+        api_key,
+        command,
+    );
+    let plain_output = strip_ansi_codes(&output);
+
+    // Test that the output contains expected content
+    assert!(plain_output.contains(&format!("All set! Your graph '{}' has been created", project_name)));
+    assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
+    assert!(plain_output.contains(&format!("APOLLO_KEY={}", api_key)));
+    // Should not contain the files section
+    assert!(!plain_output.contains("Files created:"));
+    // Should not contain supergraph.yaml in the files section
+    assert!(!plain_output.contains("supergraph.yaml\n"));
+} 

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -29,17 +29,15 @@ fn test_display_project_created_message_with_command() {
     let api_key = "test-api-key";
     let command = Some("npm start");
 
-    let output = generate_project_created_message(
-        project_name,
-        &artifacts,
-        &graph_ref,
-        api_key,
-        command,
-    );
+    let output =
+        generate_project_created_message(project_name, &artifacts, &graph_ref, api_key, command);
     let plain_output = strip_ansi_codes(&output);
 
     // Test that the output contains expected content
-    assert!(plain_output.contains(&format!("All set! Your graph '{}' has been created", project_name)));
+    assert!(plain_output.contains(&format!(
+        "All set! Your graph '{}' has been created",
+        project_name
+    )));
     assert!(plain_output.contains("supergraph.yaml"));
     assert!(plain_output.contains("getting-started.md"));
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
@@ -57,17 +55,15 @@ fn test_display_project_created_message_without_command() {
     let api_key = "test-api-key";
     let command = None;
 
-    let output = generate_project_created_message(
-        project_name,
-        &artifacts,
-        &graph_ref,
-        api_key,
-        command,
-    );
+    let output =
+        generate_project_created_message(project_name, &artifacts, &graph_ref, api_key, command);
     let plain_output = strip_ansi_codes(&output);
 
     // Test that the output contains expected content
-    assert!(plain_output.contains(&format!("All set! Your graph '{}' has been created", project_name)));
+    assert!(plain_output.contains(&format!(
+        "All set! Your graph '{}' has been created",
+        project_name
+    )));
     assert!(plain_output.contains("supergraph.yaml"));
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", api_key)));
@@ -85,21 +81,19 @@ fn test_display_project_created_message_with_empty_artifacts() {
     let api_key = "test-api-key";
     let command = None;
 
-    let output = generate_project_created_message(
-        project_name,
-        &artifacts,
-        &graph_ref,
-        api_key,
-        command,
-    );
+    let output =
+        generate_project_created_message(project_name, &artifacts, &graph_ref, api_key, command);
     let plain_output = strip_ansi_codes(&output);
 
     // Test that the output contains expected content
-    assert!(plain_output.contains(&format!("All set! Your graph '{}' has been created", project_name)));
+    assert!(plain_output.contains(&format!(
+        "All set! Your graph '{}' has been created",
+        project_name
+    )));
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", api_key)));
     // Should not contain the files section
     assert!(!plain_output.contains("Files created:"));
     // Should not contain supergraph.yaml in the files section
     assert!(!plain_output.contains("supergraph.yaml\n"));
-} 
+}

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -560,6 +560,8 @@ impl CreationConfirmed {
             artifacts,
             api_key,
             graph_ref,
+            #[cfg(feature = "init")]
+            template: Some(self.selected_template.template.clone()),
         }))
     }
 }
@@ -577,6 +579,10 @@ impl ProjectCreated {
             &self.artifacts,
             &self.graph_ref,
             &self.api_key.to_string(),
+            #[cfg(feature = "init")]
+            self.template.as_ref().and_then(|t| t.command.as_deref()),
+            #[cfg(not(feature = "init"))]
+            None,
         );
 
         Completed


### PR DESCRIPTION
## Changes
- Modified the command display logic in `display_project_created_message` to show different formats based on whether a command is provided
- When a command is provided, shows numbered steps (1 and 2)
- When no command is provided, shows a single unnumbered step with a header
- Extracted the development command into a variable to avoid repetition

## Before
```
Next steps
1) Start the project: [command]
2) Start a local development session: [dev_command]
```

## After
When command provided:
```
Next steps
1) Start the project: [command]
2) Start a local development session: [dev_command]
```

When no command provided:
```
Next steps
Start a local development session:
[dev_command]
```

### Tests
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.05s
     Running unittests src/lib.rs (target/debug/deps/rover-5da8532e5dea4f53)

running 3 tests
test command::init::tests::project_created_message_tests::test_display_project_created_message_without_command ... ok
test command::init::tests::project_created_message_tests::test_display_project_created_message_with_empty_artifacts ... ok
test command::init::tests::project_created_message_tests::test_display_project_created_message_with_command ... ok

successes:

successes:
    command::init::tests::project_created_message_tests::test_display_project_created_message_with_command
    command::init::tests::project_created_message_tests::test_display_project_created_message_with_empty_artifacts
    command::init::tests::project_created_message_tests::test_display_project_created_message_without_command

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 344 filtered out; finished in 0.04s
```