### PR TITLE
adding start_point_file to specify what file to use in output

### DIFF
--- a/src/command/init/template_fetcher.rs
+++ b/src/command/init/template_fetcher.rs
@@ -58,6 +58,17 @@ pub struct Template {
     pub routing_url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+    #[serde(
+        default = "Template::default_start_point_file",
+        rename = "start_point_file"
+    )]
+    pub start_point_file: String,
+}
+
+impl Template {
+    fn default_start_point_file() -> String {
+        "getting-started.md".to_string()
+    }
 }
 
 #[cfg(feature = "init")]
@@ -207,5 +218,44 @@ impl TemplateWrite for SelectedTemplateState {
             Fs::write_file(&full_path, contents)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_template_start_point_file_default() {
+        let json = r#"{
+            "id": "typescript",
+            "display_name": "Build an API with Typescript",
+            "path": "start-with-typescript",
+            "language": "Typescript",
+            "federation_version": "=2.10.0",
+            "max_schema_depth": 5,
+            "command": "npm ci && npm start",
+            "routing_url": "http://localhost:4001"
+        }"#;
+        let template: Template = serde_json::from_str(json).unwrap();
+        assert_eq!(template.start_point_file, "getting-started.md");
+    }
+
+    #[test]
+    fn test_template_start_point_file_override() {
+        let json = r#"{
+            "id": "typescript",
+            "display_name": "Build an API with Typescript",
+            "path": "start-with-typescript",
+            "language": "Typescript",
+            "federation_version": "=2.10.0",
+            "max_schema_depth": 5,
+            "command": "npm ci && npm start",
+            "routing_url": "http://localhost:4001",
+            "start_point_file": "readme.md"
+        }"#;
+        let template: Template = serde_json::from_str(json).unwrap();
+        assert_eq!(template.start_point_file, "readme.md");
     }
 }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

## Summary

To support driving the starting point from the templates, we're introducing a new field that supplies the path to that starting point. This allows us to change the structure over time, and users will automatically see the updated version when they initialize a project.
