### PR TITLE
feat(rover): init flow - update project creation copy for accuracy

### DIFF
--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -19,7 +19,7 @@ pub struct TemplateOperations;
 impl TemplateOperations {
     pub fn prompt_creation(artifacts: Vec<Utf8PathBuf>) -> io::Result<bool> {
         println!();
-        infoln!("You’re about to create a local directory with the following files:");
+        infoln!("You’re about to add the following files to your local directory:");
         println!();
         let mut artifacts_sorted = artifacts;
         artifacts_sorted.sort();

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -345,7 +345,7 @@ impl ProjectNamed {
 /// PROMPT UX:
 /// =========
 ///
-/// => You're about to create a local directory with the following files:
+/// => You're about to add the following files to your local directory:
 ///
 /// .vscode/extensions.json
 /// .idea/externalDependencies.xml


### PR DESCRIPTION
This PR changes the message a user sees when they're confirming the project/service about to be built in the `init` flow.  The change  better reflects that we're adding files to an existing directory rather than creating a new one.

Before:
```
You're about to create a local directory with the following files
```

Now:
```
You're about to add the following files to your local directory
```
