### PR TITLE
feat(init): Always show template selector for `recommended libraries` flow

### DIFF
--- a/src/command/init/options/project_template.rs
+++ b/src/command/init/options/project_template.rs
@@ -24,11 +24,8 @@ impl ProjectTemplateOpt {
         if templates.is_empty() {
             return Err(RoverError::new(anyhow!("No templates available")));
         }
-        // if only 1 template, return that template
-        if templates.len() == 1 {
-            return Ok(TemplateId(templates[0].id.to_string()));
-        }
-        // otherwise, let user select from list of templates
+
+        // let user select from list of templates
         let template_display_names = templates
             .iter()
             .map(|t| t.display_name.as_str())


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
Before, if there was just 1 template in the list of templates, we defaulted to that template option for the `init` command flow.
<img width="410" alt="image" src="https://github.com/user-attachments/assets/4ff866e4-3a4a-4a22-ab8c-b80273f907bd" />


Now, we always show  the template selection prompt including if there is just 1 template:
<img width="695" alt="image" src="https://github.com/user-attachments/assets/272fcf2b-2ee1-48bc-97c8-59263f287c30" />

