### PR TITLE
docs: Set the APOLLO_VCS_BRANCH environment variable in GitHub Actions

### DIFF
--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -92,6 +92,7 @@ jobs:
     # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsenv
     env:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+      APOLLO_VCS_BRANCH: ${{ github.head_ref }}
       APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
 
     steps:
@@ -202,6 +203,7 @@ jobs:
     # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsenv
     env:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+      APOLLO_VCS_BRANCH: ${{ github.head_ref }}
       APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
This PR sets the `APOLLO_VCS_BRANCH` environment variable in the GitHub Actions example workflows, ensuring that users see the correct branch on Apollo GraphOS.

## Issue

I noticed in GraphOS Studio that the schema checks run on my pull requests by GitHub Actions are displayed as if they were executed on the main branch instead of the feature branch associated with the PR.

I reproduced the issue in this PR: https://github.com/DaleSeo/my-graph-qnyr67/pull/16

![Shot 2025-05-05 at 17 06 33](https://github.com/user-attachments/assets/7309963d-a7c0-45cc-bc7c-c590a92ab204)

Here's the schema check with the incorrect branch: https://studio.apollographql.com/graph/My-Graph-qnyr67/variant/main/check/09ffeae8-734e-498a-aa32-afe2489923c8/details

![Shot 2025-05-05 at 16 57 57](https://github.com/user-attachments/assets/83e9addc-fde0-431c-9c9f-e6856fa1fd39)

![Shot 2025-05-05 at 16 57 04](https://github.com/user-attachments/assets/6f36f677-a257-44ea-b179-ca93d30fafcb)

## Investigation

The debug log of rover subgraph check indicated that the branch was set to `HEAD` instead of the feature branch for the PR.

![Shot 2025-05-05 at 17 03 45](https://github.com/user-attachments/assets/5713f829-7669-4165-b08d-4218c08ba047)

I realized that this occurs because a merge commit is added to the feature branch in GitHub Actions. 
(workflow run: https://github.com/DaleSeo/my-graph-qnyr67/actions/runs/14846080425/job/41680193349)

![Shot 2025-05-05 at 17 12 12](https://github.com/user-attachments/assets/9314ecd8-2237-430a-957d-143a5c0d7e08)

## Solution

Setting the `APOLLO_VCS_BRANCH` environment to feature the the branch associated with the pull request fixes the issue.
(workflow run: https://github.com/DaleSeo/my-graph-qnyr67/actions/runs/14846442136/job/41681341151)

![Shot 2025-05-05 at 17 23 51](https://github.com/user-attachments/assets/b3d80f0d-f760-4b17-89d9-6c1295b0bc78)

Here's the schema check with the correct branch: https://studio.apollographql.com/graph/My-Graph-qnyr67/variant/main/check/275d860f-3c56-42ad-89d7-10c3ba1cc576/schemas

![Shot 2025-05-05 at 17 17 59](https://github.com/user-attachments/assets/7bea15e2-29ae-49e0-af2b-ed4fde089f60)

![Shot 2025-05-05 at 17 18 41](https://github.com/user-attachments/assets/c232e249-f8a9-4af6-b8ad-35cae772b94b)
