### PR TITLE
fix(init) Stripping all non-alphanumeric chars from graph id during generation and adding test

### DIFF
--- a/src/command/init/graph_id/generation.rs
+++ b/src/command/init/graph_id/generation.rs
@@ -114,13 +114,16 @@ mod tests {
             "custom-id".parse::<GraphId>().unwrap()
         );
     }
-    
+
     #[test]
     fn test_generate_graph_id_with_non_alphanumeric_characters() {
         let mut generator = TestRandomStringGenerator {
             value: "teststr".to_string(),
         };
 
-        assert_eq!(generate_graph_id("/-=My Test API=-/", &mut generator, None), "my-test-api-teststr".parse::<GraphId>().unwrap());
+        assert_eq!(
+            generate_graph_id("/-=My Test API=-/", &mut generator, None),
+            "my-test-api-teststr".parse::<GraphId>().unwrap()
+        );
     }
 }

--- a/src/command/init/graph_id/generation.rs
+++ b/src/command/init/graph_id/generation.rs
@@ -31,13 +31,19 @@ fn generate_default_graph_id<T: RandomStringGenerator>(
     graph_name: &str,
     random_generator: &mut T,
 ) -> GraphId {
-    let mut slugified_name = slugify(graph_name);
-
-    let alphabetic_start_index = slugified_name
+    // Slugify the name and remove non-alphanumeric characters
+    let mut slugified_name = slugify(graph_name)
         .chars()
-        .position(|c| c.is_alphabetic())
-        .unwrap_or(slugified_name.len());
-    slugified_name = slugified_name[alphabetic_start_index..].to_string();
+        .filter(|c| c.is_alphanumeric() || *c == '-')
+        .collect::<String>();
+
+    // Ensure it starts with a letter
+    if !slugified_name.is_empty() && !slugified_name.chars().next().unwrap().is_alphabetic() {
+        slugified_name = slugified_name
+            .chars()
+            .skip_while(|c| !c.is_alphabetic())
+            .collect::<String>();
+    }
 
     // Use "id" if name is empty
     let name_part = if slugified_name.is_empty() {
@@ -107,5 +113,14 @@ mod tests {
             ),
             "custom-id".parse::<GraphId>().unwrap()
         );
+    }
+    
+    #[test]
+    fn test_generate_graph_id_with_non_alphanumeric_characters() {
+        let mut generator = TestRandomStringGenerator {
+            value: "teststr".to_string(),
+        };
+
+        assert_eq!(generate_graph_id("/-=My Test API=-/", &mut generator, None), "my-test-api-teststr".parse::<GraphId>().unwrap());
     }
 }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
Context
When using a graph name that included non-alphanumerical chars, the `generate_default_graph_id` would strip the first special character it encountered, leaving the rest.  This resulted in a `panic`:

![image](https://github.com/user-attachments/assets/ed0ac39a-9193-444e-b2b2-dfe7e645cf1e)

Change
Updated the `generate_default_graph_id` function to strip all non-alphanumerical chars from the graph name and added test