### PR TITLE
feat(rover)init: Update `Next steps` section in project creation message

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -91,10 +91,7 @@ pub fn generate_project_created_message(
         if !valid_commands.is_empty() {
             if valid_commands.len() == 1 {
                 output.push_str("1) Start the subgraph server by running the following command:\n");
-                output.push_str(&format!(
-                    "  {}\n",
-                    Style::Command.paint(valid_commands[0])
-                ));
+                output.push_str(&format!("  {}\n", Style::Command.paint(valid_commands[0])));
             } else {
                 output.push_str(
                     "1) Start the subgraph server by running the following commands in order:\n",

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -82,7 +82,8 @@ pub fn generate_project_created_message(
 
     if let Some(commands) = commands {
         // Filter out empty commands
-        let valid_commands: Vec<&str> = commands.iter()
+        let valid_commands: Vec<&str> = commands
+            .iter()
             .filter(|cmd| !cmd.trim().is_empty())
             .map(|cmd| cmd.trim())
             .collect();
@@ -90,9 +91,14 @@ pub fn generate_project_created_message(
         if !valid_commands.is_empty() {
             if valid_commands.len() == 1 {
                 output.push_str("1) Start the subgraph server by running the following command:\n");
-                output.push_str(&format!("  - {}\n", Style::Command.paint(valid_commands[0])));
+                output.push_str(&format!(
+                    "  - {}\n",
+                    Style::Command.paint(valid_commands[0])
+                ));
             } else {
-                output.push_str("1) Start the subgraph server by running the following commands in order:\n");
+                output.push_str(
+                    "1) Start the subgraph server by running the following commands in order:\n",
+                );
                 for cmd in valid_commands {
                     output.push_str(&format!("  - {}\n", Style::Command.paint(cmd)));
                 }

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -100,7 +100,7 @@ pub fn generate_project_created_message(
                     output.push_str(&format!("  {}\n", Style::Command.paint(cmd)));
                 }
             }
-            output.push_str("2) In a new terminal, start a local development session:\n\n");
+            output.push_str("\n2) In a new terminal, start a local development session:\n\n");
             output.push_str(&format!("{}\n\n", Style::Command.paint(dev_command)));
         } else {
             // If no valid commands, just show the rover dev command

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -81,36 +81,31 @@ pub fn generate_project_created_message(
     };
 
     if let Some(commands) = commands {
-        // If commands vec is not empty, display the commands
-        if !commands.is_empty() {
-            // Filter out empty commands and enumerate the valid ones
-            for (i, cmd) in commands
-                .iter()
-                .filter(|cmd| !cmd.trim().is_empty())
-                .enumerate()
-            {
-                output.push_str(&format!(
-                    "{}) Run: {}\n",
-                    i + 1,
-                    Style::Command.paint(cmd.trim())
-                ));
-            }
+        // Filter out empty commands
+        let valid_commands: Vec<&str> = commands.iter()
+            .filter(|cmd| !cmd.trim().is_empty())
+            .map(|cmd| cmd.trim())
+            .collect();
 
-            // Number the development command after all valid commands
-            // i.e. if we had 2 valid commands, it will be numbered 3)
-            let next_number = commands.iter().filter(|cmd| !cmd.trim().is_empty()).count() + 1;
-            output.push_str(&format!(
-                "{}) Start a local development session: {}\n",
-                next_number,
-                Style::Command.paint(dev_command)
-            ));
+        if !valid_commands.is_empty() {
+            if valid_commands.len() == 1 {
+                output.push_str("1) Start the subgraph server by running the following command:\n");
+                output.push_str(&format!("  - {}\n", Style::Command.paint(valid_commands[0])));
+            } else {
+                output.push_str("1) Start the subgraph server by running the following commands in order:\n");
+                for cmd in valid_commands {
+                    output.push_str(&format!("  - {}\n", Style::Command.paint(cmd)));
+                }
+            }
+            output.push_str("2) In a new terminal, start a local development session:\n");
+            output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
         } else {
-            // If commands vec is empty, just show the rover dev command
+            // If no valid commands, just show the rover dev command
             output.push_str("Start a local development session:\n");
             output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
         }
     } else {
-        // If no command is provided, just show the rover dev command
+        // If no commands provided, just show the rover dev command
         output.push_str("Start a local development session:\n");
         output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
     }

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -92,7 +92,7 @@ pub fn generate_project_created_message(
             if valid_commands.len() == 1 {
                 output.push_str("1) Start the subgraph server by running the following command:\n");
                 output.push_str(&format!(
-                    "  - {}\n",
+                    "  {}\n",
                     Style::Command.paint(valid_commands[0])
                 ));
             } else {
@@ -100,19 +100,19 @@ pub fn generate_project_created_message(
                     "1) Start the subgraph server by running the following commands in order:\n",
                 );
                 for cmd in valid_commands {
-                    output.push_str(&format!("  - {}\n", Style::Command.paint(cmd)));
+                    output.push_str(&format!("  {}\n", Style::Command.paint(cmd)));
                 }
             }
-            output.push_str("2) In a new terminal, start a local development session:\n");
-            output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
+            output.push_str("2) In a new terminal, start a local development session:\n\n");
+            output.push_str(&format!("{}\n\n", Style::Command.paint(dev_command)));
         } else {
             // If no valid commands, just show the rover dev command
-            output.push_str("Start a local development session:\n");
+            output.push_str("Start a local development session:\n\n");
             output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
         }
     } else {
         // If no commands provided, just show the rover dev command
-        output.push_str("Start a local development session:\n");
+        output.push_str("Start a local development session:\n\n");
         output.push_str(&format!("{}\n", Style::Command.paint(dev_command)));
     }
 

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -78,7 +78,8 @@ fn test_display_project_created_message_with_multiple_commands() {
     let plain_output = strip_ansi_codes(&output);
 
     // Test that the output contains expected content
-    assert!(plain_output.contains("1) Start the subgraph server by running the following commands in order:"));
+    assert!(plain_output
+        .contains("1) Start the subgraph server by running the following commands in order:"));
     assert!(plain_output.contains("  - npm install"));
     assert!(plain_output.contains("  - npm run build"));
     assert!(plain_output.contains("  - npm start"));

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -47,7 +47,7 @@ fn test_display_project_created_message_with_single_command() {
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
     assert!(plain_output.contains("Store your graph API key securely"));
     assert!(plain_output.contains("1) Start the subgraph server by running the following command:"));
-    assert!(plain_output.contains("  - npm ci"));
+    assert!(plain_output.contains("  npm ci"));
     assert!(plain_output.contains("2) In a new terminal, start a local development session:"));
     assert!(plain_output.contains("rover dev"));
     assert!(plain_output.contains(&format!(
@@ -80,9 +80,9 @@ fn test_display_project_created_message_with_multiple_commands() {
     // Test that the output contains expected content
     assert!(plain_output
         .contains("1) Start the subgraph server by running the following commands in order:"));
-    assert!(plain_output.contains("  - npm install"));
-    assert!(plain_output.contains("  - npm run build"));
-    assert!(plain_output.contains("  - npm start"));
+    assert!(plain_output.contains("  npm install"));
+    assert!(plain_output.contains("  npm run build"));
+    assert!(plain_output.contains("  npm start"));
     assert!(plain_output.contains("2) In a new terminal, start a local development session:"));
     assert!(plain_output.contains("rover dev"));
 }
@@ -108,10 +108,10 @@ fn test_display_project_created_message_with_empty_command_array() {
     let plain_output = strip_ansi_codes(&output);
 
     // Test that the output contains expected content
-    assert!(plain_output.contains("Start a local development session"));
+    assert!(plain_output.contains("Start a local development session:"));
     assert!(plain_output.contains("rover dev"));
     // Should not contain any command-specific text
-    assert!(!plain_output.contains("npm"));
+    assert!(!plain_output.contains("Start the subgraph server"));
 }
 
 #[test]
@@ -138,9 +138,10 @@ fn test_display_project_created_message_without_command() {
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
     assert!(plain_output.contains("Store your graph API key securely"));
+    assert!(plain_output.contains("Start a local development session:"));
     assert!(plain_output.contains("rover dev"));
     // Should not contain any command-specific text
-    assert!(!plain_output.contains("Start the service"));
+    assert!(!plain_output.contains("Start the subgraph server"));
     assert!(plain_output.contains(&format!(
         "For more information, check out '{}'",
         "getting-started.md"

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -27,7 +27,7 @@ fn test_display_project_created_message_with_single_command() {
     ];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
-    let commands = &["npm ci && npm start"];
+    let commands = &["npm ci"];
     let commands = Some(commands.iter().map(|&s| s.to_string()).collect::<Vec<_>>());
     let start_point_file = "getting-started.md".to_string();
 
@@ -46,8 +46,9 @@ fn test_display_project_created_message_with_single_command() {
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={}", graph_ref)));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
     assert!(plain_output.contains("Store your graph API key securely"));
-    assert!(plain_output.contains("1) Run: npm ci && npm start"));
-    assert!(plain_output.contains("2) Start a local development session"));
+    assert!(plain_output.contains("1) Start the subgraph server by running the following command:"));
+    assert!(plain_output.contains("  - npm ci"));
+    assert!(plain_output.contains("2) In a new terminal, start a local development session:"));
     assert!(plain_output.contains("rover dev"));
     assert!(plain_output.contains(&format!(
         "For more information, check out '{}'",
@@ -77,10 +78,11 @@ fn test_display_project_created_message_with_multiple_commands() {
     let plain_output = strip_ansi_codes(&output);
 
     // Test that the output contains expected content
-    assert!(plain_output.contains("1) Run: npm install"));
-    assert!(plain_output.contains("2) Run: npm run build"));
-    assert!(plain_output.contains("3) Run: npm start"));
-    assert!(plain_output.contains("4) Start a local development session"));
+    assert!(plain_output.contains("1) Start the subgraph server by running the following commands in order:"));
+    assert!(plain_output.contains("  - npm install"));
+    assert!(plain_output.contains("  - npm run build"));
+    assert!(plain_output.contains("  - npm start"));
+    assert!(plain_output.contains("2) In a new terminal, start a local development session:"));
     assert!(plain_output.contains("rover dev"));
 }
 


### PR DESCRIPTION
## Changes
- Updated the format of the `Next steps` section in the project creation message
- Updated tests to verify the new message format

## Before
```
Next steps:
1) Run: npm ci
2) Run: npm start
3) Start a local development session: APOLLO_KEY=... rover dev ...
```

## After
For a single command:
```
Next steps:
1) Start the subgraph server by running the following command:
  - npm ci
2) In a new terminal, start a local development session: APOLLO_KEY=... rover dev ...
```
For multiple commands: 
```
Next steps:
1) Start the subgraph server by running the following commands in order:
  - npm ci
  - npm start
2) In a new terminal, start a local development session: APOLLO_KEY=... rover dev ...
```