### PR TITLE
Install MCP Server binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4980,6 +4980,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml 0.9.34+deprecated",
  "serial_test",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ serial_test = "3"
 serde = "1.0"
 serde_json = "1.0"
 serde_json_traversal = "0.2"
+serde_with = { version = "3", default-features = false, features = ["macros"]}
 serde_yaml = "0.9"
 shell-candy = "0.4"
 speculoos = "0.13.0"
@@ -212,6 +213,7 @@ schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 shellexpand = { workspace = true }
 sputnik = { workspace = true }

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -1,0 +1,2 @@
+mod binary;
+mod install;

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -1,0 +1,16 @@
+use camino::Utf8PathBuf;
+use semver::Version;
+
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(derive_getters::Getters))]
+#[allow(unused)]
+pub struct McpServerBinary {
+    exe: Utf8PathBuf,
+    version: Version,
+}
+
+impl McpServerBinary {
+    pub fn new(exe: Utf8PathBuf, version: Version) -> McpServerBinary {
+        McpServerBinary { exe, version }
+    }
+}

--- a/src/command/dev/mcp/install.rs
+++ b/src/command/dev/mcp/install.rs
@@ -1,0 +1,261 @@
+use async_trait::async_trait;
+use camino::{Utf8Path, Utf8PathBuf};
+use semver::Version;
+
+use super::binary::McpServerBinary;
+use crate::command::install::McpServerVersion;
+use crate::{
+    command::{install::Plugin, Install},
+    options::LicenseAccepter,
+    utils::{client::StudioClientConfig, effect::install::InstallBinary},
+};
+
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to install the MCP Sever")]
+pub enum InstallMcpServerError {
+    #[error("unable to find dependency: \"{err}\"")]
+    MissingDependency {
+        /// The error while attempting to find the dependency
+        err: String,
+    },
+    #[error("Missing filename for path: {path}")]
+    MissingFilename { path: Utf8PathBuf },
+    #[error("Invalid semver version: \"{input}\"")]
+    Semver {
+        input: String,
+        source: semver::Error,
+    },
+}
+
+pub struct InstallMcpServer {
+    studio_client_config: StudioClientConfig,
+    mcp_server_version: McpServerVersion,
+}
+
+impl InstallMcpServer {
+    #[allow(unused)]
+    pub fn new(
+        mcp_server_version: McpServerVersion,
+        studio_client_config: StudioClientConfig,
+    ) -> InstallMcpServer {
+        InstallMcpServer {
+            mcp_server_version,
+            studio_client_config,
+        }
+    }
+}
+
+#[async_trait]
+impl InstallBinary for InstallMcpServer {
+    type Binary = McpServerBinary;
+    type Error = InstallMcpServerError;
+    async fn install(
+        &self,
+        override_install_path: Option<Utf8PathBuf>,
+        elv2_license_accepter: LicenseAccepter,
+        skip_update: bool,
+    ) -> Result<Self::Binary, Self::Error> {
+        let plugin = Plugin::McpServer(self.mcp_server_version.clone());
+        let install_command = Install {
+            force: false,
+            plugin: Some(plugin),
+            elv2_license_accepter,
+        };
+        let exe = install_command
+            .get_versioned_plugin(
+                override_install_path,
+                self.studio_client_config.clone(),
+                skip_update,
+            )
+            .await
+            .map_err(|err| InstallMcpServerError::MissingDependency {
+                err: err.to_string(),
+            })?;
+        let version = version_from_path(&exe)?;
+        let binary = McpServerBinary::new(exe, version);
+        Ok(binary)
+    }
+}
+
+fn version_from_path(path: &Utf8Path) -> Result<Version, InstallMcpServerError> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| InstallMcpServerError::MissingFilename {
+            path: path.to_path_buf(),
+        })?;
+    let without_exe = file_name.strip_suffix(".exe").unwrap_or(file_name);
+    let without_prefix = without_exe
+        .strip_prefix("apollo-mcp-server-v")
+        .unwrap_or(without_exe);
+    let version = Version::parse(without_prefix).map_err(|err| InstallMcpServerError::Semver {
+        input: without_prefix.to_string(),
+        source: err,
+    })?;
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, str::FromStr, time::Duration};
+
+    use crate::command::install::McpServerVersion;
+    use anyhow::Result;
+    use assert_fs::{NamedTempFile, TempDir};
+    use camino::Utf8PathBuf;
+    use flate2::{write::GzEncoder, Compression};
+    use houston::Config;
+    use http::Method;
+    use httpmock::MockServer;
+    use rstest::{fixture, rstest};
+    use semver::Version;
+    use speculoos::prelude::*;
+    use tracing_test::traced_test;
+
+    use super::InstallMcpServer;
+    use crate::{
+        options::LicenseAccepter,
+        utils::{
+            client::{ClientBuilder, ClientTimeout, StudioClientConfig},
+            effect::install::InstallBinary,
+        },
+    };
+
+    #[fixture]
+    #[once]
+    fn http_server() -> MockServer {
+        MockServer::start()
+    }
+
+    //noinspection HttpUrlsUsage
+    #[fixture]
+    #[once]
+    fn mock_server_endpoint(http_server: &MockServer) -> String {
+        let address = http_server.address();
+        let endpoint = format!("http://{}", address);
+        endpoint
+    }
+
+    #[fixture]
+    #[once]
+    fn home() -> TempDir {
+        TempDir::new().unwrap()
+    }
+
+    #[fixture]
+    fn mcp_server_version() -> McpServerVersion {
+        McpServerVersion::Latest
+    }
+
+    #[fixture]
+    #[once]
+    fn api_key() -> String {
+        "api-key".to_string()
+    }
+
+    #[fixture]
+    fn config(api_key: &str, home: &TempDir) -> Config {
+        let home = Utf8PathBuf::from_path_buf(home.to_path_buf()).unwrap();
+        Config {
+            home,
+            override_api_key: Some(api_key.to_string()),
+        }
+    }
+
+    #[fixture]
+    fn studio_client_config(mock_server_endpoint: &str, config: Config) -> StudioClientConfig {
+        StudioClientConfig::new(
+            Some(mock_server_endpoint.to_string()),
+            config,
+            false,
+            ClientBuilder::default(),
+            ClientTimeout::default(),
+        )
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[rstest]
+    #[timeout(Duration::from_secs(15))]
+    async fn test_install(
+        mcp_server_version: McpServerVersion,
+        studio_client_config: StudioClientConfig,
+        http_server: &MockServer,
+        mock_server_endpoint: &str,
+    ) -> Result<()> {
+        let license_accepter = LicenseAccepter {
+            elv2_license_accepted: Some(true),
+        };
+        let override_install_path = NamedTempFile::new("override_path")?;
+        let install_mcp_server = InstallMcpServer::new(mcp_server_version, studio_client_config);
+        http_server.mock(|when, then| {
+            when.matches(|request| {
+                request.method == Method::HEAD.to_string()
+                    && request.path.starts_with("/tar/apollo-mcp-server")
+            });
+            then.status(302).header("X-Version", "v0.1.0");
+        });
+        http_server.mock(|when, then| {
+            when.matches(|request| {
+                request.method == Method::GET.to_string()
+                    && request.path.starts_with("/tar/apollo-mcp-server/")
+            });
+            then.status(302).header(
+                "Location",
+                format!("{}/apollo-mcp-server/", mock_server_endpoint),
+            );
+        });
+
+        let enc = GzEncoder::new(Vec::new(), Compression::default());
+        let mut archive = tar::Builder::new(enc);
+        let contents = b"apollo-mcp-server";
+        let mut header = tar::Header::new_gnu();
+        header.set_path(format!(
+            "{}{}",
+            "dist/apollo-mcp-server",
+            env::consts::EXE_SUFFIX
+        ))?;
+        header.set_size(contents.len().try_into().unwrap());
+        header.set_cksum();
+        archive.append(&header, &contents[..]).unwrap();
+
+        let finished_archive = archive.into_inner()?;
+        let finished_archive_bytes = finished_archive.finish()?;
+
+        http_server.mock(|when, then| {
+            when.matches(|request| {
+                request.method == Method::GET.to_string()
+                    && request.path.starts_with("/apollo-mcp-server")
+            });
+            then.status(200)
+                .header("Content-Type", "application/octet-stream")
+                .body(&finished_archive_bytes);
+        });
+        let binary = temp_env::async_with_vars(
+            [("APOLLO_ROVER_DOWNLOAD_HOST", Some(mock_server_endpoint))],
+            async {
+                install_mcp_server
+                    .install(
+                        Utf8PathBuf::from_path_buf(override_install_path.to_path_buf()).ok(),
+                        license_accepter,
+                        false,
+                    )
+                    .await
+            },
+        )
+        .await;
+        let subject = assert_that!(binary).is_ok().subject;
+        assert_that!(subject.version()).is_equal_to(&Version::from_str("0.1.0")?);
+
+        let installed_binary_path = override_install_path.path().join(format!(
+            "{}{}",
+            ".rover/bin/apollo-mcp-server-v0.1.0",
+            env::consts::EXE_SUFFIX
+        ));
+        assert_that!(subject.exe())
+            .is_equal_to(&Utf8PathBuf::from_path_buf(installed_binary_path.clone()).unwrap());
+        assert_that!(installed_binary_path.exists()).is_equal_to(true);
+        let installed_binary_contents = std::fs::read(installed_binary_path)?;
+        assert_that!(installed_binary_contents).is_equal_to(b"apollo-mcp-server".to_vec());
+        Ok(())
+    }
+}

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -5,6 +5,8 @@ use camino::Utf8PathBuf;
 
 #[cfg(feature = "composition-js")]
 mod do_dev;
+#[cfg(feature = "composition-js")]
+mod mcp;
 #[cfg(not(feature = "composition-js"))]
 mod no_dev;
 #[cfg(feature = "composition-js")]

--- a/src/command/install/mod.rs
+++ b/src/command/install/mod.rs
@@ -15,6 +15,7 @@ use std::convert::TryFrom;
 use std::env;
 
 mod plugin;
+pub(crate) use plugin::McpServerVersion;
 pub(crate) use plugin::{Plugin, PluginInstaller};
 
 #[derive(Debug, Serialize, Parser)]

--- a/src/command/install/plugin/error.rs
+++ b/src/command/install/plugin/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PluginError {
+    #[error("Invalid plugin version: `{0}`")]
+    InvalidVersionFormat(String),
+}

--- a/src/command/install/plugin/mcp.rs
+++ b/src/command/install/plugin/mcp.rs
@@ -1,0 +1,58 @@
+use crate::command::install::plugin::error::PluginError;
+use crate::command::install::plugin::PluginVersion;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// An MCP Server version.
+#[derive(Debug, Clone, SerializeDisplay, DeserializeFromStr, PartialEq, Eq)]
+pub enum Version {
+    /// An exact MCP Server version
+    Exact(semver::Version),
+
+    /// The latest MCP Server version
+    Latest,
+}
+
+impl PluginVersion for Version {
+    fn get_major_version(&self) -> u64 {
+        match self {
+            Version::Exact(v) => v.major,
+            Version::Latest => 0,
+        }
+    }
+
+    fn get_tarball_version(&self) -> String {
+        match self {
+            Version::Exact(v) => format!("v{v}"),
+            Version::Latest => "latest".to_string(),
+        }
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Version::Exact(v) => write!(f, "={v}"),
+            Version::Latest => write!(f, "latest"),
+        }
+    }
+}
+
+impl FromStr for Version {
+    type Err = PluginError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "latest" {
+            return Ok(Version::Latest);
+        }
+
+        if !s.starts_with('=') && !s.starts_with('v') {
+            return Err(PluginError::InvalidVersionFormat(format!("Specified version `{s}` is not supported. You can specify 'latest' or a fully qualified version prefixed with an '=', like: =1.0.0")));
+        }
+
+        semver::Version::parse(&s[1..])
+            .map(Version::Exact)
+            .map_err(|_| PluginError::InvalidVersionFormat(format!("Specified version `{s}` is not supported. You can specify 'latest' or a fully qualified version prefixed with an '=', like: =1.0.0")))
+    }
+}


### PR DESCRIPTION
* Add the ability to install [apollo-mcp-server](https://github.com/apollographql/apollo-mcp-server) through `rover install`
* DRY up some of the code duplication in the install code

This will allow installing and running the MCP server from `rover dev`, or it can be explicitly installed like:

```console
rover install --plugin apollo-mcp-server@latest
```
(note that this command won't fully work until GitHub releases are available, and Orbiter updates to route the request are deployed)