### PR TITLE
MCP fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [Unreleased]
+
+## 🐛 Fixes
+- **MCP fixes - @pubmodmatt PR #2596**
+  - `--mcp-directory` was optional, but `rover dev` failed if it was not specified
+  - All output from the MCP server was logged as `ERROR` or `UNKNOWN`
+  - If the Router or MCP Server process died, `rover dev` would exit but leave the other process running
+
 # [0.31.0] - 2025-05-14
 
 ## 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🐛 Fixes
 - **MCP fixes - @pubmodmatt PR #2596**
   - `--mcp-directory` was optional, but `rover dev` failed if it was not specified
+  - Added `--mcp-sse-address` to set the bind address for the MCP server started by `rover dev`
   - All output from the MCP server was logged as `ERROR` or `UNKNOWN`
   - If the Router or MCP Server process died, `rover dev` would exit but leave the other process running
 

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -299,6 +299,9 @@ impl Dev {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {
                         eprintln!("\nreceived shutdown signal, stopping `rover dev` processes...");
+
+                        // Note that these calls aren't strictly necessary. The OS will send the
+                        // SIGINT signal to forked child processes, so they would exit anyway.
                         run_router.shutdown();
                         run_mcp_server.shutdown();
                         break
@@ -329,6 +332,7 @@ impl Dev {
                                     }
                                 }
                                 eprintln!("\nRouter binary exited, stopping `rover dev` processes...");
+                                run_mcp_server.shutdown();
                                 break;
                             }
                             Err(err) => {
@@ -362,6 +366,7 @@ impl Dev {
                                     }
                                 }
                                 eprintln!("\nMcp Server binary exited, stopping `rover dev` processes...");
+                                run_router.shutdown();
                                 break;
                             }
                             Err(err) => {

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -300,9 +300,7 @@ impl Dev {
                     _ = tokio::signal::ctrl_c() => {
                         eprintln!("\nreceived shutdown signal, stopping `rover dev` processes...");
                         run_router.shutdown();
-
-                            run_mcp_server.shutdown();
-
+                        run_mcp_server.shutdown();
                         break
                     },
 

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -353,19 +353,19 @@ impl Dev {
                                     Ok(status) => {
                                         match status.code() {
                                             None => {
-                                                eprintln!("Mcp Server process terminal by signal");
+                                                eprintln!("MCP Server process terminal by signal");
                                             }
                                             Some(code) => {
-                                                eprintln!("Mcp Server process exited with status code: {code}");
+                                                eprintln!("MCP Server process exited with status code: {code}");
                                             }
                                         }
 
                                     }
                                     Err(err) => {
-                                        tracing::error!("Mcp Server process exited without status code. Error: {err}")
+                                        tracing::error!("MCP Server process exited without status code. Error: {err}")
                                     }
                                 }
-                                eprintln!("\nMcp Server binary exited, stopping `rover dev` processes...");
+                                eprintln!("\nMCP Server binary exited, stopping `rover dev` processes...");
                                 run_router.shutdown();
                                 break;
                             }

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -28,6 +28,9 @@ pub struct Opts {
     #[arg(long = "mcp-directory", required = false)]
     directory: Option<Utf8PathBuf>,
 
+    #[arg(long = "mcp-sse-address", default_value = "127.0.0.1")]
+    sse_address: String,
+
     /// Start the server using the SSE transport on the given port
     #[arg(long = "mcp-sse-port", default_value = "5000")]
     sse_port: u16,

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use clap::Parser;
 use serde::Serialize;
 use strum_macros::Display;
@@ -27,7 +26,7 @@ pub struct Opts {
 
     /// The working directory to use
     #[arg(long = "mcp-directory", required = false)]
-    directory: Option<PathBuf>,
+    directory: Option<Utf8PathBuf>,
 
     /// Start the server using the SSE transport on the given port
     #[arg(long = "mcp-sse-port", default_value = "5000")]
@@ -39,7 +38,7 @@ pub struct Opts {
 
     /// Operation files to expose as MCP tools
     #[arg(long = "mcp-operations", num_args=0..)]
-    operations: Vec<PathBuf>,
+    operations: Vec<Utf8PathBuf>,
 
     /// Headers to send to the endpoint
     #[arg(long = "mcp-header", action = clap::ArgAction::Append)]
@@ -47,7 +46,7 @@ pub struct Opts {
 
     /// The path to the persisted query manifest containing operations
     #[arg(long = "mcp-manifest")]
-    manifest: Option<PathBuf>,
+    manifest: Option<Utf8PathBuf>,
 
     /// Enable use of uplink to get the schema and persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
     #[arg(long = "mcp-uplink")]
@@ -55,7 +54,7 @@ pub struct Opts {
 
     /// The path to the GraphQL custom_scalars_config file
     #[arg(long = "mcp-custom-scalars-config", required = false)]
-    custom_scalars_config: Option<PathBuf>,
+    custom_scalars_config: Option<Utf8PathBuf>,
 
     // Configure when to allow mutations
     #[arg(long = "mcp-allow-mutations", default_value_t, value_enum)]

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -102,10 +102,12 @@ where
                 self.mcp_options.sse_port.to_string(),
             ];
 
-            if let Some(directory) = self.mcp_options.directory {
-                args.push("--directory".to_string());
-                args.push(directory.display().to_string());
-            }
+            args.push("--directory".to_string());
+            args.push(
+                self.mcp_options
+                    .directory
+                    .map_or(".".to_string(), |d| d.to_string()),
+            );
 
             if let Some(value) = ValueEnum::to_possible_value(&self.mcp_options.allow_mutations) {
                 args.push("--allow-mutations".to_string());
@@ -122,7 +124,7 @@ where
                     .mcp_options
                     .operations
                     .into_iter()
-                    .map(|p| p.display().to_string())
+                    .map(|p| p.to_string())
                     .collect::<Vec<String>>();
                 args.append(&mut operation_strings);
             }
@@ -135,7 +137,7 @@ where
             // TODO: this needs auth
             if let Some(manifest) = self.mcp_options.manifest {
                 args.push("--manifest".to_string());
-                args.push(manifest.display().to_string());
+                args.push(manifest.to_string());
             }
 
             if self.mcp_options.uplink {
@@ -144,7 +146,7 @@ where
 
             if let Some(custom_scalars_config) = self.mcp_options.custom_scalars_config {
                 args.push("--custom-scalars-config".to_string());
-                args.push(custom_scalars_config.display().to_string());
+                args.push(custom_scalars_config.to_string());
             }
 
             if self.mcp_options.disable_type_description {

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -28,15 +28,13 @@ pub enum McpServerLog {
 
 impl fmt::Display for McpServerLog {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let error_prefix = Style::ErrorPrefix.paint("ERROR:");
-        let unknown_prefix = Style::ErrorPrefix.paint("UNKNOWN:");
         match self {
             Self::Stdout(stdout) => {
-                // TODO: can we parse levels like router?
-                write!(f, "{} {}", unknown_prefix, &stdout)
+                // TODO: add a JSON output option to the MCP Server so we can parse it
+                write!(f, "{}", &stdout)
             }
             Self::Stderr(stderr) => {
-                write!(f, "{} {}", error_prefix, &stderr)
+                write!(f, "{} {}", Style::ErrorPrefix.paint("ERROR:"), &stderr)
             }
         }
     }

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -100,14 +100,14 @@ where
                 self.router_address.pretty_string(),
                 "--sse-port".to_string(),
                 self.mcp_options.sse_port.to_string(),
+                "--sse-address".to_string(),
+                self.mcp_options.sse_address,
             ];
 
-            args.push("--directory".to_string());
-            args.push(
-                self.mcp_options
-                    .directory
-                    .map_or(".".to_string(), |d| d.to_string()),
-            );
+            if let Some(directory) = self.mcp_options.directory {
+                args.push("--directory".to_string());
+                args.push(directory.to_string());
+            }
 
             if let Some(value) = ValueEnum::to_possible_value(&self.mcp_options.allow_mutations) {
                 args.push("--allow-mutations".to_string());

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -50,7 +50,7 @@ pub enum RunMcpServerBinaryError {
     #[error("Failed to watch {descriptor} for logs")]
     OutputCapture { descriptor: String },
 
-    #[error("Mcp Server Binary exited")]
+    #[error("MCP Server Binary exited")]
     BinaryExited(io::Result<ExitStatus>),
 }
 


### PR DESCRIPTION
Fixes several issues with `rover dev --mcp`:

* All output from the MCP server was always logged as ERROR or UNKNOWN (which used the same styling as ERROR). This made it look as if the MCP server had failed, when in fact this was just normal output. The logging from the MCP server is now just passed through to the `rover dev` output. In the future, we'll need to add the ability to log in JSON like the Apollo Router has, so we can parse the error level and message as is done for router.
* The code to shut down the Router and MCP Server processes did not really do anything. It just stopped the spawned task that waited for the child process, but did nothing to actually stop the child process itself. Ctrl+C only worked because the OS sends the SIGINT to the forked child processes as well as the parent. But in cases where one or the other of the child processes died, the other process was not being killed. This has been fixed so either child process exiting will cause the other to be killed.
* Improve path handling. The MCP code was previously using the lossy `display()` method on `PathBuf`. It now uses `Utf8PathBuf` like the rest of the rover code.
* Added an `--mcp-sse-address` option to set the bind address for the MCP server.
