### PR TITLE
Expand supergraph config variables in file watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [Unreleased]
+
+## 🐛 Fixes
+- **Composition failures on environment variables in supergraph config - @pubmodmatt PR #XXXX**
+
 # [0.31.1] - 2025-05-21
 
 ## 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # [Unreleased]
 
 ## 🐛 Fixes
-- **Composition failures on environment variables in supergraph config - @pubmodmatt PR #XXXX**
+- **Composition failures on environment variables in supergraph config - @pubmodmatt PR #2601**
 
 # [0.31.1] - 2025-05-21
 


### PR DESCRIPTION
Although environment variables are allowed in the supergraph config (supergraph.yaml), and they work on the first load of the config, they weren't working in the supergraph config file watcher, so as soon as that started it would emit extremely unhelpful errors from `rover dev`:

```console
error: Could not parse supergraph config file.
Could not parse supergraph config: subgraphs.Space: data did not match any variant of untagged enum SchemaSource at line 4 column 16.
```

<!-- [GT-162] --/>

[GT-162]: https://apollographql.atlassian.net/browse/GT-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ