### PR TITLE
fix(init): Better error handling for graph creation permission errors

### DIFF
--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -429,8 +429,8 @@ impl CreationConfirmed {
                             .with_suggestion(RoverErrorSuggestion::ContactApolloAccountManager);
                     return Err(error);
                 }
-                let error = RoverError::from(RoverClientError::AdhocError { msg: e.to_string() })
-                    .with_suggestion(RoverErrorSuggestion::ContactApolloSupport);
+                let error =
+                    RoverError::from(e).with_suggestion(RoverErrorSuggestion::ContactApolloSupport);
                 return Err(error);
             }
         };

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -144,9 +144,8 @@ impl Display for RoverErrorSuggestion {
             }
             CheckGraphNameAndAuth => {
                 format!(
-                    "Make sure your graph name is typed correctly, and that your API key is valid.\n        You can run {} to check if you are authenticated.\n        If you are trying to create a new graph, you must do so online at {}, by clicking \"New Graph\".",
-                    Style::Command.paint("`rover config whoami`"),
-                    Style::Link.paint("https://studio.apollographql.com")
+                    "Make sure your graph name is typed correctly, and that your API key is valid.\n        You can run {} to check your authentication.",
+                    Style::Command.paint("`rover config whoami`")
                 )
             }
             ProvideValidSubgraph(valid_subgraphs) => {


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

Before, we were swallowing most errors returned from the API and returning a generic "catch-all" error instead.

Now, we are checking the error for permissions-related errors to return appropriate messaging and passing all other error results through to the user.

Adding a tracing log for errors encountered during graph creation to help with debugging.

Also removing suggestion copy regarding creating a graph in Studio.
