### PR TITLE
Log cause of introspection error

### DIFF
--- a/src/composition/supergraph/config/error/subgraph.rs
+++ b/src/composition/supergraph/config/error/subgraph.rs
@@ -36,7 +36,7 @@ pub enum ResolveSubgraphError {
         source: Arc<Box<dyn std::error::Error + Send + Sync>>,
     },
     /// Occurs when a introspection against a subgraph fails
-    #[error("Failed to introspect the subgraph \"{subgraph_name}\".")]
+    #[error("Failed to introspect the subgraph \"{subgraph_name}\": {source}")]
     IntrospectionError {
         /// The subgraph name that failed to be resolved
         subgraph_name: String,


### PR DESCRIPTION
Log the underlying cause for introspection failure.

Before:
```
error: Error occurred when composing supergraph
Error resolving subgraphs:
Unable to resolve subgraphs.
Space: Failed to introspect the subgraph "Space".
```

After:
```
error: Error occurred when composing supergraph
Error resolving subgraphs:
Unable to resolve subgraphs.
Space: Failed to introspect the subgraph "Space": Upstream service error: Unexpected(reqwest::Error { kind: Request, source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", 127.0.0.1:4001, Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) })
```