### PR TITLE
chore: configure renovate to not upgrade router major version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,18 @@
       matchPackageNames: ["apollographql/router"],
       automerge: false,
     },
+    {
+      matchPackageNames: ["apollographql/router"],
+      matchCurrentValue: "v1.*",
+      allowedVersions: ">=1.0.0 <2.0.0",
+      versioning: "semver",
+    },
+    {
+      matchPackageNames: ["apollographql/router"],
+      matchCurrentValue: "v2.*",
+      allowedVersions: ">=2.0.0 <3.0.0",
+      versioning: "semver",
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Renovate was trying to upgrade router `latest-1` to 2.x. Prevent this, and prevent it from upgrading `latest-2` to 3.x once 3.x is released.