### PR TITLE
Adds support for .env file for use with rover dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5050,6 +5056,7 @@ dependencies = [
  "derive-getters",
  "dialoguer",
  "dircpy",
+ "dotenvy",
  "duct",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ console = "0.15"
 derive-getters = "0.5.0"
 dialoguer = "0.11"
 directories-next = "2.0"
+dotenvy = "0.15"
 flate2 = "1"
 futures = "0.3"
 git-url-parse = "0.4.5"
@@ -184,6 +185,7 @@ chrono = { workspace = true }
 console = { workspace = true }
 derive-getters = { workspace = true }
 dialoguer = { workspace = true }
+dotenvy = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 graphql_client = { workspace = true }

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use anyhow::anyhow;
 use apollo_federation_types::config::{FederationVersion, RouterVersion};
 use camino::Utf8PathBuf;
+use dotenvy::dotenv;
 use futures::StreamExt;
 use rover_client::RoverClientError;
 use rover_std::{errln, infoln};
@@ -42,6 +43,7 @@ impl Dev {
         client_config: StudioClientConfig,
         log_level: Option<Level>,
     ) -> RoverResult<RoverOutput> {
+        dotenv().ok();
         let elv2_license_accepter = self.opts.plugin_opts.elv2_license_accepter;
         let skip_update = self.opts.plugin_opts.skip_update;
         let read_file_impl = FsReadFile::default();


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

- Adds `.env` support for `rover dev` command
- Uses the values in the `.env` file if present
- If `APOLLO_GRAPH_REF` and/or `APOLLO_KEY` are supplied inline with the command those values override what is defined in `.env`

### Manual Testing
#### Scenario 1: Using `.env` file containing valid `APOLLO_KEY` and `APOLLO_GRAPH_REF`
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev` with the `.env` file
```
dmallare@Mac test-rover-init % ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
By installing this plugin, you accept the terms and conditions outlined by this license.
More information on the ELv2 license can be found here: https://go.apollo.dev/elv2.
Do you accept the terms and conditions of the ELv2 license? [y/N]
y
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 2: Using `.env` file containing invalid `APOLLO_KEY` and  valid `APOLLO_GRAPH_REF`
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev` with the `.env` file containing an invalid `APOLLO_KEY`
```
dmallare@Mac test-rover-init % ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
ERROR: uplink error, the request will not be retried: code=ACCESS_DENIED message=API key service:ellie-test-rest2-99y76u2:●●●●●●●●●●●●●●●●jlsW cannot access Uplink for the 'ellie-test-rest2-99y76u2' graph.
 Please verify that the graph exists and that the API key in question has Observer access or higher.
ERROR: no valid license was supplied
ERROR: no valid license was supplied
Router process exited with status code: 1

Router binary exited, stopping `rover dev` processes...
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 3: Using `.env` file containing valid `APOLLO_KEY` and  invalid `APOLLO_GRAPH_REF`
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev` with the `.env` file containing an invalid `APOLLO_GRAPH_REF`
```
dmallare@Mac test-rover-init % ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
ERROR: uplink error, the request will not be retried: code=ACCESS_DENIED message=API key service:ellie-test-rest2-99y76u2:●●●●●●●●●●●●●●●●●●sW5A cannot access Uplink for the 'wrong' graph.
 Please verify that the graph exists and that the API key in question has Observer access or higher.
ERROR: no valid license was supplied
ERROR: no valid license was supplied
Router process exited with status code: 1

Router binary exited, stopping `rover dev` processes...
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 4: Using an empty `.env` file
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev` with  empty `.env` file 
```
dmallare@Mac test-rover-init % ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
ERROR: Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides a license for the following features:

Schema features:
* @connect
  https://specs.apollo.dev/connect/v0.1

See https://go.apollo.dev/o/elp for more information.
ERROR: license violation
ERROR: license violation
Router process exited with status code: 1

Router binary exited, stopping `rover dev` processes...
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 5: Supplying `APOLLO_GRAPH_REF` and `APOLLO_KEY` inline with the command and no `.env` file
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev` with variables
```
dmallare@Mac test-rover-init % APOLLO_KEY=<key> APOLLO_GRAPH_REF=ellie-test-rest2-99y76u2@current ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 6: Supplying `APOLLO_GRAPH_REF` and `APOLLO_KEY` inline with the command and  `.env` file containing an invalid `APOLLO_KEY`
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev`
```
dmallare@Mac test-rover-init % APOLLO_KEY=<key> APOLLO_GRAPH_REF=ellie-test-rest2-99y76u2@current ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 7: Supplying `APOLLO_GRAPH_REF` and `APOLLO_KEY` inline with the command and  `.env` file containing an invalid `APOLLO_GRAPH_REF`
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev`
```
dmallare@Mac test-rover-init % APOLLO_KEY=<key> APOLLO_GRAPH_REF=ellie-test-rest2-99y76u2@current ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```

#### Scenario 8: Supplying `APOLLO_KEY` inline with the command and  `.env` file containing an invalid `APOLLO_GRAPH_REF`
1. Run `rover config whoami` to ensure we are using the correct API key
```
dmallare@Mac test-rover-init % ./rover-test config whoami
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```
2. Run `rover dev`
```
dmallare@Mac test-rover-init % APOLLO_KEY=<key> ./rover-test dev --supergraph-config supergraph.yaml
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'products' subgraph
==> Watching /Users/dmallare/test-rover-init/products.graphql for changes
composing supergraph with Federation 2.10.0
==> Attempting to start router at http://localhost:4000.
ERROR: uplink error, the request will not be retried: code=ACCESS_DENIED message=API key service:ellie-test-rest2-99y76u2:●●●●●●●●●●●●●●●●●●sW5A cannot access Uplink for the 'wrong' graph.
 Please verify that the graph exists and that the API key in question has Observer access or higher.
ERROR: no valid license was supplied
ERROR: no valid license was supplied
Router process exited with status code: 1

Router binary exited, stopping `rover dev` processes...
```
3. Check that `rover config whoami` has not changed
```
dmallare@Mac test-rover-init % ./rover-test config whoami  
Checking identity of your API key against the registry.
┌──────────┬─────────────────────────────────────────────────────────────────────┐
│ Key Type ┆ User                                                                │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ User ID  ┆ fp.9b8ad486-bc00-4ce7-bfd8-54cce87eb1a8                             │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Origin   ┆ --profile default                                                   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ API Key  ┆ user***********************************************************JgJg │
└──────────┴─────────────────────────────────────────────────────────────────────┘
```