### PR TITLE
Add schema name step to Connectors init workflow

### DIFF
--- a/src/command/init/config.rs
+++ b/src/command/init/config.rs
@@ -1,5 +1,7 @@
 use crate::command::init::graph_id::validation::GraphId;
-use crate::command::init::options::{OrganizationId, ProjectName, ProjectType, ProjectUseCase};
+use crate::command::init::options::{
+    OrganizationId, ProjectName, ProjectType, ProjectUseCase, SchemaName,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -9,4 +11,5 @@ pub struct ProjectConfig {
     pub use_case: ProjectUseCase,
     pub project_name: ProjectName,
     pub graph_id: GraphId,
+    pub schema_name: SchemaName,
 }

--- a/src/command/init/options/mod.rs
+++ b/src/command/init/options/mod.rs
@@ -12,6 +12,8 @@ mod project_template;
 mod project_type;
 #[cfg(feature = "composition-js")]
 mod project_use_case;
+#[cfg(feature = "composition-js")]
+mod schema_name;
 
 #[cfg(feature = "composition-js")]
 pub(crate) use project_authentication::*;
@@ -27,3 +29,5 @@ pub(crate) use project_template::*;
 pub(crate) use project_type::*;
 #[cfg(feature = "composition-js")]
 pub(crate) use project_use_case::*;
+#[cfg(feature = "composition-js")]
+pub(crate) use schema_name::*;

--- a/src/command/init/options/schema_name.rs
+++ b/src/command/init/options/schema_name.rs
@@ -1,0 +1,158 @@
+use crate::command::init::options::ProjectUseCase;
+use crate::RoverResult;
+use clap::arg;
+use clap::Parser;
+use dialoguer::Input;
+use rover_std::Style;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Parser, Default)]
+pub struct SchemaNameOpt {
+    #[arg(long = "schema-name", short = 's')]
+    pub(crate) schema_name: Option<SchemaName>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaName(String);
+
+impl FromStr for SchemaName {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        const MAX_LENGTH: usize = 64;
+        const MIN_LENGTH: usize = 2;
+
+        // Check if the length of the input is within the valid range
+        if input.len() < MIN_LENGTH || input.len() > MAX_LENGTH {
+            return Err(format!(
+                "Invalid schema name length: must be between {MIN_LENGTH} and {MAX_LENGTH} characters."
+            ));
+        }
+
+        Ok(SchemaName(input.to_string()))
+    }
+}
+
+impl fmt::Display for SchemaName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl SchemaNameOpt {
+    pub fn get_schema_name(&self) -> Option<SchemaName> {
+        self.schema_name.clone()
+    }
+
+    pub fn prompt_schema_name(&self, use_case: &ProjectUseCase) -> RoverResult<SchemaName> {
+        if *use_case != ProjectUseCase::Connectors {
+            return Ok(SchemaName("unused".to_string()));
+        }
+
+        let default = self.suggest_default_name();
+
+        loop {
+            // Prompt for user input
+            let input: Input<String> = Input::new()
+                .with_prompt(Style::Prompt.paint("? Name your schema"))
+                .with_initial_text(default.clone());
+            let input_name = input.interact_text().map_err(|e| e.to_string()).unwrap();
+
+            // Try to parse the input into a SchemaName
+            let schema_name: Result<SchemaName, _> = input_name.parse();
+
+            // Check for a valid project name
+            match schema_name {
+                Ok(name) => return Ok(name),
+                Err(err) => {
+                    eprintln!("{err}"); // Print the error and continue the loop for another attempt
+                }
+            }
+        }
+    }
+
+    fn suggest_default_name(&self) -> String {
+        "main".to_string()
+    }
+
+    pub fn get_or_prompt_schema_name(&self, use_case: &ProjectUseCase) -> RoverResult<SchemaName> {
+        // If a schema name was provided via command line, validate and use it
+        if let Some(name) = self.get_schema_name() {
+            return Ok(name);
+        }
+
+        self.prompt_schema_name(use_case)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_errors_when_input_length_is_greater_than_max_length() {
+        let result: Result<SchemaName, _> =
+            "This string contains definitely more than sixty-four characters!!".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_errors_when_input_length_is_less_than_min_length() {
+        let result: Result<SchemaName, _> = "x".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_ok_when_input_includes_valid_chars_and_is_valid_length() {
+        let result: Result<SchemaName, _> = "products".parse();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_get_schema_name_with_preset_value() {
+        let instance = SchemaNameOpt {
+            schema_name: "products".parse::<SchemaName>().ok(),
+        };
+
+        let result = instance.get_schema_name();
+        assert_eq!(result, "products".parse::<SchemaName>().ok());
+    }
+
+    #[test]
+    fn test_suggest_default_name() {
+        let instance = SchemaNameOpt { schema_name: None };
+        let default_name = instance.suggest_default_name();
+
+        assert_eq!(default_name, "main");
+    }
+
+    // Default trait implementation tests
+    #[test]
+    fn test_default_trait() {
+        let default_instance = SchemaNameOpt::default();
+        assert_eq!(default_instance.schema_name, None);
+    }
+
+    // Derived trait tests (Debug, Clone, etc.)
+    #[test]
+    fn test_debug_trait() {
+        let instance = SchemaNameOpt {
+            schema_name: "test-schema".parse::<SchemaName>().ok(),
+        };
+        // Check that Debug formatting doesn't panic and has the expected content
+        let debug_str = format!("{instance:?}");
+        assert!(debug_str.contains("test-schema"));
+    }
+
+    #[test]
+    fn test_clone_trait() {
+        let original = SchemaNameOpt {
+            schema_name: "clone-schema".parse::<SchemaName>().ok(),
+        };
+        let cloned = original.clone();
+
+        assert_eq!(original.schema_name, cloned.schema_name);
+    }
+}

--- a/src/command/init/states.rs
+++ b/src/command/init/states.rs
@@ -1,6 +1,8 @@
 use crate::command::init::config::ProjectConfig;
 use crate::command::init::graph_id::validation::GraphId;
-use crate::command::init::options::{OrganizationId, ProjectName, ProjectType, ProjectUseCase};
+use crate::command::init::options::{
+    OrganizationId, ProjectName, ProjectType, ProjectUseCase, SchemaName,
+};
 use crate::command::init::template_fetcher::Template;
 use camino::Utf8PathBuf;
 use rover_client::shared::GraphRef;
@@ -60,6 +62,18 @@ pub struct GraphIdConfirmed {
     pub project_name: ProjectName,
     pub graph_id: GraphId,
     pub selected_template: SelectedTemplateState,
+}
+
+#[derive(Debug)]
+pub struct SchemaNamed {
+    pub output_path: Utf8PathBuf,
+    pub project_type: ProjectType,
+    pub organization: OrganizationId,
+    pub use_case: ProjectUseCase,
+    pub project_name: ProjectName,
+    pub graph_id: GraphId,
+    pub selected_template: SelectedTemplateState,
+    pub schema_name: SchemaName,
 }
 
 #[derive(Debug)]

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -232,8 +232,8 @@ mod tests {
     }
 
     #[test]
-    fn test_graph_id_confirmed_config() {
-        let graph_id_confirmed = GraphIdConfirmed {
+    fn test_schema_named_confirmed_config() {
+        let schema_named = SchemaNamed {
             output_path: ".".into(),
             project_type: ProjectType::CreateNew,
             organization: "test-org".parse::<OrganizationId>().unwrap(),
@@ -255,14 +255,16 @@ mod tests {
                 },
                 files: HashMap::new(),
             },
+            schema_name: "schema-name".parse().unwrap(),
         };
 
         let config = ProjectConfig {
-            project_type: graph_id_confirmed.project_type.clone(),
-            organization: graph_id_confirmed.organization.clone(),
-            use_case: graph_id_confirmed.use_case.clone(),
-            project_name: graph_id_confirmed.project_name,
-            graph_id: graph_id_confirmed.graph_id.clone(),
+            project_type: schema_named.project_type.clone(),
+            organization: schema_named.organization.clone(),
+            use_case: schema_named.use_case.clone(),
+            project_name: schema_named.project_name,
+            graph_id: schema_named.graph_id.clone(),
+            schema_name: schema_named.schema_name.clone(),
         };
 
         assert_eq!(config.project_type, ProjectType::CreateNew);
@@ -279,8 +281,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_graph_id_confirmed_preview_for_connectors() {
-        let graph_id_confirmed = GraphIdConfirmed {
+    async fn test_schema_named_preview_for_connectors() {
+        let schema_named = SchemaNamed {
             output_path: ".".into(),
             project_type: ProjectType::CreateNew,
             organization: "test-org".parse::<OrganizationId>().unwrap(),
@@ -302,17 +304,19 @@ mod tests {
                 },
                 files: HashMap::new(),
             },
+            schema_name: "schema-name".parse().unwrap(),
         };
 
         let http_service = mock::MockHttpService::default();
 
         let result: RoverResult<Option<mock::MockCreationConfirmed>> = async {
             let config = ProjectConfig {
-                project_type: graph_id_confirmed.project_type.clone(),
-                organization: graph_id_confirmed.organization.clone(),
-                use_case: graph_id_confirmed.use_case.clone(),
-                project_name: graph_id_confirmed.project_name,
-                graph_id: graph_id_confirmed.graph_id.clone(),
+                project_type: schema_named.project_type.clone(),
+                organization: schema_named.organization.clone(),
+                use_case: schema_named.use_case.clone(),
+                project_name: schema_named.project_name,
+                graph_id: schema_named.graph_id.clone(),
+                schema_name: schema_named.schema_name.clone(),
             };
 
             let template_fetcher = mock::MockTemplateFetcher::new(http_service);
@@ -353,8 +357,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_graph_id_confirmed_preview_for_graphql_template() {
-        let graph_id_confirmed = GraphIdConfirmed {
+    async fn test_schema_named_preview_for_graphql_template() {
+        let schema_named = SchemaNamed {
             project_type: ProjectType::CreateNew,
             organization: "test-org".parse::<OrganizationId>().unwrap(),
             use_case: ProjectUseCase::GraphQLTemplate,
@@ -376,21 +380,23 @@ mod tests {
                 },
                 files: HashMap::new(),
             },
+            schema_name: "schema-name".parse().unwrap(),
         };
 
         let http_service = mock::MockHttpService::default();
 
         let result: RoverResult<Option<mock::MockCreationConfirmed>> = async {
-            if graph_id_confirmed.use_case == ProjectUseCase::GraphQLTemplate {
+            if schema_named.use_case == ProjectUseCase::GraphQLTemplate {
                 return Ok(None);
             }
 
             let config = ProjectConfig {
-                project_type: graph_id_confirmed.project_type.clone(),
-                organization: graph_id_confirmed.organization.clone(),
-                use_case: graph_id_confirmed.use_case.clone(),
-                project_name: graph_id_confirmed.project_name.clone(),
-                graph_id: graph_id_confirmed.graph_id.clone(),
+                project_type: schema_named.project_type.clone(),
+                organization: schema_named.organization.clone(),
+                use_case: schema_named.use_case.clone(),
+                project_name: schema_named.project_name.clone(),
+                graph_id: schema_named.graph_id.clone(),
+                schema_name: schema_named.schema_name.clone(),
             };
 
             let template_fetcher = mock::MockTemplateFetcher::new(http_service);

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -348,6 +348,7 @@ impl SchemaNamed {
             project_name: self.project_name.clone(),
             graph_id: self.graph_id.clone(),
             project_type: self.project_type.clone(),
+            schema_name: self.schema_name.clone(),
         }
     }
 
@@ -460,6 +461,7 @@ impl CreationConfirmed {
             5,
             routing_url,
             &federation_version,
+            Some(self.config.schema_name.clone()),
         );
         supergraph.build_and_write()?;
 

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -310,6 +310,23 @@ impl ProjectNamed {
     }
 }
 
+impl GraphIdConfirmed {
+    pub async fn confirm_schema_name(self, options: &SchemaNameOpt) -> RoverResult<SchemaNamed> {
+        let schema_name = options.get_or_prompt_schema_name(&self.use_case)?;
+
+        Ok(SchemaNamed {
+            output_path: self.output_path,
+            project_type: self.project_type,
+            organization: self.organization,
+            use_case: self.use_case,
+            selected_template: self.selected_template,
+            project_name: self.project_name,
+            graph_id: self.graph_id,
+            schema_name,
+        })
+    }
+}
+
 /// PROMPT UX:
 /// =========
 ///
@@ -323,7 +340,7 @@ impl ProjectNamed {
 /// schema.graphql
 ///
 /// ? Proceed with creation? (y/n):
-impl GraphIdConfirmed {
+impl SchemaNamed {
     fn create_config(&self) -> ProjectConfig {
         ProjectConfig {
             organization: self.organization.clone(),

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -239,7 +239,7 @@ impl UseCaseSelected {
         options: &ProjectTemplateOpt,
     ) -> RoverResult<TemplateSelected> {
         // Fetch the template to get the list of files
-        let repo_ref = "release/v2";
+        let repo_ref = "release/v3-beta";
         let template_fetcher = InitTemplateFetcher::new().call(repo_ref).await?;
 
         // Determine the list of templates based on the use case


### PR DESCRIPTION
This PR adds a schema naming step to the Connectors init workflow. Previously, running `rover init` for a Connectors project would generate a boilerplate schema named `products`. Not all customers have the concept of "products," and trying to change the name of the subgraph causes unnecessary friction. This change allows users to provide their own schema name, which is then populated into the `supergraph.yaml` file.

This PR is intended to be deployed with compensating changes in `rover-init-starters`: https://github.com/apollographql/rover-init-starters/pull/51 This change should be deployed _before_ those changes, as the reverse order will cause `rover init` to panic when it encounters a root-level `.graphql` file named `schema`.

### Testing
1. Renamed `products.graphql` to `schema.graphql` in `rover-init-starters`
2. Pushed `rover-init-starters` changes to `origin/schema-rename`
3. Updated `rover` to pull templates from `schema-rename` branch by modifying `[repo_ref](https://github.com/apollographql/rover/blob/dd29b918fc84f862ab68c300b39d7f336d93f8ea/src/command/init/transitions.rs#L242)` locally
4. Ran `cargo build` to build these `rover` changes
5. Aliased `cargo rover` to `localrover` with `alias localrover='cargo run --manifest-path=/Users/alyssahursh/code/rover/Cargo.toml --bin rover --'`
6. Created new empty test directory
7. Ran `localrover init`
8. Verified that connectors init workflow prompted for a schema name
9. Verified `supergraph.yaml` file was created using the newly provided schema name

```
subgraphs:
  alyssa-schema-name-test:
    routing_url: http://ignore
    schema:
      file: schema.graphql
federation_version: =2.11.0
```


This PR is part of the 2025 Hackathon.