### PR TITLE
Hackathon improvements to `supergraph.yaml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ camino = { version = "1", features = ["serde1"] }
 clap = "4"
 chrono = "0.4"
 ci_info = "0.14"
-comfy-table = {  version = "7.1.4", features = ["custom_styling"] }
+comfy-table = { version = "7.1.4", features = ["custom_styling"] }
 console = "0.15"
 derive-getters = "0.5.0"
 dialoguer = "0.11"
@@ -133,7 +133,7 @@ serial_test = "3"
 serde = "1.0"
 serde_json = "1.0"
 serde_json_traversal = "0.2"
-serde_with = { version = "3", default-features = false, features = ["macros"]}
+serde_with = { version = "3", default-features = false, features = ["macros"] }
 serde_yaml = "0.9"
 shell-candy = "0.4"
 speculoos = "0.13.0"
@@ -172,7 +172,7 @@ zip = "4.0"
 anyhow = { workspace = true }
 assert_fs = { workspace = true }
 async-trait = { workspace = true }
-apollo-language-server = { workspace = true}
+apollo-language-server = { workspace = true }
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
 billboard = { workspace = true }
@@ -225,7 +225,7 @@ timber = { workspace = true }
 termimad = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "process", "sync"] }
-tokio-stream = { workspace = true, features = ["sync"]}
+tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }

--- a/crates/rover-client/src/operations/subgraph/fetch_all/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/mod.rs
@@ -1,6 +1,6 @@
 mod runner;
 mod service;
-mod types;
+pub mod types;
 
 pub use runner::run;
 pub use service::{SubgraphFetchAll, SubgraphFetchAllRequest};

--- a/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
+++ b/crates/rover-client/src/operations/subgraph/fetch_all/types.rs
@@ -17,7 +17,7 @@ pub struct SubgraphFetchAllResponse {
 
 #[derive(Clone, Builder, Debug, Eq, Getters, PartialEq)]
 pub struct Subgraph {
-    name: String,
-    url: Option<String>,
-    sdl: String,
+    pub name: String,
+    pub url: Option<String>,
+    pub sdl: String,
 }

--- a/crates/rover-client/src/shared/graph_ref.rs
+++ b/crates/rover-client/src/shared/graph_ref.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 use crate::RoverClientError;
 
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct GraphRef {
     pub name: String,
     pub variant: String,
@@ -58,6 +58,25 @@ impl FromStr for GraphRef {
         } else {
             Err(RoverClientError::InvalidGraphRef)
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for GraphRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let graph_id = String::deserialize(deserializer)?;
+        GraphRef::from_str(&graph_id).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for GraphRef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/command/init/operations.rs
+++ b/src/command/init/operations.rs
@@ -103,8 +103,11 @@ pub(crate) async fn publish_subgraphs(
                 );
             }
         };
-        let unresolved = UnresolvedSubgraph::new(subgraph_name.clone(), subgraph_config.clone());
-        let schema_path = unresolved.resolve_file_path(output_path, &schema_path.unwrap())?;
+        let schema_path = UnresolvedSubgraph::resolve_file_path(
+            subgraph_name,
+            output_path,
+            &schema_path.unwrap(),
+        )?;
         let sdl = read_to_string(schema_path)?;
         rover_client::operations::subgraph::publish::run(
             SubgraphPublishInput {

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -75,11 +75,7 @@ impl Compose {
 
         let write_file_impl = FsWriteFile::default();
         let exec_command_impl = TokioCommand::default();
-        let supergraph_yaml = self
-            .opts
-            .supergraph_config_source()
-            .supergraph_yaml
-            .clone();
+        let supergraph_yaml = self.opts.supergraph_config_source().supergraph_yaml.clone();
 
         let profile = self.opts.plugin_opts.profile.clone();
         let graph_ref = self.opts.supergraph_config_source.graph_ref.clone();

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -77,10 +77,9 @@ impl Compose {
         let exec_command_impl = TokioCommand::default();
         let supergraph_yaml = self
             .opts
-            .clone()
             .supergraph_config_source()
-            .clone()
-            .supergraph_yaml;
+            .supergraph_yaml
+            .clone();
 
         let profile = self.opts.plugin_opts.profile.clone();
         let graph_ref = self.opts.supergraph_config_source.graph_ref.clone();

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -7,9 +7,7 @@ use camino::Utf8PathBuf;
 use derive_getters::Getters;
 
 use crate::composition::supergraph::config::error::ResolveSubgraphError;
-use crate::composition::supergraph::config::resolver::{
-    LoadRemoteSubgraphsError, LoadSupergraphConfigError, ResolveSupergraphConfigError,
-};
+use crate::composition::supergraph::config::resolver::{LoadError, ResolveSupergraphConfigError};
 use crate::composition::supergraph::install::InstallSupergraphError;
 use crate::options::LicenseAccepter;
 use crate::utils::client::StudioClientConfig;
@@ -101,10 +99,8 @@ pub struct CompositionSubgraphRemoved {
 pub enum SupergraphConfigResolutionError {
     #[error("Could not instantiate Studio Client")]
     StudioClientInitialisationFailed(#[from] Error),
-    #[error("Could not load remote subgraphs")]
-    LoadRemoteSubgraphsFailed(#[from] LoadRemoteSubgraphsError),
-    #[error("Could not load supergraph config from local file.\n{}", .0)]
-    LoadLocalSupergraphConfigFailed(#[from] LoadSupergraphConfigError),
+    #[error("Could not load supergraph.\n{}", .0)]
+    LoadRemoteSubgraphsFailed(#[from] LoadError),
     #[error("Could not resolve local and remote elements into complete SupergraphConfig")]
     ResolveSupergraphConfigFailed(#[from] ResolveSupergraphConfigError),
 }

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -4,8 +4,9 @@ use std::fmt::Debug;
 use std::fs::canonicalize;
 
 use apollo_federation_types::config::FederationVersion::LatestFedTwo;
-use apollo_federation_types::config::{FederationVersion, SubgraphConfig, SupergraphConfig};
+use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
 use camino::Utf8PathBuf;
+use rover_client::operations::subgraph::fetch_all::SubgraphFetchAllResponse;
 use rover_client::shared::GraphRef;
 use rover_http::HttpService;
 use rover_std::warnln;
@@ -76,11 +77,7 @@ impl CompositionPipeline<state::Init> {
         default_subgraph: Option<DefaultSubgraphDefinition>,
     ) -> Result<CompositionPipeline<state::ResolveFederationVersion>, CompositionPipelineError>
     where
-        S: MakeService<
-            (),
-            FetchRemoteSubgraphsRequest,
-            Response = BTreeMap<String, SubgraphConfig>,
-        >,
+        S: MakeService<(), FetchRemoteSubgraphsRequest, Response = SubgraphFetchAllResponse>,
         S::MakeError: std::error::Error + Send + Sync + 'static,
         S::Error: std::error::Error + Send + Sync + 'static,
     {

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -94,7 +94,7 @@ impl CompositionPipeline<state::Init> {
             FileDescriptorType::Stdin => Some(FileDescriptorType::Stdin),
         });
         let supergraph_root = supergraph_yaml
-            .clone()
+            .as_ref()
             .and_then(|file| match file {
                 FileDescriptorType::File(file) => {
                     let mut current_dir =
@@ -114,10 +114,12 @@ impl CompositionPipeline<state::Init> {
                 .unwrap()
             });
         eprintln!("merging supergraph schema files");
-        let resolver = SupergraphConfigResolver::default()
-            .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
-            .await?
-            .load_from_file_descriptor(read_stdin_impl, supergraph_yaml.as_ref())?;
+        let resolver = SupergraphConfigResolver::load_remote_subgraphs(
+            fetch_remote_subgraphs_factory,
+            graph_ref.as_ref(),
+        )
+        .await?
+        .load_from_file_descriptor(read_stdin_impl, supergraph_yaml.as_ref())?;
         let resolver = match default_subgraph {
             Some(default_subgraph) => resolver
                 .define_default_subgraph_if_empty(default_subgraph)
@@ -254,7 +256,7 @@ impl CompositionPipeline<state::Run> {
 
     #[tracing::instrument(skip_all)]
     #[allow(clippy::too_many_arguments)]
-    pub async fn runner<ExecC, WriteF>(
+    pub(crate) async fn runner<ExecC, WriteF>(
         &self,
         exec_command: ExecC,
         write_file: WriteF,

--- a/src/composition/runner/state.rs
+++ b/src/composition/runner/state.rs
@@ -6,25 +6,25 @@ use crate::composition::watchers::{
     watcher::supergraph_config::SupergraphConfigWatcher,
 };
 
-pub struct SetupSubgraphWatchers;
+pub(crate) struct SetupSubgraphWatchers;
 
-pub struct SetupSupergraphConfigWatcher {
-    pub subgraph_watchers: SubgraphWatchers,
+pub(crate) struct SetupSupergraphConfigWatcher {
+    pub(crate) subgraph_watchers: SubgraphWatchers,
 }
 
-pub struct SetupCompositionWatcher {
-    pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
-    pub subgraph_watchers: SubgraphWatchers,
-    pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
+pub(crate) struct SetupCompositionWatcher {
+    pub(crate) supergraph_config_watcher: Option<SupergraphConfigWatcher>,
+    pub(crate) subgraph_watchers: SubgraphWatchers,
+    pub(crate) initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }
 
-pub struct Run<ExecC, WriteF>
+pub(crate) struct Run<ExecC, WriteF>
 where
     ExecC: Eq + PartialEq + Debug,
     WriteF: Eq + PartialEq + Debug,
 {
-    pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
-    pub subgraph_watchers: SubgraphWatchers,
-    pub composition_watcher: CompositionWatcher<ExecC, WriteF>,
-    pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
+    pub(crate) supergraph_config_watcher: Option<SupergraphConfigWatcher>,
+    pub(crate) subgraph_watchers: SubgraphWatchers,
+    pub(crate) composition_watcher: CompositionWatcher<ExecC, WriteF>,
+    pub(crate) initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -3,11 +3,11 @@
 
 use std::marker::PhantomData;
 
-use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
+use apollo_federation_types::config::FederationVersion;
 use derive_getters::Getters;
 
 use super::full::FullyResolvedSubgraph;
-use crate::command::supergraph::compose::do_compose::SupergraphComposeOpts;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 
 mod state {
     #[derive(Clone, Debug)]
@@ -68,13 +68,13 @@ impl FederationVersionResolver<state::FromSupergraphConfig> {
     /// from a [`SupergraphConfig`] (if it has one)
     pub fn from_supergraph_config(
         self,
-        supergraph_config: Option<&SupergraphConfig>,
+        supergraph_config: Option<&SupergraphConfigYaml>,
     ) -> FederationVersionResolver<state::FromSubgraphs> {
         match supergraph_config {
             Some(supergraph_config) => {
                 let federation_version = self
                     .federation_version
-                    .or(supergraph_config.get_federation_version());
+                    .or_else(|| supergraph_config.federation_version.clone());
                 FederationVersionResolver {
                     state: PhantomData::<state::FromSubgraphs>,
                     federation_version,
@@ -91,15 +91,6 @@ impl FederationVersionResolver<state::FromSupergraphConfig> {
     pub fn resolve(self) -> FederationVersion {
         self.federation_version
             .unwrap_or(FederationVersion::LatestFedTwo)
-    }
-}
-
-impl From<&SupergraphComposeOpts> for FederationVersionResolver<state::FromSupergraphConfig> {
-    fn from(value: &SupergraphComposeOpts) -> Self {
-        FederationVersionResolver {
-            federation_version: value.federation_version.clone(),
-            state: PhantomData::<state::FromSupergraphConfig>,
-        }
     }
 }
 
@@ -162,14 +153,13 @@ impl FederationVersionResolver<state::FromSubgraphs> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use apollo_federation_types::config::{
-        FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
-    };
+    use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
     use speculoos::prelude::*;
 
     use super::FederationVersionResolverFromSupergraphConfig;
     use crate::composition::supergraph::config::full::FullyResolvedSubgraph;
     use crate::composition::supergraph::config::scenario::*;
+    use crate::composition::supergraph::config::SupergraphConfigYaml;
 
     /// Test showing that federation version is selected from the user-specified fed version
     /// over local supergraph config or resolved subgraphs
@@ -188,8 +178,10 @@ mod tests {
         )]);
         let federation_version_resolver =
             FederationVersionResolverFromSupergraphConfig::new(FederationVersion::LatestFedTwo);
-        let supergraph_config =
-            SupergraphConfig::new(unresolved_subgraphs, Some(FederationVersion::LatestFedOne));
+        let supergraph_config = SupergraphConfigYaml {
+            subgraphs: unresolved_subgraphs,
+            federation_version: Some(FederationVersion::LatestFedOne),
+        };
 
         let resolved_subgraphs = [(
             subgraph_name.to_string(),
@@ -226,8 +218,10 @@ mod tests {
             SubgraphConfig::from(subgraph_scenario.unresolved_subgraph.clone()),
         )]);
         let federation_version_resolver = FederationVersionResolverFromSupergraphConfig::default();
-        let supergraph_config =
-            SupergraphConfig::new(unresolved_subgraphs, Some(FederationVersion::LatestFedTwo));
+        let supergraph_config = SupergraphConfigYaml {
+            subgraphs: unresolved_subgraphs,
+            federation_version: Some(FederationVersion::LatestFedTwo),
+        };
 
         let resolved_subgraphs = [(
             subgraph_name.to_string(),
@@ -264,7 +258,10 @@ mod tests {
             SubgraphConfig::from(subgraph_scenario.unresolved_subgraph.clone()),
         )]);
         let federation_version_resolver = FederationVersionResolverFromSupergraphConfig::default();
-        let supergraph_config = SupergraphConfig::new(unresolved_subgraphs, None);
+        let supergraph_config = SupergraphConfigYaml {
+            subgraphs: unresolved_subgraphs,
+            ..Default::default()
+        };
 
         let resolved_subgraphs = [(
             subgraph_name.to_string(),

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -181,6 +181,7 @@ mod tests {
         let supergraph_config = SupergraphConfigYaml {
             subgraphs: unresolved_subgraphs,
             federation_version: Some(FederationVersion::LatestFedOne),
+            graph_ref: None,
         };
 
         let resolved_subgraphs = [(
@@ -221,6 +222,7 @@ mod tests {
         let supergraph_config = SupergraphConfigYaml {
             subgraphs: unresolved_subgraphs,
             federation_version: Some(FederationVersion::LatestFedTwo),
+            graph_ref: None,
         };
 
         let resolved_subgraphs = [(

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -108,6 +108,15 @@ impl FederationVersionResolver<state::FromSubgraphs> {
         }
     }
 
+    /// Add in the Federation version from GraphOS, if any
+    pub fn with_graphos_version(
+        mut self,
+        federation_version: Option<FederationVersion>,
+    ) -> FederationVersionResolver<state::FromSubgraphs> {
+        self.federation_version = self.federation_version.or(federation_version);
+        self
+    }
+
     /// Returns the target [`FederationVersion`] that was defined by the user
     pub fn target_federation_version(&self) -> Option<FederationVersion> {
         self.federation_version.clone()

--- a/src/composition/supergraph/config/full/supergraph.rs
+++ b/src/composition/supergraph/config/full/supergraph.rs
@@ -13,7 +13,9 @@ use crate::composition::supergraph::config::error::ResolveSubgraphError;
 use crate::composition::supergraph::config::full::introspect::ResolveIntrospectSubgraphFactory;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
 use crate::composition::supergraph::config::resolver::ResolveSupergraphConfigError;
-use crate::composition::supergraph::config::unresolved::UnresolvedSupergraphConfig;
+use crate::composition::supergraph::config::unresolved::{
+    UnresolvedSubgraph, UnresolvedSupergraphConfig,
+};
 
 /// Represents a [`SupergraphConfig`] that has a known [`FederationVersion`] and
 /// its subgraph [`SchemaSource`]s reduced to [`SchemaSource::Sdl`]
@@ -51,40 +53,40 @@ impl FullyResolvedSupergraphConfig {
         ),
         ResolveSupergraphConfigError,
     > {
-        let subgraphs = stream::iter(
-            unresolved_supergraph_config
-                .subgraphs()
-                .clone()
-                .into_iter()
-                .map(move |(name, unresolved_subgraph)| {
-                    let fetch_remote_subgraph_factory = fetch_remote_subgraph_factory.clone();
-                    let resolve_introspect_subgraph_factory =
-                        resolve_introspect_subgraph_factory.clone();
-                    async move {
-                        match FullyResolvedSubgraph::resolver(
-                            resolve_introspect_subgraph_factory,
-                            fetch_remote_subgraph_factory,
-                            supergraph_config_root,
-                            unresolved_subgraph.clone(),
-                        )
-                        .await
-                        {
-                            Ok(mut service) => {
-                                let service = service
-                                    .ready()
-                                    .await
-                                    .map_err(|err| (name.to_string(), err))?;
-                                let result = service
-                                    .call(())
-                                    .await
-                                    .map_err(|err| (name.to_string(), err))?;
-                                Ok((name.to_string(), result))
-                            }
-                            Err(err) => Err((name.to_string(), err)),
+        let subgraphs = stream::iter(unresolved_supergraph_config.subgraphs.into_iter().map(
+            move |(name, subgraph)| {
+                let fetch_remote_subgraph_factory = fetch_remote_subgraph_factory.clone();
+                let resolve_introspect_subgraph_factory =
+                    resolve_introspect_subgraph_factory.clone();
+                async move {
+                    match FullyResolvedSubgraph::resolver(
+                        resolve_introspect_subgraph_factory,
+                        fetch_remote_subgraph_factory,
+                        supergraph_config_root,
+                        UnresolvedSubgraph {
+                            schema: subgraph.schema,
+                            routing_url: subgraph.routing_url,
+                            name: name.clone(),
+                        },
+                    )
+                    .await
+                    {
+                        Ok(mut service) => {
+                            let service = service
+                                .ready()
+                                .await
+                                .map_err(|err| (name.to_string(), err))?;
+                            let result = service
+                                .call(())
+                                .await
+                                .map_err(|err| (name.to_string(), err))?;
+                            Ok((name.to_string(), result))
                         }
+                        Err(err) => Err((name.to_string(), err)),
                     }
-                }),
-        )
+                }
+            },
+        ))
         .buffer_unordered(50)
         .collect::<Vec<Result<(String, FullyResolvedSubgraph), (String, ResolveSubgraphError)>>>()
         .await;
@@ -95,13 +97,12 @@ impl FullyResolvedSupergraphConfig {
         ) = subgraphs.into_iter().partition_result();
         let subgraphs = BTreeMap::from_iter(subgraphs);
         let federation_version = unresolved_supergraph_config
-            .federation_version_resolver()
-            .clone()
+            .federation_version_resolver
             .ok_or_else(|| ResolveSupergraphConfigError::MissingFederationVersionResolver)?
             .resolve(subgraphs.iter())?;
         Ok((
             FullyResolvedSupergraphConfig {
-                origin_path: unresolved_supergraph_config.origin_path().clone(),
+                origin_path: unresolved_supergraph_config.origin_path.clone(),
                 subgraphs,
                 federation_version,
             },

--- a/src/composition/supergraph/config/lazy/subgraph.rs
+++ b/src/composition/supergraph/config/lazy/subgraph.rs
@@ -20,26 +20,28 @@ impl LazilyResolvedSubgraph {
     /// any filepaths and confirming that they are relative to a supergraph config schema
     pub fn resolve(
         supergraph_config_root: &Utf8PathBuf,
-        unresolved_subgraph: UnresolvedSubgraph,
+        name: String,
+        unresolved_subgraph: SubgraphConfig,
     ) -> Result<LazilyResolvedSubgraph, ResolveSubgraphError> {
-        match unresolved_subgraph.schema() {
+        match unresolved_subgraph.schema {
             SchemaSource::File { file } => {
-                let file = unresolved_subgraph.resolve_file_path(
-                    &supergraph_config_root.clone(),
-                    &Utf8PathBuf::try_from(file.clone())?,
+                let file = UnresolvedSubgraph::resolve_file_path(
+                    &name,
+                    supergraph_config_root,
+                    &Utf8PathBuf::try_from(file)?,
                 )?;
                 Ok(LazilyResolvedSubgraph {
-                    name: unresolved_subgraph.name().to_string(),
-                    routing_url: unresolved_subgraph.routing_url().clone(),
+                    name,
+                    routing_url: unresolved_subgraph.routing_url,
                     schema: SchemaSource::File {
                         file: file.into_std_path_buf(),
                     },
                 })
             }
-            _ => Ok(LazilyResolvedSubgraph {
-                name: unresolved_subgraph.name().to_string(),
-                routing_url: unresolved_subgraph.routing_url().clone(),
-                schema: unresolved_subgraph.schema().clone(),
+            schema => Ok(LazilyResolvedSubgraph {
+                name,
+                routing_url: unresolved_subgraph.routing_url,
+                schema,
             }),
         }
     }

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
+use apollo_federation_types::config::FederationVersion;
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 use futures::{stream, StreamExt};
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use super::LazilyResolvedSubgraph;
 use crate::composition::supergraph::config::error::ResolveSubgraphError;
 use crate::composition::supergraph::config::unresolved::UnresolvedSupergraphConfig;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 
 /// Represents a [`SupergraphConfig`] where all its [`SchemaSource::File`] subgraphs have
 /// known and valid file paths relative to a supergraph config file (or working directory of the
@@ -30,20 +31,19 @@ impl LazilyResolvedSupergraphConfig {
         LazilyResolvedSupergraphConfig,
         BTreeMap<String, ResolveSubgraphError>,
     ) {
-        let subgraphs = stream::iter(
-            unresolved_supergraph_config
-                .subgraphs()
-                .clone()
-                .into_iter()
-                .map(|(name, unresolved_subgraph)| async move {
-                    let result = LazilyResolvedSubgraph::resolve(
-                        supergraph_config_root,
-                        unresolved_subgraph.clone(),
-                    )
-                    .map_err(|err| (name.to_string(), err))?;
-                    Ok((name.to_string(), result))
-                }),
-        )
+        let federation_version = unresolved_supergraph_config.target_federation_version();
+        let subgraphs = stream::iter(unresolved_supergraph_config.subgraphs.into_iter().map(
+            |(name, unresolved_subgraph)| async move {
+                match LazilyResolvedSubgraph::resolve(
+                    supergraph_config_root,
+                    name.clone(),
+                    unresolved_subgraph,
+                ) {
+                    Ok(result) => Ok((name, result)),
+                    Err(err) => Err((name, err)),
+                }
+            },
+        ))
         .buffer_unordered(50)
         .collect::<Vec<Result<(String, LazilyResolvedSubgraph), (String, ResolveSubgraphError)>>>()
         .await;
@@ -54,9 +54,9 @@ impl LazilyResolvedSupergraphConfig {
         ) = subgraphs.into_iter().partition_result();
         (
             LazilyResolvedSupergraphConfig {
-                origin_path: unresolved_supergraph_config.origin_path().clone(),
+                origin_path: unresolved_supergraph_config.origin_path.clone(),
                 subgraphs: BTreeMap::from_iter(subgraphs),
-                federation_version: unresolved_supergraph_config.target_federation_version(),
+                federation_version,
             },
             BTreeMap::from_iter(errors.into_iter()),
         )
@@ -70,7 +70,7 @@ impl LazilyResolvedSupergraphConfig {
     }
 }
 
-impl From<LazilyResolvedSupergraphConfig> for SupergraphConfig {
+impl From<LazilyResolvedSupergraphConfig> for SupergraphConfigYaml {
     fn from(value: LazilyResolvedSupergraphConfig) -> Self {
         let subgraphs = BTreeMap::from_iter(
             value
@@ -78,6 +78,9 @@ impl From<LazilyResolvedSupergraphConfig> for SupergraphConfig {
                 .into_iter()
                 .map(|(name, subgraph)| (name, subgraph.into())),
         );
-        SupergraphConfig::new(subgraphs, value.federation_version)
+        SupergraphConfigYaml {
+            subgraphs,
+            federation_version: value.federation_version,
+        }
     }
 }

--- a/src/composition/supergraph/config/mod.rs
+++ b/src/composition/supergraph/config/mod.rs
@@ -10,3 +10,6 @@ pub mod resolver;
 #[cfg(test)]
 pub(crate) mod scenario;
 pub mod unresolved;
+mod yaml;
+
+pub(crate) use yaml::SupergraphConfigYaml;

--- a/src/composition/supergraph/config/resolver/state.rs
+++ b/src/composition/supergraph/config/resolver/state.rs
@@ -7,12 +7,6 @@ use crate::composition::supergraph::config::federation::{
     FederationVersionResolverFromSubgraphs, FederationVersionResolverFromSupergraphConfig,
 };
 
-/// In this stage, we await the caller to optionally load subgraphs from the Studio API using
-/// the contents of the `--graph-ref` flag
-pub struct LoadRemoteSubgraphs {
-    pub federation_version_resolver: FederationVersionResolverFromSupergraphConfig,
-}
-
 /// In this stage, we await the caller to optionally load subgraphs and a specified federation
 /// version from a local supergraph config file
 pub struct LoadSupergraphConfig {

--- a/src/composition/supergraph/config/resolver/state.rs
+++ b/src/composition/supergraph/config/resolver/state.rs
@@ -1,15 +1,16 @@
 use std::collections::BTreeMap;
 
+use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
 use apollo_federation_types::config::SubgraphConfig;
 use camino::Utf8PathBuf;
-
-use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
+use rover_client::shared::GraphRef;
 
 /// In this stage, we prompt the user to provide a subgraph if they have not provided any already
 pub struct DefineDefaultSubgraph {
     pub origin_path: Option<Utf8PathBuf>,
     pub federation_version_resolver: FederationVersionResolverFromSubgraphs,
     pub subgraphs: BTreeMap<String, SubgraphConfig>,
+    pub graph_ref: Option<GraphRef>,
 }
 
 /// In this stage, we attempt to resolve subgraphs lazily: making sure file paths are correct
@@ -18,4 +19,5 @@ pub struct ResolveSubgraphs {
     pub origin_path: Option<Utf8PathBuf>,
     pub federation_version_resolver: FederationVersionResolverFromSubgraphs,
     pub subgraphs: BTreeMap<String, SubgraphConfig>,
+    pub graph_ref: Option<GraphRef>,
 }

--- a/src/composition/supergraph/config/resolver/state.rs
+++ b/src/composition/supergraph/config/resolver/state.rs
@@ -3,16 +3,7 @@ use std::collections::BTreeMap;
 use apollo_federation_types::config::SubgraphConfig;
 use camino::Utf8PathBuf;
 
-use crate::composition::supergraph::config::federation::{
-    FederationVersionResolverFromSubgraphs, FederationVersionResolverFromSupergraphConfig,
-};
-
-/// In this stage, we await the caller to optionally load subgraphs and a specified federation
-/// version from a local supergraph config file
-pub struct LoadSupergraphConfig {
-    pub federation_version_resolver: FederationVersionResolverFromSupergraphConfig,
-    pub subgraphs: BTreeMap<String, SubgraphConfig>,
-}
+use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
 
 /// In this stage, we prompt the user to provide a subgraph if they have not provided any already
 pub struct DefineDefaultSubgraph {

--- a/src/composition/supergraph/config/unresolved/subgraph.rs
+++ b/src/composition/supergraph/config/unresolved/subgraph.rs
@@ -10,9 +10,9 @@ use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
 /// Represents a `SubgraphConfig` that needs to be resolved, either fully or lazily
 #[derive(Clone, Debug, Getters)]
 pub struct UnresolvedSubgraph {
-    name: String,
-    schema: SchemaSource,
-    routing_url: Option<String>,
+    pub(crate) name: String,
+    pub(crate) schema: SchemaSource,
+    pub(crate) routing_url: Option<String>,
 }
 
 impl UnresolvedSubgraph {
@@ -27,7 +27,7 @@ impl UnresolvedSubgraph {
 
     /// Produces a canonical filepath as the path relates to the supplied root path
     pub fn resolve_file_path(
-        &self,
+        name: &str,
         root: &Utf8PathBuf,
         path: &Utf8PathBuf,
     ) -> Result<Utf8PathBuf, ResolveSubgraphError> {
@@ -36,7 +36,7 @@ impl UnresolvedSubgraph {
         match canonical_filename {
             Ok(canonical_filename) => Ok(canonical_filename),
             Err(err) => Err(ResolveSubgraphError::FileNotFound {
-                subgraph_name: self.name.to_string(),
+                subgraph_name: name.to_string(),
                 supergraph_config_path: root.clone(),
                 path: path.clone(),
                 joined_path,

--- a/src/composition/supergraph/config/unresolved/supergraph.rs
+++ b/src/composition/supergraph/config/unresolved/supergraph.rs
@@ -1,10 +1,10 @@
 //! Provides tooling to resolve subgraphs, fully or lazily
 use std::collections::BTreeMap;
 
+use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
 use apollo_federation_types::config::{FederationVersion, SubgraphConfig};
 use camino::Utf8PathBuf;
-
-use crate::composition::supergraph::config::federation::FederationVersionResolverFromSubgraphs;
+use rover_client::shared::GraphRef;
 
 /// Object that represents a [`SupergraphConfig`] that requires resolution
 #[derive(Clone)]
@@ -12,6 +12,7 @@ pub struct UnresolvedSupergraphConfig {
     pub(crate) origin_path: Option<Utf8PathBuf>,
     pub(crate) subgraphs: BTreeMap<String, SubgraphConfig>,
     pub(crate) federation_version_resolver: Option<FederationVersionResolverFromSubgraphs>,
+    pub(crate) graph_ref: Option<GraphRef>,
 }
 
 impl UnresolvedSupergraphConfig {
@@ -322,6 +323,7 @@ mod tests {
             federation_version_resolver: Some(FederationVersionResolverFromSubgraphs::new(
                 target_federation_version,
             )),
+            graph_ref: None,
         };
 
         let RemoteSubgraphScenario {
@@ -625,6 +627,7 @@ mod tests {
             federation_version_resolver: Some(FederationVersionResolverFromSubgraphs::new(Some(
                 target_federation_version.clone(),
             ))),
+            graph_ref: None,
         };
 
         let RemoteSubgraphScenario {
@@ -853,6 +856,7 @@ mod tests {
             origin_path: Some(supergraph_config_origin_path),
             subgraphs: unresolved_subgraphs,
             federation_version_resolver: Some(FederationVersionResolverFromSubgraphs::new(None)),
+            graph_ref: None,
         };
 
         let (resolved_supergraph_config, _) = LazilyResolvedSupergraphConfig::resolve(

--- a/src/composition/supergraph/config/yaml.rs
+++ b/src/composition/supergraph/config/yaml.rs
@@ -1,10 +1,14 @@
 use apollo_federation_types::config::{FederationVersion, SubgraphConfig};
-use serde::{Deserialize, Serialize};
+use rover_client::shared::GraphRef;
+use serde::Deserialize;
 use std::collections::BTreeMap;
 
 /// The YAML that a user will write to configure a supergraph.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, schemars::JsonSchema)]
 pub struct SupergraphConfigYaml {
+    #[schemars(skip)] // TODO: Set up the right graph@variant schema
+    pub(crate) graph_ref: Option<GraphRef>,
+
     // Store config in a BTreeMap, as HashMap is non-deterministic.
     pub(crate) subgraphs: BTreeMap<String, SubgraphConfig>,
 

--- a/src/composition/supergraph/config/yaml.rs
+++ b/src/composition/supergraph/config/yaml.rs
@@ -1,0 +1,13 @@
+use apollo_federation_types::config::{FederationVersion, SubgraphConfig};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The YAML that a user will write to configure a supergraph.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SupergraphConfigYaml {
+    // Store config in a BTreeMap, as HashMap is non-deterministic.
+    pub(crate) subgraphs: BTreeMap<String, SubgraphConfig>,
+
+    // The version requirement for the supergraph binary.
+    pub(crate) federation_version: Option<FederationVersion>,
+}

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -1,4 +1,3 @@
-use apollo_federation_types::config::FederationVersion::LatestFedTwo;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use tap::TapFallible;
@@ -38,7 +37,7 @@ impl SubtaskHandleStream for FederationWatcher {
                                 if let Some(fed_version) = diff.federation_version() {
                                     let _ = sender
                                         .send(CompositionInputEvent::Federation(
-                                            fed_version.clone().unwrap_or(LatestFedTwo),
+                                            fed_version.clone(),
                                         ))
                                         .tap_err(|err| error!("{:?}", err));
                                 }

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -17,7 +17,6 @@ use crate::composition::supergraph::config::full::introspect::ResolveIntrospectS
 use crate::composition::supergraph::config::full::FullyResolvedSubgraph;
 use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
-use crate::composition::supergraph::config::unresolved::UnresolvedSubgraph;
 use crate::composition::watchers::composition::CompositionInputEvent;
 use crate::composition::watchers::composition::CompositionInputEvent::Subgraph;
 use crate::composition::watchers::watcher::supergraph_config::SupergraphConfigSerialisationError;
@@ -292,10 +291,11 @@ impl SubgraphHandles {
         introspection_polling_interval: u64,
     ) -> Result<(), ResolveSubgraphError> {
         eprintln!("Adding subgraph to session: `{subgraph}`");
-        let unresolved_subgraph =
-            UnresolvedSubgraph::new(subgraph.to_string(), subgraph_config.clone());
-        let lazily_resolved_subgraph =
-            LazilyResolvedSubgraph::resolve(&self.supergraph_config_root, unresolved_subgraph)?;
+        let lazily_resolved_subgraph = LazilyResolvedSubgraph::resolve(
+            &self.supergraph_config_root,
+            subgraph.to_string(),
+            subgraph_config.clone(),
+        )?;
         let resolver = FullyResolvedSubgraph::resolver(
             self.resolve_introspect_subgraph_factory.clone(),
             self.fetch_remote_subgraph_factory.clone(),
@@ -334,11 +334,10 @@ impl SubgraphHandles {
         introspection_polling_interval: u64,
     ) -> Result<(), ResolveSubgraphError> {
         eprintln!("Change detected for subgraph: `{subgraph}`");
-        let unresolved_subgraph =
-            UnresolvedSubgraph::new(subgraph.to_string(), subgraph_config.clone());
         let lazily_resolved_subgraph = LazilyResolvedSubgraph::resolve(
             &self.supergraph_config_root.clone(),
-            unresolved_subgraph,
+            subgraph.to_string(),
+            subgraph_config.clone(),
         )?;
         let resolver = FullyResolvedSubgraph::resolver(
             self.resolve_introspect_subgraph_factory.clone(),

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use apollo_federation_types::config::{
-    ConfigError, ConfigResult, FederationVersion, SubgraphConfig, SupergraphConfig,
+    ConfigError, ConfigResult, FederationVersion, SubgraphConfig,
 };
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
@@ -23,14 +23,15 @@ use crate::composition::supergraph::config::full::FullyResolvedSupergraphConfig;
 use crate::composition::supergraph::config::lazy::LazilyResolvedSupergraphConfig;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
 use crate::composition::supergraph::config::unresolved::UnresolvedSupergraphConfig;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::composition::watchers::watcher::supergraph_config::SupergraphConfigSerialisationError::DeserializingConfigError;
-use crate::subtask::SubtaskHandleMultiStream;
 use crate::utils::expansion::expand;
 
+/// Watches a `supergraph.yaml` file and emits [`SupergraphConfigDiff`]s
 #[derive(Debug)]
-pub struct SupergraphConfigWatcher {
+pub(crate) struct SupergraphConfigWatcher {
     file_watcher: FileWatcher,
-    supergraph_config: SupergraphConfig,
+    supergraph_config: SupergraphConfigYaml,
     fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
     resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory,
 }
@@ -62,7 +63,7 @@ impl SupergraphConfigWatcher {
         supergraph_config_path: &Utf8PathBuf,
         mut unresolved_supergraph_config: UnresolvedSupergraphConfig,
         errors: BTreeMap<String, ResolveSubgraphError>,
-    ) -> SupergraphConfig {
+    ) -> SupergraphConfigYaml {
         // First filter out the subgraphs from the unresolved set
         unresolved_supergraph_config.filter_subgraphs(errors.keys().cloned().collect());
         // Then resolve the filtered version, rather than the whole thing
@@ -75,16 +76,16 @@ impl SupergraphConfigWatcher {
             "Filtered Lazily Resolved Supergraph Config: {:?}",
             lazily_resolved_supergraph_config
         );
-        SupergraphConfig::from(lazily_resolved_supergraph_config)
+        lazily_resolved_supergraph_config.into()
     }
-}
 
-impl SubtaskHandleMultiStream for SupergraphConfigWatcher {
-    type Output = Result<SupergraphConfigDiff, SupergraphConfigSerialisationError>;
-
-    fn handle(self, sender: Sender<Self::Output>, cancellation_token: Option<CancellationToken>) {
+    /// Spawn the watcher, sending diffs to the provided `sender`.
+    pub(crate) fn run(
+        self,
+        sender: Sender<Result<SupergraphConfigDiff, SupergraphConfigSerialisationError>>,
+    ) {
         let supergraph_config_path = self.file_watcher.path().clone();
-        let cancellation_token = cancellation_token.unwrap_or_default();
+        let cancellation_token = CancellationToken::new();
         tokio::spawn(async move {
             let supergraph_config_path = supergraph_config_path.clone();
             let mut latest_supergraph_config = self.supergraph_config.clone();
@@ -110,79 +111,74 @@ impl SubtaskHandleMultiStream for SupergraphConfigWatcher {
                 .watch(cancellation_token.clone())
                 .await;
             cancellation_token.run_until_cancelled(async move {
-                    while let Some(contents) = stream.next().await {
-                        eprintln!("{supergraph_config_path} changed. Applying changes to the session.");
-                        tracing::info!(
-                                "{} changed. Parsing it as a `SupergraphConfig`",
-                                supergraph_config_path
+                while let Some(contents) = stream.next().await {
+                    eprintln!("{supergraph_config_path} changed. Applying changes to the session.");
+                    tracing::info!(
+                            "{} changed. Parsing it as a `SupergraphConfig`",
+                            supergraph_config_path
+                        );
+                    debug!("Current supergraph config is: {:?}", latest_supergraph_config);
+                    match Self::read_supergraph_config(&contents) {
+                        Ok(supergraph_config) => {
+                            let unresolved_supergraph_config = UnresolvedSupergraphConfig {
+                                origin_path: Some(supergraph_config_path.clone()),
+                                federation_version_resolver: Some(FederationVersionResolver::default().from_supergraph_config(Some( &supergraph_config))),
+                                subgraphs: supergraph_config.subgraphs,
+                            };
+                            // Here we can throw away what actually gets resolved because we care about the fact it
+                            // happens not the resulting artifact.
+                            let errors = if let Ok((_, errors)) = FullyResolvedSupergraphConfig::resolve(
+                                self.resolve_introspect_subgraph_factory.clone(),
+                                self.fetch_remote_subgraph_factory.clone(),
+                                &supergraph_config_path.parent().unwrap().to_path_buf(),
+                                unresolved_supergraph_config.clone(),
+                            ).await {
+                                errors
+                            } else {
+                                tracing::error!("Could not fully resolve SupergraphConfig, will retry on next file change");
+                                continue
+                            };
+                            let new_supergraph_config = Self::generate_correct_lazily_resolved_supergraph_config(&supergraph_config_path, unresolved_supergraph_config, errors.clone()).await;
+
+                            let supergraph_config_diff = SupergraphConfigDiff::new(
+                                latest_supergraph_config,
+                                new_supergraph_config.clone(),
+                                errors.clone(),
+                                broken
                             );
-                        debug!("Current supergraph config is: {:?}", latest_supergraph_config);
-                        match Self::read_supergraph_config(&contents) {
-                            Ok(supergraph_config) => {
-                                let subgraphs = BTreeMap::from_iter(supergraph_config.clone().into_iter());
-                                let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()
-                                    .origin_path(supergraph_config_path.clone())
-                                    .subgraphs(subgraphs)
-                                    .federation_version_resolver(FederationVersionResolver::default().from_supergraph_config(Some(&supergraph_config)))
-                                    .build();
-                                // Here we can throw away what actually gets resolved because we care about the fact it
-                                // happens not the resulting artifact.
-                                let errors = if let Ok((_, errors)) = FullyResolvedSupergraphConfig::resolve(
-                                    self.resolve_introspect_subgraph_factory.clone(),
-                                    self.fetch_remote_subgraph_factory.clone(),
-                                    &supergraph_config_path.parent().unwrap().to_path_buf(),
-                                    unresolved_supergraph_config.clone(),
-                                ).await {
-                                    errors
-                                } else {
-                                    tracing::error!("Could not fully resolve SupergraphConfig, will retry on next file change");
-                                    continue
-                                };
-                                let new_supergraph_config = Self::generate_correct_lazily_resolved_supergraph_config(&supergraph_config_path, unresolved_supergraph_config, errors.clone()).await;
-
-                                let supergraph_config_diff = SupergraphConfigDiff::new(
-                                    &latest_supergraph_config,
-                                    new_supergraph_config.clone(),
-                                    errors.clone(),
-                                    broken
-                                );
-                                match supergraph_config_diff {
-                                    Ok(supergraph_config_diff) => {
-                                        debug!("{supergraph_config_diff}");
-                                        let _ = sender
-                                            .send(Ok(supergraph_config_diff))
-                                            .tap_err(|err| tracing::error!("{:?}", err));
-                                    }
-                                    Err(err) => {
-                                        tracing::error!("Failed to construct a diff between the current and previous `SupergraphConfig`s.\n{}", err);
-                                    }
+                            match supergraph_config_diff {
+                                Ok(supergraph_config_diff) => {
+                                    debug!("{supergraph_config_diff}");
+                                    let _ = sender
+                                        .send(Ok(supergraph_config_diff))
+                                        .tap_err(|err| tracing::error!("{:?}", err));
                                 }
+                                Err(err) => {
+                                    tracing::error!("Failed to construct a diff between the current and previous `SupergraphConfig`s.\n{}", err);
+                                }
+                            }
 
-                                latest_supergraph_config = new_supergraph_config;
-                                broken = false;
-                            }
-                            Err(err) => {
-                                broken = true;
-                                let old_fed_version = latest_supergraph_config.get_federation_version().clone();
-                                latest_supergraph_config = SupergraphConfig::new(BTreeMap::new(),old_fed_version);
-                                tracing::error!("could not parse supergraph config file: {:?}", err);
-                                errln!("Could not parse supergraph config file.\n{}", err);
-                                let _ = sender
-                                    .send(Err(DeserializingConfigError {
-                                        source: Arc::new(err)
-                                    }))
-                                    .tap_err(|err| tracing::error!("{:?}", err));
-                            }
+                            latest_supergraph_config = new_supergraph_config;
+                            broken = false;
+                        }
+                        Err(err) => {
+                            broken = true;
+                            tracing::error!("could not parse supergraph config file: {:?}", err);
+                            errln!("Could not parse supergraph config file.\n{}", err);
+                            let _ = sender
+                                .send(Err(DeserializingConfigError {
+                                    source: Arc::new(err)
+                                }))
+                                .tap_err(|err| tracing::error!("{:?}", err));
                         }
                     }
-                }).await;
+                }
+            }).await;
         });
     }
-}
 
-impl SupergraphConfigWatcher {
     /// Read the supergraph config from YAML contents and expand any variables
-    fn read_supergraph_config(contents: &str) -> ConfigResult<SupergraphConfig> {
+    fn read_supergraph_config(contents: &str) -> ConfigResult<SupergraphConfigYaml> {
         fn to_config_err(e: impl ToString) -> ConfigError {
             ConfigError::InvalidConfiguration {
                 message: e.to_string(),
@@ -190,8 +186,7 @@ impl SupergraphConfigWatcher {
         }
         let yaml_contents = expand(serde_yaml::from_str(contents).map_err(to_config_err)?)
             .map_err(to_config_err)?;
-        let yaml_contents = serde_yaml::to_string(&yaml_contents).map_err(to_config_err)?;
-        SupergraphConfig::new_from_yaml(&yaml_contents)
+        serde_yaml::from_value(yaml_contents).map_err(to_config_err)
     }
 }
 
@@ -200,7 +195,7 @@ pub struct SupergraphConfigDiff {
     added: Vec<(String, SubgraphConfig)>,
     changed: Vec<(String, SubgraphConfig)>,
     removed: Vec<(String, Option<ResolveSubgraphError>)>,
-    federation_version: Option<Option<FederationVersion>>,
+    federation_version: Option<FederationVersion>,
     previously_broken: bool,
 }
 
@@ -224,29 +219,19 @@ impl SupergraphConfigDiff {
     /// Compares the differences between two supergraph configs,
     /// returning the added and removed subgraphs.
     pub fn new(
-        old: &SupergraphConfig,
-        new: SupergraphConfig,
+        old: SupergraphConfigYaml,
+        new: SupergraphConfigYaml,
         resolution_errors: BTreeMap<String, ResolveSubgraphError>,
         previously_broken: bool,
     ) -> Result<SupergraphConfigDiff, ConfigError> {
         debug!("Old Supergraph Config: {:?}", old);
         debug!("New Supergraph Config: {:?}", new);
 
-        let old_subgraph_names: HashSet<String> = old
-            .clone()
-            .into_iter()
-            .map(|(name, _config)| name)
-            .collect();
-
-        let new_subgraph_names: HashSet<String> = new
-            .clone()
-            .into_iter()
-            .map(|(name, _config)| name)
-            .collect();
+        let old_subgraph_names: HashSet<String> = old.subgraphs.keys().cloned().collect();
+        let new_subgraph_names: HashSet<String> = new.subgraphs.keys().cloned().collect();
 
         // Collect the subgraph definitions from the new supergraph config.
-        let new_subgraphs: BTreeMap<String, SubgraphConfig> = new.clone().into_iter().collect();
-
+        let new_subgraphs: BTreeMap<String, SubgraphConfig> = new.subgraphs;
         // Compare the old and new subgraph names to find additions.
         let added_names: HashSet<String> =
             HashSet::from_iter(new_subgraph_names.difference(&old_subgraph_names).cloned());
@@ -264,7 +249,7 @@ impl SupergraphConfigDiff {
 
         // Find any in-place changes (eg, SDL, SchemaSource::Subgraph)
         let changed = old
-            .clone()
+            .subgraphs
             .into_iter()
             .filter(|(old_name, _)| !removed.contains(old_name))
             .filter_map(|(old_name, old_subgraph)| {
@@ -279,13 +264,12 @@ impl SupergraphConfigDiff {
             })
             .collect::<Vec<_>>();
 
-        let federation_version = if old.get_federation_version() != new.get_federation_version() {
+        let federation_version = if old.federation_version != new.federation_version {
             debug!(
                 "Detected federation version change. Changing from {:?} to {:?}",
-                old.get_federation_version(),
-                new.get_federation_version()
+                old.federation_version, new.federation_version,
             );
-            Some(new.get_federation_version())
+            new.federation_version
         } else {
             None
         };
@@ -320,11 +304,10 @@ pub enum SupergraphConfigSerialisationError {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::collections::BTreeMap;
 
-    use apollo_federation_types::config::{
-        ConfigError, SchemaSource, SubgraphConfig, SupergraphConfig,
-    };
+    use apollo_federation_types::config::{ConfigError, SchemaSource, SubgraphConfig};
     use rstest::rstest;
 
     use crate::composition::watchers::watcher::supergraph_config::SupergraphConfigWatcher;
@@ -346,17 +329,23 @@ mod tests {
             ("subgraph_a".to_string(), subgraph_def.clone()),
             ("subgraph_b".to_string(), subgraph_def.clone()),
         ]);
-        let old = SupergraphConfig::new(old_subgraph_defs, None);
+        let old = SupergraphConfigYaml {
+            subgraphs: old_subgraph_defs,
+            ..Default::default()
+        };
 
         // Create a new supergraph config with 1 new and 1 old subgraph definitions.
         let new_subgraph_defs: BTreeMap<String, SubgraphConfig> = BTreeMap::from([
             ("subgraph_a".to_string(), subgraph_def.clone()),
             ("subgraph_c".to_string(), subgraph_def.clone()),
         ]);
-        let new = SupergraphConfig::new(new_subgraph_defs, None);
+        let new = SupergraphConfigYaml {
+            subgraphs: new_subgraph_defs,
+            ..Default::default()
+        };
 
         // Assert diff contain correct additions and removals.
-        let diff = SupergraphConfigDiff::new(&old, new, BTreeMap::default(), false).unwrap();
+        let diff = SupergraphConfigDiff::new(old, new, BTreeMap::default(), false).unwrap();
         assert_eq!(1, diff.added().len());
         assert_eq!(1, diff.removed().len());
         assert!(diff
@@ -399,15 +388,21 @@ mod tests {
         // Create an old supergraph config with subgraph definitions.
         let old_subgraph_defs: BTreeMap<String, SubgraphConfig> =
             BTreeMap::from([("subgraph_a".to_string(), old_subgraph_config.clone())]);
-        let old = SupergraphConfig::new(old_subgraph_defs, None);
+        let old = SupergraphConfigYaml {
+            subgraphs: old_subgraph_defs,
+            ..Default::default()
+        };
 
         // Create a new supergraph config with 1 new and 1 old subgraph definitions.
         let new_subgraph_defs: BTreeMap<String, SubgraphConfig> =
             BTreeMap::from([("subgraph_a".to_string(), new_subgraph_config.clone())]);
-        let new = SupergraphConfig::new(new_subgraph_defs, None);
+        let new = SupergraphConfigYaml {
+            subgraphs: new_subgraph_defs,
+            ..Default::default()
+        };
 
         // Assert diff contain correct additions and removals.
-        let diff = SupergraphConfigDiff::new(&old, new, BTreeMap::default(), false).unwrap();
+        let diff = SupergraphConfigDiff::new(old, new, BTreeMap::default(), false).unwrap();
 
         assert_eq!(diff.changed().len(), 1);
         assert!(diff
@@ -430,6 +425,7 @@ mod tests {
         std::env::set_var("TEST_SUBGRAPH_PORT", "4000");
         let routing_url = SupergraphConfigWatcher::read_supergraph_config(yaml_config)
             .unwrap()
+            .subgraphs
             .into_iter()
             .find(|(name, _)| name == "test_subgraph")
             .map(|(_, config)| config)

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -124,6 +124,7 @@ impl SupergraphConfigWatcher {
                                 origin_path: Some(supergraph_config_path.clone()),
                                 federation_version_resolver: Some(FederationVersionResolver::default().from_supergraph_config(Some( &supergraph_config))),
                                 subgraphs: supergraph_config.subgraphs,
+                                graph_ref: supergraph_config.graph_ref,
                             };
                             // Here we can throw away what actually gets resolved because we care about the fact it
                             // happens not the resulting artifact.

--- a/src/options/graph.rs
+++ b/src/options/graph.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use rover_client::shared::GraphRef;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Debug, Serialize, Deserialize, Parser)]
+#[derive(Debug, Serialize, Parser)]
 pub struct GraphRefOpt {
     /// <NAME>@<VARIANT> of graph in Apollo Studio.
     /// @<VARIANT> may be left off, defaulting to @current
@@ -11,7 +11,7 @@ pub struct GraphRefOpt {
     pub graph_ref: GraphRef,
 }
 
-#[derive(Debug, Serialize, Deserialize, Parser)]
+#[derive(Debug, Serialize, Parser)]
 pub struct OptionalGraphRefOpt {
     /// <NAME>@<VARIANT> of graph in Apollo Studio.
     /// @<VARIANT> may be left off, defaulting to @current

--- a/src/subtask.rs
+++ b/src/subtask.rs
@@ -56,10 +56,8 @@
 //! ```
 
 use futures::stream::BoxStream;
-use tokio::sync::broadcast;
-use tokio::sync::broadcast::Sender;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
-use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream};
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 /// A trait whose implementation will be able to send events
@@ -84,15 +82,8 @@ pub trait SubtaskHandleStream {
     );
 }
 
-/// A trait whose implementation will be able to send events to multiple channels with
-/// broadcast semantics.
-pub trait SubtaskHandleMultiStream {
-    type Output;
-    fn handle(self, sender: Sender<Self::Output>, cancellation_token: Option<CancellationToken>);
-}
-
 /// A trait whose implementation can run a subtask that only ingests messages
-pub trait SubtaskRunUnit {
+pub(crate) trait SubtaskRunUnit {
     fn run(self, cancellation_token: Option<CancellationToken>);
 }
 
@@ -126,29 +117,6 @@ impl<T, Output> Subtask<T, Output> {
     }
 }
 
-#[derive(Debug)]
-pub struct BroadcastSubtask<T, Output> {
-    inner: T,
-    sender: Sender<Output>,
-}
-
-impl<T, Output: Clone + Send + 'static> BroadcastSubtask<T, Output> {
-    /// Crates a new Subtask with bounded channels for transmitting and receiving in a broadcast
-    /// manner. A version of transmitter is returned to the caller so that it can be used to send
-    /// messages to the Subtask's receiver, however more can be acquired via the subscribe method.
-    pub fn new(inner: T) -> (BroadcastStream<Output>, BroadcastSubtask<T, Output>) {
-        let (tx, rx) = broadcast::channel(100);
-        (
-            BroadcastStream::new(rx),
-            BroadcastSubtask { inner, sender: tx },
-        )
-    }
-
-    pub fn subscribe(&self) -> BroadcastStream<Output> {
-        BroadcastStream::new(self.sender.subscribe())
-    }
-}
-
 impl<T: SubtaskHandleUnit<Output = Output>, Output> SubtaskRunUnit for Subtask<T, Output> {
     /// Begin running the subtask, calling handle() on the type implementing the SubTaskHandleUnit trait
     fn run(self, cancellation_token: Option<CancellationToken>) {
@@ -165,14 +133,5 @@ impl<T: SubtaskHandleStream<Output = Output>, Output> SubtaskRunStream for Subta
         cancellation_token: Option<CancellationToken>,
     ) {
         self.inner.handle(self.sender, input, cancellation_token)
-    }
-}
-
-impl<T: SubtaskHandleMultiStream<Output = Output>, Output> SubtaskRunUnit
-    for BroadcastSubtask<T, Output>
-{
-    /// Begin running the subtask, calling handle() on the type implementing the SubTaskHandleUnit trait
-    fn run(self, cancellation_token: Option<CancellationToken>) {
-        self.inner.handle(self.sender, cancellation_token)
     }
 }


### PR DESCRIPTION
1. Use a local struct for `supergraph.yaml` ser/de instead of `apollo-federation-types`
2. Add a `graph_ref` property to `supergraph.yaml` which works like `--graph-ref`
3. Load federation version from GraphOS when `--graph-ref` or `graph_ref` is set
4. Refactorings to support the above