### PR TITLE
Add graph_ref to and remove federation_version from subgraph.yaml

### DIFF
--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -449,6 +449,11 @@ impl CreationConfirmed {
             }
         };
 
+        let graph_ref = GraphRef {
+            name: create_graph_response.id.clone(),
+            variant: DEFAULT_VARIANT.to_string(),
+        };
+
         // Write the template files without asking for confirmation again
         // (confirmation was done in the previous state)
         self.selected_template.write_template(&self.output_path)?;
@@ -460,18 +465,14 @@ impl CreationConfirmed {
             self.output_path.clone(),
             5,
             routing_url,
-            &federation_version,
             Some(self.config.schema_name.clone()),
+            graph_ref.clone(),
         );
         supergraph.build_and_write()?;
 
         let artifacts = self.selected_template.list_files()?;
 
         let subgraphs = supergraph.generate_subgraphs()?;
-        let graph_ref = GraphRef {
-            name: create_graph_response.id.clone(),
-            variant: DEFAULT_VARIANT.to_string(),
-        };
 
         publish_subgraphs(&client, &self.output_path, &graph_ref, subgraphs).await?;
 

--- a/src/composition/supergraph/config/yaml.rs
+++ b/src/composition/supergraph/config/yaml.rs
@@ -1,10 +1,10 @@
 use apollo_federation_types::config::{FederationVersion, SubgraphConfig};
 use rover_client::shared::GraphRef;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// The YAML that a user will write to configure a supergraph.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SupergraphConfigYaml {
     #[schemars(skip)] // TODO: Set up the right graph@variant schema
     pub(crate) graph_ref: Option<GraphRef>,
@@ -13,5 +13,6 @@ pub struct SupergraphConfigYaml {
     pub(crate) subgraphs: BTreeMap<String, SubgraphConfig>,
 
     // The version requirement for the supergraph binary.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) federation_version: Option<FederationVersion>,
 }


### PR DESCRIPTION
This PR adds `graph_ref` to and removes `federation_version` from subgraph.yaml.

### Testing
1. Ran `cargo build` to build these `rover` changes
1. Aliased `cargo rover` to `localrover` with `alias localrover='cargo run --manifest-path=/Users/alyssahursh/code/rover/Cargo.toml --bin rover --'`
1. Created new empty test directory
1. Ran `localrover init`
1. Verified that graph_ref appeared in `supergraph.yaml`
1. Verified that `federation_version` did not appear in `supergraph.yaml`

```
graph_ref: alyssa-dylan-3-test-laucpkd@current
subgraphs:
  products:
    routing_url: http://ignore
    schema:
      file: products.graphql
```


This PR is part of the 2025 Hackathon.