### PR TITLE
Updating output for `init` & renaming generated "supergraph.yaml" -> "rover.yaml"

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Run the following command to authenticate with GraphOS:
 
     $ rover config auth
 
-Once you're authenticated, create a new supergraph:
+Once you're authenticated, create a new supergraph or subgraph:
 
     $ rover init
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Run the following command to authenticate with GraphOS:
 
     $ rover config auth
 
-Once you're authenticated, create a new graph:
+Once you're authenticated, Start a new supergraph:
 
     $ rover init
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Run the following command to authenticate with GraphOS:
 
     $ rover config auth
 
-Once you're authenticated, Start a new supergraph:
+Once you're authenticated, create a new graph:
 
     $ rover init
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Run the following command to authenticate with GraphOS:
 
     $ rover config auth
 
-Once you're authenticated, create a new graph:
+Once you're authenticated, create a new supergraph:
 
     $ rover init
 

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -10,7 +10,7 @@ Rover enables you to create a graph with a single interactive command.
 ## Initializing a graph
 ### `rover init`
 
-Running `rover init` starts a short wizard that helps you Start a new supergraph.
+Running `rover init` starts a wizard that walks you through creating a new supergraph and/or adding a new subgraph to an existing supergraph.
 
 ```terminal showLineNumbers=false
 rover init

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -10,7 +10,7 @@ Rover enables you to create a graph with a single interactive command.
 ## Initializing a graph
 ### `rover init`
 
-Running `rover init` starts a wizard that guides you through creating a new supergraph and/or adding a new subgraph to an existing supergraph.
+Running `rover init` starts a wizard that guides you through creating a new supergraph or adding a new subgraph to an existing supergraph.
 
 ```terminal showLineNumbers=false
 rover init
@@ -42,7 +42,7 @@ rover init \
 | ------ | ----------- | --------------- |
 | `--project-type` | Whether to create a new supergraph or add a subgraph to an existing supergraph. | `create-new`, <br/>`add-subgraph` |
 | `--organization` | The ID of the [GraphOS organization](/graphos/platform/access-management/org#view-your-organizations) where the graph should be created. | *(your organization ID)* |
-| `--project-use-case` | Helps prec-onfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
+| `--project-use-case` | Helps pre-configure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
 | `--project-name` | The name for your new graph. | *(your graph name)* |
 | `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
 
@@ -66,7 +66,7 @@ After you've chosen your use case, the wizard prompts you for a project name. It
 
 ## Next steps
 
-Check out `getting-started.md` to learn more about your new supergraph or service.
+Read `getting-started.md` to learn more about your new supergraph or service.
 
 
 

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -53,7 +53,7 @@ Once you run `rover init`, the wizard prompts you to select your use case.
 - **Connect to REST services with Apollo Connectors**
     - Select this option to integrate REST APIs into your graph using Apollo Connectors.
 - **Build a GraphQL service with Apollo Server**
-    - Select this option to build a subgraph using the Apollo Server library.
+    - Select this option to build a subgraph using Apollo Server.
 
 ### Created credentials
 
@@ -66,7 +66,7 @@ After you've chosen your use case, the wizard prompts you for a project name. It
 
 ## Next steps
 
-Read `getting-started.md` to learn more about your new supergraph or service.
+Open `getting-started.md` to learn more about your new supergraph or service.
 
 
 

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -10,7 +10,7 @@ Rover enables you to create a graph with a single interactive command.
 ## Initializing a graph
 ### `rover init`
 
-Running `rover init` starts a short wizard that helps you create a new graph.
+Running `rover init` starts a short wizard that helps you Start a new supergraph.
 
 ```terminal showLineNumbers=false
 rover init
@@ -40,7 +40,7 @@ rover init \
 
 | Option | Description | Possible Values |
 | ------ | ----------- | --------------- |
-| `--project-type` | Whether to create a new graph or add a subgraph to an existing graph. | `create-new`, <br/>`add-subgraph` |
+| `--project-type` | Whether to Start a new supergraph or Add a subgraph to an existing supergraph. | `create-new`, <br/>`add-subgraph` |
 | `--organization` | The ID of the [GraphOS organization](/graphos/platform/access-management/org#view-your-organizations) where the graph should be created. | *(your organization ID)* |
 | `--project-use-case` | Helps preconfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
 | `--project-name` | The name for your new graph. | *(your graph name)* |
@@ -50,9 +50,9 @@ rover init \
 
 Once you run `rover init`, the wizard prompts you to select your use case.
 
-- **Start a graph with one or more REST APIs**
+- **Connect existing REST services using Apollo Connectors**
     - Select this option to integrate REST APIs into your graph using Apollo Connectors.
-- **Start a graph with recommended libraries**
+- **Create a new GraphQL API with resolvers and Apollo libraries**
     - Select this option if you want to integrate data that's not accessible via a REST API. This option helps you set up a graph using the Apollo Server library.
 
 ### Created credentials

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -10,7 +10,7 @@ Rover enables you to create a graph with a single interactive command.
 ## Initializing a graph
 ### `rover init`
 
-Running `rover init` starts a wizard that walks you through creating a new supergraph and/or adding a new subgraph to an existing supergraph.
+Running `rover init` starts a wizard that guides you through creating a new supergraph and/or adding a new subgraph to an existing supergraph.
 
 ```terminal showLineNumbers=false
 rover init
@@ -42,7 +42,7 @@ rover init \
 | ------ | ----------- | --------------- |
 | `--project-type` | Whether to create a new supergraph or add a subgraph to an existing supergraph. | `create-new`, <br/>`add-subgraph` |
 | `--organization` | The ID of the [GraphOS organization](/graphos/platform/access-management/org#view-your-organizations) where the graph should be created. | *(your organization ID)* |
-| `--project-use-case` | Helps preconfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
+| `--project-use-case` | Helps prec-onfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
 | `--project-name` | The name for your new graph. | *(your graph name)* |
 | `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
 
@@ -50,10 +50,10 @@ rover init \
 
 Once you run `rover init`, the wizard prompts you to select your use case.
 
-- **Connect existing REST services using Apollo Connectors**
+- **Connect to REST services with Apollo Connectors**
     - Select this option to integrate REST APIs into your graph using Apollo Connectors.
-- **Create a new GraphQL API with resolvers and Apollo libraries**
-    - Select this option if you want to integrate data that's not accessible via a REST API. This option helps you set up a graph using the Apollo Server library.
+- **Build a GraphQL service with Apollo Server**
+    - Select this option to build a subgraph using the Apollo Server library.
 
 ### Created credentials
 
@@ -66,55 +66,11 @@ After you've chosen your use case, the wizard prompts you for a project name. It
 
 ## Next steps
 
-Once you've completed the wizard, it provides a [`rover dev`](./dev) command with prepopulated credentials. Run this command to start developing your graph.
+Check out `getting-started.md` to learn more about your new supergraph or service.
 
-    <Tabs>
-
-        <Tab label="Linux / MacOS">
-
-        ```terminal showLineNumbers=false
-        APOLLO_KEY=<key> \
-        APOLLO_GRAPH_REF=<graph-ref> \
-        rover dev --supergraph-config supergraph.yaml
-        ```
-
-        (If you set `APOLLO_KEY` as an environment variable, you don't need to include it in your command.)
-
-        </Tab>
-        <Tab label="Windows">
-
-        ##### Powershell
-
-        ```terminal showLineNumbers=false
-        $env:APOLLO_KEY = "<key>"; $env:APOLLO_GRAPH_REF = "<graph-ref>"; rover dev --supergraph-config supergraph.yaml
-        ```
-
-        ##### Command Prompt
-
-        ```terminal showLineNumbers=false
-        set APOLLO_KEY=<key> && set APOLLO_GRAPH_REF=<graph-ref> && rover dev --supergraph-config supergraph.yaml
-        ```
-
-        </Tab>
-
-    </Tabs>
-
-<Note>
-
-    If you started with TypeScript, you also need to run the following commands in a separate terminal window before running `rover dev`:
-
-    ```terminal
-    npm ci
-    npm start
-    ```
-
-    These commands start a subgraph server that `rover dev` depends on. Learn more in the `getting-started.md` generated when you run `rover init`.
-
-</Note>
 
 
 ### Additional resources
 
-- After running `rover init`, open the generated `getting-started.md` file for next steps.
 - To go further, check out the [Getting started guide](/graphos/get-started/guides/rest) to learn what else you can do with Apollo Connectors.
 - If you learn best with videos and exercises, this [interactive course](https://www.apollographql.com/tutorials/connectors-intro-rest) teaches you how to integrate a demo REST API into a graph using Apollo Connectors.

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -40,7 +40,7 @@ rover init \
 
 | Option | Description | Possible Values |
 | ------ | ----------- | --------------- |
-| `--project-type` | Whether to Start a new supergraph or Add a subgraph to an existing supergraph. | `create-new`, <br/>`add-subgraph` |
+| `--project-type` | Whether to create a new supergraph or add a subgraph to an existing supergraph. | `create-new`, <br/>`add-subgraph` |
 | `--organization` | The ID of the [GraphOS organization](/graphos/platform/access-management/org#view-your-organizations) where the graph should be created. | *(your organization ID)* |
 | `--project-use-case` | Helps preconfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
 | `--project-name` | The name for your new graph. | *(your graph name)* |

--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -10,7 +10,7 @@
     "repository": "https://github.com/apollographql/router",
     "versions": {
       "latest-1": "v1.61.7",
-      "latest-2": "v2.3.0"
+      "latest-2": "v2.4.0"
     }
   }
 }

--- a/latest_plugin_versions.json
+++ b/latest_plugin_versions.json
@@ -9,7 +9,7 @@
   "router": {
     "repository": "https://github.com/apollographql/router",
     "versions": {
-      "latest-1": "v1.61.7",
+      "latest-1": "v1.61.9",
       "latest-2": "v2.4.0"
     }
   }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,7 @@ Run the following command to authenticate with GraphOS:
 
     {}
 
-Once you're authenticated, create a new graph:
+Once you're authenticated, Start a new supergraph:
 
     {}
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,7 @@ Run the following command to authenticate with GraphOS:
 
     {}
 
-Once you're authenticated, Start a new supergraph:
+Once you're authenticated, you can create a new supergraph or add a subgraph to an existing supergraph:
 
     {}
 

--- a/src/command/init/graph_id/generation.rs
+++ b/src/command/init/graph_id/generation.rs
@@ -84,7 +84,7 @@ mod tests {
 
         // Name starting with non-alphabetic
         assert_eq!(
-            generate_graph_id("123My API", &mut generator, None),
+            generate_graph_id("123My Supergraph", &mut generator, None),
             "my-api-teststr".parse::<GraphId>().unwrap()
         );
 

--- a/src/command/init/graph_id/generation.rs
+++ b/src/command/init/graph_id/generation.rs
@@ -85,7 +85,7 @@ mod tests {
         // Name starting with non-alphabetic
         assert_eq!(
             generate_graph_id("123My Supergraph", &mut generator, None),
-            "my-api-teststr".parse::<GraphId>().unwrap()
+            "my-supergraph-teststr".parse::<GraphId>().unwrap()
         );
 
         // Empty string

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -18,49 +18,6 @@ pub fn display_welcome_message() {
     println!();
 }
 
-pub(crate) fn get_command(api_key: &str, graph_ref: &str, supergraph_config: bool) -> String {
-    #[cfg(target_os = "windows")]
-    {
-        let mut output = String::new();
-
-        // PowerShell command
-        output.push_str("PowerShell:\n");
-        output.push_str(&format!(
-            "$env:APOLLO_KEY = \"{}\"; $env:APOLLO_GRAPH_REF = \"{}\"; rover dev",
-            api_key, graph_ref
-        ));
-        if supergraph_config {
-            output.push_str(" --supergraph-config supergraph.yaml");
-        }
-
-        output.push_str("\n\n");
-
-        // CMD
-        output.push_str("Command Prompt:\n");
-        output.push_str(&format!(
-            "set APOLLO_KEY={} && set APOLLO_GRAPH_REF={} && rover dev",
-            api_key, graph_ref
-        ));
-        if supergraph_config {
-            output.push_str(" --supergraph-config supergraph.yaml");
-        }
-
-        output
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        let mut output = String::new();
-        output.push_str(&format!(
-            "APOLLO_KEY={api_key} APOLLO_GRAPH_REF={graph_ref} rover dev"
-        ));
-        if supergraph_config {
-            output.push_str(" --supergraph-config supergraph.yaml");
-        }
-        output
-    }
-}
-
 pub fn generate_project_created_message(
     project_name: String,
     artifacts: &[Utf8PathBuf],
@@ -114,7 +71,7 @@ pub fn generate_project_created_message(
 
     // Add next steps section
     output.push_str(&format!("{}\n", Style::Heading.paint("Next steps")));
-    let dev_command = get_command(&api_key, &graph_ref.to_string(), !artifacts.is_empty());
+    let dev_command = "rover dev".to_string();
 
     if let Some(commands) = commands {
         // Filter out empty commands

--- a/src/command/init/options/project_name.rs
+++ b/src/command/init/options/project_name.rs
@@ -51,7 +51,7 @@ impl ProjectNameOpt {
         loop {
             // Prompt for user input
             let input: Input<String> = Input::new()
-                .with_prompt(Style::Prompt.paint("? Name your graph"))
+                .with_prompt(Style::Prompt.paint("? Name your supergraph"))
                 .with_initial_text(default.clone());
             let input_name = input.interact_text().map_err(|e| e.to_string()).unwrap();
 
@@ -69,7 +69,7 @@ impl ProjectNameOpt {
     }
 
     fn suggest_default_name(&self) -> String {
-        "My API".to_string()
+        "My Supergraph".to_string()
     }
 
     pub fn get_or_prompt_project_name(&self) -> RoverResult<ProjectName> {
@@ -120,7 +120,7 @@ mod tests {
         let instance = ProjectNameOpt { project_name: None };
         let default_name = instance.suggest_default_name();
 
-        assert_eq!(default_name, "My API");
+        assert_eq!(default_name, "My Supergraph");
     }
 
     // Default trait implementation tests

--- a/src/command/init/options/project_type.rs
+++ b/src/command/init/options/project_type.rs
@@ -51,7 +51,7 @@ impl Display for ProjectType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ProjectType::*;
         let readable = match self {
-            CreateNew => "Start a new supergraph",
+            CreateNew => "Create a new supergaph",
             AddSubgraph => "Add a subgraph to an existing supergraph",
         };
         write!(f, "{readable}")
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn test_display_trait_for_create_new() {
         let project_type = ProjectType::CreateNew;
-        assert_eq!(project_type.to_string(), "Start a new supergraph");
+        assert_eq!(project_type.to_string(), "Create a new supergaph");
     }
 
     #[test]

--- a/src/command/init/options/project_type.rs
+++ b/src/command/init/options/project_type.rs
@@ -51,7 +51,7 @@ impl Display for ProjectType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ProjectType::*;
         let readable = match self {
-            CreateNew => "Create a new supergaph",
+            CreateNew => "Create a new supergraph",
             AddSubgraph => "Add a subgraph to an existing supergraph",
         };
         write!(f, "{readable}")
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn test_display_trait_for_create_new() {
         let project_type = ProjectType::CreateNew;
-        assert_eq!(project_type.to_string(), "Create a new supergaph");
+        assert_eq!(project_type.to_string(), "Create a new supergraph");
     }
 
     #[test]

--- a/src/command/init/options/project_type.rs
+++ b/src/command/init/options/project_type.rs
@@ -21,7 +21,7 @@ impl ProjectTypeOpt {
     pub fn prompt_project_type(&self) -> RoverResult<ProjectType> {
         let project_types = <ProjectType as ValueEnum>::value_variants();
         let selection = Select::new()
-            .with_prompt(Style::Prompt.paint("? Select option"))
+            .with_prompt(Style::Prompt.paint("? Choose an action"))
             .items(project_types)
             .default(0)
             .interact_on_opt(&Term::stderr())?;
@@ -51,8 +51,8 @@ impl Display for ProjectType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ProjectType::*;
         let readable = match self {
-            CreateNew => "Create a new graph",
-            AddSubgraph => "Add a subgraph to an existing graph",
+            CreateNew => "Start a new supergraph",
+            AddSubgraph => "Add a subgraph to an existing supergraph",
         };
         write!(f, "{readable}")
     }
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn test_display_trait_for_create_new() {
         let project_type = ProjectType::CreateNew;
-        assert_eq!(project_type.to_string(), "Create a new graph");
+        assert_eq!(project_type.to_string(), "Start a new supergraph");
     }
 
     #[test]
@@ -117,7 +117,7 @@ mod tests {
         let project_type = ProjectType::AddSubgraph;
         assert_eq!(
             project_type.to_string(),
-            "Add a subgraph to an existing graph"
+            "Add a subgraph to an existing supergraph"
         );
     }
 

--- a/src/command/init/options/project_use_case.rs
+++ b/src/command/init/options/project_use_case.rs
@@ -21,7 +21,7 @@ impl ProjectUseCaseOpt {
             let use_cases = <ProjectUseCase as ValueEnum>::value_variants();
 
             let selection = Select::new()
-                .with_prompt(Style::Prompt.paint("? Select use case"))
+                .with_prompt(Style::Prompt.paint("? How would you like to get started"))
                 .items(use_cases)
                 .default(0)
                 .interact_on_opt(&Term::stderr())?;
@@ -48,13 +48,13 @@ pub enum ProjectUseCase {
     GraphQLTemplate,
 }
 
-const USE_CASE_DESCRIPTION: &str = "Start a graph with recommended libraries";
+const USE_CASE_DESCRIPTION: &str = "Create a new GraphQL API with resolvers and Apollo libraries";
 
 impl Display for ProjectUseCase {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ProjectUseCase::*;
         let readable = match self {
-            Connectors => "Start a graph with one or more REST APIs",
+            Connectors => "Connect existing REST services using Apollo Connectors",
             GraphQLTemplate => USE_CASE_DESCRIPTION,
         };
         write!(f, "{readable}")

--- a/src/command/init/options/project_use_case.rs
+++ b/src/command/init/options/project_use_case.rs
@@ -48,13 +48,13 @@ pub enum ProjectUseCase {
     GraphQLTemplate,
 }
 
-const USE_CASE_DESCRIPTION: &str = "Create a new GraphQL API with resolvers and Apollo libraries";
+const USE_CASE_DESCRIPTION: &str = "Build a GraphQL service with Apollo Server";
 
 impl Display for ProjectUseCase {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ProjectUseCase::*;
         let readable = match self {
-            Connectors => "Connect existing REST services using Apollo Connectors",
+            Connectors => "Connect to REST services with Apollo Connectors",
             GraphQLTemplate => USE_CASE_DESCRIPTION,
         };
         write!(f, "{readable}")

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -318,7 +318,7 @@ impl SupergraphBuilder {
 
     pub fn build_and_write(&self) -> RoverResult<()> {
         let supergraph = self.build_supergraph()?;
-        let output_path = self.directory.join("supergraph.yaml");
+        let output_path = self.directory.join("rover.yaml");
         let mut file = File::create(output_path)?;
         serde_yaml::to_writer(&mut file, &supergraph)?;
 
@@ -406,10 +406,6 @@ mod tests {
         let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
-
-        Ok(())
-    }
-
     #[test]
     fn test_multiple_deep_nested_file() -> io::Result<()> {
         let temp_dir = tempdir()?;

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deep_nested_file() -> io::Result<(), io::Error> {
+    fn test_deep_nested_file() -> io::Result<()> {
         let temp_dir = tempdir()?;
         let path = Utf8PathBuf::from_path_buf(temp_dir.path().to_owned()).unwrap();
 
@@ -406,6 +406,8 @@ mod tests {
         let actual_file = File::open(temp_dir.path().join("rover.yaml"))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
+
+        Ok(())
     }
 
     #[test]

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -371,7 +371,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yaml"))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
@@ -403,7 +403,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yaml"))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
     }
@@ -439,7 +439,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yaml"))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
@@ -483,7 +483,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yaml"))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -407,7 +407,7 @@ mod tests {
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
     }
-    
+
     #[test]
     fn test_multiple_deep_nested_file() -> io::Result<()> {
         let temp_dir = tempdir()?;

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deep_nested_file() -> io::Result<()> {
+    fn test_deep_nested_file() -> io::Result<(), io::Error> {
         let temp_dir = tempdir()?;
         let path = Utf8PathBuf::from_path_buf(temp_dir.path().to_owned()).unwrap();
 

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -371,7 +371,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
@@ -403,9 +403,11 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
+    }
+    
     #[test]
     fn test_multiple_deep_nested_file() -> io::Result<()> {
         let temp_dir = tempdir()?;
@@ -437,7 +439,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
@@ -481,7 +483,7 @@ mod tests {
         supergraph_builder.build_and_write().unwrap();
         let expected = supergraph_builder.build_supergraph().unwrap();
 
-        let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
+        let actual_file = File::open(temp_dir.path().join("rover.yam."))?;
         let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -31,7 +31,7 @@ fn test_get_command() {
         assert!(cmd.contains("Command Prompt:"));
         assert!(cmd.contains("$env:APOLLO_KEY"));
         assert!(cmd.contains("set APOLLO_KEY"));
-        assert!(cmd.contains("--supergraph-config supergraph.yaml"));
+        assert!(cmd.contains("--supergraph-config rover.yam."));
 
         // Test Windows command without supergraph config
         let cmd = get_command(api_key, graph_ref, false);
@@ -48,7 +48,7 @@ fn test_get_command() {
         let cmd = get_command(api_key, graph_ref, true);
         assert!(cmd.contains("APOLLO_KEY=test-api-key"));
         assert!(cmd.contains("APOLLO_GRAPH_REF=my-graph@main"));
-        assert!(cmd.contains("--supergraph-config supergraph.yaml"));
+        assert!(cmd.contains("--supergraph-config rover.yam."));
 
         // Test Unix command without supergraph config
         let cmd = get_command(api_key, graph_ref, false);
@@ -62,7 +62,7 @@ fn test_get_command() {
 fn test_display_project_created_message_with_single_command() {
     let project_name = "my-graph".to_string();
     let artifacts = vec![
-        Utf8PathBuf::from("supergraph.yaml"),
+        Utf8PathBuf::from("rover.yam."),
         Utf8PathBuf::from("getting-started.md"),
     ];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
@@ -99,7 +99,7 @@ fn test_display_project_created_message_with_single_command() {
 #[test]
 fn test_display_project_created_message_with_multiple_commands() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("supergraph.yaml")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = &["npm install", "npm run build", "npm start"];
@@ -130,7 +130,7 @@ fn test_display_project_created_message_with_multiple_commands() {
 #[test]
 fn test_display_project_created_message_with_empty_command_array() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("supergraph.yaml")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = Some(Vec::new());
@@ -157,7 +157,7 @@ fn test_display_project_created_message_with_empty_command_array() {
 #[test]
 fn test_display_project_created_message_without_command() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("supergraph.yaml")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = None;
@@ -213,8 +213,8 @@ fn test_display_project_created_message_with_empty_artifacts() {
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
     // Should not contain the files section
     assert!(!plain_output.contains("Files created:"));
-    // Should not contain supergraph.yaml in the files section
-    assert!(!plain_output.contains("supergraph.yaml\n"));
+    // Should not contain rover.yam. in the files section
+    assert!(!plain_output.contains("rover.yam.\n"));
     assert!(plain_output.contains(&format!(
         "For more information, check out '{}'",
         "getting-started.md"
@@ -224,7 +224,7 @@ fn test_display_project_created_message_with_empty_artifacts() {
 #[test]
 fn test_display_project_created_message_with_custom_start_point() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("supergraph.yaml")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = None;

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use rover_client::shared::GraphRef;
 use std::string::String;
 
-use crate::command::init::helpers::{generate_project_created_message, get_command};
+use crate::command::init::helpers::{generate_project_created_message};
 
 // Helper function to strip ANSI color codes
 fn strip_ansi_codes(s: &str) -> String {
@@ -16,46 +16,6 @@ fn strip_ansi_codes(s: &str) -> String {
         .replace("\x1b[37m", "")
         .replace("\x1b[38;5;", "")
         .replace("\x1b[39m", "")
-}
-
-#[test]
-fn test_get_command() {
-    let api_key = "test-api-key";
-    let graph_ref = "my-graph@main";
-
-    #[cfg(target_os = "windows")]
-    {
-        // Test Windows command with supergraph config
-        let cmd = get_command(api_key, graph_ref, true);
-        assert!(cmd.contains("PowerShell:"));
-        assert!(cmd.contains("Command Prompt:"));
-        assert!(cmd.contains("$env:APOLLO_KEY"));
-        assert!(cmd.contains("set APOLLO_KEY"));
-        assert!(cmd.contains("--supergraph-config rover.yaml"));
-
-        // Test Windows command without supergraph config
-        let cmd = get_command(api_key, graph_ref, false);
-        assert!(cmd.contains("PowerShell:"));
-        assert!(cmd.contains("Command Prompt:"));
-        assert!(cmd.contains("$env:APOLLO_KEY"));
-        assert!(cmd.contains("set APOLLO_KEY"));
-        assert!(!cmd.contains("--supergraph-config"));
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        // Test Unix command with supergraph config
-        let cmd = get_command(api_key, graph_ref, true);
-        assert!(cmd.contains("APOLLO_KEY=test-api-key"));
-        assert!(cmd.contains("APOLLO_GRAPH_REF=my-graph@main"));
-        assert!(cmd.contains("--supergraph-config rover.yaml"));
-
-        // Test Unix command without supergraph config
-        let cmd = get_command(api_key, graph_ref, false);
-        assert!(cmd.contains("APOLLO_KEY=test-api-key"));
-        assert!(cmd.contains("APOLLO_GRAPH_REF=my-graph@main"));
-        assert!(!cmd.contains("--supergraph-config"));
-    }
 }
 
 #[test]

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use rover_client::shared::GraphRef;
 use std::string::String;
 
-use crate::command::init::helpers::{generate_project_created_message};
+use crate::command::init::helpers::generate_project_created_message;
 
 // Helper function to strip ANSI color codes
 fn strip_ansi_codes(s: &str) -> String {

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -31,7 +31,7 @@ fn test_get_command() {
         assert!(cmd.contains("Command Prompt:"));
         assert!(cmd.contains("$env:APOLLO_KEY"));
         assert!(cmd.contains("set APOLLO_KEY"));
-        assert!(cmd.contains("--supergraph-config rover.yam."));
+        assert!(cmd.contains("--supergraph-config rover.yaml"));
 
         // Test Windows command without supergraph config
         let cmd = get_command(api_key, graph_ref, false);
@@ -48,7 +48,7 @@ fn test_get_command() {
         let cmd = get_command(api_key, graph_ref, true);
         assert!(cmd.contains("APOLLO_KEY=test-api-key"));
         assert!(cmd.contains("APOLLO_GRAPH_REF=my-graph@main"));
-        assert!(cmd.contains("--supergraph-config rover.yam."));
+        assert!(cmd.contains("--supergraph-config rover.yaml"));
 
         // Test Unix command without supergraph config
         let cmd = get_command(api_key, graph_ref, false);
@@ -62,7 +62,7 @@ fn test_get_command() {
 fn test_display_project_created_message_with_single_command() {
     let project_name = "my-graph".to_string();
     let artifacts = vec![
-        Utf8PathBuf::from("rover.yam."),
+        Utf8PathBuf::from("rover.yaml"),
         Utf8PathBuf::from("getting-started.md"),
     ];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
@@ -99,7 +99,7 @@ fn test_display_project_created_message_with_single_command() {
 #[test]
 fn test_display_project_created_message_with_multiple_commands() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yaml")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = &["npm install", "npm run build", "npm start"];
@@ -130,7 +130,7 @@ fn test_display_project_created_message_with_multiple_commands() {
 #[test]
 fn test_display_project_created_message_with_empty_command_array() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yaml")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = Some(Vec::new());
@@ -157,7 +157,7 @@ fn test_display_project_created_message_with_empty_command_array() {
 #[test]
 fn test_display_project_created_message_without_command() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yaml")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = None;
@@ -213,8 +213,8 @@ fn test_display_project_created_message_with_empty_artifacts() {
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
     // Should not contain the files section
     assert!(!plain_output.contains("Files created:"));
-    // Should not contain rover.yam. in the files section
-    assert!(!plain_output.contains("rover.yam.\n"));
+    // Should not contain rover.yaml in the files section
+    assert!(!plain_output.contains("rover.yaml\n"));
     assert!(plain_output.contains(&format!(
         "For more information, check out '{}'",
         "getting-started.md"
@@ -224,7 +224,7 @@ fn test_display_project_created_message_with_empty_artifacts() {
 #[test]
 fn test_display_project_created_message_with_custom_start_point() {
     let project_name = "my-graph".to_string();
-    let artifacts = vec![Utf8PathBuf::from("rover.yam.")];
+    let artifacts = vec![Utf8PathBuf::from("rover.yaml")];
     let graph_ref = GraphRef::new("my-graph".to_string(), Some("main".to_string())).unwrap();
     let api_key = "test-api-key".to_string();
     let commands = None;

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -208,8 +208,8 @@ impl ProjectTypeSelected {
 /// =========
 ///
 /// ? How would you like to get started:
-/// > Connect existing REST services using Apollo Connectors
-/// > Create a new GraphQL API with resolvers and Apollo libraries
+/// > Connect to REST services with Apollo Connectors
+/// > Build a GraphQL service with Apollo Server
 impl OrganizationSelected {
     pub fn select_use_case(
         self,

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -336,7 +336,7 @@ impl GraphIdConfirmed {
 /// .idea/externalDependencies.xml
 /// getting-started.md
 /// router.yaml
-/// supergraph.yaml
+/// rover.yaml
 /// schema.graphql
 ///
 /// ? Proceed with creation? (y/n):

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -113,7 +113,7 @@ impl UserAuthenticated {
 /// To learn more about init, run `rover init -h` or visit https://www.apollographql.com/docs/rover/commands/init
 ///
 /// ? Choose an action:
-/// > Start a new supergraph
+/// > Create a new supergaph
 /// > Add a subgraph to an existing supergraph
 impl Welcome {
     pub fn new() -> Self {

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -113,7 +113,7 @@ impl UserAuthenticated {
 /// To learn more about init, run `rover init -h` or visit https://www.apollographql.com/docs/rover/commands/init
 ///
 /// ? Choose an action:
-/// > Create a new supergaph
+/// > Create a new supergraph
 /// > Add a subgraph to an existing supergraph
 impl Welcome {
     pub fn new() -> Self {

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -239,7 +239,7 @@ impl UseCaseSelected {
         options: &ProjectTemplateOpt,
     ) -> RoverResult<TemplateSelected> {
         // Fetch the template to get the list of files
-        let repo_ref = "release/v3-beta";
+        let repo_ref = "taylor/update-schema-name";
         let template_fetcher = InitTemplateFetcher::new().call(repo_ref).await?;
 
         // Determine the list of templates based on the use case

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -112,9 +112,9 @@ impl UserAuthenticated {
 /// Welcome! This command helps you initialize a federated graph in your current directory.
 /// To learn more about init, run `rover init -h` or visit https://www.apollographql.com/docs/rover/commands/init
 ///
-/// ? Select option:
-/// > Create a new graph
-/// > Add a subgraph to an existing graph
+/// ? Choose an action:
+/// > Start a new supergraph
+/// > Add a subgraph to an existing supergraph
 impl Welcome {
     pub fn new() -> Self {
         Welcome {}
@@ -207,9 +207,9 @@ impl ProjectTypeSelected {
 /// PROMPT UX:
 /// =========
 ///
-/// ? Select use case:
-/// > Start a graph with one or more REST APIs
-/// > Start a graph with recommended libraries
+/// ? How would you like to get started:
+/// > Connect existing REST services using Apollo Connectors
+/// > Create a new GraphQL API with resolvers and Apollo libraries
 impl OrganizationSelected {
     pub fn select_use_case(
         self,
@@ -274,7 +274,7 @@ impl UseCaseSelected {
 /// PROMPT UX:
 /// =========
 ///
-/// ? Name your Graph:
+/// ? Name your supergraph:
 impl TemplateSelected {
     pub fn enter_project_name(self, options: &ProjectNameOpt) -> RoverResult<ProjectNamed> {
         let project_name = options.get_or_prompt_project_name()?;

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -239,7 +239,7 @@ impl UseCaseSelected {
         options: &ProjectTemplateOpt,
     ) -> RoverResult<TemplateSelected> {
         // Fetch the template to get the list of files
-        let repo_ref = "taylor/update-schema-name";
+        let repo_ref = "release/v3-beta";
         let template_fetcher = InitTemplateFetcher::new().call(repo_ref).await?;
 
         // Determine the list of templates based on the use case

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -335,7 +335,7 @@ mod tests {
             ..Default::default()
         };
 
-        // Create a new supergraph config with 1 new and 1 old subgraph definitions.
+        // Start a new supergraph config with 1 new and 1 old subgraph definitions.
         let new_subgraph_defs: BTreeMap<String, SubgraphConfig> = BTreeMap::from([
             ("subgraph_a".to_string(), subgraph_def.clone()),
             ("subgraph_c".to_string(), subgraph_def.clone()),
@@ -394,7 +394,7 @@ mod tests {
             ..Default::default()
         };
 
-        // Create a new supergraph config with 1 new and 1 old subgraph definitions.
+        // Start a new supergraph config with 1 new and 1 old subgraph definitions.
         let new_subgraph_defs: BTreeMap<String, SubgraphConfig> =
             BTreeMap::from([("subgraph_a".to_string(), new_subgraph_config.clone())]);
         let new = SupergraphConfigYaml {


### PR DESCRIPTION
* Updates the prompt copy for the first 2 questions of the `init` wizard
* Renames `supergraph.yaml` => `rover.yaml`
* Removes env vars & flags from `rover dev` output messaging from `init`
