### PR TITLE
Generates .env file with rover init

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -61,13 +61,7 @@ pub fn generate_project_created_message(
     ));
     output.push('\n');
 
-    // Add warning section
-    output.push_str(&format!(
-        "{}\n",
-        Style::WarningHeading.paint("️▲ Before you proceed:")
-    ));
-    output
-        .push_str("- Store your graph API key securely, you won't be able to access it again!\n\n");
+    output.push_str("Your GraphOS credentials can be find in your `.env` file.\n\n");
 
     // Add next steps section
     output.push_str(&format!("{}\n", Style::Heading.paint("Next steps")));

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -59,15 +59,15 @@ pub fn generate_project_created_message(
             api_key
         ))
     ));
-    output.push('\n');
 
-    // Add warning section
+    output.push('\n');
+    output.push('\n');
     output.push_str(&format!(
-        "{}\n",
-        Style::WarningHeading.paint("️▲ Before you proceed:")
+        "Writing {} and {} to .env\n",
+        Style::GraphRef.paint("APOLLO_GRAPH_REF"),
+        Style::GraphRef.paint("APOLLO_API_KEY"),
     ));
-    output
-        .push_str("- Store your graph API key securely, you won't be able to access it again!\n\n");
+    output.push('\n');
 
     // Add next steps section
     output.push_str(&format!("{}\n", Style::Heading.paint("Next steps")));

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -59,15 +59,15 @@ pub fn generate_project_created_message(
             api_key
         ))
     ));
+    output.push('\n');
 
-    output.push('\n');
-    output.push('\n');
+    // Add warning section
     output.push_str(&format!(
-        "Writing {} and {} to .env\n",
-        Style::GraphRef.paint("APOLLO_GRAPH_REF"),
-        Style::GraphRef.paint("APOLLO_API_KEY"),
+        "{}\n",
+        Style::WarningHeading.paint("️▲ Before you proceed:")
     ));
-    output.push('\n');
+    output
+        .push_str("- Store your graph API key securely, you won't be able to access it again!\n\n");
 
     // Add next steps section
     output.push_str(&format!("{}\n", Style::Heading.paint("Next steps")));

--- a/src/command/init/template_fetcher.rs
+++ b/src/command/init/template_fetcher.rs
@@ -128,6 +128,8 @@ impl InitTemplateOptions {
                 template.path
             )));
         }
+        // Add .env
+        files.insert(Utf8PathBuf::from(".env"), vec![]);
 
         Ok(SelectedTemplateState {
             template: template.clone(),

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -45,6 +45,7 @@ fn test_display_project_created_message_with_single_command() {
     // Test that the output contains expected content
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={graph_ref}")));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
+    assert!(plain_output.contains("Store your graph API key securely"));
     assert!(plain_output.contains("1) Start the subgraph server by running the following command:"));
     assert!(plain_output.contains("npm ci"));
     assert!(plain_output.contains("2) In a new terminal, start a local development session:"));
@@ -136,6 +137,7 @@ fn test_display_project_created_message_without_command() {
     // Test that the output contains expected content
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={graph_ref}")));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
+    assert!(plain_output.contains("Store your graph API key securely"));
     assert!(plain_output.contains("Start a local development session:"));
     assert!(plain_output.contains("rover dev"));
     // Should not contain any command-specific text

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -45,7 +45,6 @@ fn test_display_project_created_message_with_single_command() {
     // Test that the output contains expected content
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={graph_ref}")));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
-    assert!(plain_output.contains("Store your graph API key securely"));
     assert!(plain_output.contains("1) Start the subgraph server by running the following command:"));
     assert!(plain_output.contains("npm ci"));
     assert!(plain_output.contains("2) In a new terminal, start a local development session:"));
@@ -137,7 +136,6 @@ fn test_display_project_created_message_without_command() {
     // Test that the output contains expected content
     assert!(plain_output.contains(&format!("APOLLO_GRAPH_REF={graph_ref}")));
     assert!(plain_output.contains(&format!("APOLLO_KEY={}", "test-api-key")));
-    assert!(plain_output.contains("Store your graph API key securely"));
     assert!(plain_output.contains("Start a local development session:"));
     assert!(plain_output.contains("rover dev"));
     // Should not contain any command-specific text

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -385,12 +385,11 @@ impl SchemaNamed {
 }
 
 impl CreationConfirmed {
-    fn populate_env_file(&self, api_key: String, graph_ref: GraphRef) -> io::Result<()> {
+    fn populate_env_file(&self, api_key: &str) -> io::Result<()> {
         let env_path = Utf8PathBuf::from(".env");
         let mut file = OpenOptions::new().write(true).open(&env_path)?;
 
         writeln!(file, "APOLLO_KEY={api_key}")?;
-        writeln!(file, "APOLLO_GRAPH_REF={graph_ref}")?;
         Ok(())
     }
 
@@ -503,7 +502,7 @@ impl CreationConfirmed {
         .await?;
 
         // Write api key and graph ref to .env
-        self.populate_env_file(api_key.clone(), graph_ref.clone())?;
+        self.populate_env_file(&api_key)?;
 
         spinner.success("Successfully created files and generated GraphOS credentials.");
 


### PR DESCRIPTION
- Generates `.env` file with `rover init` containing the user's `APOLLO_GRAPH_REF` and `APOLLO_KEY`
- Updates the subsequent `rover dev` prompt to no longer use the inline variables

## Testing
### Scenario 1: connectors (Start a graph with one or more REST APIs)
```
dmallare@Mac ellie-test % ../test-rover init

Welcome! This command helps you initialize a federated graph in your current directory.

To learn more about init, run `rover init -h` or visit https://www.apollographql.com/docs/rover/commands/init

? Choose an action: Create a new supergraph
? How would you like to get started: Connect to REST services with Apollo Connectors
? Name your supergraph: ellie-test-rest
Confirm or modify graph ID (start with a letter and use only letters, numbers, and dashes): ellie-test-rest-s22ttlk
? Name your schema: hello-world

==> You’re about to add the following files to your local directory:

.env
README.md
connectors_debugger.png
getting-started.md
schema.graphql
.idea/
  .gitignore
  graphql-settings.xml
.vscode/
  extensions.json

? Proceed with creation? [Y/n]
Y

✓ Successfully created files and generated GraphOS credentials.

All set! Your graph 'ellie-test-rest' has been created. Please review details below to see what was generated.

✓ .env
✓ README.md
✓ connectors_debugger.png
✓ getting-started.md
✓ schema.graphql
✓ .idea/
✓   .gitignore
✓   graphql-settings.xml
✓ .vscode/
✓   extensions.json

GraphOS credentials for your graph
APOLLO_GRAPH_REF=ellie-test-rest-s22ttlk@current (Formatted graph-id@variant, references a graph in the Apollo GraphOS platform)
APOLLO_KEY=service:ellie-test-rest-s22ttlk:qX0a1bFup6GfQPFztM14fQ (This is your graph's API key)

Writing APOLLO_KEY to .env

Next steps
Start a local development session:

rover dev

For more information, check out 'getting-started.md'.

dmallare@Mac ellie-test % ../test-rover dev
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'hello-world' subgraph
==> Watching /Users/dmallare/ellie-test/schema.graphql for changes
composing supergraph with Federation 2.11.0
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```

**Contents of `.env` file**
```
APOLLO_KEY=service:<rest of key>
```

### Scenario 2: Start a graph with recommended libraries
```
dmallare@Mac ellie-test % ../test-rover init

Welcome! This command helps you initialize a federated graph in your current directory.

To learn more about init, run `rover init -h` or visit https://www.apollographql.com/docs/rover/commands/init

? Choose an action: Create a new supergraph
? How would you like to get started: Build a GraphQL service with Apollo Server
? Select a language and server library template: Build an API with TypeScript and Apollo Server
? Name your supergraph: ellie-test
Confirm or modify graph ID (start with a letter and use only letters, numbers, and dashes): ellie-test-wj5yicj

==> You’re about to add the following files to your local directory:

.env
.gitignore
README.md
codegen.ts
getting-started.md
package-lock.json
package.json
schema.graphql
tsconfig.json
.vscode/
  extensions.json
src/
  index.ts
  __generated__/
  __tests__/
  resolvers/
  types/

? Proceed with creation? [Y/n]
Y

✓ Successfully created files and generated GraphOS credentials.

All set! Your graph 'ellie-test' has been created. Please review details below to see what was generated.

✓ .env
✓ .gitignore
✓ README.md
✓ codegen.ts
✓ getting-started.md
✓ package-lock.json
✓ package.json
✓ schema.graphql
✓ tsconfig.json
✓ .vscode/
✓   extensions.json
✓ src/
✓   index.ts
✓   __generated__/
✓   __tests__/
✓   resolvers/
✓   types/

GraphOS credentials for your graph
APOLLO_GRAPH_REF=ellie-test-wj5yicj@current (Formatted graph-id@variant, references a graph in the Apollo GraphOS platform)
APOLLO_KEY=service:<rest of the key> (This is your graph's API key)

Writing APOLLO_KEY to .env

Next steps
1) Start the subgraph server by running the following commands in order:

npm i
npm run dev

2) In a new terminal, start a local development session:

rover dev


For more information, check out 'getting-started.md'.


dmallare@Mac ellie-test % ../test-rover dev
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'unused' subgraph
==> Watching /Users/dmallare/ellie-test/schema.graphql for changes
composing supergraph with Federation 2.10.2
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph

```

**Contents of `.env` file**
```
APOLLO_KEY=service:<rest of key>
```