### PR TITLE
Remove use case guard clause in schema name prompt

### DIFF
--- a/src/command/init/options/schema_name.rs
+++ b/src/command/init/options/schema_name.rs
@@ -1,4 +1,3 @@
-use crate::command::init::options::ProjectUseCase;
 use crate::RoverResult;
 use clap::arg;
 use clap::Parser;
@@ -46,11 +45,7 @@ impl SchemaNameOpt {
         self.schema_name.clone()
     }
 
-    pub fn prompt_schema_name(&self, use_case: &ProjectUseCase) -> RoverResult<SchemaName> {
-        if *use_case != ProjectUseCase::Connectors {
-            return Ok(SchemaName("unused".to_string()));
-        }
-
+    pub fn prompt_schema_name(&self) -> RoverResult<SchemaName> {
         let default = self.suggest_default_name();
 
         loop {
@@ -77,13 +72,13 @@ impl SchemaNameOpt {
         "main".to_string()
     }
 
-    pub fn get_or_prompt_schema_name(&self, use_case: &ProjectUseCase) -> RoverResult<SchemaName> {
+    pub fn get_or_prompt_schema_name(&self) -> RoverResult<SchemaName> {
         // If a schema name was provided via command line, validate and use it
         if let Some(name) = self.get_schema_name() {
             return Ok(name);
         }
 
-        self.prompt_schema_name(use_case)
+        self.prompt_schema_name()
     }
 }
 

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -312,7 +312,7 @@ impl ProjectNamed {
 
 impl GraphIdConfirmed {
     pub async fn confirm_schema_name(self, options: &SchemaNameOpt) -> RoverResult<SchemaNamed> {
-        let schema_name = options.get_or_prompt_schema_name(&self.use_case)?;
+        let schema_name = options.get_or_prompt_schema_name()?;
 
         Ok(SchemaNamed {
             output_path: self.output_path,


### PR DESCRIPTION
This PR removes the use case guard clause in the schema name prompt. When the original work to add the schema name prompt was written (https://github.com/apollographql/rover/pull/2647), I made the incorrect assumption that we would only want to prompt for a schema name in the Connector use case. My changes were tested with and intended to work with this PR: https://github.com/apollographql/rover-init-starters/pull/51

Because this work was done as part of the 2025 Hackathon project, a different commit to `rover-init-starters` was merged instead: https://github.com/apollographql/rover-init-starters/pull/52 This version assumes that the schema prompt will happen regardless of project type. This PR adapts 2467 to work with the work that was merged in `rover-init-starters`

### Testing
1. Ran `cargo build` to build these `rover` changes
1. Aliased `cargo rover` to `localrover` with `alias localrover='cargo run --manifest-path=/Users/alyssahursh/code/rover/Cargo.toml --bin rover --'`
1. Created new empty test directory
1. Ran `localrover init`
1. Verified that connectors init workflow prompted for a schema name
1. Verified `supergraph.yaml` file was created using the newly provided schema name

```
graph_ref: my-api-m55izjn@current
subgraphs:
  main-schema-name:
    routing_url: http://localhost:4001
    schema:
      file: schema.graphql
```
