### PR TITLE
Update MCP options for rover dev

### DIFF
--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -2,6 +2,7 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use serde::Serialize;
 use strum_macros::Display;
+use tracing::Level;
 
 pub mod binary;
 pub mod install;
@@ -79,4 +80,13 @@ pub struct Opts {
     /// Disable schema type definitions referenced by all fields returned by the operation in the tool description
     #[arg(long = "mcp-disable-schema-description")]
     disable_schema_description: bool,
+
+    /// Expose a tool that returns the URL to open a GraphQL operation in Apollo Explorer (requires APOLLO_GRAPH_REF)
+    #[arg(long = "mcp-explorer")]
+    explorer: bool,
+
+    /// Change the level at which the MCP Server logs
+    #[arg(long = "mcp-log", default_value_t = Level::INFO)]
+    #[serde(skip)]
+    log_level: Level,
 }

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -60,9 +60,9 @@ pub struct Opts {
     #[arg(long = "mcp-collection")]
     collection: Option<String>,
 
-    /// Enable use of uplink to get the schema and persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
-    #[arg(long = "mcp-uplink")]
-    uplink: bool,
+    /// Enable use of uplink to get persisted queries (requires APOLLO_KEY and APOLLO_GRAPH_REF)
+    #[arg(long = "mcp-uplink-manifest")]
+    uplink_manifest: bool,
 
     /// The path to the GraphQL custom_scalars_config file
     #[arg(long = "mcp-custom-scalars-config", required = false)]

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -2,7 +2,6 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use serde::Serialize;
 use strum_macros::Display;
-use tracing::Level;
 
 pub mod binary;
 pub mod install;
@@ -65,6 +64,10 @@ pub struct Opts {
     #[arg(long = "mcp-uplink-manifest")]
     uplink_manifest: bool,
 
+    /// Deprecated alias for mcp-uplink-manifest to make it backwards compatible
+    #[arg(hide = true, long = "mcp-uplink")]
+    uplink: bool,
+
     /// The path to the GraphQL custom_scalars_config file
     #[arg(long = "mcp-custom-scalars-config", required = false)]
     custom_scalars_config: Option<Utf8PathBuf>,
@@ -84,9 +87,4 @@ pub struct Opts {
     /// Expose a tool that returns the URL to open a GraphQL operation in Apollo Explorer (requires APOLLO_GRAPH_REF)
     #[arg(long = "mcp-explorer")]
     explorer: bool,
-
-    /// Change the level at which the MCP Server logs
-    #[arg(long = "mcp-log", default_value_t = Level::INFO)]
-    #[serde(skip)]
-    log_level: Level,
 }

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -144,8 +144,8 @@ where
                 args.push(manifest.to_string());
             }
 
-            if self.mcp_options.uplink {
-                args.push("--uplink".to_string());
+            if self.mcp_options.uplink_manifest {
+                args.push("--uplink-manifest".to_string());
             }
 
             if let Some(custom_scalars_config) = self.mcp_options.custom_scalars_config {

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -144,7 +144,7 @@ where
                 args.push(manifest.to_string());
             }
 
-            if self.mcp_options.uplink_manifest {
+            if self.mcp_options.uplink_manifest || self.mcp_options.uplink {
                 args.push("--uplink-manifest".to_string());
             }
 
@@ -164,9 +164,6 @@ where
             if self.mcp_options.explorer {
                 args.push("--explorer".to_string());
             }
-
-            args.push("--log".to_string());
-            args.push(self.mcp_options.log_level.to_string());
 
             let child = spawn
                 .ready()

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -161,6 +161,13 @@ where
                 args.push("--disable-schema-description".to_string());
             }
 
+            if self.mcp_options.explorer {
+                args.push("--explorer".to_string());
+            }
+
+            args.push("--log".to_string());
+            args.push(self.mcp_options.log_level.to_string());
+
             let child = spawn
                 .ready()
                 .and_then(|spawn| {


### PR DESCRIPTION
<!--https://apollographql.atlassian.net/browse/GT-298-->

This PR updates the MCP options for `rover dev` as follows:

-  `--mcp-uplink` is deprecated in favor of `--mcp-uplink-manifest`.
-  The missing `--mcp-explorer` ~and `--mcp-log`~ options have been added.