### PR TITLE
Use a local config for `supergraph.yaml` files instead of `apollo-federation-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,9 +3107,12 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "inotify"
@@ -3187,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -204,6 +204,7 @@ impl Rover {
                     )
                     .await
             }
+            #[cfg(feature = "composition-js")]
             Command::Supergraph(command) => {
                 command
                     .run(
@@ -400,6 +401,7 @@ pub enum Command {
     Dev(Box<command::Dev>),
 
     /// Supergraph schema commands
+    #[cfg(feature = "composition-js")]
     Supergraph(command::Supergraph),
 
     /// Graph API schema commands

--- a/src/command/init/operations.rs
+++ b/src/command/init/operations.rs
@@ -103,8 +103,11 @@ pub(crate) async fn publish_subgraphs(
                 );
             }
         };
-        let unresolved = UnresolvedSubgraph::new(subgraph_name.clone(), subgraph_config.clone());
-        let schema_path = unresolved.resolve_file_path(output_path, &schema_path.unwrap())?;
+        let schema_path = UnresolvedSubgraph::resolve_file_path(
+            subgraph_name,
+            output_path,
+            &schema_path.unwrap(),
+        )?;
         let sdl = read_to_string(schema_path)?;
         rover_client::operations::subgraph::publish::run(
             SubgraphPublishInput {

--- a/src/command/init/template_operations.rs
+++ b/src/command/init/template_operations.rs
@@ -1,10 +1,9 @@
 use crate::command::init::template_operations::PrintMode::{Confirmation, Normal};
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
 use crate::{RoverError, RoverResult};
 use anyhow::format_err;
-use apollo_federation_types::config::{
-    FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
-};
+use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
 use camino::Utf8PathBuf;
 use rover_std::infoln;
 use rover_std::prompt::prompt_confirm_default_yes;
@@ -304,14 +303,14 @@ impl SupergraphBuilder {
         Ok(format!("{parent_parent_name}_{base_name}"))
     }
 
-    pub fn build_supergraph(&self) -> RoverResult<SupergraphConfig> {
+    pub fn build_supergraph(&self) -> RoverResult<SupergraphConfigYaml> {
         let subgraphs = self.generate_subgraphs()?;
-        Ok(SupergraphConfig::new(
+        Ok(SupergraphConfigYaml {
             subgraphs,
-            Some(FederationVersion::from_str(
+            federation_version: Some(FederationVersion::from_str(
                 self.federation_version.as_str(),
             )?),
-        ))
+        })
     }
 
     pub fn build_and_write(&self) -> RoverResult<()> {
@@ -362,7 +361,7 @@ mod tests {
         let expected = supergraph_builder.build_supergraph().unwrap();
 
         let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
-        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
         Ok(())
@@ -386,7 +385,7 @@ mod tests {
         let expected = supergraph_builder.build_supergraph().unwrap();
 
         let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
-        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
         Ok(())
@@ -416,7 +415,7 @@ mod tests {
         let expected = supergraph_builder.build_supergraph().unwrap();
 
         let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
-        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
         Ok(())
@@ -452,7 +451,7 @@ mod tests {
         let expected = supergraph_builder.build_supergraph().unwrap();
 
         let actual_file = File::open(temp_dir.path().join("supergraph.yaml"))?;
-        let actual: SupergraphConfig = serde_yaml::from_reader(actual_file).unwrap();
+        let actual: SupergraphConfigYaml = serde_yaml::from_reader(actual_file).unwrap();
         assert_eq!(actual, expected);
 
         Ok(())

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod output;
 mod persisted_queries;
 mod readme;
 pub(crate) mod subgraph;
+#[cfg(feature = "composition-js")]
 pub(crate) mod supergraph;
 pub(crate) mod template;
 mod update;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -43,6 +43,7 @@ pub use output::RoverOutput;
 pub use persisted_queries::PersistedQueries;
 pub use readme::Readme;
 pub use subgraph::Subgraph;
+#[cfg(feature = "composition-js")]
 pub use supergraph::Supergraph;
 pub use template::Template;
 pub use update::Update;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1,12 +1,12 @@
-#[cfg(feature = "composition-js")]
-use crate::command::connector::run::{RunConnector, RunConnectorOutput};
 use crate::command::docs::shortlinks::ShortlinkInfo;
+#[cfg(feature = "composition-js")]
+use crate::command::{
+    connector::run::{RunConnector, RunConnectorOutput},
+    supergraph::compose::CompositionOutput,
+};
 use crate::{
     RoverError,
-    command::{
-        supergraph::compose::CompositionOutput,
-        template::queries::list_templates_for_language::ListTemplatesForLanguageTemplates,
-    },
+    command::template::queries::list_templates_for_language::ListTemplatesForLanguageTemplates,
     options::{JsonVersion, ProjectLanguage},
     utils::table,
 };
@@ -65,6 +65,7 @@ pub enum RoverOutput {
     FetchResponse(FetchResponse),
     SupergraphSchema(String),
     JsonSchema(String),
+    #[cfg(feature = "composition-js")]
     CompositionResult(CompositionOutput),
     SubgraphList(SubgraphListResponse),
     CheckWorkflowResponse(CheckWorkflowResponse),
@@ -344,6 +345,7 @@ impl RoverOutput {
             }
             RoverOutput::SupergraphSchema(csdl) => Some((csdl).to_string()),
             RoverOutput::JsonSchema(schema) => Some(schema.clone()),
+            #[cfg(feature = "composition-js")]
             RoverOutput::CompositionResult(composition_output) => {
                 let warn_prefix = Style::HintPrefix.paint("HINT:");
 
@@ -609,6 +611,7 @@ impl RoverOutput {
             RoverOutput::FetchResponse(fetch_response) => json!(fetch_response),
             RoverOutput::SupergraphSchema(csdl) => json!({ "core_schema": csdl }),
             RoverOutput::JsonSchema(schema) => Value::String(schema.clone()),
+            #[cfg(feature = "composition-js")]
             RoverOutput::CompositionResult(composition_output) => {
                 if let Some(federation_version) = &composition_output.federation_version {
                     json!({
@@ -797,6 +800,7 @@ impl RoverOutput {
                 SdlType::Graph | SdlType::Subgraph { .. } => Some("Schema"),
                 SdlType::Supergraph => Some("Supergraph Schema"),
             },
+            #[cfg(feature = "composition-js")]
             RoverOutput::CompositionResult(_) | RoverOutput::SupergraphSchema(_) => {
                 Some("Supergraph Schema")
             }

--- a/src/command/supergraph/config/schema.rs
+++ b/src/command/supergraph/config/schema.rs
@@ -1,8 +1,8 @@
-use apollo_federation_types::config::SupergraphConfig;
 use clap::Parser;
 use schemars::schema_for;
 use serde::Serialize;
 
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize, Parser)]
@@ -10,7 +10,7 @@ pub struct Schema {}
 
 impl Schema {
     pub fn run(&self) -> RoverResult<RoverOutput> {
-        let schema = schema_for!(SupergraphConfig);
+        let schema = schema_for!(SupergraphConfigYaml);
         Ok(RoverOutput::JsonSchema(
             serde_json::to_string_pretty(&schema).unwrap(),
         ))

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::fs::canonicalize;
 
 use apollo_federation_types::config::FederationVersion::LatestFedTwo;
-use apollo_federation_types::config::{FederationVersion, SubgraphConfig, SupergraphConfig};
+use apollo_federation_types::config::{FederationVersion, SubgraphConfig};
 use camino::Utf8PathBuf;
 use rover_client::shared::GraphRef;
 use rover_http::HttpService;
@@ -24,6 +24,7 @@ use super::supergraph::config::resolver::{
 };
 use super::supergraph::install::{InstallSupergraph, InstallSupergraphError};
 use super::{CompositionError, CompositionSuccess, FederationUpdaterConfig};
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::composition::supergraph::config::full::FullyResolvedSupergraphConfig;
 use crate::composition::supergraph::config::lazy::LazilyResolvedSupergraphConfig;
 use crate::options::LicenseAccepter;
@@ -94,7 +95,7 @@ impl CompositionPipeline<state::Init> {
             FileDescriptorType::Stdin => Some(FileDescriptorType::Stdin),
         });
         let supergraph_root = supergraph_yaml
-            .clone()
+            .as_ref()
             .and_then(|file| match file {
                 FileDescriptorType::File(file) => {
                     let mut current_dir =
@@ -113,10 +114,13 @@ impl CompositionPipeline<state::Init> {
                 )
                 .unwrap()
             });
-        let resolver = SupergraphConfigResolver::default()
-            .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
-            .await?
-            .load_from_file_descriptor(read_stdin_impl, supergraph_yaml.as_ref())?;
+        eprintln!("merging supergraph schema files");
+        let resolver = SupergraphConfigResolver::load_remote_subgraphs(
+            fetch_remote_subgraphs_factory,
+            graph_ref.as_ref(),
+        )
+        .await?
+        .load_from_file_descriptor(read_stdin_impl, supergraph_yaml.as_ref())?;
         let resolver = match default_subgraph {
             Some(default_subgraph) => resolver
                 .define_default_subgraph_if_empty(default_subgraph)
@@ -236,8 +240,10 @@ impl CompositionPipeline<state::Run> {
         write_file_impl
             .write_file(
                 &supergraph_config_filepath,
-                serde_yaml::to_string(&SupergraphConfig::from(fully_resolved_supergraph_config))?
-                    .as_bytes(),
+                serde_yaml::to_string(&SupergraphConfigYaml::from(
+                    fully_resolved_supergraph_config,
+                ))?
+                .as_bytes(),
             )
             .await
             .map_err(|err| CompositionError::WriteFile {
@@ -254,7 +260,7 @@ impl CompositionPipeline<state::Run> {
 
     #[tracing::instrument(skip_all)]
     #[allow(clippy::too_many_arguments)]
-    pub async fn runner<ExecC, WriteF>(
+    pub(crate) async fn runner<ExecC, WriteF>(
         &self,
         exec_command: ExecC,
         write_file: WriteF,

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -9,6 +9,8 @@ use std::fmt::Debug;
 use camino::Utf8PathBuf;
 use futures::stream::{BoxStream, StreamExt, select};
 use rover_http::HttpService;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
 use tower::ServiceExt;
 
 use self::state::SetupSubgraphWatchers;
@@ -27,7 +29,7 @@ use crate::composition::supergraph::install::InstallSupergraphError;
 use crate::composition::watchers::federation::FederationWatcher;
 use crate::composition::watchers::watcher::file::FileWatcher;
 use crate::composition::watchers::watcher::supergraph_config::SupergraphConfigWatcher;
-use crate::subtask::{BroadcastSubtask, Subtask, SubtaskRunStream, SubtaskRunUnit};
+use crate::subtask::{Subtask, SubtaskRunStream};
 use crate::utils::effect::exec::ExecCommand;
 use crate::utils::effect::write_file::WriteFile;
 
@@ -174,7 +176,7 @@ impl Runner<state::SetupCompositionWatcher> {
 }
 
 /// Alias for a [`Runner`] that is ready to be run
-pub type CompositionRunner<ExecC, WriteF> = Runner<state::Run<ExecC, WriteF>>;
+pub(crate) type CompositionRunner<ExecC, WriteF> = Runner<state::Run<ExecC, WriteF>>;
 
 impl<ExecC, WriteF> Runner<state::Run<ExecC, WriteF>>
 where
@@ -183,29 +185,14 @@ where
 {
     /// Runs the [`Runner`]
     pub fn run(self) -> BoxStream<'static, CompositionEvent> {
-        let (
-            supergraph_config_stream_for_subtask_watcher,
-            supergraph_config_stream_for_federation_watcher,
-            supergraph_config_subtask,
-        ) = if let Some(supergraph_config_watcher) = self.state.supergraph_config_watcher {
-            tracing::info!("Watching subgraphs for changes...");
-            let (supergraph_config_stream, supergraph_config_subtask) =
-                BroadcastSubtask::new(supergraph_config_watcher);
-            (
-                supergraph_config_stream.boxed(),
-                supergraph_config_subtask.subscribe().boxed(),
-                Some(supergraph_config_subtask),
-            )
-        } else {
+        let Some(supergraph_config_watcher) = self.state.supergraph_config_watcher else {
             tracing::warn!(
                 "No supergraph config detected, changes to subgraph configurations will not be applied automatically"
             );
-            (
-                tokio_stream::empty().boxed(),
-                tokio_stream::empty().boxed(),
-                None,
-            )
+            return tokio_stream::empty().boxed();
         };
+        tracing::info!("Watching subgraphs for changes...");
+        let (tx, rx) = broadcast::channel(100);
 
         let (subgraph_change_stream, subgraph_watcher_subtask) =
             Subtask::new(self.state.subgraph_watchers);
@@ -224,7 +211,7 @@ where
 
         // Start subgraph watchers, listening for events from the supergraph change stream.
         subgraph_watcher_subtask.run(
-            supergraph_config_stream_for_subtask_watcher
+            BroadcastStream::new(rx)
                 .filter_map(|recv_res| async move {
                     match recv_res {
                         Ok(res) => Some(res),
@@ -239,7 +226,7 @@ where
         );
 
         federation_watcher_subtask.run(
-            supergraph_config_stream_for_federation_watcher
+            BroadcastStream::new(tx.subscribe())
                 .filter_map(|recv_res| async move {
                     match recv_res {
                         Ok(res) => Some(res),
@@ -253,10 +240,7 @@ where
             None,
         );
 
-        // Start the supergraph watcher subtask.
-        if let Some(supergraph_config_subtask) = supergraph_config_subtask {
-            supergraph_config_subtask.run(None);
-        }
+        supergraph_config_watcher.run(tx);
 
         composition_messages.boxed()
     }

--- a/src/composition/runner/state.rs
+++ b/src/composition/runner/state.rs
@@ -6,25 +6,25 @@ use crate::composition::watchers::{
     watcher::supergraph_config::SupergraphConfigWatcher,
 };
 
-pub struct SetupSubgraphWatchers;
+pub(crate) struct SetupSubgraphWatchers;
 
-pub struct SetupSupergraphConfigWatcher {
-    pub subgraph_watchers: SubgraphWatchers,
+pub(crate) struct SetupSupergraphConfigWatcher {
+    pub(crate) subgraph_watchers: SubgraphWatchers,
 }
 
-pub struct SetupCompositionWatcher {
-    pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
-    pub subgraph_watchers: SubgraphWatchers,
-    pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
+pub(crate) struct SetupCompositionWatcher {
+    pub(crate) supergraph_config_watcher: Option<SupergraphConfigWatcher>,
+    pub(crate) subgraph_watchers: SubgraphWatchers,
+    pub(crate) initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }
 
-pub struct Run<ExecC, WriteF>
+pub(crate) struct Run<ExecC, WriteF>
 where
     ExecC: Eq + PartialEq + Debug,
     WriteF: Eq + PartialEq + Debug,
 {
-    pub supergraph_config_watcher: Option<SupergraphConfigWatcher>,
-    pub subgraph_watchers: SubgraphWatchers,
-    pub composition_watcher: CompositionWatcher<ExecC, WriteF>,
-    pub initial_supergraph_config: LazilyResolvedSupergraphConfig,
+    pub(crate) supergraph_config_watcher: Option<SupergraphConfigWatcher>,
+    pub(crate) subgraph_watchers: SubgraphWatchers,
+    pub(crate) composition_watcher: CompositionWatcher<ExecC, WriteF>,
+    pub(crate) initial_supergraph_config: LazilyResolvedSupergraphConfig,
 }

--- a/src/composition/supergraph/config/federation.rs
+++ b/src/composition/supergraph/config/federation.rs
@@ -3,11 +3,11 @@
 
 use std::marker::PhantomData;
 
-use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
+use apollo_federation_types::config::FederationVersion;
 use derive_getters::Getters;
 
 use super::full::FullyResolvedSubgraph;
-use crate::command::supergraph::compose::do_compose::SupergraphComposeOpts;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 
 mod state {
     #[derive(Clone, Debug)]
@@ -68,13 +68,13 @@ impl FederationVersionResolver<state::FromSupergraphConfig> {
     /// from a [`SupergraphConfig`] (if it has one)
     pub fn from_supergraph_config(
         self,
-        supergraph_config: Option<&SupergraphConfig>,
+        supergraph_config: Option<&SupergraphConfigYaml>,
     ) -> FederationVersionResolver<state::FromSubgraphs> {
         match supergraph_config {
             Some(supergraph_config) => {
                 let federation_version = self
                     .federation_version
-                    .or_else(|| supergraph_config.get_federation_version());
+                    .or_else(|| supergraph_config.federation_version.clone());
                 FederationVersionResolver {
                     state: PhantomData::<state::FromSubgraphs>,
                     federation_version,
@@ -91,15 +91,6 @@ impl FederationVersionResolver<state::FromSupergraphConfig> {
     pub fn resolve(self) -> FederationVersion {
         self.federation_version
             .unwrap_or(FederationVersion::LatestFedTwo)
-    }
-}
-
-impl From<&SupergraphComposeOpts> for FederationVersionResolver<state::FromSupergraphConfig> {
-    fn from(value: &SupergraphComposeOpts) -> Self {
-        FederationVersionResolver {
-            federation_version: value.federation_version.clone(),
-            state: PhantomData::<state::FromSupergraphConfig>,
-        }
     }
 }
 
@@ -158,12 +149,11 @@ impl FederationVersionResolver<state::FromSubgraphs> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use apollo_federation_types::config::{
-        FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
-    };
+    use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
     use speculoos::prelude::*;
 
     use super::FederationVersionResolverFromSupergraphConfig;
+    use crate::composition::supergraph::config::SupergraphConfigYaml;
     use crate::composition::supergraph::config::full::FullyResolvedSubgraph;
     use crate::composition::supergraph::config::scenario::*;
 
@@ -184,8 +174,10 @@ mod tests {
         )]);
         let federation_version_resolver =
             FederationVersionResolverFromSupergraphConfig::new(FederationVersion::LatestFedTwo);
-        let supergraph_config =
-            SupergraphConfig::new(unresolved_subgraphs, Some(FederationVersion::LatestFedOne));
+        let supergraph_config = SupergraphConfigYaml {
+            subgraphs: unresolved_subgraphs,
+            federation_version: Some(FederationVersion::LatestFedOne),
+        };
 
         let resolved_subgraphs = [(
             subgraph_name.to_string(),
@@ -222,8 +214,10 @@ mod tests {
             SubgraphConfig::from(subgraph_scenario.unresolved_subgraph.clone()),
         )]);
         let federation_version_resolver = FederationVersionResolverFromSupergraphConfig::default();
-        let supergraph_config =
-            SupergraphConfig::new(unresolved_subgraphs, Some(FederationVersion::LatestFedTwo));
+        let supergraph_config = SupergraphConfigYaml {
+            subgraphs: unresolved_subgraphs,
+            federation_version: Some(FederationVersion::LatestFedTwo),
+        };
 
         let resolved_subgraphs = [(
             subgraph_name.to_string(),
@@ -260,7 +254,10 @@ mod tests {
             SubgraphConfig::from(subgraph_scenario.unresolved_subgraph.clone()),
         )]);
         let federation_version_resolver = FederationVersionResolverFromSupergraphConfig::default();
-        let supergraph_config = SupergraphConfig::new(unresolved_subgraphs, None);
+        let supergraph_config = SupergraphConfigYaml {
+            subgraphs: unresolved_subgraphs,
+            ..Default::default()
+        };
 
         let resolved_subgraphs = [(
             subgraph_name.to_string(),

--- a/src/composition/supergraph/config/lazy/subgraph.rs
+++ b/src/composition/supergraph/config/lazy/subgraph.rs
@@ -20,26 +20,28 @@ impl LazilyResolvedSubgraph {
     /// any filepaths and confirming that they are relative to a supergraph config schema
     pub fn resolve(
         supergraph_config_root: &Utf8PathBuf,
-        unresolved_subgraph: UnresolvedSubgraph,
+        name: String,
+        unresolved_subgraph: SubgraphConfig,
     ) -> Result<LazilyResolvedSubgraph, ResolveSubgraphError> {
-        match unresolved_subgraph.schema() {
+        match unresolved_subgraph.schema {
             SchemaSource::File { file } => {
-                let file = unresolved_subgraph.resolve_file_path(
-                    &supergraph_config_root.clone(),
-                    &Utf8PathBuf::try_from(file.clone())?,
+                let file = UnresolvedSubgraph::resolve_file_path(
+                    &name,
+                    supergraph_config_root,
+                    &Utf8PathBuf::try_from(file)?,
                 )?;
                 Ok(LazilyResolvedSubgraph {
-                    name: unresolved_subgraph.name().to_string(),
-                    routing_url: unresolved_subgraph.routing_url().clone(),
+                    name,
+                    routing_url: unresolved_subgraph.routing_url,
                     schema: SchemaSource::File {
                         file: file.into_std_path_buf(),
                     },
                 })
             }
-            _ => Ok(LazilyResolvedSubgraph {
-                name: unresolved_subgraph.name().to_string(),
-                routing_url: unresolved_subgraph.routing_url().clone(),
-                schema: unresolved_subgraph.schema().clone(),
+            schema => Ok(LazilyResolvedSubgraph {
+                name,
+                routing_url: unresolved_subgraph.routing_url,
+                schema,
             }),
         }
     }

--- a/src/composition/supergraph/config/lazy/supergraph.rs
+++ b/src/composition/supergraph/config/lazy/supergraph.rs
@@ -1,12 +1,13 @@
 use std::collections::BTreeMap;
 
-use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
+use apollo_federation_types::config::FederationVersion;
 use camino::Utf8PathBuf;
 use derive_getters::Getters;
 use futures::{StreamExt, stream};
 use itertools::Itertools;
 
 use super::LazilyResolvedSubgraph;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::composition::supergraph::config::error::ResolveSubgraphError;
 use crate::composition::supergraph::config::unresolved::UnresolvedSupergraphConfig;
 
@@ -30,20 +31,19 @@ impl LazilyResolvedSupergraphConfig {
         LazilyResolvedSupergraphConfig,
         BTreeMap<String, ResolveSubgraphError>,
     ) {
-        let subgraphs = stream::iter(
-            unresolved_supergraph_config
-                .subgraphs()
-                .clone()
-                .into_iter()
-                .map(|(name, unresolved_subgraph)| async move {
-                    let result = LazilyResolvedSubgraph::resolve(
-                        supergraph_config_root,
-                        unresolved_subgraph.clone(),
-                    )
-                    .map_err(|err| (name.to_string(), err))?;
-                    Ok((name.to_string(), result))
-                }),
-        )
+        let federation_version = unresolved_supergraph_config.target_federation_version();
+        let subgraphs = stream::iter(unresolved_supergraph_config.subgraphs.into_iter().map(
+            |(name, unresolved_subgraph)| async move {
+                match LazilyResolvedSubgraph::resolve(
+                    supergraph_config_root,
+                    name.clone(),
+                    unresolved_subgraph,
+                ) {
+                    Ok(result) => Ok((name, result)),
+                    Err(err) => Err((name, err)),
+                }
+            },
+        ))
         .buffer_unordered(50)
         .collect::<Vec<Result<(String, LazilyResolvedSubgraph), (String, ResolveSubgraphError)>>>()
         .await;
@@ -54,9 +54,9 @@ impl LazilyResolvedSupergraphConfig {
         ) = subgraphs.into_iter().partition_result();
         (
             LazilyResolvedSupergraphConfig {
-                origin_path: unresolved_supergraph_config.origin_path().clone(),
+                origin_path: unresolved_supergraph_config.origin_path.clone(),
                 subgraphs: BTreeMap::from_iter(subgraphs),
-                federation_version: unresolved_supergraph_config.target_federation_version(),
+                federation_version,
             },
             BTreeMap::from_iter(errors.into_iter()),
         )
@@ -70,7 +70,7 @@ impl LazilyResolvedSupergraphConfig {
     }
 }
 
-impl From<LazilyResolvedSupergraphConfig> for SupergraphConfig {
+impl From<LazilyResolvedSupergraphConfig> for SupergraphConfigYaml {
     fn from(value: LazilyResolvedSupergraphConfig) -> Self {
         let subgraphs = BTreeMap::from_iter(
             value
@@ -78,6 +78,9 @@ impl From<LazilyResolvedSupergraphConfig> for SupergraphConfig {
                 .into_iter()
                 .map(|(name, subgraph)| (name, subgraph.into())),
         );
-        SupergraphConfig::new(subgraphs, value.federation_version)
+        SupergraphConfigYaml {
+            subgraphs,
+            federation_version: value.federation_version,
+        }
     }
 }

--- a/src/composition/supergraph/config/mod.rs
+++ b/src/composition/supergraph/config/mod.rs
@@ -10,3 +10,6 @@ pub mod resolver;
 #[cfg(test)]
 pub(crate) mod scenario;
 pub mod unresolved;
+mod yaml;
+
+pub(crate) use yaml::SupergraphConfigYaml;

--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -16,9 +16,7 @@ use std::collections::BTreeMap;
 use std::io::IsTerminal;
 
 use anyhow::Context;
-use apollo_federation_types::config::{
-    ConfigError, FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
-};
+use apollo_federation_types::config::{ConfigError, SchemaSource, SubgraphConfig};
 use camino::Utf8PathBuf;
 use clap::CommandFactory;
 use clap::error::ErrorKind as ClapErrorKind;
@@ -31,16 +29,14 @@ use url::Url;
 use self::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
 use self::fetch_remote_subgraphs::FetchRemoteSubgraphsRequest;
 use super::error::ResolveSubgraphError;
-use super::federation::{
-    FederationVersionMismatch, FederationVersionResolver,
-    FederationVersionResolverFromSupergraphConfig,
-};
+use super::federation::{FederationVersionMismatch, FederationVersionResolver};
 use super::full::FullyResolvedSupergraphConfig;
 use super::full::introspect::ResolveIntrospectSubgraphFactory;
 use super::lazy::LazilyResolvedSupergraphConfig;
 use super::unresolved::UnresolvedSupergraphConfig;
 use crate::RoverError;
 use crate::cli::Rover;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::utils::effect::read_stdin::ReadStdin;
 use crate::utils::expansion::expand;
 use crate::utils::parsers::FileDescriptorType;
@@ -54,31 +50,6 @@ pub struct SupergraphConfigResolver<State> {
     state: State,
 }
 
-impl SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
-    /// Creates a new [`SupergraphConfigResolver`] using a target federation Version
-    pub const fn new(
-        federation_version: FederationVersion,
-    ) -> SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
-        SupergraphConfigResolver {
-            state: state::LoadRemoteSubgraphs {
-                federation_version_resolver: FederationVersionResolverFromSupergraphConfig::new(
-                    federation_version,
-                ),
-            },
-        }
-    }
-}
-
-impl Default for SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
-    fn default() -> Self {
-        SupergraphConfigResolver {
-            state: state::LoadRemoteSubgraphs {
-                federation_version_resolver: FederationVersionResolver::default(),
-            },
-        }
-    }
-}
-
 /// Errors that may occur when loading remote subgraphs
 #[derive(thiserror::Error, Debug)]
 pub enum LoadRemoteSubgraphsError {
@@ -87,11 +58,10 @@ pub enum LoadRemoteSubgraphsError {
     FetchRemoteSubgraphsError(Box<dyn std::error::Error + Send + Sync>),
 }
 
-impl SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
+impl SupergraphConfigResolver<state::LoadSupergraphConfig> {
     /// Optionally loads subgraphs from the Studio API using the contents of the `--graph-ref` flag
     /// and an implementation of [`FetchRemoteSubgraphs`]
     pub async fn load_remote_subgraphs<S>(
-        self,
         mut fetch_remote_subgraphs_factory: S,
         graph_ref: Option<&GraphRef>,
     ) -> Result<SupergraphConfigResolver<state::LoadSupergraphConfig>, LoadRemoteSubgraphsError>
@@ -119,14 +89,14 @@ impl SupergraphConfigResolver<state::LoadRemoteSubgraphs> {
                 })?;
             Ok(SupergraphConfigResolver {
                 state: state::LoadSupergraphConfig {
-                    federation_version_resolver: self.state.federation_version_resolver,
+                    federation_version_resolver: FederationVersionResolver::default(),
                     subgraphs: remote_subgraphs,
                 },
             })
         } else {
             Ok(SupergraphConfigResolver {
                 state: state::LoadSupergraphConfig {
-                    federation_version_resolver: self.state.federation_version_resolver,
+                    federation_version_resolver: FederationVersionResolver::default(),
                     subgraphs: BTreeMap::default(),
                 },
             })
@@ -172,7 +142,7 @@ impl SupergraphConfigResolver<state::LoadSupergraphConfig> {
                 .federation_version_resolver
                 .from_supergraph_config(Some(&supergraph_config));
             let mut merged_subgraphs = self.state.subgraphs;
-            for (name, subgraph_config) in supergraph_config.into_iter() {
+            for (name, subgraph_config) in supergraph_config.subgraphs {
                 let subgraph_config = SubgraphConfig {
                     routing_url: subgraph_config.routing_url.or_else(|| {
                         merged_subgraphs
@@ -207,18 +177,18 @@ impl SupergraphConfigResolver<state::LoadSupergraphConfig> {
     fn get_supergraph_config(
         read_stdin_impl: &mut impl ReadStdin,
         file_descriptor_type: &FileDescriptorType,
-    ) -> Result<SupergraphConfig, LoadSupergraphConfigError> {
+    ) -> Result<SupergraphConfigYaml, LoadSupergraphConfigError> {
         let contents = file_descriptor_type
             .read_file_descriptor("supergraph config", read_stdin_impl)
             .map_err(LoadSupergraphConfigError::ReadFileDescriptor)?;
         let yaml_contents = expand(serde_yaml::from_str(&contents)?)
             .map_err(LoadSupergraphConfigError::ExpansionError)?;
-        match SupergraphConfig::new_from_yaml(&(serde_yaml::to_string(&yaml_contents)?)) {
+        match serde_yaml::from_value(yaml_contents) {
             Ok(supergraph_config) => Ok(supergraph_config),
             Err(err) => {
                 warn!("Could not initially parse supergraph config: {}", err);
                 warn!("Proceeding with empty supergraph config");
-                Ok(SupergraphConfig::new(BTreeMap::new(), None))
+                Ok(SupergraphConfigYaml::default())
             }
         }
     }
@@ -253,7 +223,7 @@ impl SupergraphConfigResolver<state::DefineDefaultSubgraph> {
                 },
             );
         } else {
-            tracing::warn!(
+            warn!(
                 "Attempting to define a default subgraph when the existing subgraph set is not empty"
             );
         }
@@ -322,10 +292,11 @@ impl SupergraphConfigResolver<state::ResolveSubgraphs> {
         ),
         ResolveSupergraphConfigError,
     > {
-        let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()
-            .subgraphs(self.state.subgraphs.clone())
-            .federation_version_resolver(self.state.federation_version_resolver.clone())
-            .build();
+        let unresolved_supergraph_config = UnresolvedSupergraphConfig {
+            subgraphs: self.state.subgraphs.clone(),
+            federation_version_resolver: Some(self.state.federation_version_resolver.clone()),
+            origin_path: None,
+        };
         let resolved_supergraph_config = FullyResolvedSupergraphConfig::resolve(
             resolve_introspect_subgraph_factory,
             fetch_remote_subgraph_factory,
@@ -350,11 +321,11 @@ impl SupergraphConfigResolver<state::ResolveSubgraphs> {
         ),
         ResolveSupergraphConfigError,
     > {
-        let unresolved_supergraph_config = UnresolvedSupergraphConfig::builder()
-            .and_origin_path(self.state.origin_path.clone())
-            .subgraphs(self.state.subgraphs.clone())
-            .federation_version_resolver(self.state.federation_version_resolver.clone())
-            .build();
+        let unresolved_supergraph_config = UnresolvedSupergraphConfig {
+            origin_path: self.state.origin_path.clone(),
+            subgraphs: self.state.subgraphs.clone(),
+            federation_version_resolver: Some(self.state.federation_version_resolver.clone()),
+        };
         let resolved_supergraph_config = LazilyResolvedSupergraphConfig::resolve(
             supergraph_config_root,
             unresolved_supergraph_config,
@@ -484,9 +455,7 @@ mod tests {
     use std::sync::Arc;
 
     use anyhow::Result;
-    use apollo_federation_types::config::{
-        FederationVersion, SchemaSource, SubgraphConfig, SupergraphConfig,
-    };
+    use apollo_federation_types::config::{FederationVersion, SchemaSource, SubgraphConfig};
     use assert_fs::TempDir;
     use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild};
     use camino::Utf8PathBuf;
@@ -506,6 +475,7 @@ mod tests {
         FetchRemoteSubgraphsRequest, MakeFetchRemoteSubgraphsError,
     };
     use super::{DefaultSubgraphDefinition, MockPrompt, SupergraphConfigResolver};
+    use crate::composition::supergraph::config::SupergraphConfigYaml;
     use crate::composition::supergraph::config::error::ResolveSubgraphError;
     use crate::composition::supergraph::config::full::FullyResolvedSubgraph;
     use crate::composition::supergraph::config::full::introspect::{
@@ -515,243 +485,6 @@ mod tests {
     use crate::utils::effect::introspect::MockIntrospectSubgraph;
     use crate::utils::effect::read_stdin::MockReadStdin;
     use crate::utils::parsers::FileDescriptorType;
-
-    /// Test showing that federation version is selected from the user-specified fed version
-    /// over local supergraph config, remote composition version, or version inferred from
-    /// resolved SDLs
-    /// For these tests, we only need to test against a remote schema source and a local one.
-    /// The sdl schema source was chosen as local, since it's the easiest one to configure
-    #[rstest]
-    /// Case: both local and remote subgraphs exist with fed 1 SDLs
-    #[case(
-        Some(remote_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            routing_url(),
-            SubgraphFederationVersion::One
-        )),
-        Some(sdl_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            SubgraphFederationVersion::One,
-            routing_url()
-        ))
-    )]
-    /// Case: only a remote subgraph exists with a fed 1 SDL
-    #[case(
-        Some(remote_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            routing_url(),
-            SubgraphFederationVersion::One
-        )),
-        None
-    )]
-    /// Case: only a local subgraph exists with a fed 1 SDL
-    #[case(
-        None,
-        Some(sdl_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            SubgraphFederationVersion::One,
-            routing_url()
-        ))
-    )]
-    /// Case: both local and remote subgraphs exist with fed 2 SDLs
-    #[case(
-        Some(remote_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            routing_url(),
-            SubgraphFederationVersion::Two
-        )),
-        Some(sdl_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            SubgraphFederationVersion::Two,
-            routing_url()
-        ))
-    )]
-    /// Case: only a remote subgraph exists with a fed 2 SDL
-    #[case(
-        Some(remote_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            routing_url(),
-            SubgraphFederationVersion::Two
-        )),
-        None
-    )]
-    /// Case: only a local subgraph exists with a fed 2 SDL
-    #[case(
-        None,
-        Some(sdl_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            SubgraphFederationVersion::Two,
-            routing_url()
-        ))
-    )]
-    /// Case: both local and remote subgraphs exist with varying fed version SDLs
-    #[case(
-        Some(remote_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            routing_url(),
-            SubgraphFederationVersion::One
-        )),
-        Some(sdl_subgraph_scenario(
-            sdl(),
-            subgraph_name(),
-            SubgraphFederationVersion::Two,
-            routing_url()
-        ))
-    )]
-    /// This test further uses #[values] to make sure we have a matrix of tests
-    /// All possible combinations result in using the target federation version,
-    /// since that is the highest order of precedence
-    #[tokio::test]
-    async fn test_select_federation_version_from_user_selection(
-        #[case] remote_subgraph_scenario: Option<RemoteSubgraphScenario>,
-        #[case] sdl_subgraph_scenario: Option<SdlSubgraphScenario>,
-        // Dictates whether to load the remote supergraph schema from a the local config or using the --graph_ref flag
-        #[values(true, false)] fetch_remote_subgraph_from_config: bool,
-        // Dictates whether to load the local supergraph schema from a file or stdin
-        #[values(true, false)] load_supergraph_config_from_file: bool,
-        // The optional fed version attached to a local supergraph config
-        #[values(Some(FederationVersion::LatestFedOne), None)]
-        local_supergraph_federation_version: Option<FederationVersion>,
-    ) -> Result<()> {
-        // user-specified federation version
-        let target_federation_version =
-            FederationVersion::ExactFedTwo(Version::from_str("2.7.1").unwrap());
-        let mut subgraphs = BTreeMap::new();
-
-        let (resolve_introspect_subgraph_service, mut resolve_introspect_subgraph_handle) =
-            tower_test::mock::spawn::<(), FullyResolvedSubgraph>();
-
-        let (fetch_remote_subgraphs_service, fetch_remote_subgraphs_handle) =
-            tower_test::mock::spawn::<FetchRemoteSubgraphsRequest, BTreeMap<String, SubgraphConfig>>(
-            );
-        let (fetch_remote_subgraph_service, fetch_remote_subgraph_handle) =
-            tower_test::mock::spawn::<FetchRemoteSubgraphRequest, RemoteSubgraph>();
-
-        setup_remote_subgraph_scenario(
-            fetch_remote_subgraph_from_config,
-            remote_subgraph_scenario.as_ref(),
-            &mut subgraphs,
-            fetch_remote_subgraphs_handle,
-            fetch_remote_subgraph_handle,
-        );
-
-        setup_sdl_subgraph_scenario(sdl_subgraph_scenario.as_ref(), &mut subgraphs);
-
-        let mut mock_read_stdin = MockReadStdin::new();
-
-        let local_supergraph_config =
-            SupergraphConfig::new(subgraphs, local_supergraph_federation_version);
-        let local_supergraph_config_str = serde_yaml::to_string(&local_supergraph_config)?;
-        let local_supergraph_config_dir = assert_fs::TempDir::new()?;
-        let local_supergraph_config_path =
-            Utf8PathBuf::from_path_buf(local_supergraph_config_dir.path().to_path_buf()).unwrap();
-
-        let file_descriptor_type = setup_file_descriptor(
-            load_supergraph_config_from_file,
-            &local_supergraph_config_dir,
-            &local_supergraph_config_str,
-            &mut mock_read_stdin,
-        )?;
-
-        // init resolver with a target fed version
-        let resolver = SupergraphConfigResolver::new(target_federation_version.clone());
-
-        // determine whether to try to load from graph refs
-        let graph_ref = remote_subgraph_scenario
-            .as_ref()
-            .and_then(|remote_subgraph_scenario| {
-                if fetch_remote_subgraph_from_config {
-                    None
-                } else {
-                    Some(remote_subgraph_scenario.graph_ref.clone())
-                }
-            });
-
-        let fetch_remote_subgraphs_factory =
-            ServiceBuilder::new()
-                .boxed_clone()
-                .service_fn(move |_: ()| {
-                    let fetch_remote_subgraphs_service = fetch_remote_subgraphs_service.clone();
-                    async move {
-                        Ok::<_, MakeFetchRemoteSubgraphsError>(
-                            ServiceBuilder::new()
-                                .map_err(RoverClientError::ServiceReady)
-                                .service(fetch_remote_subgraphs_service.into_inner())
-                                .boxed_clone(),
-                        )
-                    }
-                });
-
-        // load remote subgraphs
-        let resolver = resolver
-            .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
-            .await?;
-
-        // load from the file descriptor
-        let resolver = resolver
-            .load_from_file_descriptor(&mut mock_read_stdin, Some(&file_descriptor_type))?
-            .define_default_subgraph_if_empty(DefaultSubgraphDefinition::Prompt(Box::new(
-                MockPrompt::default(),
-            )))?;
-
-        let fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory = ServiceBuilder::new()
-            .boxed_clone()
-            .service_fn(move |_: ()| {
-                let fetch_remote_subgraph_service = fetch_remote_subgraph_service.clone();
-                async move {
-                    Ok::<_, MakeFetchRemoteSubgraphError>(
-                        ServiceBuilder::new()
-                            .map_err(FetchRemoteSubgraphError::Service)
-                            .service(fetch_remote_subgraph_service.into_inner())
-                            .boxed_clone(),
-                    )
-                }
-            });
-
-        // we never introspect subgraphs in this test, but we still have to account for the effect
-        resolve_introspect_subgraph_handle.allow(0);
-
-        let resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory =
-            ServiceBuilder::new().boxed_clone().service_fn(
-                move |_: MakeResolveIntrospectSubgraphRequest| {
-                    let resolve_introspect_subgraph_service =
-                        resolve_introspect_subgraph_service.clone();
-                    async move {
-                        Ok(ServiceBuilder::new()
-                            .boxed_clone()
-                            .map_err(|err| ResolveSubgraphError::IntrospectionError {
-                                subgraph_name: "dont-call-me".to_string(),
-                                source: Arc::new(err),
-                            })
-                            .service(resolve_introspect_subgraph_service.into_inner()))
-                    }
-                },
-            );
-
-        // fully resolve subgraphs into their SDLs
-        let (fully_resolved_supergraph_config, _) = resolver
-            .fully_resolve_subgraphs(
-                resolve_introspect_subgraph_factory,
-                fetch_remote_subgraph_factory,
-                &local_supergraph_config_path,
-            )
-            .await?;
-
-        // validate that the federation version is correct
-        assert_that!(fully_resolved_supergraph_config.federation_version())
-            .is_equal_to(&target_federation_version);
-
-        Ok(())
-    }
 
     /// Test showing that federation version is selected from the local supergraph config fed version
     /// over remote composition version, or version inferred from resolved SDLs
@@ -883,8 +616,10 @@ mod tests {
 
         let mut mock_read_stdin = MockReadStdin::new();
 
-        let local_supergraph_config =
-            SupergraphConfig::new(subgraphs, Some(local_supergraph_federation_version.clone()));
+        let local_supergraph_config = SupergraphConfigYaml {
+            subgraphs,
+            federation_version: Some(local_supergraph_federation_version.clone()),
+        };
         let local_supergraph_config_str = serde_yaml::to_string(&local_supergraph_config)?;
         let local_supergraph_config_dir = assert_fs::TempDir::new()?;
         let local_supergraph_config_path =
@@ -896,9 +631,6 @@ mod tests {
             &local_supergraph_config_str,
             &mut mock_read_stdin,
         )?;
-
-        // init resolver with no target fed version
-        let resolver = SupergraphConfigResolver::default();
 
         // determine whether to try to load from graph refs
         let graph_ref = remote_subgraph_scenario
@@ -927,9 +659,11 @@ mod tests {
                 });
 
         // load remote subgraphs
-        let resolver = resolver
-            .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
-            .await?;
+        let resolver = SupergraphConfigResolver::load_remote_subgraphs(
+            fetch_remote_subgraphs_factory,
+            graph_ref.as_ref(),
+        )
+        .await?;
 
         // load from the file descriptor
         let resolver = resolver
@@ -1114,7 +848,10 @@ mod tests {
 
         let mut mock_read_stdin = MockReadStdin::new();
 
-        let local_supergraph_config = SupergraphConfig::new(subgraphs, None);
+        let local_supergraph_config = SupergraphConfigYaml {
+            subgraphs,
+            federation_version: None,
+        };
         let local_supergraph_config_str = serde_yaml::to_string(&local_supergraph_config)?;
         let local_supergraph_config_dir = assert_fs::TempDir::new()?;
         let local_supergraph_config_path =
@@ -1132,9 +869,6 @@ mod tests {
         mock_introspect_subgraph
             .expect_introspect_subgraph()
             .times(0);
-
-        // init resolver with no target fed version
-        let resolver = SupergraphConfigResolver::default();
 
         // determine whether to try to load from graph refs
         let graph_ref = remote_subgraph_scenario
@@ -1163,9 +897,11 @@ mod tests {
                 });
 
         // load remote subgraphs
-        let resolver = resolver
-            .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
-            .await?;
+        let resolver = SupergraphConfigResolver::load_remote_subgraphs(
+            fetch_remote_subgraphs_factory,
+            graph_ref.as_ref(),
+        )
+        .await?;
 
         // load from the file descriptor
         let resolver = resolver
@@ -1398,13 +1134,15 @@ subgraphs:
                 });
 
         temp_env::async_with_vars(kvs, async {
-            let resolver = SupergraphConfigResolver::default()
-                .load_remote_subgraphs(fetch_remote_subgraphs_factory, None)
-                .await
-                .expect("Couldn't load remote subgraphs.")
-                .load_from_file_descriptor(&mut mock_stdin, Some(&file_descriptor_type))
-                .expect("Couldn't load local subgraphs.")
-                .skip_default_subgraph();
+            let resolver = SupergraphConfigResolver::load_remote_subgraphs(
+                fetch_remote_subgraphs_factory,
+                None,
+            )
+            .await
+            .expect("Couldn't load remote subgraphs.")
+            .load_from_file_descriptor(&mut mock_stdin, Some(&file_descriptor_type))
+            .expect("Couldn't load local subgraphs.")
+            .skip_default_subgraph();
 
             assert_that!(
                 resolver

--- a/src/composition/supergraph/config/resolver/state.rs
+++ b/src/composition/supergraph/config/resolver/state.rs
@@ -7,12 +7,6 @@ use crate::composition::supergraph::config::federation::{
     FederationVersionResolverFromSubgraphs, FederationVersionResolverFromSupergraphConfig,
 };
 
-/// In this stage, we await the caller to optionally load subgraphs from the Studio API using
-/// the contents of the `--graph-ref` flag
-pub struct LoadRemoteSubgraphs {
-    pub federation_version_resolver: FederationVersionResolverFromSupergraphConfig,
-}
-
 /// In this stage, we await the caller to optionally load subgraphs and a specified federation
 /// version from a local supergraph config file
 pub struct LoadSupergraphConfig {

--- a/src/composition/supergraph/config/unresolved/subgraph.rs
+++ b/src/composition/supergraph/config/unresolved/subgraph.rs
@@ -10,9 +10,9 @@ use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
 /// Represents a `SubgraphConfig` that needs to be resolved, either fully or lazily
 #[derive(Clone, Debug, Getters)]
 pub struct UnresolvedSubgraph {
-    name: String,
-    schema: SchemaSource,
-    routing_url: Option<String>,
+    pub(crate) name: String,
+    pub(crate) schema: SchemaSource,
+    pub(crate) routing_url: Option<String>,
 }
 
 impl UnresolvedSubgraph {
@@ -27,7 +27,7 @@ impl UnresolvedSubgraph {
 
     /// Produces a canonical filepath as the path relates to the supplied root path
     pub fn resolve_file_path(
-        &self,
+        name: &str,
         root: &Utf8PathBuf,
         path: &Utf8PathBuf,
     ) -> Result<Utf8PathBuf, ResolveSubgraphError> {
@@ -36,7 +36,7 @@ impl UnresolvedSubgraph {
         match canonical_filename {
             Ok(canonical_filename) => Ok(canonical_filename),
             Err(err) => Err(ResolveSubgraphError::FileNotFound {
-                subgraph_name: self.name.to_string(),
+                subgraph_name: name.to_string(),
                 supergraph_config_path: root.clone(),
                 path: path.clone(),
                 joined_path,

--- a/src/composition/supergraph/config/yaml.rs
+++ b/src/composition/supergraph/config/yaml.rs
@@ -1,0 +1,13 @@
+use apollo_federation_types::config::{FederationVersion, SubgraphConfig};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The YAML that a user will write to configure a supergraph.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SupergraphConfigYaml {
+    // Store config in a BTreeMap, as HashMap is non-deterministic.
+    pub(crate) subgraphs: BTreeMap<String, SubgraphConfig>,
+
+    // The version requirement for the supergraph binary.
+    pub(crate) federation_version: Option<FederationVersion>,
+}

--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use apollo_federation_types::config::{FederationVersion, SupergraphConfig};
+use apollo_federation_types::config::FederationVersion;
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
 use futures::stream::BoxStream;
@@ -14,6 +14,7 @@ use tracing::{error, info};
 use crate::composition::CompositionError::ResolvingSubgraphsError;
 use crate::composition::events::CompositionEvent;
 use crate::composition::supergraph::binary::SupergraphBinary;
+use crate::composition::supergraph::config::SupergraphConfigYaml;
 use crate::composition::supergraph::config::error::ResolveSubgraphError;
 use crate::composition::supergraph::config::full::FullyResolvedSupergraphConfig;
 use crate::composition::supergraph::config::resolver::ResolveSupergraphConfigError;
@@ -240,7 +241,7 @@ where
         supergraph_config: &FullyResolvedSupergraphConfig,
         target_file: &Utf8PathBuf,
     ) -> Result<(), CompositionError> {
-        let supergraph_config = SupergraphConfig::from(supergraph_config.clone());
+        let supergraph_config = SupergraphConfigYaml::from(supergraph_config.clone());
         let supergraph_config_yaml = serde_yaml::to_string(&supergraph_config);
 
         let supergraph_config_yaml = match supergraph_config_yaml {

--- a/src/composition/watchers/federation.rs
+++ b/src/composition/watchers/federation.rs
@@ -1,4 +1,3 @@
-use apollo_federation_types::config::FederationVersion::LatestFedTwo;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use tap::TapFallible;
@@ -38,7 +37,7 @@ impl SubtaskHandleStream for FederationWatcher {
                                 if let Some(fed_version) = diff.federation_version() {
                                     let _ = sender
                                         .send(CompositionInputEvent::Federation(
-                                            fed_version.clone().unwrap_or(LatestFedTwo),
+                                            fed_version.clone(),
                                         ))
                                         .tap_err(|err| error!("{:?}", err));
                                 }

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -17,7 +17,6 @@ use crate::composition::supergraph::config::full::FullyResolvedSubgraph;
 use crate::composition::supergraph::config::full::introspect::ResolveIntrospectSubgraphFactory;
 use crate::composition::supergraph::config::lazy::LazilyResolvedSubgraph;
 use crate::composition::supergraph::config::resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory;
-use crate::composition::supergraph::config::unresolved::UnresolvedSubgraph;
 use crate::composition::watchers::composition::CompositionInputEvent;
 use crate::composition::watchers::composition::CompositionInputEvent::Subgraph;
 use crate::composition::watchers::watcher::supergraph_config::SupergraphConfigSerialisationError;
@@ -291,10 +290,11 @@ impl SubgraphHandles {
         introspection_polling_interval: u64,
     ) -> Result<(), ResolveSubgraphError> {
         eprintln!("Adding subgraph to session: `{subgraph}`");
-        let unresolved_subgraph =
-            UnresolvedSubgraph::new(subgraph.to_string(), subgraph_config.clone());
-        let lazily_resolved_subgraph =
-            LazilyResolvedSubgraph::resolve(&self.supergraph_config_root, unresolved_subgraph)?;
+        let lazily_resolved_subgraph = LazilyResolvedSubgraph::resolve(
+            &self.supergraph_config_root,
+            subgraph.to_string(),
+            subgraph_config.clone(),
+        )?;
         let resolver = FullyResolvedSubgraph::resolver(
             self.resolve_introspect_subgraph_factory.clone(),
             self.fetch_remote_subgraph_factory.clone(),
@@ -333,11 +333,10 @@ impl SubgraphHandles {
         introspection_polling_interval: u64,
     ) -> Result<(), ResolveSubgraphError> {
         eprintln!("Change detected for subgraph: `{subgraph}`");
-        let unresolved_subgraph =
-            UnresolvedSubgraph::new(subgraph.to_string(), subgraph_config.clone());
         let lazily_resolved_subgraph = LazilyResolvedSubgraph::resolve(
             &self.supergraph_config_root.clone(),
-            unresolved_subgraph,
+            subgraph.to_string(),
+            subgraph_config.clone(),
         )?;
         let resolver = FullyResolvedSubgraph::resolver(
             self.resolve_introspect_subgraph_factory.clone(),


### PR DESCRIPTION
There are really two different `supergraph.yaml`s: 

1. The one that _only_ Rover knows about, which users author and use as a `--supergraph-config` or `--config` for various commands. There's no reason for this one to be in the `apollo-federation-types` crate, as its not actually shared. This is the one that I've moved in this PR.
2. The interface to the `supergraph` binary, which is also a YAML file, but much more restrictive.  This one _should_ be shared, but `apollo_federation_types::SupergraphConfig` doesn't properly represent it, so we use `FullyResolvedSupergraphConfig` as a proxy.

This sets us up to more easily make additional changes (also prototyped in the hackathon), like adding `graph_ref` to the file.

Also did some code simplification while trying to trace the usages of this file:
1. Remove some unused trait indirection to make jumping to/from usages easier during iteration
4. Collapse part of `SupergraphConfigResolver` since loading remote subgraphs won't be one-time anymore
5. Turn some `pub` into `pub(crate)` for better dead code detection as I change things
6. Remove some unnecessary cloning by getting rid of some buildstructors that were only creating simple structs

Those changes will be extra important when trying to watch for `graph_ref` changes.
