### PR TITLE
Add `rover connector` namespace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@ docs @apollographql/docs @apollographql/graph-tooling
 src/command/init @apollographql/team-growth @apollographql/graph-tooling
 src/command/tests @apollographql/team-growth @apollographql/graph-tooling
 src/options @apollographql/team-growth @apollographql/graph-tooling
+src/command/connector @apollographql/graph-dev
+src/command/lsp @apollographql/graph-dev

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -188,6 +188,7 @@ impl Rover {
             Command::Init(command) => command.run(self.get_client_config()?).await,
             Command::Cloud(command) => command.run(self.get_client_config()?).await,
             Command::Config(command) => command.run(self.get_client_config()?).await,
+            #[cfg(feature = "composition-js")]
             Command::Connector(command) => command.run().await,
             Command::Contract(command) => command.run(self.get_client_config()?).await,
             Command::Dev(command) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -188,6 +188,7 @@ impl Rover {
             Command::Init(command) => command.run(self.get_client_config()?).await,
             Command::Cloud(command) => command.run(self.get_client_config()?).await,
             Command::Config(command) => command.run(self.get_client_config()?).await,
+            Command::Connector(command) => command.run().await,
             Command::Contract(command) => command.run(self.get_client_config()?).await,
             Command::Dev(command) => {
                 command
@@ -369,6 +370,10 @@ pub enum Command {
 
     /// Cloud configuration commands
     Cloud(command::Cloud),
+
+    #[cfg(feature = "composition-js")]
+    #[clap(hide = true)]
+    Connector(command::Connector),
 
     /// Configuration profile commands
     Config(command::Config),

--- a/src/command/connector/mod.rs
+++ b/src/command/connector/mod.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+use serde::Serialize;
+
+use crate::RoverOutput::EmptySuccess;
+use crate::{RoverOutput, RoverResult};
+
+#[derive(Debug, Serialize, Parser)]
+pub struct Connector {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Parser, Clone, Serialize)]
+#[clap(about = "Work with Apollo Connectors")]
+pub enum Command {
+    /// Generate a new connector
+    Generate,
+    /// Run a single connector
+    Run,
+    /// Run tests for one or more connectors
+    Test,
+    /// List all available connectors
+    List,
+}
+
+impl Connector {
+    pub(crate) async fn run(&self) -> RoverResult<RoverOutput> {
+        use Command::*;
+        match self.command {
+            Generate => {
+                // TODO: Logic for generating a new connector
+                Ok(EmptySuccess)
+            }
+            Run => {
+                // TODO: Logic for running a single connector
+                Ok(EmptySuccess)
+            }
+            Test => {
+                // TODO: Logic for running tests for connectors
+                Ok(EmptySuccess)
+            }
+            List => {
+                // TODO: Logic for listing all available connectors
+                Ok(EmptySuccess)
+            }
+        }
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,5 +1,7 @@
 mod cloud;
 mod config;
+#[cfg(feature = "composition-js")]
+mod connector;
 mod contract;
 mod dev;
 mod docs;
@@ -21,6 +23,8 @@ mod update;
 
 pub use cloud::Cloud;
 pub use config::Config;
+#[cfg(feature = "composition-js")]
+pub use connector::Connector;
 pub use contract::Contract;
 pub use dev::Dev;
 pub use docs::Docs;


### PR DESCRIPTION
Some baseline setup for new Connectors commands coming soon. Just giving graph-dev a place to iterate.