### PR TITLE
deps: upgrade schemars and apollo-federation-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,25 +203,28 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e157139267c29db64d8620a2e896977cd8d3dd5a1521a80e0fe81419ec55dbfa"
+checksum = "6f1d337f07ef7b97a9c0a08e7fb29537aa263d8677f305584b35ce12636a7d7d"
 dependencies = [
  "apollo-compiler",
  "derive_more",
  "either",
+ "form_urlencoded",
  "hashbrown 0.15.4",
  "http 1.3.1",
  "indexmap 2.9.0",
  "itertools 0.14.0",
  "levenshtein",
  "line-col",
+ "mime",
  "multi_try",
  "multimap",
  "nom",
  "nom_locate",
+ "parking_lot",
  "percent-encoding",
- "petgraph",
+ "petgraph 0.8.2",
  "regex",
  "serde",
  "serde_json",
@@ -237,14 +240,14 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.15.4"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a9e0493ec9ecb11105cc2f9e70952750efb51ec84f1a06a84bc05fd29afc67"
+checksum = "e1e786f51433c6a2dc668647c883ebf6a09fb33e3f3b5e3e2908012dd953836a"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
  "log",
- "schemars 0.8.22",
+ "schemars 1.0.4",
  "semver",
  "serde",
  "serde_json",
@@ -2058,6 +2061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,7 +3334,7 @@ dependencies = [
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.6.5",
  "pico-args",
  "regex",
  "regex-syntax 0.8.5",
@@ -4352,7 +4361,18 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
+ "indexmap 2.9.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "serde",
  "serde_derive",
@@ -5053,7 +5073,7 @@ dependencies = [
  "rover-std",
  "rover-studio",
  "rstest",
- "schemars 0.8.22",
+ "schemars 1.0.4",
  "semver",
  "serde",
  "serde_json",
@@ -5425,19 +5445,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -5449,10 +5456,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars_derive"
-version = "0.8.22"
+name = "schemars"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = { version = "0.15.3", features = ["json_schema"] }
+apollo-federation-types = { version = "0.15.8", features = ["json_schema"] }
 
 apollo-language-server = { version = "0.4.1", default-features = false, features = ["tokio"] }
 
@@ -126,7 +126,7 @@ rand = "=0.9.1"
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
 rstest = "0.25.0"
-schemars = "0.8.22"
+schemars = "1.0.4"
 semver = "1"
 serial_test = "3"
 serde = "1.0"


### PR DESCRIPTION
Renovate is unable to update the `schemars` library in PR #2641 and #2673 because `apollo-federation-types` relies on an outdated version. This has now been upgraded in https://github.com/apollographql/federation-rs/pull/637. In this PR, I updated both and it seems working. 