### PR TITLE
Adds support for from-curl

### DIFF
--- a/src/command/connector/analyze.rs
+++ b/src/command/connector/analyze.rs
@@ -1,0 +1,222 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use camino::Utf8PathBuf;
+use clap::Parser;
+use http::{HeaderMap, HeaderName, HeaderValue};
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
+
+use crate::composition::supergraph::binary::SupergraphBinary;
+use crate::utils::effect::exec::TokioCommand;
+use crate::{RoverOutput, RoverResult};
+use reqwest::{Method, Url};
+use serde_json::Value;
+
+/// Failure modes of Loading Test data from a file or command line input
+#[derive(Debug, thiserror::Error)]
+pub enum ParsingError {
+    #[error("Invalid format: {0}")]
+    InvalidFormat(String),
+    #[error(transparent)]
+    InvalidUrl(#[from] url::ParseError),
+    #[error("Invalid method value: {0}")]
+    InvalidMethod(String),
+    #[error(transparent)]
+    JsonSerializeError(#[from] serde_json::error::Error),
+    #[error("Invalid header value: {0}")]
+    InvalidHeaderData(String),
+    #[error(transparent)]
+    InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
+    #[error(transparent)]
+    InvalidHeaderName(#[from] http::header::InvalidHeaderName),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error("Unexpected Content Type {0}")]
+    UnexpectedContentType(String),
+}
+
+#[derive(Debug, Parser, Serialize)]
+pub struct AnalyzeCurl {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Parser, Serialize)]
+pub enum Command {
+    /// Analyze a curl command
+    // Boxed to reduce enum size
+    Curl(Box<Curl>),
+    /// Remove current analysis snapshots
+    Clean(Clean),
+    /// Start an interactive analysis session
+    Interactive(Interactive),
+}
+
+/// Command to remove existing analysis files
+#[derive(Debug, Parser, Clone, Serialize)]
+pub struct Clean {}
+
+/// Start an interactive analysis session
+#[derive(Debug, Parser, Clone, Serialize)]
+pub struct Interactive {
+    /// The port to run the proxy server for the interactive session. Defaults to 9999.
+    #[clap(short, long, value_name = "PORT")]
+    port: Option<u16>,
+}
+
+#[derive(Debug, Parser, Serialize)]
+pub struct Curl {
+    /// Sets the endpoint to call
+    url: Url,
+
+    /// Headers to include in request
+    #[clap(short='H', long, value_name = "HEADERS", num_args = 1..)]
+    headers: Vec<HeaderData>,
+
+    /// Request method to use for call
+    #[clap(short = 'X', long, value_name = "REQUEST")]
+    #[serde(skip_serializing)]
+    method: Option<Method>,
+
+    /// Connection timeout in seconds
+    #[clap(short = 't', long, value_name = "CONNECT_TIMEOUT")]
+    timeout: Option<u64>,
+
+    /// Add JSON data to the request
+    #[clap(short, long, value_name = "DATA")]
+    #[arg(value_parser = parse_json)]
+    data: Option<Value>,
+
+    /// Set analysis directory to save data to
+    #[clap(short, long, value_name = "ANALYSIS_DIR")]
+    analysis_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct HeaderData {
+    pub(crate) name: HeaderName,
+    pub(crate) value: HeaderValue,
+}
+
+impl Serialize for HeaderData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("HeaderData", 2)?;
+        state.serialize_field("name", &self.name.to_string())?;
+        state.serialize_field("value", &self.value.to_str().unwrap_or_default())?;
+        state.end()
+    }
+}
+
+impl HeaderData {
+    #[allow(dead_code)]
+    pub(crate) fn from_header_map(headers: &HeaderMap) -> Vec<Self> {
+        headers
+            .iter()
+            .filter(|(name, _)| !IGNORED_HEADERS.contains(&name.as_str()))
+            .map(|(k, v)| HeaderData {
+                name: k.clone(),
+                value: v.clone(),
+            })
+            .collect()
+    }
+}
+
+impl FromStr for HeaderData {
+    type Err = ParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((key, value)) = s.split_once(':') {
+            let name = HeaderName::from_str(key)?;
+            let value = HeaderValue::from_str(value)?;
+            Ok(Self { name, value })
+        } else {
+            Err(ParsingError::InvalidHeaderData(s.to_string()))
+        }
+    }
+}
+
+fn parse_json(arg: &str) -> Result<Value, serde_json::Error> {
+    let data: String = arg.parse().unwrap_or_default();
+
+    serde_json::from_str(&data)
+}
+
+impl AnalyzeCurl {
+    pub async fn run(&self, supergraph_binary: SupergraphBinary) -> RoverResult<RoverOutput> {
+        let exec_command_impl = TokioCommand::default();
+        // self.output_dir.as_ref()
+        // .and_then(|path| camino::Utf8PathBuf::from_path_buf(path.to_path_buf()).ok())
+        let result = match &self.command {
+            Command::Curl(curl) =>
+            // supergraph_binary
+            //     .analyze_curl(
+            //         &exec_command_impl,
+            //         curl.analysis_dir,
+            //         curl.data,
+            //         curl.headers,
+            //         curl.method,
+            //         curl.timeout,
+            //         curl.url
+            //     )
+            //     .await?,
+            {
+                todo!()
+            }
+            Command::Clean(_) => supergraph_binary.analyze_clean(&exec_command_impl).await?,
+            Command::Interactive(interactive) => {
+                supergraph_binary
+                    .analyze_interactive(&exec_command_impl, interactive.port)
+                    .await?
+            }
+        };
+        Ok(result)
+    }
+}
+
+static IGNORED_HEADERS: &[&str] = &[
+    "content-length",
+    "content-range",
+    "trailer",
+    "transfer-encoding",
+    "content-type",
+    "content-encoding",
+    "content-location",
+    "content-language",
+    "accept-patch",
+    "accept-ranges",
+    "age",
+    "allow",
+    "alt-svc",
+    "cache-control",
+    "connection",
+    "date",
+    "delta-base",
+    "etag",
+    "expires",
+    "im",
+    "last-modified",
+    "host",
+    "location",
+    "link",
+    "pragma",
+    "proxy-authenticate",
+    "public-key-pins",
+    "retry-after",
+    "server",
+    "set-cookie",
+    "strict-transport-security",
+    "tk",
+    "upgrade",
+    "vary",
+    "via",
+    "warning",
+    "www-authenticate",
+    "proxy-connection",
+    "user-agent",
+    "accept",
+    "accept-encoding",
+];

--- a/src/command/connector/generate.rs
+++ b/src/command/connector/generate.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use serde::Serialize;
+
+use crate::composition::supergraph::binary::SupergraphBinary;
+use crate::utils::effect::exec::TokioCommand;
+use crate::{RoverOutput, RoverResult};
+
+#[derive(Debug, Parser, Clone, Serialize)]
+pub struct GenerateConnector {
+    /// Sets the name of the generate file (`<name>.graphql` will be generated file`).
+    ///
+    /// Defaults to `output`
+    #[clap(short, long, value_name = "NAME")]
+    name: Option<String>,
+
+    /// Set analysis directory to load data from.
+    ///
+    /// Defaults to `$(pwd)/analysis/`
+    #[clap(short, long, value_name = "ANALYSIS_DIR")]
+    analysis_dir: Option<PathBuf>,
+
+    /// Set a custom directory to generate output files to.
+    ///
+    /// Defaults to `build/connectors/`.
+    #[clap(long, value_name = "OUTPUT_DIR")]
+    output_dir: Option<PathBuf>,
+}
+
+impl GenerateConnector {
+    pub async fn run(&self, supergraph_binary: SupergraphBinary) -> RoverResult<RoverOutput> {
+        let exec_command_impl = TokioCommand::default();
+        let result = supergraph_binary
+            .generate_connector(
+                &exec_command_impl,
+                self.name.clone(),
+                self.analysis_dir
+                    .as_ref()
+                    .and_then(|path| camino::Utf8PathBuf::from_path_buf(path.to_path_buf()).ok()),
+                self.output_dir
+                    .as_ref()
+                    .and_then(|path| camino::Utf8PathBuf::from_path_buf(path.to_path_buf()).ok()),
+            )
+            .await?;
+        Ok(result)
+    }
+}

--- a/src/command/connector/generate.rs
+++ b/src/command/connector/generate.rs
@@ -26,6 +26,16 @@ pub struct GenerateConnector {
     /// Defaults to `build/connectors/`.
     #[clap(long, value_name = "OUTPUT_DIR")]
     output_dir: Option<PathBuf>,
+
+    // TODO: Remove after logging config has been integrated
+    /// Hides test progression. Defaults to 'false'
+    #[arg(long = "quiet", short = 'q', default_value = "false")]
+    pub quiet: bool,
+
+    // TODO: Remove after logging config has been integrated
+    /// Enable verbose logging. Defaults to 'false'.
+    #[arg(long = "verbose", short = 'v')]
+    pub verbose: bool,
 }
 
 impl GenerateConnector {
@@ -41,6 +51,8 @@ impl GenerateConnector {
                 self.output_dir
                     .as_ref()
                     .and_then(|path| camino::Utf8PathBuf::from_path_buf(path.to_path_buf()).ok()),
+                self.verbose,
+                self.quiet,
             )
             .await?;
         Ok(result)

--- a/src/command/connector/list.rs
+++ b/src/command/connector/list.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use serde::Serialize;
+
+use crate::composition::supergraph::binary::SupergraphBinary;
+use crate::utils::effect::exec::TokioCommand;
+use crate::{RoverOutput, RoverResult};
+
+#[derive(Debug, Parser, Clone, Serialize)]
+pub struct ListConnector {
+    #[arg(long, value_name = "SCHEMA_PATH")]
+    schema_path: PathBuf,
+}
+
+impl ListConnector {
+    pub async fn run(&self, supergraph_binary: SupergraphBinary) -> RoverResult<RoverOutput> {
+        let exec_command_impl = TokioCommand::default();
+        let result = supergraph_binary
+            .list_connector(
+                &exec_command_impl,
+                camino::Utf8PathBuf::from_path_buf(self.schema_path.to_path_buf())
+                    .unwrap_or_default(),
+            )
+            .await?;
+        Ok(result)
+    }
+}

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -258,6 +258,194 @@ impl SupergraphBinary {
 
         Ok(RoverOutput::ConnectorTestResponse { output })
     }
+
+    pub async fn generate_connector(
+        &self,
+        exec_impl: &impl ExecCommand,
+        name: Option<String>,
+        analysis_dir: Option<Utf8PathBuf>,
+        output_dir: Option<Utf8PathBuf>,
+    ) -> Result<RoverOutput, TestConnectorError> {
+        let mut args = vec!["generate-connector-schema".to_string()];
+
+        if let Some(name) = name {
+            args.push("--name".to_string());
+            args.push(name);
+        }
+
+        if let Some(analysis_dir) = analysis_dir {
+            args.push("--analysis-dir".to_string());
+            args.push(analysis_dir.into_string());
+        }
+
+        if let Some(output_dir) = output_dir {
+            args.push("--output-dir".to_string());
+            args.push(output_dir.into_string());
+        }
+
+        let config = ExecCommandConfig::builder()
+            .exe(self.exe.clone())
+            .args(args)
+            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .build();
+
+        let output = exec_impl
+            .exec_command(config)
+            .await
+            .tap_err(|err| tracing::error!("{:?}", err))
+            .map_err(|err| TestConnectorError::Binary {
+                error: format!("{err:?}"),
+            })?;
+
+        let exit_code = output.status.code();
+        if exit_code != Some(0) && exit_code != Some(1) {
+            return Err(TestConnectorError::BinaryExit {
+                exit_code,
+                stdout: String::from_utf8(output.stdout).unwrap(),
+                stderr: String::from_utf8(output.stderr).unwrap(),
+            });
+        }
+
+        let output = std::str::from_utf8(&output.stdout)
+            .map_err(|err| TestConnectorError::InvalidOutput {
+                binary: self.exe.clone(),
+                error: format!("{err:?}"),
+            })?
+            .to_string();
+
+        Ok(RoverOutput::ConnectorTestResponse { output })
+    }
+
+    pub async fn list_connector(
+        &self,
+        exec_impl: &impl ExecCommand,
+        schema_path: Utf8PathBuf,
+    ) -> Result<RoverOutput, TestConnectorError> {
+        let mut args = vec!["list-connectors".to_string()];
+
+        args.push("--path".to_string());
+        args.push(schema_path.into_string());
+
+        let config = ExecCommandConfig::builder()
+            .exe(self.exe.clone())
+            .args(args)
+            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .build();
+
+        let output = exec_impl
+            .exec_command(config)
+            .await
+            .tap_err(|err| tracing::error!("{:?}", err))
+            .map_err(|err| TestConnectorError::Binary {
+                error: format!("{err:?}"),
+            })?;
+
+        let exit_code = output.status.code();
+        if exit_code != Some(0) && exit_code != Some(1) {
+            return Err(TestConnectorError::BinaryExit {
+                exit_code,
+                stdout: String::from_utf8(output.stdout).unwrap(),
+                stderr: String::from_utf8(output.stderr).unwrap(),
+            });
+        }
+
+        let output = std::str::from_utf8(&output.stdout)
+            .map_err(|err| TestConnectorError::InvalidOutput {
+                binary: self.exe.clone(),
+                error: format!("{err:?}"),
+            })?
+            .to_string();
+
+        Ok(RoverOutput::ConnectorTestResponse { output })
+    }
+
+    pub async fn analyze_clean(
+        &self,
+        exec_impl: &impl ExecCommand,
+    ) -> Result<RoverOutput, TestConnectorError> {
+        let mut args = vec!["analyze-for-connector".to_string()];
+
+        args.push("clean".to_string());
+
+        let config = ExecCommandConfig::builder()
+            .exe(self.exe.clone())
+            .args(args)
+            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .build();
+
+        let output = exec_impl
+            .exec_command(config)
+            .await
+            .tap_err(|err| tracing::error!("{:?}", err))
+            .map_err(|err| TestConnectorError::Binary {
+                error: format!("{err:?}"),
+            })?;
+
+        let exit_code = output.status.code();
+        if exit_code != Some(0) && exit_code != Some(1) {
+            return Err(TestConnectorError::BinaryExit {
+                exit_code,
+                stdout: String::from_utf8(output.stdout).unwrap(),
+                stderr: String::from_utf8(output.stderr).unwrap(),
+            });
+        }
+
+        let output = std::str::from_utf8(&output.stdout)
+            .map_err(|err| TestConnectorError::InvalidOutput {
+                binary: self.exe.clone(),
+                error: format!("{err:?}"),
+            })?
+            .to_string();
+
+        Ok(RoverOutput::ConnectorTestResponse { output })
+    }
+
+    pub async fn analyze_interactive(
+        &self,
+        exec_impl: &impl ExecCommand,
+        port: Option<u16>,
+    ) -> Result<RoverOutput, TestConnectorError> {
+        let mut args = vec!["analyze-for-connector".to_string()];
+
+        args.push("interactive".to_string());
+
+        if let Some(port) = port {
+            args.push("--port".to_string());
+            args.push(port.to_string());
+        }
+
+        let config = ExecCommandConfig::builder()
+            .exe(self.exe.clone())
+            .args(args)
+            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .build();
+
+        let output = exec_impl
+            .exec_command(config)
+            .await
+            .tap_err(|err| tracing::error!("{:?}", err))
+            .map_err(|err| TestConnectorError::Binary {
+                error: format!("{err:?}"),
+            })?;
+
+        let exit_code = output.status.code();
+        if exit_code != Some(0) && exit_code != Some(1) {
+            return Err(TestConnectorError::BinaryExit {
+                exit_code,
+                stdout: String::from_utf8(output.stdout).unwrap(),
+                stderr: String::from_utf8(output.stderr).unwrap(),
+            });
+        }
+
+        let output = std::str::from_utf8(&output.stdout)
+            .map_err(|err| TestConnectorError::InvalidOutput {
+                binary: self.exe.clone(),
+                error: format!("{err:?}"),
+            })?
+            .to_string();
+
+        Ok(RoverOutput::ConnectorTestResponse { output })
+    }
 }
 
 #[cfg(test)]

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -7,6 +7,8 @@ use apollo_federation_types::{
 };
 use buildstructor::Builder;
 use camino::Utf8PathBuf;
+use http::Method;
+use serde_json::Value;
 use tap::TapFallible;
 
 use super::version::SupergraphVersion;
@@ -265,6 +267,8 @@ impl SupergraphBinary {
         name: Option<String>,
         analysis_dir: Option<Utf8PathBuf>,
         output_dir: Option<Utf8PathBuf>,
+        verbose: bool,
+        quiet: bool,
     ) -> Result<RoverOutput, TestConnectorError> {
         let mut args = vec!["generate-connector-schema".to_string()];
 
@@ -281,6 +285,14 @@ impl SupergraphBinary {
         if let Some(output_dir) = output_dir {
             args.push("--output-dir".to_string());
             args.push(output_dir.into_string());
+        }
+
+        if verbose {
+            args.push("--verbose".to_string());
+        }
+
+        if quiet {
+            args.push("--quiet".to_string());
         }
 
         let config = ExecCommandConfig::builder()
@@ -412,6 +424,98 @@ impl SupergraphBinary {
         if let Some(port) = port {
             args.push("--port".to_string());
             args.push(port.to_string());
+        }
+
+        let config = ExecCommandConfig::builder()
+            .exe(self.exe.clone())
+            .args(args)
+            .output(
+                ExecCommandOutput::builder()
+                    .stdin(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
+            .should_spawn(true)
+            .build();
+
+        let output = exec_impl
+            .exec_command(config)
+            .await
+            .tap_err(|err| tracing::error!("{:?}", err))
+            .map_err(|err| TestConnectorError::Binary {
+                error: format!("{err:?}"),
+            })?;
+
+        let exit_code = output.status.code();
+        if exit_code != Some(0) && exit_code != Some(1) {
+            return Err(TestConnectorError::BinaryExit {
+                exit_code,
+                stdout: String::from_utf8(output.stdout).unwrap(),
+                stderr: String::from_utf8(output.stderr).unwrap(),
+            });
+        }
+
+        let output = std::str::from_utf8(&output.stdout)
+            .map_err(|err| TestConnectorError::InvalidOutput {
+                binary: self.exe.clone(),
+                error: format!("{err:?}"),
+            })?
+            .to_string();
+
+        Ok(RoverOutput::ConnectorTestResponse { output })
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    pub async fn analyze_curl(
+        &self,
+        exec_impl: &impl ExecCommand,
+        url: &url::Url,
+        headers: &[crate::command::connector::analyze::HeaderData],
+        method: Option<&Method>,
+        timeout: Option<&u64>,
+        data: Option<&Value>,
+        analysis_dir: Option<Utf8PathBuf>,
+        quiet: bool,
+        verbose: bool,
+    ) -> Result<RoverOutput, TestConnectorError> {
+        let mut args = vec!["analyze-for-connector".to_string()];
+
+        args.push("curl".to_string());
+
+        args.push(url.to_string());
+
+        for header in headers {
+            args.push("-H".to_string());
+            args.push(header.to_string());
+        }
+
+        if let Some(method) = method {
+            args.push("-X".to_string());
+            args.push(method.to_string());
+        }
+
+        if let Some(timeout) = timeout {
+            args.push("--timeout".to_string());
+            args.push(timeout.to_string());
+        }
+
+        if let Some(data) = data {
+            args.push("--data".to_string());
+            args.push(serde_json::to_string(data).unwrap_or_default());
+        }
+
+        if let Some(analysis_dir) = analysis_dir {
+            args.push("--analysis-dir".to_string());
+            args.push(analysis_dir.into_string());
+        }
+
+        if verbose {
+            args.push("--verbose".to_string());
+        }
+
+        if quiet {
+            args.push("--quiet".to_string());
         }
 
         let config = ExecCommandConfig::builder()

--- a/src/utils/effect/exec.rs
+++ b/src/utils/effect/exec.rs
@@ -18,6 +18,7 @@ pub struct ExecCommandConfig {
     args: Option<Vec<String>>,
     env: Option<HashMap<String, String>>,
     output: Option<ExecCommandOutput>,
+    should_spawn: Option<bool>,
 }
 
 #[derive(Builder, Default, Debug)]
@@ -46,9 +47,15 @@ pub struct TokioCommand {}
 impl ExecCommand for TokioCommand {
     type Error = std::io::Error;
     async fn exec_command<'a>(&self, config: ExecCommandConfig) -> Result<Output, Self::Error> {
+        let should_spawn = config.should_spawn.is_some_and(|can_spawn| can_spawn);
         let mut command = Command::new(config.exe.clone());
         let command = build_command(&mut command, config);
-        command.output().await
+
+        if should_spawn {
+            command.spawn().unwrap().wait_with_output().await
+        } else {
+            command.output().await
+        }
     }
 }
 


### PR DESCRIPTION
- `connectors analyze clean`: cleans analysis dir
- `connectors analyze interactive`: opens interactive child sh to make curl requests then analyzes them
- `connectors analyze curl`:  analyzes a single curl request
- `connectors list`: list all available connectors in a schema. Relevant for testing with correct names