### PR TITLE
Support supergraph.yaml in `connector` commands

### DIFF
--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -1,4 +1,4 @@
-use std::{fs, io::stdin};
+use std::fs;
 
 use apollo_federation_types::config::FederationVersion;
 use camino::Utf8PathBuf;
@@ -6,8 +6,8 @@ use clap::{Args, Parser};
 use derive_getters::Getters;
 use rover_client::shared::GraphRef;
 use serde::Serialize;
-use tower::ServiceExt;
 
+use crate::composition::get_supergraph_binary;
 use crate::options::PluginOpts;
 use crate::utils::client::StudioClientConfig;
 use crate::utils::effect::exec::TokioCommand;
@@ -62,64 +62,18 @@ impl Compose {
         client_config: StudioClientConfig,
         output_file: Option<Utf8PathBuf>,
     ) -> RoverResult<RoverOutput> {
-        use crate::composition::{
-            pipeline::CompositionPipeline,
-            supergraph::config::{
-                full::introspect::MakeResolveIntrospectSubgraph,
-                resolver::{
-                    fetch_remote_subgraph::MakeFetchRemoteSubgraph,
-                    fetch_remote_subgraphs::MakeFetchRemoteSubgraphs,
-                },
-            },
-        };
-
         let write_file_impl = FsWriteFile::default();
         let exec_command_impl = TokioCommand::default();
-        let supergraph_yaml = self
-            .opts
-            .clone()
-            .supergraph_config_source()
-            .clone()
-            .supergraph_yaml;
 
-        let profile = self.opts.plugin_opts.profile.clone();
-        let graph_ref = self.opts.supergraph_config_source.graph_ref.clone();
-
-        let fetch_remote_subgraphs_factory = MakeFetchRemoteSubgraphs::builder()
-            .studio_client_config(client_config.clone())
-            .profile(profile.clone())
-            .build();
-
-        let fetch_remote_subgraph_factory = MakeFetchRemoteSubgraph::builder()
-            .studio_client_config(client_config.clone())
-            .profile(profile.clone())
-            .build()
-            .boxed_clone();
-        let resolve_introspect_subgraph_factory =
-            MakeResolveIntrospectSubgraph::new(client_config.service()?).boxed_clone();
-
-        let composition_pipeline = CompositionPipeline::default()
-            .init(
-                &mut stdin(),
-                fetch_remote_subgraphs_factory,
-                supergraph_yaml,
-                graph_ref.clone(),
-                None,
-            )
-            .await?
-            .resolve_federation_version(
-                resolve_introspect_subgraph_factory,
-                fetch_remote_subgraph_factory,
-                self.opts.federation_version.clone(),
-            )
-            .await
-            .install_supergraph_binary(
-                client_config.clone(),
-                override_install_path.clone(),
-                self.opts.plugin_opts.elv2_license_accepter,
-                self.opts.plugin_opts.skip_update,
-            )
-            .await?;
+        let composition_pipeline = get_supergraph_binary(
+            self.opts.federation_version.clone(),
+            client_config,
+            override_install_path,
+            self.opts.plugin_opts.clone(),
+            self.opts.supergraph_config_source.supergraph_yaml().clone(),
+            self.opts.supergraph_config_source.graph_ref().clone(),
+        )
+        .await?;
         let composition_success = composition_pipeline
             .compose(&exec_command_impl, &write_file_impl)
             .await?;

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -113,7 +113,6 @@ impl CompositionPipeline<state::Init> {
                 )
                 .unwrap()
             });
-        eprintln!("merging supergraph schema files");
         let resolver = SupergraphConfigResolver::default()
             .load_remote_subgraphs(fetch_remote_subgraphs_factory, graph_ref.as_ref())
             .await?
@@ -124,7 +123,6 @@ impl CompositionPipeline<state::Init> {
                 .map_err(CompositionPipelineError::ResolveSubgraphFromPrompt)?,
             None => resolver.skip_default_subgraph(),
         };
-        eprintln!("supergraph config loaded successfully");
         Ok(CompositionPipeline {
             state: state::ResolveFederationVersion {
                 resolver,
@@ -365,7 +363,7 @@ impl CompositionPipeline<state::Run> {
     }
 }
 
-mod state {
+pub(crate) mod state {
     use apollo_federation_types::config::FederationVersion;
     use camino::Utf8PathBuf;
 

--- a/src/composition/supergraph/version.rs
+++ b/src/composition/supergraph/version.rs
@@ -139,6 +139,18 @@ impl TryFrom<FederationVersion> for SupergraphVersion {
     }
 }
 
+impl PartialEq<Version> for SupergraphVersion {
+    fn eq(&self, other: &Version) -> bool {
+        self.version == *other
+    }
+}
+
+impl PartialOrd<Version> for SupergraphVersion {
+    fn partial_cmp(&self, other: &Version) -> Option<std::cmp::Ordering> {
+        self.version.partial_cmp(other)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;


### PR DESCRIPTION
1. Extracts the federation version resolution & supergraph installation logic from `do_compose` into a shared function
2. Use that shared function in `connector` commands instead of the custom `install_supergraph_binary`
3. Support `supergraph.yaml` and `graph-ref` as sources for federation version
4. Default to a local path called `supergraph.yaml` with no options for `connector` commands (this is what IDE extensions do)
5. Enforce a minimum version `supergraph` for `connector` commands (rather than erroring with a cryptic message)
6. Remove some `eprintln!` that won't mean much to users

In the future we probably want to refactor this further to simplify the supergraph-binary-getting code and decouple it from composition-specific things. But this at least _starts_ sharing all that logic.

Depends on #2703 