### PR TITLE
Fixes stderr and spawn child process issue

### DIFF
--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -46,7 +46,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl
@@ -146,7 +151,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl
@@ -231,7 +241,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl
@@ -298,7 +313,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl
@@ -341,7 +361,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl
@@ -382,7 +407,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl
@@ -436,7 +466,6 @@ impl SupergraphBinary {
                     .stdout(Stdio::inherit())
                     .build(),
             )
-            .should_spawn(true)
             .build();
 
         let output = exec_impl
@@ -521,7 +550,12 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
+            .output(
+                ExecCommandOutput::builder()
+                    .stderr(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .build(),
+            )
             .build();
 
         let output = exec_impl

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -46,11 +46,7 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(
-                ExecCommandOutput::builder()
-                    .stdout(Stdio::piped())
-                    .build(),
-            )
+            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
             .build();
 
         let output = exec_impl
@@ -150,9 +146,7 @@ impl SupergraphBinary {
         let config = ExecCommandConfig::builder()
             .exe(self.exe.clone())
             .args(args)
-            .output(
-                ExecCommandOutput::builder().stdout(Stdio::piped()).build()
-            )
+            .output(ExecCommandOutput::builder().stdout(Stdio::piped()).build())
             .build();
 
         let output = exec_impl

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -48,8 +48,7 @@ impl SupergraphBinary {
             .args(args)
             .output(
                 ExecCommandOutput::builder()
-                    .stderr(Stdio::inherit())
-                    .stdout(Stdio::inherit())
+                    .stdout(Stdio::piped())
                     .build(),
             )
             .build();
@@ -152,10 +151,7 @@ impl SupergraphBinary {
             .exe(self.exe.clone())
             .args(args)
             .output(
-                ExecCommandOutput::builder()
-                    .stderr(Stdio::inherit())
-                    .stdout(Stdio::inherit())
-                    .build(),
+                ExecCommandOutput::builder().stdout(Stdio::piped()).build()
             )
             .build();
 
@@ -247,6 +243,7 @@ impl SupergraphBinary {
                     .stdout(Stdio::inherit())
                     .build(),
             )
+            .should_spawn(true)
             .build();
 
         let output = exec_impl
@@ -363,8 +360,8 @@ impl SupergraphBinary {
             .args(args)
             .output(
                 ExecCommandOutput::builder()
-                    .stderr(Stdio::inherit())
-                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
                     .build(),
             )
             .build();
@@ -409,8 +406,8 @@ impl SupergraphBinary {
             .args(args)
             .output(
                 ExecCommandOutput::builder()
-                    .stderr(Stdio::inherit())
-                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
                     .build(),
             )
             .build();
@@ -466,6 +463,7 @@ impl SupergraphBinary {
                     .stdout(Stdio::inherit())
                     .build(),
             )
+            .should_spawn(true)
             .build();
 
         let output = exec_impl
@@ -552,8 +550,8 @@ impl SupergraphBinary {
             .args(args)
             .output(
                 ExecCommandOutput::builder()
-                    .stderr(Stdio::inherit())
-                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
                     .build(),
             )
             .build();

--- a/src/utils/effect/exec.rs
+++ b/src/utils/effect/exec.rs
@@ -18,7 +18,6 @@ pub struct ExecCommandConfig {
     args: Option<Vec<String>>,
     env: Option<HashMap<String, String>>,
     output: Option<ExecCommandOutput>,
-    should_spawn: Option<bool>,
 }
 
 #[derive(Builder, Default, Debug)]
@@ -47,15 +46,10 @@ pub struct TokioCommand {}
 impl ExecCommand for TokioCommand {
     type Error = std::io::Error;
     async fn exec_command<'a>(&self, config: ExecCommandConfig) -> Result<Output, Self::Error> {
-        let should_spawn = config.should_spawn.is_some_and(|can_spawn| can_spawn);
         let mut command = Command::new(config.exe.clone());
         let command = build_command(&mut command, config);
 
-        if should_spawn {
-            command.spawn().unwrap().wait_with_output().await
-        } else {
-            command.output().await
-        }
+        command.spawn().unwrap().wait_with_output().await
     }
 }
 

--- a/src/utils/effect/exec.rs
+++ b/src/utils/effect/exec.rs
@@ -18,6 +18,7 @@ pub struct ExecCommandConfig {
     args: Option<Vec<String>>,
     env: Option<HashMap<String, String>>,
     output: Option<ExecCommandOutput>,
+    should_spawn: Option<bool>,
 }
 
 #[derive(Builder, Default, Debug)]
@@ -46,10 +47,14 @@ pub struct TokioCommand {}
 impl ExecCommand for TokioCommand {
     type Error = std::io::Error;
     async fn exec_command<'a>(&self, config: ExecCommandConfig) -> Result<Output, Self::Error> {
+        let should_spawn = config.should_spawn.is_some_and(|can_spawn| can_spawn);
         let mut command = Command::new(config.exe.clone());
         let command = build_command(&mut command, config);
-
-        command.spawn().unwrap().wait_with_output().await
+        if should_spawn {
+            command.spawn().unwrap().wait_with_output().await
+        } else {
+            command.output().await
+        }
     }
 }
 


### PR DESCRIPTION
supergraph binary connectors' library now required stderr due to that we need to spawn and wait for output
