### PR TITLE
Improve `connector` commands `--schema` param.

### DIFF
--- a/src/command/connector/list.rs
+++ b/src/command/connector/list.rs
@@ -12,7 +12,7 @@ pub struct ListConnector {
     /// The path to the schema file containing the connector.
     ///
     /// Optional if there is a `supergraph.yaml` containing only a single subgraph
-    #[arg(long = "schema")]
+    #[arg(long = "schema", value_name = "SCHEMA_FILE_PATH")]
     schema_path: Option<PathBuf>,
 }
 

--- a/src/command/connector/list.rs
+++ b/src/command/connector/list.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-
+use anyhow::anyhow;
 use clap::Parser;
 use serde::Serialize;
+use std::path::PathBuf;
 
 use crate::composition::supergraph::binary::SupergraphBinary;
 use crate::utils::effect::exec::TokioCommand;
@@ -9,18 +9,27 @@ use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Parser, Clone, Serialize)]
 pub struct ListConnector {
-    #[arg(long, value_name = "SCHEMA_PATH")]
-    schema_path: PathBuf,
+    /// The path to the schema file containing the connector.
+    ///
+    /// Optional if there is a `supergraph.yaml` containing only a single subgraph
+    #[arg(long = "schema")]
+    schema_path: Option<PathBuf>,
 }
 
 impl ListConnector {
-    pub async fn run(&self, supergraph_binary: SupergraphBinary) -> RoverResult<RoverOutput> {
+    pub async fn run(
+        &self,
+        supergraph_binary: SupergraphBinary,
+        default_subgraph: Option<PathBuf>,
+    ) -> RoverResult<RoverOutput> {
         let exec_command_impl = TokioCommand::default();
+        let schema_path = self.schema_path.clone().or(default_subgraph).ok_or_else(|| anyhow!(
+            "A schema path must be provided either via --schema or a `supergraph.yaml` containing a single subgraph"
+        ))?;
         let result = supergraph_binary
             .list_connector(
                 &exec_command_impl,
-                camino::Utf8PathBuf::from_path_buf(self.schema_path.to_path_buf())
-                    .unwrap_or_default(),
+                camino::Utf8PathBuf::from_path_buf(schema_path).unwrap_or_default(),
             )
             .await?;
         Ok(result)

--- a/src/command/connector/run.rs
+++ b/src/command/connector/run.rs
@@ -17,7 +17,7 @@ pub struct RunConnector {
     /// The path to the schema file containing the connector.
     ///
     /// Optional if there is a `supergraph.yaml` containing only a single subgraph
-    #[arg(long = "schema")]
+    #[arg(long = "schema", value_name = "SCHEMA_FILE_PATH")]
     schema_path: Option<PathBuf>,
     /// The ID of the connector to run, which can be:
     ///

--- a/src/command/connector/run.rs
+++ b/src/command/connector/run.rs
@@ -1,11 +1,11 @@
-use std::fmt::Write;
-use std::path::PathBuf;
-
+use anyhow::anyhow;
 use clap::Parser;
 use rover_std::Style;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
+use std::fmt::Write;
+use std::path::PathBuf;
 
 use crate::composition::supergraph::binary::SupergraphBinary;
 use crate::utils::effect::exec::TokioCommand;
@@ -14,10 +14,22 @@ use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Parser, Clone, Serialize)]
 pub struct RunConnector {
-    #[arg(short = 'p', long = "path")]
-    schema_path: PathBuf,
+    /// The path to the schema file containing the connector.
+    ///
+    /// Optional if there is a `supergraph.yaml` containing only a single subgraph
+    #[arg(long = "schema")]
+    schema_path: Option<PathBuf>,
+    /// The ID of the connector to run, which can be:
+    ///
+    /// 1. The name of a type, like `MyType`, if the connector is on the type
+    /// 2. A type & field, like `Query.myField`, if the connector is on a field
+    /// 3. One of the above with an [index], like `Query.myField[1]`, if there are multiple connectors on the same element
+    ///
+    /// Use `rover connector list` to see available connectors and their IDs.
     #[arg(short = 'c', long = "connector-id")]
     connector_id: String,
+    /// JSON data containing the variables required by the connector.
+    /// For example: `'{"$args": {"id": "123"}}'`
     #[arg(short = 'v', long = "variables")]
     variables: String,
 }
@@ -56,12 +68,19 @@ struct Problem {
 }
 
 impl RunConnector {
-    pub async fn run(&self, supergraph_binary: SupergraphBinary) -> RoverResult<RoverOutput> {
+    pub async fn run(
+        &self,
+        supergraph_binary: SupergraphBinary,
+        default_subgraph: Option<PathBuf>,
+    ) -> RoverResult<RoverOutput> {
         let exec_command_impl = TokioCommand::default();
+        let schema_path = self.schema_path.clone().or(default_subgraph).ok_or_else(|| anyhow!(
+            "A schema path must be provided either via --schema or a `supergraph.yaml` containing a single subgraph"
+        ))?;
         let result = supergraph_binary
             .run_connector(
                 &exec_command_impl,
-                self.schema_path.clone(),
+                schema_path,
                 self.connector_id.clone(),
                 self.variables.clone(),
             )

--- a/src/command/connector/test.rs
+++ b/src/command/connector/test.rs
@@ -27,7 +27,7 @@ pub struct TestConnector {
     ///
     /// If there is a `supergraph.yaml` containing a single subgraph, that subgraph's schema will
     /// be used by default.
-    #[arg(long = "schema")]
+    #[arg(long = "schema", value_name = "SCHEMA_FILE_PATH")]
     schema: Option<PathBuf>,
 
     /// JUnit XML Report output location

--- a/src/composition/supergraph/binary.rs
+++ b/src/composition/supergraph/binary.rs
@@ -166,7 +166,7 @@ impl SupergraphBinary {
         file: Option<PathBuf>,
         directory: Option<PathBuf>,
         no_fail: bool,
-        schema_file: Option<String>,
+        schema_file: Option<PathBuf>,
         output_file: Option<Utf8PathBuf>,
         verbose: bool,
         quiet: bool,
@@ -202,7 +202,7 @@ impl SupergraphBinary {
 
         if let Some(schema_file) = schema_file {
             args.push("--schema-file".to_string());
-            args.push(schema_file);
+            args.push(schema_file.to_str().unwrap_or_default().to_string());
         }
 
         let config = ExecCommandConfig::builder()


### PR DESCRIPTION
Unify `--schema` param for `connector` commands and default it to single-subgraph `supergraph.yaml`

<!-- [CNN-1004] -->


[CNN-1004]: https://apollographql.atlassian.net/browse/CNN-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ