### PR TITLE
feat(init): Remove credentials from rover init instructions when running `rover dev`

### DIFF
--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -73,12 +73,8 @@ Once you've completed the wizard, it provides a [`rover dev`](./dev) command wit
         <Tab label="Linux / MacOS">
 
         ```terminal showLineNumbers=false
-        APOLLO_KEY=<key> \
-        APOLLO_GRAPH_REF=<graph-ref> \
         rover dev --supergraph-config supergraph.yaml
         ```
-
-        (If you set `APOLLO_KEY` as an environment variable, you don't need to include it in your command.)
 
         </Tab>
         <Tab label="Windows">
@@ -86,13 +82,13 @@ Once you've completed the wizard, it provides a [`rover dev`](./dev) command wit
         ##### Powershell
 
         ```terminal showLineNumbers=false
-        $env:APOLLO_KEY = "<key>"; $env:APOLLO_GRAPH_REF = "<graph-ref>"; rover dev --supergraph-config supergraph.yaml
+        rover dev --supergraph-config supergraph.yaml
         ```
 
         ##### Command Prompt
 
         ```terminal showLineNumbers=false
-        set APOLLO_KEY=<key> && set APOLLO_GRAPH_REF=<graph-ref> && rover dev --supergraph-config supergraph.yaml
+        rover dev --supergraph-config supergraph.yaml
         ```
 
         </Tab>

--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -18,47 +18,12 @@ pub fn display_welcome_message() {
     println!();
 }
 
-pub(crate) fn get_command(api_key: &str, graph_ref: &str, supergraph_config: bool) -> String {
-    #[cfg(target_os = "windows")]
-    {
-        let mut output = String::new();
-
-        // PowerShell command
-        output.push_str("PowerShell:\n");
-        output.push_str(&format!(
-            "$env:APOLLO_KEY = \"{}\"; $env:APOLLO_GRAPH_REF = \"{}\"; rover dev",
-            api_key, graph_ref
-        ));
-        if supergraph_config {
-            output.push_str(" --supergraph-config supergraph.yaml");
-        }
-
-        output.push_str("\n\n");
-
-        // CMD
-        output.push_str("Command Prompt:\n");
-        output.push_str(&format!(
-            "set APOLLO_KEY={} && set APOLLO_GRAPH_REF={} && rover dev",
-            api_key, graph_ref
-        ));
-        if supergraph_config {
-            output.push_str(" --supergraph-config supergraph.yaml");
-        }
-
-        output
+pub(crate) fn get_command(supergraph_config: bool) -> String {
+    let mut output = String::from("rover dev");
+    if supergraph_config {
+        output.push_str(" --supergraph-config supergraph.yaml");
     }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        let mut output = String::new();
-        output.push_str(&format!(
-            "APOLLO_KEY={api_key} APOLLO_GRAPH_REF={graph_ref} rover dev"
-        ));
-        if supergraph_config {
-            output.push_str(" --supergraph-config supergraph.yaml");
-        }
-        output
-    }
+    output
 }
 
 pub fn generate_project_created_message(
@@ -114,7 +79,7 @@ pub fn generate_project_created_message(
 
     // Add next steps section
     output.push_str(&format!("{}\n", Style::Heading.paint("Next steps")));
-    let dev_command = get_command(&api_key, &graph_ref.to_string(), !artifacts.is_empty());
+    let dev_command = get_command(!artifacts.is_empty());
 
     if let Some(commands) = commands {
         // Filter out empty commands

--- a/src/command/init/tests/project_created_message_tests.rs
+++ b/src/command/init/tests/project_created_message_tests.rs
@@ -20,42 +20,13 @@ fn strip_ansi_codes(s: &str) -> String {
 
 #[test]
 fn test_get_command() {
-    let api_key = "test-api-key";
-    let graph_ref = "my-graph@main";
+    // Test command with supergraph config
+    let cmd = get_command(true);
+    assert_eq!(cmd, "rover dev --supergraph-config supergraph.yaml");
 
-    #[cfg(target_os = "windows")]
-    {
-        // Test Windows command with supergraph config
-        let cmd = get_command(api_key, graph_ref, true);
-        assert!(cmd.contains("PowerShell:"));
-        assert!(cmd.contains("Command Prompt:"));
-        assert!(cmd.contains("$env:APOLLO_KEY"));
-        assert!(cmd.contains("set APOLLO_KEY"));
-        assert!(cmd.contains("--supergraph-config supergraph.yaml"));
-
-        // Test Windows command without supergraph config
-        let cmd = get_command(api_key, graph_ref, false);
-        assert!(cmd.contains("PowerShell:"));
-        assert!(cmd.contains("Command Prompt:"));
-        assert!(cmd.contains("$env:APOLLO_KEY"));
-        assert!(cmd.contains("set APOLLO_KEY"));
-        assert!(!cmd.contains("--supergraph-config"));
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        // Test Unix command with supergraph config
-        let cmd = get_command(api_key, graph_ref, true);
-        assert!(cmd.contains("APOLLO_KEY=test-api-key"));
-        assert!(cmd.contains("APOLLO_GRAPH_REF=my-graph@main"));
-        assert!(cmd.contains("--supergraph-config supergraph.yaml"));
-
-        // Test Unix command without supergraph config
-        let cmd = get_command(api_key, graph_ref, false);
-        assert!(cmd.contains("APOLLO_KEY=test-api-key"));
-        assert!(cmd.contains("APOLLO_GRAPH_REF=my-graph@main"));
-        assert!(!cmd.contains("--supergraph-config"));
-    }
+    // Test command without supergraph config
+    let cmd = get_command(false);
+    assert_eq!(cmd, "rover dev");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Removes `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables from the `rover dev` command shown in `rover init` output, as these are no longer required for Connectors projects.

## Changes

### Code Changes
- **`src/command/init/helpers.rs`**: Simplified `get_command()` function to only return `rover dev` command without
  environment variables
- **`src/command/init/tests/project_created_message_tests.rs`**: Updated tests to reflect the new command format

### Documentation Changes  
- **`docs/source/commands/init.mdx`**: Removed environment variables from example commands in all platforms 
  (Linux/MacOS/Windows)

#### Before
```
APOLLO_KEY=<credential> APOLLO_GRAPH_REF=<credential> rover dev --supergraph-config supergraph.yaml
```

####  After
```
rover dev --supergraph-config supergraph.yaml
```

###  Impact

This change simplifies the experience by removing the need to manually pass credentials when starting local
development sessions with rover dev. The credentials are now handled automatically by Rover's configuration system.

### Testing
- All existing tests pass
- Updated unit tests for the new command format
- Verified the message still includes the security reminder about storing API keys