### PR TITLE
feat: add .env support for rover dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5123,6 +5129,7 @@ dependencies = [
  "derive-getters",
  "dialoguer",
  "dircpy",
+ "dotenvy",
  "duct",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ console = "0.16"
 derive-getters = "0.5.0"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 directories-next = "2.0"
+dotenvy = "0.15"
 flate2 = "1"
 futures = "0.3"
 git-url-parse = "0.4.5"
@@ -184,6 +185,7 @@ chrono = { workspace = true }
 console = { workspace = true }
 derive-getters = { workspace = true }
 dialoguer = { workspace = true }
+dotenvy = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 graphql_client = { workspace = true }

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use anyhow::anyhow;
 use apollo_federation_types::config::{FederationVersion, RouterVersion};
 use camino::Utf8PathBuf;
+use dotenvy::dotenv;
 use futures::StreamExt;
 use rover_client::RoverClientError;
 use rover_std::{errln, infoln};
@@ -42,6 +43,7 @@ impl Dev {
         client_config: StudioClientConfig,
         log_level: Option<Level>,
     ) -> RoverResult<RoverOutput> {
+        dotenv().ok();
         let elv2_license_accepter = self.opts.plugin_opts.elv2_license_accepter;
         let skip_update = self.opts.plugin_opts.skip_update;
         let read_file_impl = FsReadFile::default();


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-16 -->

While testing the `rover init --mcp`, we realized that although the project template includes a `.env` file with the `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables, these variables are not used unless the user loads them manually each time they run `rover dev`. During the testing party, we heard concerns that this creates unnecessary friction. It seems pointless and even confusing to generate a `.env` file if users have to load it manually. Also, using a `.env` file is nearly an industry standard for managing environment variables in local development. This PR adds support for `.env` files in `rover dev` to enhance the onboarding experience.

## Test

`rever dev` fails with `ERROR: Error: Missing environment variable: APOLLO_GRAPH_REF`.

```sh
$ rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml 
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'github' subgraph
==> Watching /Users/dale.seo/temp/rover-init-testing/github.graphql for changes
composing supergraph with Federation 2.11.0
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
2025-09-29T16:45:16.960434Z  INFO Apollo MCP Server v0.8.0 // (c) Apollo Graph, Inc. // Licensed under MIT
ERROR: Error: Missing environment variable: APOLLO_GRAPH_REF
MCP Server process exited with status code: 1

MCP Server binary exited, stopping `rover dev` processes...
```

The current workaround is to load the environment variables in `.env` manually.

```sh
$ set -a && source .env && set +a && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml         
merging supergraph schema files
supergraph config loaded successfully
starting a session with the 'github' subgraph
==> Watching /Users/dale.seo/temp/rover-init-testing/github.graphql for changes
composing supergraph with Federation 2.11.0
==> Attempting to start router at http://localhost:4000.
2025-09-29T16:46:54.472354Z  INFO Apollo MCP Server v0.8.0 // (c) Apollo Graph, Inc. // Licensed under MIT
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
2025-09-29T16:46:55.035700Z  INFO Tool GoodQuery loaded with a character count of 406. Estimated tokens: 101
2025-09-29T16:46:55.035967Z  INFO Tool BadQuery loaded with a character count of 405. Estimated tokens: 101
2025-09-29T16:46:55.042718Z  INFO Indexed 4 types in 6.23ms
2025-09-29T16:46:55.042864Z  INFO Starting MCP server in Streamable HTTP mode port=5000 address=127.0.0.1
```

With this change, you can just run `rover dev`.

```sh
$ /Users/dale.seo/work/rover/target/debug/rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
starting a session with the 'github' subgraph
==> Watching /Users/dale.seo/temp/rover-init-testing/github.graphql for changes
composing supergraph with Federation 2.11.0
==> Attempting to start router at http://localhost:4000.
2025-09-29T16:48:11.649075Z  INFO Apollo MCP Server v0.8.0 // (c) Apollo Graph, Inc. // Licensed under MIT
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
2025-09-29T16:48:12.034559Z  INFO Tool GoodQuery loaded with a character count of 406. Estimated tokens: 101
2025-09-29T16:48:12.034825Z  INFO Tool BadQuery loaded with a character count of 405. Estimated tokens: 101
2025-09-29T16:48:12.037721Z  INFO Indexed 4 types in 2.85ms
2025-09-29T16:48:12.037824Z  INFO Starting MCP server in Streamable HTTP mode port=5000 address=127.0.0.1
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```