### PR TITLE
add --mcp content to rover init and dev docs

### DIFF
--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -4,6 +4,8 @@ subtitle: Run your supergraph or MCP server in your local dev environment
 description: Use the Rover CLI dev command to run your federated GraphQL API in your local development environment. Learn how to start a router session, add and remove subgraphs, and more.
 ---
 
+The `rover dev` command runs your supergraph locally. With the `--mcp` flag, it can also [run your MCP server](#run-your-mcp-server) alongside your supergraph.
+
 # Run your supergraph
 
 A _supergraph_ is an architecture consisting of multiple GraphQL APIs (_subgraphs_) and a _graph router_ that runs in front of them:
@@ -229,7 +231,7 @@ By default, `rover dev` uses the version of the router and composition plugins [
 
 # Run your MCP server
 
-Following the `[rover init --mcp](/rover/commands/init#initializing-an-mcp-server)` command, which walks you through the [Apollo MCP Server](/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
+Run and test your [Apollo MCP Server](/apollo-mcp-server) locally alongside your graph.
 
 ### `rover dev --mcp`
 
@@ -241,13 +243,13 @@ rover dev \
   --mcp .apollo/mcp.local.yaml
 ```
 
-You can define your `APOLLO_KEY` and `APOLLO_GRAPH_REF` in the terminal as environment variables - or set a source `.env` file, depending on your preference.
+This starts and serves your graph and MCP server as two local endpoints:
 
-Sourcing an `.env` file:
+- GraphQL API: `http://localhost:4000`
+- MCP Server: `http://localhost:5000`
 
-```terminal showLineNumbers=false
-source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
-```
+To provide your graph credentials, you can define the `APOLLO_KEY` and `APOLLO_GRAPH_REF` in the terminal as environment variables, or set a source `.env` file.
+
 
 Setting environment variables:
 
@@ -276,12 +278,10 @@ Setting environment variables:
 
   </Tabs>
 
-This starts and serves your graph API and MCP server as two local endpoints:
+Sourcing an `.env` file:
 
 ```terminal showLineNumbers=false
-# This starts:
-# → GraphQL API: http://localhost:4000
-# → MCP Server: http://localhost:5000
+source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
 ```
 
 ### Additional resources

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -229,7 +229,7 @@ By default, `rover dev` uses the version of the router and composition plugins [
 
 # Run Your MCP Server
 
-Following the `[rover init --mcp](https://www.apollographql.com/docs/rover/commands/init#initializing-a-graph)` command, which walks you through the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
+Following the `[rover init --mcp](https://www.apollographql.com/docs/rover/commands/init#initializing-an-mcp-server)` command, which walks you through the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
 
 ### `rover dev --mcp`
 
@@ -248,7 +248,7 @@ This starts and serves your graph API and MCP server as two local endpoints:
 source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
 # This starts:
 # → GraphQL API: http://localhost:4000
-# → MCP Server: http://localhost:5050
+# → MCP Server: http://localhost:5000
 ```
 
 ### Additional resources

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -229,16 +229,16 @@ By default, `rover dev` uses the version of the router and composition plugins [
 
 # Run Your MCP Server
 
-Following the `[rover init --mcp](./init#initializing-an-mcp-server)` command, which walks you through the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
+Following the `[rover init --mcp](https://www.apollographql.com/docs/rover/commands/init#initializing-a-graph)` command, which walks you through the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
 
 ### `rover dev --mcp`
 
 Use the `rover dev` command, with the addition of the `--mcp` flag to start your MCP server, with an optional configuration file:
 
 ```terminal showLineNumbers=false
-rover init \
-  --supergraph-config <SUPERGRAPH_YAML> \
-  --mcp <MCP_ENV_YAML>
+rover dev \
+  --supergraph-config supergraph.yaml \
+  --mcp mcp-config.yaml
 ```
 
 This starts and serves your graph API and MCP server as two local endpoints:
@@ -253,6 +253,6 @@ source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.l
 
 ### Additional resources
 
-There are multiple ways to run [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) - `rover dev --mcp` being one of them. You can also run the Apollo MCP Server via Docker, Apollo Runtime Container or using the MCP server binary.
+There are multiple ways to run [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) - `rover dev --mcp` being one of them. You can also run the Apollo MCP Server with [Docker](https://www.apollographql.com/docs/apollo-mcp-server/run#with-docker), the [Apollo Runtime Container](https://www.apollographql.com/docs/apollo-mcp-server/run#with-the-apollo-runtime-container) or using the [standalone MCP server binary](https://www.apollographql.com/docs/apollo-mcp-server/run#standalone-mcp-server-binary).
 
 Read [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run) for a full guide on the different ways to run your MCP server.

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -241,7 +241,7 @@ rover dev \
   --mcp .apollo/mcp.local.yaml
 ```
 
-You can define your GraphOS credentials in the terminal as environment variables - or set a source `.env` file, depending on your preference.
+You can define your `APOLLO_KEY` and `APOLLO_GRAPH_REF` in the terminal as environment variables - or set a source `.env` file, depending on your preference.
 
 Sourcing an `.env` file:
 
@@ -249,7 +249,7 @@ Sourcing an `.env` file:
 source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
 ```
 
-Setting credentials as environment variables:
+Setting environment variables:
 
   <Tabs>
 

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -1,8 +1,10 @@
 ---
 title: The Rover dev Command
-subtitle: Run your supergraph in your local dev environment
+subtitle: Run your supergraph or MCP server in your local dev environment
 description: Use the Rover CLI dev command to run your federated GraphQL API in your local development environment. Learn how to start a router session, add and remove subgraphs, and more.
 ---
+
+# Run your supergraph
 
 A _supergraph_ is an architecture consisting of multiple GraphQL APIs (_subgraphs_) and a _graph router_ that runs in front of them:
 
@@ -224,3 +226,33 @@ The ELv2-licensed plugins, `supergraph` (built from [this source](https://github
 ## Versioning
 
 By default, `rover dev` uses the version of the router and composition plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override either of these by setting the environment variables `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0` and `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`. If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
+
+# Run Your MCP Server
+
+Following the `[rover init --mcp](./init#initializing-an-mcp-server)` command, which walks you through the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
+
+### `rover dev --mcp`
+
+Use the `rover dev` command, with the addition of the `--mcp` flag to start your MCP server, with an optional configuration file:
+
+```terminal showLineNumbers=false
+rover init \
+  --supergraph-config <SUPERGRAPH_YAML> \
+  --mcp <MCP_ENV_YAML>
+```
+
+This starts and serves your graph API and MCP server as two local endpoints:
+
+```bash
+# Load environment and start GraphQL API + MCP server
+source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
+# This starts:
+# → GraphQL API: http://localhost:4000
+# → MCP Server: http://localhost:5050
+```
+
+### Additional resources
+
+There are multiple ways to run [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) - `rover dev --mcp` being one of them. You can also run the Apollo MCP Server via Docker, Apollo Runtime Container or using the MCP server binary.
+
+Read [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run) for a full guide on the different ways to run your MCP server.

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -227,9 +227,9 @@ The ELv2-licensed plugins, `supergraph` (built from [this source](https://github
 
 By default, `rover dev` uses the version of the router and composition plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override either of these by setting the environment variables `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0` and `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`. If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
 
-# Run Your MCP Server
+# Run your MCP server
 
-Following the `[rover init --mcp](https://www.apollographql.com/docs/rover/commands/init#initializing-an-mcp-server)` command, which walks you through the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
+Following the `[rover init --mcp](/rover/commands/init#initializing-an-mcp-server)` command, which walks you through the [Apollo MCP Server](/apollo-mcp-server) creation wizard in your CLI, the `rover dev --mcp` command provides a way to run and test your MCP tools locally alongside your Graph API.
 
 ### `rover dev --mcp`
 
@@ -238,14 +238,47 @@ Use the `rover dev` command, with the addition of the `--mcp` flag to start your
 ```terminal showLineNumbers=false
 rover dev \
   --supergraph-config supergraph.yaml \
-  --mcp mcp-config.yaml
+  --mcp .apollo/mcp.local.yaml
 ```
+
+You can define your GraphOS credentials in the terminal as environment variables - or set a source `.env` file, depending on your preference.
+
+Sourcing an `.env` file:
+
+```terminal showLineNumbers=false
+source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
+```
+
+Setting credentials as environment variables:
+
+  <Tabs>
+
+    <Tab label="Linux / MacOS">
+
+    ```terminal showLineNumbers=false
+    # MacOS / Linux
+    APOLLO_KEY=<YOUR_APOLLO_KEY> \
+    APOLLO_GRAPH_REF=<YOUR_APOLLO_GRAPH_REF> \
+    rover dev <OPTIONS>
+    ```
+
+    </Tab>
+    <Tab label="Windows">
+
+    ```terminal showLineNumbers=false
+    # Windows
+    $env:APOLLO_KEY="<YOUR_APOLLO_KEY>"; `
+    $env:APOLLO_GRAPH_REF="<YOUR_APOLLO_GRAPH_REF>"; `
+    rover dev <OPTIONS>
+    ```
+
+    </Tab>
+
+  </Tabs>
 
 This starts and serves your graph API and MCP server as two local endpoints:
 
-```bash
-# Load environment and start GraphQL API + MCP server
-source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
+```terminal showLineNumbers=false
 # This starts:
 # → GraphQL API: http://localhost:4000
 # → MCP Server: http://localhost:5000
@@ -253,6 +286,6 @@ source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.l
 
 ### Additional resources
 
-There are multiple ways to run [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server) - `rover dev --mcp` being one of them. You can also run the Apollo MCP Server with [Docker](https://www.apollographql.com/docs/apollo-mcp-server/run#with-docker), the [Apollo Runtime Container](https://www.apollographql.com/docs/apollo-mcp-server/run#with-the-apollo-runtime-container) or using the [standalone MCP server binary](https://www.apollographql.com/docs/apollo-mcp-server/run#standalone-mcp-server-binary).
+You can also run the Apollo MCP Server with [Docker](/apollo-mcp-server/run#with-docker), the [Apollo Runtime Container](/apollo-mcp-server/run#with-the-apollo-runtime-container) or using the [standalone MCP server binary](/apollo-mcp-server/run#standalone-mcp-server-binary).
 
-Read [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run) for a full guide on the different ways to run your MCP server.
+For a full guide on the different ways to run your MCP server, read [Running the Apollo MCP Server](/apollo-mcp-server/run).

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -160,7 +160,7 @@ rover init --mcp \
 | `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
 
 
-### Next Steps
+### Next steps
 
 #### Run your MCP server
 

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -127,7 +127,7 @@ Rover's `init --mcp` command provides a helpful starting point for working with 
 rover init --mcp
 ```
 
-The `init` CLI wizard walks you through the process of configuring and creating an MCP server, with MCP tools based on your GraphQL API operations.
+The `init` CLI wizard walks you through the process of configuring and creating an MCP server. When you're done, you'll have starter files for an MCP server and a graph to run locally.
 
 The command creates the following files:
 

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -1,11 +1,11 @@
 ---
 title: The Rover init Command
-subtitle: Initialize a graph locally and on GraphOS
-description: Use the Rover CLI init command to initialize a federated GraphQL API using Apollo Federation and the GraphOS Router.
+subtitle: Initialize a graph or MCP server locally and on GraphOS
+description: Use the Rover CLI init command to initialize a federated GraphQL API or MCP Server using Apollo Federation and the GraphOS Router.
 minVersion: Rover v0.29.0
 ---
 
-Rover enables you to create a graph with a single interactive command.
+Rover enables you to create a graph or MCP server with a single interactive command.
 
 ## Initializing a graph
 ### `rover init`
@@ -36,6 +36,8 @@ rover init \
   --graph-id <GRAPH_ID>
 ```
 
+For `rover init --mcp` options, see the [Initializing an MCP Server](#initializing-an-mcp-server) section.
+
 ##### Available options
 
 | Option | Description | Possible Values |
@@ -45,8 +47,9 @@ rover init \
 | `--project-use-case` | Helps preconfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
 | `--project-name` | The name for your new graph. | *(your graph name)* |
 | `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
+| `--mcp` | See the [Initializing an MCP Server](#initializing-an-mcp-server) section.) |  |
 
-### Choosing your use case
+#### Choosing your use case
 
 Once you run `rover init`, the wizard prompts you to select your use case.
 
@@ -55,7 +58,7 @@ Once you run `rover init`, the wizard prompts you to select your use case.
 - **Start a graph with recommended libraries**
     - Select this option if you want to integrate data that's not accessible via a REST API. This option helps you set up a graph using the Apollo Server library.
 
-### Created credentials
+#### Created credentials
 
 After you've chosen your use case, the wizard prompts you for a project name. It generates the following credentials based on the name you enter:
 
@@ -64,7 +67,7 @@ After you've chosen your use case, the wizard prompts you for a project name. It
 - **Graph API key**- Once it's generated, store it securely—you won't be able to access it later.
     - See the [configuration docs](/rover/configuring#with-an-environment-variable) to learn how to set your API key as an environment variable
 
-## Next steps
+### Next steps
 
 Once you've completed the wizard, it provides a [`rover dev`](./dev) command with prepopulated credentials. Run this command to start developing your graph.
 
@@ -109,8 +112,102 @@ Once you've completed the wizard, it provides a [`rover dev`](./dev) command wit
 </Note>
 
 
-### Additional resources
+#### Additional resources
 
 - After running `rover init`, open the generated `GETTING_STARTED.md` file for next steps.
 - To go further, check out the [Getting started guide](/graphos/get-started/guides/rest) to learn what else you can do with Apollo Connectors.
 - If you learn best with videos and exercises, this [interactive course](https://www.apollographql.com/tutorials/connectors-intro-rest) teaches you how to integrate a demo REST API into a graph using Apollo Connectors.
+
+
+## Initializing an MCP Server
+### `rover init --mcp`
+
+Rover's `init --mcp` command provides a helpful starting point for working with the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server). 
+
+```terminal showLineNumbers=false
+rover init --mcp
+```
+
+The `init` CLI wizard walks you through the process of configuring and creating an MCP server, with MCP tools based on your GraphQL API operations.
+
+The command creates the following files:
+
+- MCP config YAML for local and staging scenarios
+- MCP config for adding to Claude Desktop
+- Starter MCP tools, based on your GraphQL API operations
+- `.env` files for running the GraphQL API and MCP Server
+- A set of local configuration files and boilerplate code that represent the graph
+- mcp.Dockerfile (optional Docker container) 
+
+##### Options
+
+You can also pass options directly to `rover init --mcp` instead of answering prompts in the wizard. The wizard still asks for any information not provided via an option and always asks for confirmation before creating any files locally.
+
+```terminal showLineNumbers=false
+rover init --mcp \
+  --project-type <PROJECT_TYPE> \
+  --org-id <ORGANIZATION_ID> \
+  --project-name <PROJECT_NAME> \
+  --graph-id <GRAPH_ID>
+```
+
+##### Available options
+
+| Option | Description | Possible Values |
+| ------ | ----------- | --------------- |
+| `--project-type` | Whether to create MCP tools from a new Apollo GraphOS project or an existing Apollo GraphOS project. | `create-new`, <br/>`add-subgraph` |
+| `--org-id` | The ID of the [GraphOS organization](/graphos/platform/access-management/org#view-your-organizations) where the graph should be created. | *(your organization ID)* |
+| `--project-name` | The name for your new graph. | *(your graph name)* |
+| `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
+
+
+#### Next Steps
+
+Once you've completed the wizard, you will be shown recommended next steps for using and running your MCP server.
+
+#### Configure Your Environment
+
+The `rover init --mcp` command generates a starter `.env.template` file, which you will need to modify:
+
+```bash
+# Create environment file
+cp .env.template .env
+
+# Edit .env with your API details:
+PROJECT_NAME="your-project-name"
+GRAPHQL_ENDPOINT="http://localhost:4000/graphql"
+```
+
+#### Connect your MCP server to Claude Desktop
+
+```bash
+# Copy the configuration for Claude Desktop
+# macOS:
+cp claude_desktop_config.json ~/Library/Application\ Support/Claude/claude_desktop_config.json
+
+# Windows:
+copy claude_desktop_config.json "%APPDATA%\Claude\claude_desktop_config.json"
+
+# Linux:
+cp claude_desktop_config.json ~/.config/Claude/claude_desktop_config.json
+
+# Restart Claude Desktop
+```
+
+For instructions on adding your MCP server to other AI clients, see the [MCP Quickstart guide](https://www.apollographql.com/docs/apollo-mcp-server/quickstart).
+
+
+#### Run your MCP server and GraphQL API
+
+When the `rover init` wizard is complete, you can use [`rover dev`](./dev) to start everything together:
+
+```bash
+# Load environment and start GraphQL API + MCP server
+source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
+
+# This starts:
+# → GraphQL API: http://localhost:4000
+# → MCP Server: http://localhost:5050
+```
+
+There are many ways to run the MCP server. In addition to `rover dev` you can use Docker, the Apollo Runtime Container, or the server binary. Read [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run) for the full guide on the different ways to run your MCP server.

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -195,7 +195,7 @@ source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.l
 
 # This starts:
 # → GraphQL API: http://localhost:4000
-# → MCP Server: http://localhost:5050
+# → MCP Server: http://localhost:5000
 ```
 
 There are many ways to run the MCP server. In addition to `rover dev` you can use Docker, the Apollo Runtime Container, or the server binary. Read [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run) for the full guide on the different ways to run your MCP server.

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -121,7 +121,7 @@ Once you've completed the wizard, it provides a [`rover dev`](./dev) command wit
 ## Initializing an MCP server
 ### `rover init --mcp`
 
-Rover's `init --mcp` command provides a helpful starting point for working with the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server). 
+Rover's `init --mcp` command provides a helpful starting point for working with the [Apollo MCP Server](/apollo-mcp-server). 
 
 ```terminal showLineNumbers=false
 rover init --mcp
@@ -133,7 +133,7 @@ The command creates the following files:
 
 - MCP config YAML for local and staging scenarios
 - MCP config for adding to Claude Desktop
-- Starter [MCP tools](https://www.apollographql.com/docs/apollo-mcp-server/define-tools), based on your GraphQL API operations
+- Starter [MCP tools](/apollo-mcp-server/define-tools), based on your GraphQL API operations
 - `.env` files for running the GraphQL API and MCP Server
 - A set of local configuration files and boilerplate code that represent the graph
 - mcp.Dockerfile (optional Docker container) 

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -47,7 +47,7 @@ For `rover init --mcp` options, see the [Initializing an MCP Server](#initializi
 | `--project-use-case` | Helps preconfigure your graph for specific patterns. | `connectors`, <br/>`graph-ql-template` |
 | `--project-name` | The name for your new graph. | *(your graph name)* |
 | `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
-| `--mcp` | See the [Initializing an MCP Server](#initializing-an-mcp-server) section.) |  |
+| `--mcp` | See the [Initializing an MCP Server](#initializing-an-mcp-server) section.|  |
 
 #### Choosing your use case
 
@@ -118,7 +118,6 @@ Once you've completed the wizard, it provides a [`rover dev`](./dev) command wit
 - To go further, check out the [Getting started guide](/graphos/get-started/guides/rest) to learn what else you can do with Apollo Connectors.
 - If you learn best with videos and exercises, this [interactive course](https://www.apollographql.com/tutorials/connectors-intro-rest) teaches you how to integrate a demo REST API into a graph using Apollo Connectors.
 
-
 ## Initializing an MCP server
 ### `rover init --mcp`
 
@@ -134,7 +133,7 @@ The command creates the following files:
 
 - MCP config YAML for local and staging scenarios
 - MCP config for adding to Claude Desktop
-- Starter MCP tools, based on your GraphQL API operations
+- Starter [MCP tools](https://www.apollographql.com/docs/apollo-mcp-server/define-tools), based on your GraphQL API operations
 - `.env` files for running the GraphQL API and MCP Server
 - A set of local configuration files and boilerplate code that represent the graph
 - mcp.Dockerfile (optional Docker container) 
@@ -163,13 +162,14 @@ rover init --mcp \
 
 ### Next Steps
 
-Once you've completed the wizard, you will be shown recommended next steps for using and running your MCP server.
+#### Run your MCP server
 
+When the `rover init` wizard is complete, you can use [`rover dev`](./dev) to start everything together. See [Running the Apollo MCP Server](/apollo-mcp-server/run).
 
 #### Connect your MCP server to Claude Desktop
 
 ```bash
-# Copy the configuration for Claude Desktop
+# Copy and provide the configuration to Claude Desktop
 # macOS:
 cp claude_desktop_config.json ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
@@ -182,20 +182,4 @@ cp claude_desktop_config.json ~/.config/Claude/claude_desktop_config.json
 # Restart Claude Desktop
 ```
 
-For instructions on adding your MCP server to other AI clients, see the [MCP Quickstart guide](https://www.apollographql.com/docs/apollo-mcp-server/quickstart).
-
-
-#### Run your MCP server and GraphQL API
-
-When the `rover init` wizard is complete, you can use [`rover dev`](./dev) to start everything together:
-
-```bash
-# Load environment and start GraphQL API + MCP server
-source .env && rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
-
-# This starts:
-# → GraphQL API: http://localhost:4000
-# → MCP Server: http://localhost:5000
-```
-
-There are many ways to run the MCP server. In addition to `rover dev` you can use Docker, the Apollo Runtime Container, or the server binary. Read [Running the Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server/run) for the full guide on the different ways to run your MCP server.
+For instructions on adding your MCP server to other AI clients, see the [MCP Quickstart guide](/apollo-mcp-server/quickstart).

--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -119,7 +119,7 @@ Once you've completed the wizard, it provides a [`rover dev`](./dev) command wit
 - If you learn best with videos and exercises, this [interactive course](https://www.apollographql.com/tutorials/connectors-intro-rest) teaches you how to integrate a demo REST API into a graph using Apollo Connectors.
 
 
-## Initializing an MCP Server
+## Initializing an MCP server
 ### `rover init --mcp`
 
 Rover's `init --mcp` command provides a helpful starting point for working with the [Apollo MCP Server](https://www.apollographql.com/docs/apollo-mcp-server). 
@@ -161,22 +161,10 @@ rover init --mcp \
 | `--graph-id` | The ID for your graph in GraphOS. (This must be a unique identifier.) | *(your graph ID)* |
 
 
-#### Next Steps
+### Next Steps
 
 Once you've completed the wizard, you will be shown recommended next steps for using and running your MCP server.
 
-#### Configure Your Environment
-
-The `rover init --mcp` command generates a starter `.env.template` file, which you will need to modify:
-
-```bash
-# Create environment file
-cp .env.template .env
-
-# Edit .env with your API details:
-PROJECT_NAME="your-project-name"
-GRAPHQL_ENDPOINT="http://localhost:4000/graphql"
-```
 
 #### Connect your MCP server to Claude Desktop
 


### PR DESCRIPTION
This adds docs following the #2731 MCP Init feature work, adding to the existing context for the `init` and `dev` structure, but for the `--mcp` workflow. 

These docs need to also link to / connect with the main [Apollo MCP Server docs](https://github.com/apollographql/apollo-mcp-server/tree/main/docs/source) (quickstart, run, config), which are being updated to mirror the changes in #2731.

* `rover init --mcp` 
* `rover dev --mcp`