### PR TITLE
feat(init|docs): Remove `claude_desktop_config.json` from MCP template and update `Next Steps` UX

### DIFF
--- a/docs/source/commands/init.mdx
+++ b/docs/source/commands/init.mdx
@@ -132,7 +132,6 @@ The `init` CLI wizard walks you through the process of configuring and creating 
 The command creates the following files:
 
 - MCP config YAML for local and staging scenarios
-- MCP config for adding to Claude Desktop
 - Starter [MCP tools](/apollo-mcp-server/define-tools), based on your GraphQL API operations
 - `.env` files for running the GraphQL API and MCP Server
 - A set of local configuration files and boilerplate code that represent the graph

--- a/src/command/docs/shortlinks.rs
+++ b/src/command/docs/shortlinks.rs
@@ -98,6 +98,14 @@ pub fn get_shortlinks_with_info() -> BTreeMap<&'static str, ShortlinkInfo> {
             "define-tools",
         ),
     );
+    links.insert(
+        "mcp-claude",
+        ShortlinkInfo::new(
+            "Connect Claude Desktop to Apollo MCP Server",
+            "mcp",
+            "claude",
+        ),
+    );
     links
 }
 

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -559,22 +559,13 @@ impl ProjectCreated {
         println!("{}", Style::Heading.paint("Next steps ↴"));
         println!();
 
-        // Step 1: Always Claude Desktop configuration first
-        println!("1. Configure Claude Desktop by copying claude_desktop_config.json to:");
-        println!(
-            "   • macOS: {}",
-            Style::Path.paint("~/Library/Application Support/Claude/claude_desktop_config.json")
-        );
-        println!(
-            "   • Windows: {}",
-            Style::Path.paint("%APPDATA%\\Claude\\claude_desktop_config.json")
-        );
-        println!(
-            "   • Linux: {}",
-            Style::Path.paint("~/.config/Claude/claude_desktop_config.json")
-        );
+        // Step 1: AI client setup
+        println!("1. Connect an AI client to your MCP server:");
         println!();
-        println!("   Then restart Claude Desktop.");
+        println!("   Your MCP server name: {}", Style::Command.paint(format!("mcp-{}", self.config.project_name)));
+        println!("   MCP endpoint: {}", Style::Link.paint("http://127.0.0.1:5050/mcp"));
+        println!();
+        println!("   For Claude Desktop setup: {}", Style::Command.paint("rover docs open mcp-claude"));
         println!();
 
         // Step 2: Base template commands (npm install, npm start, etc.) if they exist

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -562,10 +562,19 @@ impl ProjectCreated {
         // Step 1: AI client setup
         println!("1. Connect an AI client to your MCP server:");
         println!();
-        println!("   Your MCP server name: {}", Style::Command.paint(format!("mcp-{}", self.config.project_name)));
-        println!("   MCP endpoint: {}", Style::Link.paint("http://127.0.0.1:5050/mcp"));
+        println!(
+            "   Your MCP server name: {}",
+            Style::Command.paint(format!("mcp-{}", self.config.project_name))
+        );
+        println!(
+            "   MCP endpoint: {}",
+            Style::Link.paint("http://127.0.0.1:5050/mcp")
+        );
         println!();
-        println!("   For Claude Desktop setup: {}", Style::Command.paint("rover docs open mcp-claude"));
+        println!(
+            "   For Claude Desktop setup: {}",
+            Style::Command.paint("rover docs open mcp-claude")
+        );
         println!();
 
         // Step 2: Base template commands (npm install, npm start, etc.) if they exist

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -534,7 +534,7 @@ impl ProjectCreated {
         // Project Details section
         println!();
         println!("{}", Style::Heading.paint("Project details"));
-        println!("   • MCP Server Name: mcp-{}", self.config.project_name);
+        println!("   • MCP Server Name: {}", self.config.project_name);
         println!("   • GraphOS Organization: {}", self.config.organization);
         println!();
 
@@ -564,7 +564,7 @@ impl ProjectCreated {
         println!();
         println!(
             "   Your MCP server name: {}",
-            Style::Command.paint(format!("mcp-{}", self.config.project_name))
+            Style::Command.paint(format!("{}", self.config.project_name))
         );
         println!(
             "   MCP endpoint: {}",


### PR DESCRIPTION
## Summary

This PR addresses feedback from https://github.com/apollographql/rover-init-starters/pull/84 which removes `claude_desktop_config.json` from the MCP template. After team discussion, we aligned on removing the config file to avoid being overly prescriptive about AI client choice while still providing clear setup guidance.

### Key decisions made:
  - Remove `claude_desktop_config.json` from template 
  - Update "Next Steps" to be more inclusive while still helpful

### What Changed

#### 1. Added new shortlink for Claude Desktop setup

File: **`src/command/docs/shortlinks.rs`**

Added `mcp-claude` shortlink that maps to the Apollo MCP Server quickstart (Claude Desktop setup section)

Note: The corresponding redirect has been added to forward to: https://www.apollographql.com/docs/apollo-mcp-server/quickstart#step-4-connect-claude-desktop

#### 2. Removed the reference to a Claude Desktop configuration file in our docs ([preview](https://www.apollographql.com/docs/deploy-preview/35c6a54cafca59016c493593/rover/commands/init))

#### 3. Updated MCP "Next Steps" messaging

File: **`src/command/init/transitions.rs`**

**Before:**

```
  1. Configure Claude Desktop by copying claude_desktop_config.json to:
     • macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
     • Windows: %APPDATA%\Claude\claude_desktop_config.json
     • Linux: ~/.config/Claude/claude_desktop_config.json

     Then restart Claude Desktop.
```

**After:**
```
  1. Connect an AI client to your MCP server:

     Your MCP server name: mcp-{project-name}
     MCP endpoint: http://127.0.0.1:5050/mcp

     For Claude Desktop setup: rover docs open mcp-claude
```

#### Output Examples

**REST/Connectors Project (no npm commands)**

```
  Next steps ↴

  1. Connect an AI client to your MCP server:

     Your MCP server name: mcp-my-rest-api
     MCP endpoint: http://127.0.0.1:5050/mcp

     For Claude Desktop setup: rover docs open mcp-claude

  2. Start MCP server (after completing the above steps):

     Linux/macOS: set -a && source .env && set +a && rover dev --supergraph-config supergraph.yaml
  --mcp .apollo/mcp.local.yaml
     ...
```

**GraphQL Project (with npm commands)**

```
  Next steps ↴

  1. Connect an AI client to your MCP server:

     Your MCP server name: mcp-my-graphql-api
     MCP endpoint: http://127.0.0.1:5050/mcp

     For Claude Desktop setup: rover docs open mcp-claude

  2. Start the subgraph server by running the following commands in order:

     npm install
     npm start

  3. In a new terminal, start a local development session:

     rover dev --supergraph-config supergraph.yaml --mcp .apollo/mcp.local.yaml
     ...
```

### Testing
- `rover docs open mcp-claude` opens correct URL
- MCP project creation shows updated "Next Steps"
- No references to `claude_desktop_config.json` in output