### PR TITLE
docs: change MCP's default port from 5000 to 8000

### DIFF
--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -246,7 +246,7 @@ rover dev \
 This starts and serves your graph and MCP server as two local endpoints:
 
 - GraphQL API: `http://localhost:4000`
-- MCP Server: `http://localhost:5000`
+- MCP Server: `http://localhost:8000`
 
 To provide your graph credentials, you can define the `APOLLO_KEY` and `APOLLO_GRAPH_REF` in the terminal as environment variables, or set a source `.env` file.
 


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-42 -->

MCP's default port is changing from 5000 to 8000.

(Keep this open until https://github.com/apollographql/apollo-mcp-server/pull/417 is released)