### PR TITLE
ci: Fix a bunch of Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,42 +1,8 @@
 {
   extends: [
-    "github>apollographql/renovate-config-apollo-open-source:default.json5",
     "github>Turbo87/renovate-config//rust/updateToolchain",
   ],
   packageRules: [
-    // Bunch up all non-major npm dependencies into a single PR.  In the common case
-    // where the upgrades apply cleanly, this causes less noise and is resolved faster
-    // than starting a bunch of upgrades in parallel for what may turn out to be
-    // a suite of related packages all released at once.
-    //
-    // Since too much in the Rust ecosystem is pre-1.0, we make an exception here.
-    {
-      matchPackageNames: ["harmonizer"],
-      matchManagers: ["cargo"],
-      groupName: "harmonizer",
-      groupSlug: "harmonizer",
-    },
-    {
-      matchCurrentVersion: "< 1.0.0",
-      separateMinorPatch: true,
-      matchManagers: ["cargo"],
-      minor: {
-        groupName: "cargo pre-1.0 packages",
-        groupSlug: "cargo-all-pre-1.0",
-      },
-      patch: {
-        groupName: "cargo pre-1.0 packages",
-        groupSlug: "cargo-all-pre-1.0",
-        automerge: false,
-      },
-    },
-    {
-      matchCurrentVersion: ">= 1.0.0",
-      matchManagers: ["cargo", "npm"],
-      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
-      groupName: "all non-major packages >= 1.0",
-      groupSlug: "all-non-major-gte-1.0",
-    },
     {
       matchPackageNames: ["apollographql/federation-rs"],
       extractVersion: "^supergraph@(?<version>v\\d+\\.\\d+\\.\\d+)$",
@@ -92,6 +58,6 @@
     enabled: true,
   },
   lockFileMaintenance: {
-    enabled: false,
+    enabled: true,
   },
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ os_info = "3.7"
 os_type = "2.6"
 predicates = "3"
 pretty_assertions = "1"
-rand = "=0.9.2"
+rand = "0.9.2"
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
 rstest = "0.25.0"
@@ -239,25 +239,25 @@ comfy-table = { workspace = true }
 assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 assert-json-diff = { workspace = true }
-dircpy = "=0.3.19"
-duct = "=1.1.0"
+dircpy = "0.3.19"
+duct = "1.1.0"
 git2 = { workspace = true, features = ["https"] }
-graphql-schema-diff = "=0.2.0"
+graphql-schema-diff = "0.2.0"
 httpmock = { workspace = true }
 indoc = { workspace = true }
-jsonschema = "=0.30.0"
-mime = "=0.3.17"
-mockall = "=0.13.1"
-portpicker = "=0.1.1"
+jsonschema = "0.30.0"
+mime = "0.3.17"
+mockall = "0.13.1"
+portpicker = "0.1.1"
 predicates = { workspace = true }
-rand_regex = "=0.18.1"
+rand_regex = "0.18.1"
 reqwest = { workspace = true, features = ["native-tls-vendored"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 speculoos = { workspace = true }
 tower-test = { workspace = true }
 tracing-test = { workspace = true }
-temp-env = { version = "=0.3.6", features = ["async_closure"] }
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 # For sputnik, run tests with debug_assertions disabled. This is necessary because telemetry is not sent if
 # debug_assertions is enabled, and the tests rely on telemetry being sent to mock APIs.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -42,6 +42,6 @@ octocrab = "0.44.0"
 lychee-lib = { version = "0.19", features = ["vendored-openssl"] }
 
 [dev-dependencies]
-mockito = "=1.7.0"
+mockito = "1.7.0"
 rstest = { workspace = true }
 speculoos = { workspace = true }


### PR DESCRIPTION
1. Don't pin dev dependencies which is best practice for some ecosystems but not Rust (came from `extends`)
2. Don't update groups of packages together, that makes it too hard to approve small changes
3. Update lockfiles so we can periodically test the latest compatible packages
