### PR TITLE
fix(init|mcp): Remove conditional header in VSCode file from MCP template processing

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -288,23 +288,7 @@ pub fn process_mcp_template_placeholders(content: &str, ctx: &MCPTemplateContext
     let graph_ref_str = ctx.graph_ref.to_string();
     let docker_tag = normalize_docker_tag(ctx.graph_id);
 
-    // Add header for .env files containing Apollo credentials
-    let mut processed_content = if content.contains("APOLLO_KEY") || content.contains("apollo_key")
-    {
-        let header = r#"# Apollo GraphOS Credentials for MCP Server
-# These credentials connect your MCP server to Apollo GraphOS
-#
-# Usage:
-# - For VSCode: These variables are automatically loaded
-# - For manual runs: Source this file before running rover dev
-#   Linux/macOS: set -a && source .env && set +a && rover dev --mcp .apollo/mcp.local.yaml
-#   Windows: Get-Content .env | ForEach-Object { $name, $value = $_.split('=',2); [System.Environment]::SetEnvironmentVariable($name, $value) }; rover dev --mcp .apollo/mcp.local.yaml
-
-"#;
-        format!("{}{}", header, content)
-    } else {
-        content.to_string()
-    };
+    let mut processed_content = content.to_string();
 
     // Process both ${} format (for YAML files) and {{}} format (for other templates)
     processed_content = processed_content

--- a/src/command/init/tests/mcp_prompting_tests.rs
+++ b/src/command/init/tests/mcp_prompting_tests.rs
@@ -484,11 +484,6 @@ GRAPHQL_ENDPOINT="{{GRAPHQL_ENDPOINT}}"
             processed_content
                 .contains("GRAPHQL_ENDPOINT=\"http://host.docker.internal:4000/graphql\"")
         );
-
-        // Check that header comments were added
-        assert!(processed_content.contains("# Apollo GraphOS Credentials for MCP Server"));
-        assert!(processed_content.contains("# Usage:"));
-        assert!(processed_content.contains("set -a && source .env && set +a"));
     }
 
     #[test]
@@ -580,8 +575,7 @@ APOLLO_GRAPH_REF={{APOLLO_GRAPH_REF}}
         assert!(processed_content.contains(&format!("APOLLO_KEY={}", api_key)));
         assert!(processed_content.contains("APOLLO_GRAPH_REF=test-graph-id@current"));
 
-        // Check that both old and new comments exist
-        assert!(processed_content.contains("# Apollo GraphOS Credentials for MCP Server"));
+        // Check that existing comment is preserved
         assert!(processed_content.contains("# Existing comment"));
     }
 
@@ -824,6 +818,5 @@ APOLLO_GRAPH_REF={{APOLLO_GRAPH_REF}}
         assert!(processed_content.contains("PROJECT_NAME=integration-test"));
         assert!(processed_content.contains(&format!("APOLLO_KEY={}", api_key)));
         assert!(processed_content.contains("APOLLO_GRAPH_REF=integration-test-graph@current"));
-        assert!(processed_content.contains("# Apollo GraphOS Credentials for MCP Server"));
     }
 }


### PR DESCRIPTION
## Summary
This PR removes the unneeded header that was injected within the `process_mcp_template_placeholders` function, which added  documentation to files containing `APOLLO_KEY` or `apollo_key`.

### What changed
- **helpers.rs**: Removed conditional logic that added a header to VSCode files 
- **mcp_prompting_tests.rs**: Updated three tests to remove assertions checking for the removed header:
  - `test_mcp_env_file_processing_with_template_vars`
  - `test_mcp_env_file_processing`
  - `test_mcp_creation_confirmed_env_processing_integration`

### Testing
All existing tests pass with assertions updated to reflect the new behavior. Template placeholder replacement continues to work correctly without the header injection.
