### PR TITLE
Enable overriding MCP version in `rover dev`

### DIFF
--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -229,9 +229,9 @@ The ELv2-licensed plugins, `supergraph` (built from [this source](https://github
 
 By default, `rover dev` uses the version of the router, composition, and MCP server plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override any of these versions:
 
-- **Router**: Set the `APOLLO_ROVER_DEV_ROUTER_VERSION` environment variable (e.g., `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0`)
-- **Composition**: Use the `--federation-version` flag or set the `APOLLO_ROVER_DEV_COMPOSITION_VERSION` environment variable (e.g., `--federation-version 2.0.0` or `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`)
-- **MCP Server**: Use the `--mcp-version` flag or set the `APOLLO_ROVER_DEV_MCP_VERSION` environment variable (e.g., `--mcp-version 1.0.0` or `APOLLO_ROVER_DEV_MCP_VERSION=1.0.0`)
+- Router: Set the `APOLLO_ROVER_DEV_ROUTER_VERSION` environment variable (e.g., `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0`)
+- Composition: Use the `--federation-version` flag or set the `APOLLO_ROVER_DEV_COMPOSITION_VERSION` environment variable (e.g., `--federation-version 2.0.0` or `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`)
+- MCP Server: Use the `--mcp-version` flag or set the `APOLLO_ROVER_DEV_MCP_VERSION` environment variable (e.g., `--mcp-version 1.0.0` or `APOLLO_ROVER_DEV_MCP_VERSION=1.0.0`)
 
 If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
 

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -227,7 +227,7 @@ The ELv2-licensed plugins, `supergraph` (built from [this source](https://github
 
 ## Versioning
 
-By default, `rover dev` uses the version of the router and composition plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override either of these by setting the environment variables `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0` and `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`. If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
+By default, `rover dev` uses the version of the router, composition, and MCP server plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override any of these by setting the environment variables `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0`, `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`, and `APOLLO_ROVER_DEV_MCP_VERSION=0.1.0`. If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
 
 # Run your MCP server
 

--- a/docs/source/commands/dev.mdx
+++ b/docs/source/commands/dev.mdx
@@ -227,7 +227,13 @@ The ELv2-licensed plugins, `supergraph` (built from [this source](https://github
 
 ## Versioning
 
-By default, `rover dev` uses the version of the router, composition, and MCP server plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override any of these by setting the environment variables `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0`, `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`, and `APOLLO_ROVER_DEV_MCP_VERSION=0.1.0`. If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
+By default, `rover dev` uses the version of the router, composition, and MCP server plugins [defined in the Rover GitHub repo](https://raw.githubusercontent.com/apollographql/rover/main/latest_plugin_versions.json). You can override any of these versions:
+
+- **Router**: Set the `APOLLO_ROVER_DEV_ROUTER_VERSION` environment variable (e.g., `APOLLO_ROVER_DEV_ROUTER_VERSION=1.0.0`)
+- **Composition**: Use the `--federation-version` flag or set the `APOLLO_ROVER_DEV_COMPOSITION_VERSION` environment variable (e.g., `--federation-version 2.0.0` or `APOLLO_ROVER_DEV_COMPOSITION_VERSION=2.0.0`)
+- **MCP Server**: Use the `--mcp-version` flag or set the `APOLLO_ROVER_DEV_MCP_VERSION` environment variable (e.g., `--mcp-version 1.0.0` or `APOLLO_ROVER_DEV_MCP_VERSION=1.0.0`)
+
+If you already have these plugins installed, you can pass `--skip-update` to `rover dev` in order to keep the plugins at the same version.
 
 # Run your MCP server
 
@@ -241,6 +247,15 @@ Use the `rover dev` command, with the addition of the `--mcp` flag to start your
 rover dev \
   --supergraph-config supergraph.yaml \
   --mcp .apollo/mcp.local.yaml
+```
+
+You can optionally specify a specific version of the MCP server to use:
+
+```terminal showLineNumbers=false
+rover dev \
+  --supergraph-config supergraph.yaml \
+  --mcp .apollo/mcp.local.yaml \
+  --mcp-version 1.1.0-rc.1
 ```
 
 This starts and serves your graph and MCP server as two local endpoints:

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -84,7 +84,7 @@ Internally, the `npm` installer downloads router binaries from `https://rover.ap
 
    <Note>
 
-   This environment variable also changes the host that plugins for `rover supergraph compose` and `rover dev` are downloaded from. By default, `rover dev` attempts to install the latest version of plugins for the router and composition. To maintain this behavior, an `X-Version: vX.X.X` header must be present in the response from the binary mirror. To circumvent the need for this header, plugin versions can instead be pinned with the `APOLLO_ROVER_DEV_COMPOSITION_VERSION` and `APOLLO_ROVER_DEV_ROUTER_VERSION` environment variables. For more details, see [versioning for `rover dev`](./commands/dev/#versioning).
+   This environment variable also changes the host that plugins for `rover supergraph compose` and `rover dev` are downloaded from. By default, `rover dev` attempts to install the latest version of plugins for the router, composition, and MCP server. To maintain this behavior, an `X-Version: vX.X.X` header must be present in the response from the binary mirror. To circumvent the need for this header, plugin versions can instead be pinned with the `APOLLO_ROVER_DEV_COMPOSITION_VERSION`, `APOLLO_ROVER_DEV_ROUTER_VERSION`, and `APOLLO_ROVER_DEV_MCP_VERSION` environment variables. For more details, see [versioning for `rover dev`](./commands/dev/#versioning).
 
    </Note>
 

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -20,7 +20,7 @@ use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort}
 use crate::command::dev::router::hot_reload::HotReloadConfigOverrides;
 use crate::command::dev::router::run::RunRouter;
 use crate::command::dev::{
-    OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_MCP_VERSION, OVERRIDE_DEV_ROUTER_VERSION,
+    OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION,
 };
 use crate::command::install::McpServerVersion;
 use crate::composition::events::CompositionEvent;
@@ -277,17 +277,12 @@ impl Dev {
             .await;
 
         if let Some(ref config) = self.opts.mcp.config {
-            let mcp_version = match &*OVERRIDE_DEV_MCP_VERSION {
-                Some(version) => match McpServerVersion::from_str(&format!("={version}")) {
-                    Ok(version) => version,
-                    Err(err) => {
-                        errln!("{err}");
-                        tracing::error!("{:?}", err);
-                        McpServerVersion::Latest
-                    }
-                },
-                None => McpServerVersion::Latest,
-            };
+            let mcp_version = self
+                .opts
+                .mcp
+                .version
+                .clone()
+                .unwrap_or(McpServerVersion::Latest);
 
             let run_mcp_server = RunMcpServer::default()
                 .install(

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -19,9 +19,7 @@ use crate::command::dev::router::binary::RunRouterBinaryError;
 use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort};
 use crate::command::dev::router::hot_reload::HotReloadConfigOverrides;
 use crate::command::dev::router::run::RunRouter;
-use crate::command::dev::{
-    OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION,
-};
+use crate::command::dev::{OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION};
 use crate::command::install::McpServerVersion;
 use crate::composition::events::CompositionEvent;
 use crate::composition::pipeline::CompositionPipeline;

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -19,7 +19,9 @@ use crate::command::dev::router::binary::RunRouterBinaryError;
 use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort};
 use crate::command::dev::router::hot_reload::HotReloadConfigOverrides;
 use crate::command::dev::router::run::RunRouter;
-use crate::command::dev::{OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_ROUTER_VERSION};
+use crate::command::dev::{
+    OVERRIDE_DEV_COMPOSITION_VERSION, OVERRIDE_DEV_MCP_VERSION, OVERRIDE_DEV_ROUTER_VERSION,
+};
 use crate::command::install::McpServerVersion;
 use crate::composition::events::CompositionEvent;
 use crate::composition::pipeline::CompositionPipeline;
@@ -275,9 +277,21 @@ impl Dev {
             .await;
 
         if let Some(ref config) = self.opts.mcp.config {
+            let mcp_version = match &*OVERRIDE_DEV_MCP_VERSION {
+                Some(version) => match McpServerVersion::from_str(&format!("={version}")) {
+                    Ok(version) => version,
+                    Err(err) => {
+                        errln!("{err}");
+                        tracing::error!("{:?}", err);
+                        McpServerVersion::Latest
+                    }
+                },
+                None => McpServerVersion::Latest,
+            };
+
             let run_mcp_server = RunMcpServer::default()
                 .install(
-                    McpServerVersion::Latest,
+                    mcp_version,
                     client_config.clone(),
                     override_install_path,
                     elv2_license_accepter,

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use camino::Utf8PathBuf;
 use clap::Parser;
 use serde::Serialize;
@@ -7,6 +9,16 @@ use crate::command::install::McpServerVersion;
 pub mod binary;
 pub mod install;
 pub mod run;
+
+fn parse_mcp_version(s: &str) -> Result<McpServerVersion, String> {
+    // Add the '=' prefix if not already present, as McpServerVersion expects it
+    let prefixed = if s.starts_with('=') || s == "latest" {
+        s.to_string()
+    } else {
+        format!("={}", s)
+    };
+    McpServerVersion::from_str(&prefixed).map_err(|e| e.to_string())
+}
 
 #[derive(Debug, Clone, Serialize, Parser)]
 pub struct Opts {
@@ -19,6 +31,6 @@ pub struct Opts {
     /// The version of the MCP server to use
     ///
     /// You can also use the `APOLLO_ROVER_DEV_MCP_VERSION` environment variable
-    #[arg(long = "mcp-version", env = "APOLLO_ROVER_DEV_MCP_VERSION")]
+    #[arg(long = "mcp-version", env = "APOLLO_ROVER_DEV_MCP_VERSION", value_parser = parse_mcp_version)]
     pub version: Option<McpServerVersion>,
 }

--- a/src/command/dev/mcp.rs
+++ b/src/command/dev/mcp.rs
@@ -2,6 +2,8 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use serde::Serialize;
 
+use crate::command::install::McpServerVersion;
+
 pub mod binary;
 pub mod install;
 pub mod run;
@@ -13,4 +15,10 @@ pub struct Opts {
     /// Note: This uses default options if omitted
     #[arg(long = "mcp", default_missing_value = None)]
     pub config: Option<Option<Utf8PathBuf>>,
+
+    /// The version of the MCP server to use
+    ///
+    /// You can also use the `APOLLO_ROVER_DEV_MCP_VERSION` environment variable
+    #[arg(long = "mcp-version", env = "APOLLO_ROVER_DEV_MCP_VERSION")]
+    pub version: Option<McpServerVersion>,
 }

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -113,7 +113,4 @@ lazy_static::lazy_static! {
     // https://www.apollographql.com/docs/router/federation-version-support/#support-table
     pub(crate) static ref OVERRIDE_DEV_COMPOSITION_VERSION: Option<String> =
         std::env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION").ok();
-
-    pub(crate) static ref OVERRIDE_DEV_MCP_VERSION: Option<String> =
-        std::env::var("APOLLO_ROVER_DEV_MCP_VERSION").ok();
 }

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -113,4 +113,7 @@ lazy_static::lazy_static! {
     // https://www.apollographql.com/docs/router/federation-version-support/#support-table
     pub(crate) static ref OVERRIDE_DEV_COMPOSITION_VERSION: Option<String> =
         std::env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION").ok();
+
+    pub(crate) static ref OVERRIDE_DEV_MCP_VERSION: Option<String> =
+        std::env::var("APOLLO_ROVER_DEV_MCP_VERSION").ok();
 }

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -48,6 +48,9 @@ fn run_rover_dev(run_subgraphs_retail_supergraph: &RetailSupergraph) -> String {
     if let Ok(version) = env::var("APOLLO_ROVER_DEV_ROUTER_VERSION") {
         cmd.env("APOLLO_ROVER_DEV_ROUTER_VERSION", version);
     };
+    if let Ok(version) = env::var("APOLLO_ROVER_DEV_MCP_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_MCP_VERSION", version);
+    };
     cmd.spawn().expect("Could not run rover dev command");
     tokio::task::block_in_place(|| {
         let handle = tokio::runtime::Handle::current();


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-53 -->

Adds support for overriding the MCP server version in the `rover dev` command via the `--mcp-version` CLI flag and `APOLLO_ROVER_DEV_MCP_VERSION` environment variable. This allows users to specify the version of Apollo MCP Server they want to use during local development, making it easy to test with release candidates or specific versions.

The implementation follows the pattern of `--federation-version`, providing both a discoverable CLI flag (visible in `--help`) and environment variable fallback for session-wide configuration.

## Usage

Users can now specify a custom MCP server version directly (recommended):

```sh
$ rover dev --supergraph-config supergraph.yaml --mcp mcp.yaml --mcp-version 1.1.0-rc.1
```

Alternatively, set the environment variable for the session:

```sh
$ export APOLLO_ROVER_DEV_MCP_VERSION=1.1.0-rc.1
$ rover dev --supergraph-config supergraph.yaml --mcp mcp.yaml
```

Or inline:

```sh
$ APOLLO_ROVER_DEV_MCP_VERSION=1.1.0-rc.1 rover dev --supergraph-config supergraph.yaml --mcp mcp.yaml
```

## Testing

Set `--mcp-version` to an old version or an RC version of MCP.

<img width="1820" height="532" alt="2025-10-22 at 14 14 56" src="https://github.com/user-attachments/assets/b958b111-8b88-457e-ab95-763ea18543d1" />

Or set `APOLLO_ROVER_DEV_MCP_VERSION` to an old version or an RC version of MCP.

<img width="1818" height="508" alt="2025-10-20 at 16 31 59" src="https://github.com/user-attachments/assets/48444282-f5d2-4d22-b689-255f1351b5ab" />

Without it, the latest version will be picked up as it is.

<img width="1810" height="478" alt="2025-10-20 at 16 43 32" src="https://github.com/user-attachments/assets/6aa10570-2b6f-4d4b-ba76-893aa601b9e6" />