### PR TITLE
Move glibc check to Mise & GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
-      CHECK_GLIBC: "true"
       LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
 
@@ -48,7 +47,6 @@ executors:
     resource_class: arm.large
     environment:
       XTASK_TARGET: "aarch64-unknown-linux-gnu"
-      CHECK_GLIBC: "true"
       LATEST_FED_VERSION_JSON_KEY: "latest-2"
 
   amd_musl: &amd_musl_executor

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,3 +55,17 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@e3d7b8d67a7958d1207f6ed871e83b1ea780e7b0 # v3.3.1
       - run: mise run install_${{matrix.package_manager}}
+
+  check_glibc:
+    name: Check linked glibc versions
+    runs-on: ubuntu-latest
+    container: ghcr.io/apollographql/ci-utility-docker-images/apollo-rust-builder:0.21.1
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+    - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+    - uses: jdx/mise-action@e3d7b8d67a7958d1207f6ed871e83b1ea780e7b0 # v3.3.1
+    - run: cargo build
+    - run: mise run check-glibc

--- a/.mise/tasks/check-glibc.sh
+++ b/.mise/tasks/check-glibc.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-# This scripts checks if Rover's compiled executable only asks for 
+# This scripts checks if Rover's compiled executable only asks for
 # supported versions of glibc
 
 # source: https://gist.github.com/fasterthanlime/17e002a8f5e0f189861c
 
-# usage: ./check_glibc.sh ./target/debug/rover
-
-MAX_VER=2.17
+MAX_VER=2.28
 
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
-BINARY=$1
+BINARY="target/debug/rover"
 
 # Version comparison function in bash
 vercomp () {

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -1,14 +1,7 @@
-use std::{env, str::FromStr};
-
 use anyhow::Result;
-use camino::Utf8PathBuf;
 use clap::Parser;
 
-use crate::{
-    target::Target,
-    tools::{CargoRunner, Runner},
-    utils::PKG_PROJECT_ROOT,
-};
+use crate::{target::Target, tools::CargoRunner};
 
 #[derive(Debug, Parser)]
 pub struct Test {
@@ -21,15 +14,6 @@ impl Test {
     pub fn run(&self) -> Result<()> {
         let cargo_runner = CargoRunner::new()?;
         cargo_runner.test(&self.target)?;
-
-        if let Target::LinuxUnknownGnu = self.target {
-            if env::var_os("CHECK_GLIBC").is_some() {
-                let check_glibc_script = "./check_glibc.sh".to_string();
-                let runner = Runner::new(Utf8PathBuf::from_str(&check_glibc_script)?.as_str());
-                let bin_path = format!("./target/{}/debug/rover", &self.target);
-                runner.exec(&[&bin_path], &PKG_PROJECT_ROOT, None)?;
-            }
-        }
 
         Ok(())
     }


### PR DESCRIPTION
We probably want to do this in the same job as `cargo test` later just so we don't redo the debug build twice—but for now this is an incremental step toward moving the CCI test job over to GitHub Actions
