### PR TITLE
Remove OpenSSL from dependencies

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
           run: |
             yum -y update && yum -y upgrade
             yum groupinstall -y "Development Tools"
-            yum -y install perl-core gcc openssl-devel openssl git
+            yum -y install perl-core gcc git
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             . "$HOME/.cargo/env"
             rustup show active-toolchain || rustup toolchain install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,16 +921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
  "crossterm",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1553,21 +1549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,8 +1712,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1742,9 +1725,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1787,8 +1772,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -2141,19 +2124,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
+name = "hyper-rustls"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "bytes",
- "http-body-util",
+ "http",
  "hyper",
  "hyper-util",
- "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2611,7 +2595,6 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -2739,6 +2722,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
@@ -2892,23 +2881,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3122,60 +3094,6 @@ dependencies = [
  "bstr",
  "normpath",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.108",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.4+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3511,6 +3429,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,20 +3703,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
  "tower-http",
@@ -3752,6 +3726,21 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4015,7 +4004,7 @@ dependencies = [
  "countme",
  "hashbrown 0.14.5",
  "memoffset",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "text-size",
 ]
 
@@ -4027,7 +4016,7 @@ checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "text-size",
 ]
 
@@ -4073,6 +4062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,12 +4103,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4144,15 +4165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4192,29 +4204,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -4927,6 +4916,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4954,12 +4958,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -5334,6 +5338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5537,6 +5547,25 @@ checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ assert_cmd = { workspace = true }
 assert-json-diff = { workspace = true }
 dircpy = "0.3.19"
 duct = "1.1.0"
-git2 = { workspace = true, features = ["https"] }
+git2 = { workspace = true }
 graphql-schema-diff = "0.2.0"
 httpmock = { workspace = true }
 indoc = { workspace = true }
@@ -255,7 +255,7 @@ mockall = "0.13.1"
 portpicker = "0.1.1"
 predicates = { workspace = true }
 rand_regex = "0.18.1"
-reqwest = { workspace = true, features = ["native-tls-vendored"] }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 speculoos = { workspace = true }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -18,9 +18,7 @@ chrono = { workspace = true, features = ["serde"] }
 comfy-table = { workspace = true, features = ["custom_styling"]}
 derive-getters = { workspace = true }
 git-url-parse = { workspace = true }
-git2 = { workspace = true, features = [
-    "vendored-openssl",
-] }
+git2 = { workspace = true }
 graphql_client = { workspace = true }
 houston = { workspace = true }
 http = { workspace = true }
@@ -32,7 +30,7 @@ reqwest = { workspace = true, features = [
     "brotli",
     "gzip",
     "json",
-    "native-tls-vendored",
+    "rustls-tls",
     "socks",
 ] }
 rover-graphql = { workspace = true }
@@ -57,7 +55,7 @@ serde_json = { workspace = true }
 reqwest = { workspace = true, features = [
     "json",
     "blocking",
-    "native-tls-vendored",
+    "rustls-tls",
 ] }
 
 [dev-dependencies]
@@ -73,4 +71,3 @@ tracing-test = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/crates/rover-http/Cargo.toml
+++ b/crates/rover-http/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { workspace = true, features = [
     "brotli",
     "gzip",
     "json",
-    "native-tls-vendored",
+    "rustls-tls",
     "socks",
 ] }
 thiserror = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MPL-2.0",

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -12,7 +12,7 @@ camino = { workspace = true }
 directories-next = { workspace = true }
 flate2 = { workspace = true }
 rover-std = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "native-tls", "socks"] }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls", "socks"] }
 thiserror = { workspace = true }
 tar = { workspace = true }
 tempfile = {  workspace = true }

--- a/src/command/init/template_fetcher.rs
+++ b/src/command/init/template_fetcher.rs
@@ -12,11 +12,7 @@ use rover_std::Fs;
 use serde::{Deserialize, Serialize};
 use tower::Service;
 
-use crate::{
-    RoverError, RoverResult,
-    command::init::states::SelectedTemplateState,
-    options::{TemplateListFiles, TemplateWrite},
-};
+use crate::{RoverError, RoverResult, command::init::states::SelectedTemplateState};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplateManifest {
@@ -362,14 +358,12 @@ impl InitTemplateFetcher {
     }
 }
 
-impl TemplateListFiles for SelectedTemplateState {
-    fn list_files(&self) -> RoverResult<Vec<Utf8PathBuf>> {
+impl SelectedTemplateState {
+    pub(crate) fn list_files(&self) -> RoverResult<Vec<Utf8PathBuf>> {
         Ok(self.files.keys().cloned().collect())
     }
-}
 
-impl TemplateWrite for SelectedTemplateState {
-    fn write_template(&self, template_path: &Utf8PathBuf) -> RoverResult<()> {
+    pub(crate) fn write_template(&self, template_path: &Utf8PathBuf) -> RoverResult<()> {
         for (path, contents) in &self.files {
             let full_path = template_path.join(path);
             if let Some(parent) = full_path.parent() {

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -23,7 +23,7 @@ use crate::{
         template_fetcher::TemplateId,
         template_operations::{SupergraphBuilder, TemplateOperations},
     },
-    options::{ProfileOpt, TemplateListFiles, TemplateWrite},
+    options::ProfileOpt,
     utils::client::StudioClientConfig,
 };
 

--- a/src/command/template/mod.rs
+++ b/src/command/template/mod.rs
@@ -6,7 +6,6 @@ mod r#use;
 
 use clap::Parser;
 pub use list::List;
-use rover_http::ReqwestService;
 use serde::Serialize;
 pub use r#use::Use;
 
@@ -29,10 +28,8 @@ enum Command {
 
 impl Template {
     pub(crate) async fn run(&self) -> RoverResult<RoverOutput> {
-        let request_service = ReqwestService::builder().build()?;
-
         match &self.command {
-            Command::Use(use_template) => use_template.run(request_service).await,
+            Command::Use(use_template) => use_template.run().await,
             Command::List(list) => list.run().await,
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod service;
 pub mod stringify;
 pub mod table;
 pub mod telemetry;
+pub mod template;
 pub mod version;
 
 #[cfg(feature = "composition-js")]

--- a/src/utils/template.rs
+++ b/src/utils/template.rs
@@ -1,0 +1,35 @@
+use std::io::Cursor;
+
+use anyhow::{Result, anyhow};
+use camino::Utf8Path;
+use rover_std::Fs;
+use url::Url;
+
+pub async fn download_template(url: Url, to_path: &Utf8Path) -> Result<()> {
+    tracing::debug!("Downloading from {}", &url);
+    let res = reqwest::Client::new()
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/octet-stream")
+        .header(reqwest::header::USER_AGENT, "rover-client")
+        .send()
+        .await?;
+    let res = res.bytes().await?;
+
+    if res.is_empty() {
+        return Err(anyhow!("No template found"));
+    }
+
+    let cursor = Cursor::new(&res);
+    let tar = flate2::read::GzDecoder::new(cursor);
+    let mut archive = tar::Archive::new(tar);
+
+    archive.unpack(to_path)?;
+
+    let extra_dir_name = Fs::get_dir_entries(to_path)?.find(|_| true);
+    if let Some(Ok(extra_dir_name)) = extra_dir_name {
+        Fs::copy_dir_all(extra_dir_name.path(), to_path)?;
+        Fs::remove_dir_all(extra_dir_name.path())?;
+    }
+
+    Ok(())
+}

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -38,7 +38,7 @@ fn run_rover_dev(run_subgraphs_retail_supergraph: &RetailSupergraph) -> String {
         "--elv2-license",
         "accept",
     ]);
-    cmd.current_dir(run_subgraphs_retail_supergraph.get_working_directory());
+    cmd.current_dir(&run_subgraphs_retail_supergraph.working_dir);
     if let Ok(version) = env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION") {
         cmd.env("APOLLO_ROVER_DEV_COMPOSITION_VERSION", version);
     };

--- a/tests/e2e/graph/introspect.rs
+++ b/tests/e2e/graph/introspect.rs
@@ -30,7 +30,7 @@ use crate::e2e::{
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 async fn e2e_test_rover_graph_introspect(
-    run_subgraphs_retail_supergraph: &RetailSupergraph<'_>,
+    run_subgraphs_retail_supergraph: &RetailSupergraph,
     test_artifacts_directory: PathBuf,
 ) {
     // Extract the inventory URL from the supergraph.yaml

--- a/tests/e2e/subgraph/introspect.rs
+++ b/tests/e2e/subgraph/introspect.rs
@@ -27,7 +27,7 @@ use crate::e2e::{
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 async fn e2e_test_rover_subgraph_introspect(
-    run_subgraphs_retail_supergraph: &RetailSupergraph<'_>,
+    run_subgraphs_retail_supergraph: &RetailSupergraph,
     test_artifacts_directory: PathBuf,
 ) {
     // Extract the inventory URL from the supergraph.yaml

--- a/tests/e2e/supergraph/compose.rs
+++ b/tests/e2e/supergraph/compose.rs
@@ -1,7 +1,6 @@
 use std::{env, process::Command};
 
 use assert_cmd::prelude::CommandCargoExt;
-use camino::Utf8PathBuf;
 use regex::RegexSet;
 use rstest::*;
 use tracing::error;
@@ -13,7 +12,7 @@ use crate::e2e::{RetailSupergraph, retail_supergraph};
 #[ignore]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
-async fn e2e_test_run_rover_supergraph_compose(retail_supergraph: &RetailSupergraph<'_>) {
+async fn e2e_test_run_rover_supergraph_compose(retail_supergraph: &RetailSupergraph) {
     // GIVEN
     //   - a supergraph config yaml (fixture)
     //   - retail supergraphs representing any set of subgraphs to be composed into a supergraph
@@ -37,7 +36,7 @@ async fn e2e_test_run_rover_supergraph_compose(retail_supergraph: &RetailSupergr
         args.push(format!("={version}"));
     };
     cmd.args(args);
-    cmd.current_dir(retail_supergraph.get_working_directory());
+    cmd.current_dir(&retail_supergraph.working_dir);
     let match_set: Vec<String> = retail_supergraph
         .get_subgraph_names()
         .into_iter()
@@ -66,13 +65,10 @@ async fn e2e_test_run_rover_supergraph_compose(retail_supergraph: &RetailSupergr
     // AND
     //   - the composition result is saved in the tmp dir
     //   - the composition result joins all the graphs named in the supergraph config
-    let composition_result_path = Utf8PathBuf::from_path_buf(
-        retail_supergraph
-            .get_working_directory()
-            .path()
-            .join("composition-result"),
-    )
-    .expect("failed to get composition result path");
+    let composition_result_path = retail_supergraph
+        .working_dir
+        .path()
+        .join("composition-result");
     let composition_result = std::fs::read_to_string(composition_result_path)
         .expect("Could not read composition result file");
     let matched_len: usize = re_set.matches(&composition_result).into_iter().count();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,7 +22,7 @@ rover-client = { workspace = true }
 serde_json = { workspace = true }
 tar = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "native-tls", "json"] }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls", "json"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 shell-candy = { workspace = true }


### PR DESCRIPTION
openssl-sys is our slowest building dependency at 27s on my machine and is difficult to build cross-target (as we want to in CI).

It was included via:
1. `git2` in an end-to-end test which only really needed the same logic as our templates use, so I am sharing that
2. `git2` in `rover-client` to gather local repo context for `rover subgraph publish`. As far as I can tell, it doesn't need OpenSSL to do that
3. `reqwest` in all sorts of places, which I replaced with rustls

We now have to compile `rustls` + `ring` instead of `openssl-sys`, but they combined take ~20 seconds less for me locally and should have no trouble cross-compiling.

While making the template logic more reusable I also deleted a bunch of unnecessary wrappers that weren't adding any functionality.