### PR TITLE
Upgrade macOS compile target to 14

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         compile_target:
           - target: x86_64-apple-darwin
-            compiles_on: macos-13-xlarge
+            compiles_on: macos-14-xlarge
           - target: aarch64-apple-darwin
-            compiles_on: macos-13-xlarge
+            compiles_on: macos-14-xlarge
           - target: x86_64-pc-windows-msvc
             compiles_on: windows-2022
           - target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
Updated GitHub Action Runners for macOS compile target from mac-13 to mac-14.

Today is macOS brownout day for 13, so maybe time to upgrade anyhow!

Ref: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
