### PR TITLE
docs: Add rover connector reference documentation page

### DIFF
--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -25,6 +25,8 @@ items:
         href: ./commands/cloud    
       - label: config
         href: ./commands/config
+      - label: connector
+        href: ./commands/connectors
       - label: contract
         href: ./commands/contracts
       - label: dev

--- a/docs/source/commands/connectors.mdx
+++ b/docs/source/commands/connectors.mdx
@@ -1,9 +1,9 @@
 ---
 title: Rover connector Commands
-subtitle: Analyze API requests, generate schemas, and create automated tests with Rover
+subtitle: Analyze requests, generate schemas, and create tests for connectors
 description: Analyze API requests, generate schemas, and create automated tests with Rover.
 ---
 
-Rover provides a set of commands for managing [Apollo Connectors](https://www.apollographql.com/docs/graphos/connectors) from the command line. They all begin with `rover connector`.
+Rover provides a set of `rover connector` commands for managing [Apollo Connectors](/graphos/connectors). These allow you to run and analyze API requests, generate schemas based on that analysis, and create automated tests for your connectors. 
 
-Connector related commands allow you to analyze API requests, generate schemas based on that analysis, and create automated tests for your connectors. There are other management capabilities provided by Rover as well. For full documentation, review the Apollo Connector documentation on [CLI tools for connectors](https://www.apollographql.com/docs/graphos/connectors/tooling/cli-tools).
+For a complete reference, see the [CLI tools for connectors](/graphos/connectors/tooling/cli-tools).

--- a/docs/source/commands/connectors.mdx
+++ b/docs/source/commands/connectors.mdx
@@ -1,0 +1,9 @@
+---
+title: Rover connector Commands
+subtitle: Analyze API requests, generate schemas, and create automated tests with Rover
+description: Analyze API requests, generate schemas, and create automated tests with Rover.
+---
+
+Rover provides a set of commands for managing [Apollo Connectors](https://www.apollographql.com/docs/graphos/connectors) from the command line. They all begin with `rover connector`.
+
+Connector related commands allow you to analyze API requests, generate schemas based on that analysis, and create automated tests for your connectors. There are other management capabilities provided by Rover as well. For full documentation, review the Apollo Connector documentation on [CLI tools for connectors](https://www.apollographql.com/docs/graphos/connectors/tooling/cli-tools).


### PR DESCRIPTION
This update provides a new documentation page about the `rover connector` commands. Full details are linked to on the Apollo Connector documentation, but a brief overview of what is possible with the commands is provided.