### PR TITLE
Remove patch version from cargo to improve renovate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,88 +89,88 @@ ariadne = "0.6"
 assert_fs = "1"
 assert_cmd = "2"
 assert-json-diff = "2"
-async-trait = "0.1.83"
+async-trait = "0.1"
 backtrace = "0.3"
-backon = { version = "1.4.0", features = ["std", "tokio-sleep"] }
+backon = { version = "1.4", features = ["std", "tokio-sleep"] }
 base64 = "0.22"
 billboard = "0.2"
-buildstructor = "0.6.0"
-bytes = "1.8.0"
+buildstructor = "0.6"
+bytes = "1"
 cargo_metadata = "0.23"
 calm_io = "0.1"
 camino = { version = "1", features = ["serde1"] }
 clap = "4"
 chrono = "0.4"
 ci_info = "0.14"
-comfy-table = { version = "7.1.4", features = ["custom_styling"] }
+comfy-table = { version = "7", features = ["custom_styling"] }
 console = "0.16"
-derive-getters = "0.5.0"
+derive-getters = "0.5"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
-directories-next = "2.0"
+directories-next = "2"
 dotenvy = "0.15"
 flate2 = "1"
 futures = "0.3"
-git-url-parse = "0.6.0"
+git-url-parse = "0.6"
 git2 = { version = "0.20", default-features = false }
 graphql_client = "0.14"
 heck = "0.5"
-humantime = "2.1.0"
-http = "1.1.0"
-http-body = "1.0.1"
-http-body-util = "0.1.2"
+humantime = "2"
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
 httpmock = "0.8"
-hyper = "1.0"
+hyper = "1"
 indoc = "2"
-itertools = "0.14.0"
+itertools = "0.14"
 lazycell = "1"
-lazy_static = "1.4"
+lazy_static = "1"
 notify = { version = "8" }
 opener = "0.8"
-os_info = "3.7"
-os_type = "2.6"
+os_info = "3"
+os_type = "2"
 predicates = "3"
 pretty_assertions = "1"
-rand = "0.9.2"
+rand = "0.9"
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
-rstest = "0.26.0"
-schemars = "1.0.4"
+rstest = "0.26"
+schemars = "1"
 semver = "1"
 serial_test = "3"
-serde = "1.0"
-serde_json = "1.0"
+serde = "1"
+serde_json = "1"
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 serde_yaml = "0.9"
 shell-candy = "0.4"
-speculoos = "0.13.0"
+speculoos = "0.13"
 strip-ansi-escapes = "0.2"
 strsim = "0.11"
 strum = "0.27"
 strum_macros = "0.27"
 sha2 = "0.10"
-shellexpand = "3.1"
-termcolor = "1.3"
+shellexpand = "3"
+termcolor = "1"
 thiserror = "2"
-tap = "1.0.1"
+tap = "1"
 tar = "0.4"
 termimad = "0.34"
-tempfile = "3.8"
-tokio = { version = "1.38", features = ["signal"] }
+tempfile = "3"
+tokio = { version = "1", features = ["signal"] }
 tokio-stream = "0.1"
-tokio-test = "0.4.4"
-tokio-util = "0.7.12"
+tokio-test = "0.4"
+tokio-util = "0.7"
 toml = "0.9"
-tower = { version = "0.5.2", features = ["make", "retry", "timeout"] }
-tower-test = "0.4.0"
+tower = { version = "0.5", features = ["make", "retry", "timeout"] }
+tower-test = "0.4"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.3"
-tracing-test = "0.2.5"
+tracing-test = "0.2"
 which = "8"
 wsl = "0.1"
 uuid = "1"
 url = "2"
-zip = "6.0"
+zip = "6"
 
 ### rover specific dependencies
 [dependencies]
@@ -234,7 +234,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
-tower-lsp = { version = "0.20.0" }
+tower-lsp = { version = "0.20" }
 tracing = { workspace = true }
 uuid = { workspace = true }
 url = { workspace = true, features = ["serde"] }
@@ -243,25 +243,25 @@ comfy-table = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 assert-json-diff = { workspace = true }
-dircpy = "0.3.19"
-duct = "1.1.0"
+dircpy = "0.3"
+duct = "1"
 git2 = { workspace = true }
-graphql-schema-diff = "0.2.0"
+graphql-schema-diff = "0.2"
 httpmock = { workspace = true }
 indoc = { workspace = true }
-jsonschema = "0.33.0"
-mime = "0.3.17"
-mockall = "0.13.1"
-portpicker = "0.1.1"
+jsonschema = "0.33"
+mime = "0.3"
+mockall = "0.13"
+portpicker = "0.1"
 predicates = { workspace = true }
-rand_regex = "0.18.1"
+rand_regex = "0.18"
 reqwest = { workspace = true, features = ["rustls-tls"] }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 speculoos = { workspace = true }
 tower-test = { workspace = true }
 tracing-test = { workspace = true }
-temp-env = { version = "0.3.6", features = ["async_closure"] }
+temp-env = { version = "0.3", features = ["async_closure"] }
 
 # For sputnik, run tests with debug_assertions disabled. This is necessary because telemetry is not sent if
 # debug_assertions is enabled, and the tests rely on telemetry being sent to mock APIs.


### PR DESCRIPTION
Removes patches from versioning from Cargo dependencies to improve renovate flow