### PR TITLE
feat: Adding support for depreacted both on args and input (#2822)

### DIFF
--- a/crates/rover-client/src/operations/graph/introspect/fixtures/interfaces.json
+++ b/crates/rover-client/src/operations/graph/introspect/fixtures/interfaces.json
@@ -24,7 +24,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "5"
+                                    "defaultValue": "5",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -51,7 +53,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "5"
+                                    "defaultValue": "5",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "after",
@@ -61,7 +65,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "0"
+                                    "defaultValue": "0",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "type",
@@ -71,7 +77,9 @@
                                         "name": "ProductType",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -195,7 +203,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "5"
+                                    "defaultValue": "5",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "after",
@@ -205,7 +215,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "0"
+                                    "defaultValue": "0",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -731,7 +743,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -802,7 +816,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1472,7 +1488,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "5"
+                                    "defaultValue": "5",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "after",
@@ -1482,7 +1500,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "0"
+                                    "defaultValue": "0",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1505,7 +1525,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "5"
+                                    "defaultValue": "5",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "after",
@@ -1515,7 +1537,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "0"
+                                    "defaultValue": "0",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1554,7 +1578,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": "\" \""
+                                    "defaultValue": "\" \"",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1781,7 +1807,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "5"
+                                    "defaultValue": "5",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "after",
@@ -1791,7 +1819,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": "0"
+                                    "defaultValue": "0",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1837,7 +1867,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -1862,7 +1894,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -1882,7 +1916,9 @@
                                 "name": "String",
                                 "ofType": null
                             },
-                            "defaultValue": "\"No longer supported\""
+                            "defaultValue": "\"No longer supported\"",
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 }

--- a/crates/rover-client/src/operations/graph/introspect/fixtures/simple.json
+++ b/crates/rover-client/src/operations/graph/introspect/fixtures/simple.json
@@ -44,7 +44,9 @@
                                             }
                                         }
                                     },
-                                    "defaultValue": "[\"Nori\"]"
+                                    "defaultValue": "[\"Nori\"]",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -93,7 +95,9 @@
                                 "name": "Boolean",
                                 "ofType": null
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         },
                         {
                             "name": "ne",
@@ -103,7 +107,9 @@
                                 "name": "Boolean",
                                 "ofType": null
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         },
                         {
                             "name": "in",
@@ -117,7 +123,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         },
                         {
                             "name": "nin",
@@ -131,7 +139,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "interfaces": null,
@@ -371,7 +381,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -442,7 +454,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -473,7 +487,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -614,7 +630,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1096,7 +1114,9 @@
                                 "name": "Int",
                                 "ofType": null
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         },
                         {
                             "name": "scope",
@@ -1106,7 +1126,9 @@
                                 "name": "CacheControlScope",
                                 "ofType": null
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -1131,7 +1153,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -1156,7 +1180,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -1178,7 +1204,9 @@
                                 "name": "String",
                                 "ofType": null
                             },
-                            "defaultValue": "\"No longer supported\""
+                            "defaultValue": "\"No longer supported\"",
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -1201,7 +1229,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 }

--- a/crates/rover-client/src/operations/graph/introspect/fixtures/swapi.json
+++ b/crates/rover-client/src/operations/graph/introspect/fixtures/swapi.json
@@ -24,7 +24,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -34,7 +36,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -44,7 +48,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -54,7 +60,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -77,7 +85,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "filmID",
@@ -87,7 +97,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -110,7 +122,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -120,7 +134,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -130,7 +146,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -140,7 +158,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -163,7 +183,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "personID",
@@ -173,7 +195,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -196,7 +220,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -206,7 +232,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -216,7 +244,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -226,7 +256,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -249,7 +281,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "planetID",
@@ -259,7 +293,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -282,7 +318,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -292,7 +330,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -302,7 +342,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -312,7 +354,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -335,7 +379,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "speciesID",
@@ -345,7 +391,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -368,7 +416,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -378,7 +428,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -388,7 +440,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -398,7 +452,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -421,7 +477,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "starshipID",
@@ -431,7 +489,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -454,7 +514,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -464,7 +526,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -474,7 +538,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -484,7 +550,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -507,7 +575,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "vehicleID",
@@ -517,7 +587,9 @@
                                         "name": "ID",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -544,7 +616,9 @@
                                             "ofType": null
                                         }
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -861,7 +935,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -871,7 +947,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -881,7 +959,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -891,7 +971,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -914,7 +996,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -924,7 +1008,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -934,7 +1020,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -944,7 +1032,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -967,7 +1057,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -977,7 +1069,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -987,7 +1081,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -997,7 +1093,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1020,7 +1118,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -1030,7 +1130,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -1040,7 +1142,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -1050,7 +1154,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1073,7 +1179,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -1083,7 +1191,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -1093,7 +1203,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -1103,7 +1215,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1493,7 +1607,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -1503,7 +1619,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -1513,7 +1631,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -1523,7 +1643,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1546,7 +1668,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -1556,7 +1680,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -1566,7 +1692,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -1576,7 +1704,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1782,7 +1912,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -1792,7 +1924,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -1802,7 +1936,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -1812,7 +1948,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -1835,7 +1973,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -1845,7 +1985,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -1855,7 +1997,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -1865,7 +2009,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -2163,7 +2309,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -2173,7 +2321,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -2183,7 +2333,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -2193,7 +2345,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -2228,7 +2382,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -2238,7 +2394,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -2248,7 +2406,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -2258,7 +2418,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -2281,7 +2443,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -2291,7 +2455,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -2301,7 +2467,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -2311,7 +2479,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -2771,7 +2941,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -2781,7 +2953,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -2791,7 +2965,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -2801,7 +2977,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -2824,7 +3002,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -2834,7 +3014,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -2844,7 +3026,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -2854,7 +3038,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -3400,7 +3586,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -3410,7 +3598,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -3420,7 +3610,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -3430,7 +3622,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -3453,7 +3647,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "first",
@@ -3463,7 +3659,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "before",
@@ -3473,7 +3671,9 @@
                                         "name": "String",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 },
                                 {
                                     "name": "last",
@@ -3483,7 +3683,9 @@
                                         "name": "Int",
                                         "ofType": null
                                     },
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -5242,7 +5444,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -5313,7 +5517,9 @@
                                         "name": "Boolean",
                                         "ofType": null
                                     },
-                                    "defaultValue": "false"
+                                    "defaultValue": "false",
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
                                 }
                             ],
                             "type": {
@@ -5905,7 +6111,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -5930,7 +6138,9 @@
                                     "ofType": null
                                 }
                             },
-                            "defaultValue": null
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 },
@@ -5950,7 +6160,9 @@
                                 "name": "String",
                                 "ofType": null
                             },
-                            "defaultValue": "\"No longer supported\""
+                            "defaultValue": "\"No longer supported\"",
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ]
                 }

--- a/crates/rover-client/src/operations/graph/introspect/introspect_query.graphql
+++ b/crates/rover-client/src/operations/graph/introspect/introspect_query.graphql
@@ -30,7 +30,7 @@ fragment FullType on __Type {
   fields(includeDeprecated: true) {
     name
     description
-    args {
+    args(includeDeprecated:true) {
       ...InputValue
     }
     type {
@@ -39,7 +39,7 @@ fragment FullType on __Type {
     isDeprecated
     deprecationReason
   }
-  inputFields {
+  inputFields(includeDeprecated:true) {
     ...InputValue
   }
   interfaces {
@@ -63,6 +63,8 @@ fragment InputValue on __InputValue {
     ...TypeRef
   }
   defaultValue
+  isDeprecated
+  deprecationReason
 }
 
 fragment TypeRef on __Type {

--- a/crates/rover-client/src/operations/graph/introspect/introspect_schema.graphql
+++ b/crates/rover-client/src/operations/graph/introspect/introspect_schema.graphql
@@ -51,6 +51,8 @@ type __InputValue {
   name: String!
   description: String
   type: __Type!
+  isDeprecated: Boolean!
+  deprecationReason: String
   defaultValue: String
 }
 

--- a/crates/rover-client/src/operations/graph/introspect/schema.rs
+++ b/crates/rover-client/src/operations/graph/introspect/schema.rs
@@ -244,12 +244,15 @@ impl Schema {
     fn encode_input_field(field: FullTypeInputField) -> InputField {
         let ty = Self::encode_type(field.type_);
         let mut field_def = InputField::new(field.name, ty);
-
         if let Some(default_value) = field.default_value {
             field_def.default_value(default_value);
         }
         if let Some(desc) = field.description {
             field_def.description(desc);
+        }
+
+        if field.is_deprecated {
+            field_def.directive(create_deprecated_directive(field.deprecation_reason));
         }
         field_def
     }
@@ -257,12 +260,15 @@ impl Schema {
     fn encode_arg(value: FullTypeFieldArg) -> InputValueDefinition {
         let ty = Self::encode_type(value.type_);
         let mut value_def = InputValueDefinition::new(value.name, ty);
-
         if let Some(default_value) = value.default_value {
             value_def.default_value(default_value);
         }
         if let Some(desc) = value.description {
             value_def.description(desc);
+        }
+
+        if value.is_deprecated {
+            value_def.directive(create_deprecated_directive(value.deprecation_reason));
         }
         value_def
     }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to
Apollo!

Here are some important details to follow:

* ⏰ Your time is important
To save your precious time, if the contribution you are making will
take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
Feature requests can be created and discussed within a GitHub Issue.
Be sure to search for existing feature requests (and related issues!)
prior to opening a new request. If an existing issue covers the need,
please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
These can be created and discussed in this repository. When fixing a
bug,
please _try_ to add a test which verifies the fix. If you cannot, you
should
still submit the PR but we may still ask you (and help you!) to create a
test.

* 📖 Contribution guidelines
Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
when submitting a pull request. Make sure existing tests still pass, and
add
        tests for all new behavior.

* ✏️ Explain your pull request
Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as
much
as possible. Without following these guidelines, you may be missing
context
that can help you succeed with your contribution, which is why we
encourage
discussion first. Ultimately, there is no guarantee that we will be able
to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

Fixing an issue where the rover will remove deprecated input fields when
using the `rover graph introspect` command.



It requires the following proposed changes to `graphql-client` crate
https://github.com/graphql-rust/graphql-client/pull/553.

Co-authored-by: @lpessoa 