### PR TITLE
tests: Adding tests for both deprecated arg and inputs in graph introspect -  related to #2822

### DIFF
--- a/crates/rover-client/src/operations/graph/introspect/fixtures/simple.json
+++ b/crates/rover-client/src/operations/graph/introspect/fixtures/simple.json
@@ -64,6 +64,39 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "dogs",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "excludeChihuahuas",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false",
+                                    "isDeprecated": true,
+                                    "deprecationReason": "Chihuahuas are dogs too!"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -142,6 +175,97 @@
                             "defaultValue": null,
                             "isDeprecated": false,
                             "deprecationReason": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StringQueryOperatorInput",
+                    "description": null,
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "eq",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ne",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "in",
+                            "description": null,
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "nin",
+                            "description": null,
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "regex",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null,
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "glob",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": null,
+                            "isDeprecated": true,
+                            "deprecationReason": "Glob is deprecated, use regex instead"
                         }
                     ],
                     "interfaces": null,

--- a/crates/rover-client/src/operations/graph/introspect/schema.rs
+++ b/crates/rover-client/src/operations/graph/introspect/schema.rs
@@ -428,6 +428,7 @@ mod tests {
           "A simple type for getting started!"
           hello: String
           cats(cat: [String]! = ["Nori"]): [String]!
+          dogs(excludeChihuahuas: Boolean = false @deprecated(reason: "Chihuahuas are dogs too!")): [String]!
         }
         enum CacheControlScope {
           PUBLIC
@@ -438,6 +439,14 @@ mod tests {
           ne: Boolean
           in: [Boolean]
           nin: [Boolean]
+        }
+        input StringQueryOperatorInput {
+          eq: String
+          ne: String
+          in: [String]
+          nin: [String]
+          regex: String
+          glob: String @deprecated(reason: "Glob is deprecated, use regex instead")
         }
         directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
         "Exposes a URL that specifies the behaviour of this scalar."


### PR DESCRIPTION
Refers to #2822 

Adding tests for both deprecated arg and inputs in graph introspect.

@naomijub 