### PR TITLE
Auto-configure MCP server endpoint with router's custom path

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -265,6 +265,8 @@ impl Dev {
         // the overrides for the temporary config we set for hot-reloading the router, but also as
         // a message to the user for where to find their router
         let router_address = *run_router.state.config.address();
+        // Extract the router's listen path from the config to construct the full endpoint URL for MCP
+        let router_path = run_router.state.config.listen_path();
         let hot_reload_overrides = HotReloadConfigOverrides::builder()
             .address(router_address)
             .build();
@@ -313,6 +315,7 @@ impl Dev {
                     TokioSpawn::default(),
                     run_router.state.hot_reload_schema_path.clone(),
                     router_address,
+                    router_path,
                     config.clone(),
                     run_router.state.env.clone(),
                 )

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -266,7 +266,7 @@ impl Dev {
         // a message to the user for where to find their router
         let router_address = *run_router.state.config.address();
         // Extract the router's listen path from the config to construct the full endpoint URL for MCP
-        let router_path = run_router.state.config.listen_path();
+        let router_url_path = run_router.state.config.listen_path();
         let hot_reload_overrides = HotReloadConfigOverrides::builder()
             .address(router_address)
             .build();
@@ -315,7 +315,7 @@ impl Dev {
                     TokioSpawn::default(),
                     run_router.state.hot_reload_schema_path.clone(),
                     router_address,
-                    router_path,
+                    router_url_path,
                     config.clone(),
                     run_router.state.env.clone(),
                 )

--- a/src/command/dev/mcp/binary.rs
+++ b/src/command/dev/mcp/binary.rs
@@ -78,7 +78,7 @@ pub struct RunMcpServerBinary<Spawn: Send> {
     supergraph_schema_path: Utf8PathBuf,
     spawn: Spawn,
     router_address: RouterAddress,
-    router_path: Option<String>,
+    router_url_path: Option<String>,
     mcp_config_path: Option<Utf8PathBuf>,
     env: HashMap<String, String>,
 }
@@ -89,7 +89,7 @@ impl<Spawn: Send> RunMcpServerBinary<Spawn> {
     // TODO: Magic strings are not fun to debug later.
     fn opts_into_env(self) -> HashMap<String, String> {
         // Build the endpoint URL with the optional path from router config
-        let endpoint = if let Some(path) = &self.router_path {
+        let endpoint = if let Some(path) = &self.router_url_path {
             format!("{}{}", self.router_address.pretty_string(), path)
         } else {
             self.router_address.pretty_string()
@@ -267,7 +267,7 @@ mod tests {
     struct MockSpawn;
 
     #[test]
-    fn test_mcp_endpoint_without_router_path() {
+    fn test_mcp_endpoint_without_router_url_path() {
         let router_address = RouterAddress::new(
             Some(RouterHost::Default(IpAddr::V4(std::net::Ipv4Addr::new(
                 127, 0, 0, 1,
@@ -280,7 +280,7 @@ mod tests {
             Version::parse("1.0.0").unwrap(),
         );
 
-        let router_path: Option<String> = None;
+        let router_url_path: Option<String> = None;
         let mcp_config_path: Option<Utf8PathBuf> = None;
 
         let runner = RunMcpServerBinary::<MockSpawn>::builder()
@@ -288,7 +288,7 @@ mod tests {
             .supergraph_schema_path(Utf8PathBuf::from("/fake/schema.graphql"))
             .spawn(MockSpawn)
             .router_address(router_address)
-            .and_router_path(router_path)
+            .and_router_url_path(router_url_path)
             .and_mcp_config_path(mcp_config_path)
             .env(HashMap::new())
             .build();
@@ -300,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mcp_endpoint_with_router_path() {
+    fn test_mcp_endpoint_with_router_url_path() {
         let router_address = RouterAddress::new(
             Some(RouterHost::Default(IpAddr::V4(std::net::Ipv4Addr::new(
                 127, 0, 0, 1,
@@ -320,7 +320,7 @@ mod tests {
             .supergraph_schema_path(Utf8PathBuf::from("/fake/schema.graphql"))
             .spawn(MockSpawn)
             .router_address(router_address)
-            .and_router_path(Some("/graphql".to_string()))
+            .and_router_url_path(Some("/graphql".to_string()))
             .and_mcp_config_path(mcp_config_path)
             .env(HashMap::new())
             .build();
@@ -352,7 +352,7 @@ mod tests {
             .supergraph_schema_path(Utf8PathBuf::from("/fake/schema.graphql"))
             .spawn(MockSpawn)
             .router_address(router_address)
-            .and_router_path(Some("/custom-path".to_string()))
+            .and_router_url_path(Some("/custom-path".to_string()))
             .and_mcp_config_path(mcp_config_path)
             .env(HashMap::new())
             .build();

--- a/src/command/dev/mcp/run.rs
+++ b/src/command/dev/mcp/run.rs
@@ -57,7 +57,7 @@ impl RunMcpServer<state::Run> {
         spawn: Spawn,
         supergraph_schema_path: Utf8PathBuf,
         router_address: RouterAddress,
-        router_path: Option<String>,
+        router_url_path: Option<String>,
         mcp_config_path: Option<Utf8PathBuf>,
         env: HashMap<String, String>,
     ) -> Result<RunMcpServer<state::Abort>, RunMcpServerBinaryError>
@@ -71,7 +71,7 @@ impl RunMcpServer<state::Run> {
             .supergraph_schema_path(supergraph_schema_path.clone())
             .spawn(spawn)
             .router_address(router_address)
-            .and_router_path(router_path)
+            .and_router_url_path(router_url_path)
             .and_mcp_config_path(mcp_config_path)
             .env(env)
             .build();

--- a/src/command/dev/mcp/run.rs
+++ b/src/command/dev/mcp/run.rs
@@ -57,6 +57,7 @@ impl RunMcpServer<state::Run> {
         spawn: Spawn,
         supergraph_schema_path: Utf8PathBuf,
         router_address: RouterAddress,
+        router_path: Option<String>,
         mcp_config_path: Option<Utf8PathBuf>,
         env: HashMap<String, String>,
     ) -> Result<RunMcpServer<state::Abort>, RunMcpServerBinaryError>
@@ -70,6 +71,7 @@ impl RunMcpServer<state::Run> {
             .supergraph_schema_path(supergraph_schema_path.clone())
             .spawn(spawn)
             .router_address(router_address)
+            .and_router_path(router_path)
             .and_mcp_config_path(mcp_config_path)
             .env(env)
             .build();


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-55 -->

When users configure a custom path in their router config (e.g., `supergraph.path: /graphql`), the MCP server fails to connect to the router with error code `-32603`. This occurs because Rover was not including the custom path when setting the `APOLLO_MCP_ENDPOINT` environment variable for the MCP server.

This PR makes `rover dev` automatically detect and use the router's custom path when configuring the MCP server endpoint. The router configuration becomes the single source of truth for both Router and Apollo MCP server.