### PR TITLE
Handle InvalidGraphRef error gracefully instead of panicking

### DIFF
--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -248,9 +248,10 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                     Some(RoverErrorCode::E027),
                 ),
                 RoverClientError::AdhocError { .. } => (None, None),
-                RoverClientError::InvalidGraphRef => {
-                    unreachable!("Graph ref parse errors should be caught via clap")
-                }
+                RoverClientError::InvalidGraphRef => (
+                    Some(RoverErrorSuggestion::CheckGraphNameAndAuth),
+                    Some(RoverErrorCode::E010),
+                ),
                 RoverClientError::InvalidValidationPeriodDuration(_)
                 | RoverClientError::ValidationPeriodTooGranular => {
                     unreachable!("Validation period parse errors should be caught via clap")


### PR DESCRIPTION
Fixes #2920

When running `rover subgraph fetch` with certain graph refs, users encountered a panic:

```
Panic occurred in file 'src/error/metadata/mod.rs' at line 252
cause = "internal error: entered unreachable code: Graph ref parse errors should be caught via clap"
```

The error handling code assumed `InvalidGraphRef` errors could only occur during CLI argument parsing. However, the Apollo Studio API can also return `InvalidRefFormat` at runtime via the `GraphVariantLookup` union type, which triggers this error path.

This PR replaces the `unreachable!()` with proper error handling that provides a helpful suggestion to check the graph name and authentication.

## Testing

Before:

```sh
$ rover subgraph fetch --name test "foo@"
Fetching SDL from foo@ (subgraph: test) using credentials from the default profile.

thread 'main' (2842302) panicked at src/error/metadata/mod.rs:252:21:
internal error: entered unreachable code: Graph ref parse errors should be caught via clap
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```sh
$ rover subgraph fetch --name test "foo@"
Fetching SDL from foo@ (subgraph: test) using credentials from the default profile.
error[E010]: Graph IDs must be in the format <NAME> or <NAME>@<VARIANT>, where <NAME> can only contain letters, numbers, or the characters `-` or `_`, and must be 64 characters or less. <VARIANT> must be 64 characters or less.
        Make sure your graph name is typed correctly, and that your API key is valid.
        You can run `rover config whoami` to check your authentication.
```
