### PR TITLE
fix: replace hardcoded plugin URL with wildcards

### DIFF
--- a/regressions/e2e/connectors/list.md
+++ b/regressions/e2e/connectors/list.md
@@ -5,8 +5,8 @@
 ```console
 $ rover connector --elv2-license accept list --schema fixtures/body.graphql
 merging supergraph schema files
-downloading the 'supergraph' plugin from https://rover.apollo.dev/tar/supergraph/x86_64-unknown-linux-gnu/latest-2
-the 'supergraph' plugin was successfully installed to /home/runner/.rover/bin/supergraph-v2.12.1
+downloading the 'supergraph' plugin from [..]
+the 'supergraph' plugin was successfully installed to [..]
 {
   "connectors": [
     {


### PR DESCRIPTION
I noticed that the E2E tests for the connectors were failing in the main branch while releasing v0.37.1. It turns out the expected output in `list.md` has the supergraph plugin version hardcoded as `v2.12.1`. This version became outdated when `latest_plugin_versions.json` was updated to `v2.12.2` in #2919 causing the test to fail. This PR replaces the hardcoded plugin URL and installation path with trycmd wildcards, which makes the test more resilient to future version updates.

#### Before

<img width="2974" height="1356" alt="2025-12-16 at 09 30 51" src="https://github.com/user-attachments/assets/df78d807-d6c7-44ad-961a-37d14f2af8d5" />

https://github.com/apollographql/rover/actions/runs/20249286584/job/58193242690

#### After

<img width="3024" height="1616" alt="2025-12-16 at 09 33 39" src="https://github.com/user-attachments/assets/9188aa2b-a234-49be-a321-c36e23ef739a" />

https://github.com/apollographql/rover/actions/runs/20270957564/job/58206355891?pr=2931
