### PR TITLE
feat: Removing project type selection from `init` command

### DIFF
--- a/src/command/init/helpers.rs
+++ b/src/command/init/helpers.rs
@@ -152,18 +152,6 @@ pub fn display_project_created_message(
     println!("{message}");
 }
 
-pub fn display_use_template_message() {
-    println!();
-    println!(
-        "To add a new subgraph to an existing graph, use `{}`.",
-        Style::Command.paint("rover template")
-    );
-    println!(
-        "To learn more about templates, run `{}`",
-        Style::Command.paint("rover docs open template")
-    );
-}
-
 /// Print categorized MCP file listing
 pub fn print_mcp_file_categories(file_paths: Vec<Utf8PathBuf>) {
     // Categorize files for MCP-specific display

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -185,9 +185,7 @@ impl Init {
         // Branch to MCP flow BEFORE directory validation
         if self.project_template.mcp {
             // Create ProjectTypeSelected state for MCP flow (bypasses directory check)
-            let project_type = self
-                .project_type
-                .get_project_type();
+            let project_type = self.project_type.get_project_type();
 
             let current_dir = env::current_dir()?;
             let output_path = Utf8PathBuf::from_path_buf(self.path.clone().unwrap_or(current_dir))
@@ -203,8 +201,7 @@ impl Init {
                 .await;
         }
 
-        let project_type_selected =
-            welcome.select_project_type( &self.path)?;
+        let project_type_selected = welcome.select_project_type(&self.path)?;
 
         // Handle new project creation flow
         let use_case_selected = match project_type_selected
@@ -282,9 +279,7 @@ impl Init {
                             let welcome = UserAuthenticated::new()
                                 .check_authentication(&client_config, &self.profile)
                                 .await?;
-                            welcome.select_project_type(
-                                &self.path,
-                            )?;
+                            welcome.select_project_type(&self.path)?;
                             return Ok(RoverOutput::EmptySuccess);
                         }
                         _ => {

--- a/src/command/init/options/project_type.rs
+++ b/src/command/init/options/project_type.rs
@@ -1,44 +1,17 @@
 use std::fmt::{self, Display};
 
-use anyhow::anyhow;
-use clap::{Parser, ValueEnum};
-use dialoguer::{Select, console::Term};
-use rover_std::Style;
+use clap::Parser;
 use serde::{Deserialize, Serialize};
-
-use crate::{RoverError, RoverResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser, Default)]
 pub struct ProjectTypeOpt {
     #[arg(long = "project-type", short = 't', value_enum)]
-    pub project_type: Option<ProjectType>,
+    pub project_type: Option<crate::command::init::options::ProjectType>,
 }
 
 impl ProjectTypeOpt {
     pub fn get_project_type(&self) -> Option<ProjectType> {
         self.project_type.clone()
-    }
-
-    pub fn prompt_project_type(&self) -> RoverResult<ProjectType> {
-        let project_types = <ProjectType as ValueEnum>::value_variants();
-        let selection = Select::new()
-            .with_prompt(Style::Prompt.paint("? Select option"))
-            .items(project_types)
-            .default(0)
-            .interact_on_opt(&Term::stderr())?;
-
-        self.handle_project_type_selection(project_types, selection)
-    }
-
-    fn handle_project_type_selection(
-        &self,
-        project_types: &[ProjectType],
-        selection: Option<usize>,
-    ) -> RoverResult<ProjectType> {
-        match selection {
-            Some(index) => Ok(project_types[index].clone()),
-            None => Err(RoverError::new(anyhow!("No project type selected"))),
-        }
     }
 }
 
@@ -62,6 +35,7 @@ impl Display for ProjectType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::ValueEnum;
 
     #[test]
     fn test_get_project_type_with_preset_value() {

--- a/src/command/init/options/project_type.rs
+++ b/src/command/init/options/project_type.rs
@@ -34,8 +34,9 @@ impl Display for ProjectType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use clap::ValueEnum;
+
+    use super::*;
 
     #[test]
     fn test_get_project_type_with_preset_value() {

--- a/src/command/init/options/project_type.rs
+++ b/src/command/init/options/project_type.rs
@@ -54,28 +54,6 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    #[test]
-    fn test_handle_project_type_selection_with_valid_selection() {
-        let instance = ProjectTypeOpt { project_type: None };
-
-        let project_types = <ProjectType as ValueEnum>::value_variants();
-        let result = instance.handle_project_type_selection(project_types, Some(0));
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), ProjectType::CreateNew);
-    }
-
-    #[test]
-    fn test_handle_project_type_selection_with_invalid_selection() {
-        let instance = ProjectTypeOpt { project_type: None };
-
-        let project_types = <ProjectType as ValueEnum>::value_variants();
-        let result = instance.handle_project_type_selection(project_types, None);
-
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().message(), "No project type selected");
-    }
-
     // Display trait implementation tests
 
     #[test]

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -415,13 +415,13 @@ async fn test_graph_id_confirmed_preview_for_graphql_template() {
 fn test_project_type_dialog() {
     let options = ProjectTypeOpt::default();
 
-    assert_eq!(options.get_project_type(), ProjectType::CreateNew);
+    assert_eq!(options.get_project_type(), Some(ProjectType::CreateNew));
 
     let options_with_value = ProjectTypeOpt {
         project_type: Some(ProjectType::CreateNew),
     };
     assert_eq!(
         options_with_value.get_project_type(),
-        ProjectType::CreateNew
+        Some(ProjectType::CreateNew)
     );
 }

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -288,7 +288,7 @@ async fn test_graph_id_confirmed_preview_for_connectors() {
         project_type: ProjectType::CreateNew,
         organization: "test-org".parse::<OrganizationId>().unwrap(),
         use_case: ProjectUseCase::Connectors,
-        project_name: "test-graph".parse().unwrap(),
+        project_name: "test-graph".parse::<ProjectName>().unwrap(),
         graph_id: "test-graph-id".parse::<GraphId>().unwrap(),
         selected_template: SelectedTemplateState {
             template: Template {
@@ -314,7 +314,7 @@ async fn test_graph_id_confirmed_preview_for_connectors() {
             project_type: graph_id_confirmed.project_type.clone(),
             organization: graph_id_confirmed.organization.clone(),
             use_case: graph_id_confirmed.use_case.clone(),
-            project_name: graph_id_confirmed.project_name,
+            project_name: graph_id_confirmed.project_name.clone(),
             graph_id: graph_id_confirmed.graph_id.clone(),
         };
 
@@ -415,13 +415,13 @@ async fn test_graph_id_confirmed_preview_for_graphql_template() {
 fn test_project_type_dialog() {
     let options = ProjectTypeOpt::default();
 
-    assert_eq!(options.get_project_type(), None);
+    assert_eq!(options.get_project_type(), ProjectType::CreateNew);
 
     let options_with_value = ProjectTypeOpt {
         project_type: Some(ProjectType::CreateNew),
     };
     assert_eq!(
         options_with_value.get_project_type(),
-        Some(ProjectType::CreateNew)
+        ProjectType::CreateNew
     );
 }

--- a/src/command/init/tests/transitions_tests.rs
+++ b/src/command/init/tests/transitions_tests.rs
@@ -288,7 +288,7 @@ async fn test_graph_id_confirmed_preview_for_connectors() {
         project_type: ProjectType::CreateNew,
         organization: "test-org".parse::<OrganizationId>().unwrap(),
         use_case: ProjectUseCase::Connectors,
-        project_name: "test-graph".parse::<ProjectName>().unwrap(),
+        project_name: "test-graph".parse().unwrap(),
         graph_id: "test-graph-id".parse::<GraphId>().unwrap(),
         selected_template: SelectedTemplateState {
             template: Template {
@@ -314,7 +314,7 @@ async fn test_graph_id_confirmed_preview_for_connectors() {
             project_type: graph_id_confirmed.project_type.clone(),
             organization: graph_id_confirmed.organization.clone(),
             use_case: graph_id_confirmed.use_case.clone(),
-            project_name: graph_id_confirmed.project_name.clone(),
+            project_name: graph_id_confirmed.project_name,
             graph_id: graph_id_confirmed.graph_id.clone(),
         };
 
@@ -415,7 +415,7 @@ async fn test_graph_id_confirmed_preview_for_graphql_template() {
 fn test_project_type_dialog() {
     let options = ProjectTypeOpt::default();
 
-    assert_eq!(options.get_project_type(), Some(ProjectType::CreateNew));
+    assert_eq!(options.get_project_type(), None);
 
     let options_with_value = ProjectTypeOpt {
         project_type: Some(ProjectType::CreateNew),

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -118,9 +118,7 @@ impl Welcome {
 
     pub fn select_project_type(
         self,
-        options: &ProjectTypeOpt,
         override_install_path: &Option<PathBuf>,
-        _template_options: &ProjectTemplateOpt,
     ) -> RoverResult<ProjectTypeSelected> {
         display_welcome_message();
 
@@ -145,17 +143,12 @@ impl Welcome {
                     )));
         }
 
-        let project_type = match options.get_project_type() {
-            Some(ptype) => ptype,
-            None => options.prompt_project_type()?,
-        };
-
         Ok(ProjectTypeSelected {
-            project_type,
+            project_type: ProjectType::CreateNew,
             output_path,
         })
     }
-}
+}   
 
 /// PROMPT UX:
 /// =========

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -148,7 +148,7 @@ impl Welcome {
             output_path,
         })
     }
-}   
+}
 
 /// PROMPT UX:
 /// =========


### PR DESCRIPTION
Simplifying the `init` command by removing the "project type" selection & defaulting to "create new graph" option.
The project type flag is still available with the use of the `--mcp` flag.