### PR TITLE
fix: pass raw router config to avoid env var double expansion 

### DIFF
--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -21,7 +21,6 @@ use crate::{
             router::{
                 binary::RunRouterBinaryError,
                 config::{RouterAddress, RouterHost, RouterPort},
-                hot_reload::HotReloadConfigOverrides,
                 run::RunRouter,
             },
         },
@@ -262,15 +261,11 @@ impl Dev {
             .await;
         // This RouterAddress has some logic figuring out _which_ of the potentially multiple
         // address options we should use (eg, CLI, config, env var, or default). It will be used in
-        // the overrides for the temporary config we set for hot-reloading the router, but also as
-        // a message to the user for where to find their router
+        // the cli arguments for the router, but also as a message to the user for
+        // where to find their router
         let router_address = *run_router.state.config.address();
         // Extract the router's listen path from the config to construct the full endpoint URL for MCP
         let router_url_path = run_router.state.config.listen_path();
-        let hot_reload_overrides = HotReloadConfigOverrides::builder()
-            .address(router_address)
-            .build();
-
         infoln!(
             "Attempting to start router at {}.",
             router_address.pretty_string()
@@ -289,7 +284,7 @@ impl Dev {
                 log_level,
             )
             .await?
-            .watch_for_changes(write_file_impl, composition_messages, hot_reload_overrides)
+            .watch_for_changes(write_file_impl, composition_messages)
             .await;
 
         if let Some(ref config) = self.opts.mcp.config {

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -312,12 +312,12 @@ telemetry:
     .await
     .unwrap_or(false);
 
-    // On Unix, send SIGTERM so rover can gracefully shut down the router
-    // On Windows, use taskkill /T to kill the entire process tree
+    // On Unix, send SIGINT so Rover can gracefully shut down the router (rover handles ctrl_c/SIGINT)
+    // On Windows, use taskkill /T to kill the entire process tree since there's no SIGINT equivalent
     #[cfg(unix)]
     {
         let _ = Command::new("kill")
-            .args(["-TERM", &child.id().to_string()])
+            .args(["-INT", &child.id().to_string()])
             .output();
     }
     #[cfg(windows)]

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -13,6 +13,7 @@ use portpicker::pick_unused_port;
 use reqwest::{Client, header::CONTENT_TYPE};
 use rstest::*;
 use serde_json::{Value, json};
+use serial_test::serial;
 use speculoos::assert_that;
 use tempfile::TempDir;
 use tokio::time::timeout;
@@ -185,6 +186,7 @@ impl JsonMatcher for AnyLengthArray {
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
+#[serial]
 async fn e2e_test_rover_dev(
     #[from(run_rover_dev)] router_url: &str,
     #[case] query: String,
@@ -222,6 +224,7 @@ async fn e2e_test_rover_dev(
 #[ignore]
 #[tokio::test]
 #[traced_test]
+#[serial]
 async fn e2e_test_router_config_env_var_with_dollar_sign() {
     let temp_dir = TempDir::new().expect("Could not create temp directory");
     let temp_path = temp_dir.path();


### PR DESCRIPTION
Fixes #2751 - Router config env var double expansion bug                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
When router.yaml contains ${env.VAR} placeholders and the env var value contains a $ character, rover dev would fail because Rover was expanding the placeholder before writing to the temp config file, then the router would attempt to expand it again.                                                       
                                                                                                                                                                                                                                                                                                                   
  Before: Rover expands ${env.SERVICE_NAME} → my$service → writes to temp config → Router tries to expand $service → fails                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
  After: Rover writes raw config with ${env.SERVICE_NAME} intact → Router expands → my$service ✓ 
                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
  Changes                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  - Remove HotReloadConfig and HotReloadConfigOverrides - no longer needed                                                                                                                                                                                                                                         
  - Write raw router config directly to temp file (preserving env var placeholders)                                                                                                                                                                                                                                
  - Pass listen address via [--listen CLI flag](https://www.apollographql.com/docs/graphos/routing/configuration/cli#--listen) instead of modifying YAML                                                                                                                                                                                                                                            
  - Address precedence (CLI > config > default) still works - computed during config parsing, enforced via --listen    

