### PR TITLE
Add `rover describe` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4635,6 +4635,7 @@ dependencies = [
  "rover-client",
  "rover-graphql",
  "rover-http",
+ "rover-schema",
  "rover-std",
  "rover-studio",
  "rstest",
@@ -4768,6 +4769,19 @@ dependencies = [
  "tokio",
  "tower 0.5.3",
  "tracing",
+]
+
+[[package]]
+name = "rover-schema"
+version = "0.0.0"
+dependencies = [
+ "apollo-compiler",
+ "heck",
+ "itertools 0.14.0",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/sputnik",
     "crates/timber",
     "installers/binstall",
+    "crates/rover-schema",
     "regressions"
 ]
 
@@ -68,6 +69,7 @@ houston = { path = "./crates/houston" }
 robot-panic = { path = "./crates/robot-panic" }
 rover-client = { path = "./crates/rover-client" }
 rover-http = { path = "./crates/rover-http" }
+rover-schema = { path = "./crates/rover-schema" }
 rover-graphql = { path = "./crates/rover-graphql" }
 rover-std = { path = "./crates/rover-std" }
 rover-studio = { path = "./crates/rover-studio" }
@@ -78,6 +80,7 @@ timber = { path = "./crates/timber" }
 # apollo maintained dependencies
 
 # https://github.com/apollographql/apollo-rs
+apollo-compiler = "1"
 apollo-parser = "0.8"
 apollo-encoder = "0.8"
 
@@ -219,6 +222,7 @@ robot-panic = { workspace = true }
 rover-client = { workspace = true }
 rover-graphql = { workspace = true }
 rover-http = { workspace = true }
+rover-schema = { workspace = true }
 rover-std = { workspace = true }
 rover-studio = { workspace = true }
 schemars = { workspace = true }

--- a/crates/rover-schema/Cargo.toml
+++ b/crates/rover-schema/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["Apollo Developers <opensource@apollographql.com>"]
+description = "Schema analysis and exploration for the Rover CLI"
+edition = "2024"
+name = "rover-schema"
+version = "0.0.0"
+
+publish = false
+
+[dependencies]
+apollo-compiler = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+heck = { workspace = true }
+itertools = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rover-schema/src/describe.rs
+++ b/crates/rover-schema/src/describe.rs
@@ -1,0 +1,915 @@
+use apollo_compiler::{
+    Schema,
+    coordinate::SchemaCoordinate,
+    schema::{ExtendedType, FieldDefinition, InputValueDefinition},
+};
+
+use crate::{error::SchemaError, format::ARROW, root_paths, util::unwrap_type_name};
+
+/// Result of describing a schema at different levels of detail.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "kind")]
+pub enum DescribeResult {
+    Overview(SchemaOverview),
+    TypeDetail(TypeDetail),
+    FieldDetail(FieldDetail),
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SchemaOverview {
+    pub graph_ref: String,
+    pub total_types: usize,
+    pub total_fields: usize,
+    pub total_deprecated: usize,
+    pub query_fields: Vec<FieldSummary>,
+    pub mutation_fields: Vec<FieldSummary>,
+    pub objects: Vec<String>,
+    pub inputs: Vec<String>,
+    pub enums: Vec<String>,
+    pub interfaces: Vec<String>,
+    pub unions: Vec<String>,
+    pub scalars: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TypeDetail {
+    pub name: String,
+    pub kind: TypeKind,
+    pub description: Option<String>,
+    pub field_count: usize,
+    pub deprecated_count: usize,
+    pub implements: Vec<String>,
+    pub fields: Vec<FieldInfo>,
+    pub enum_values: Vec<EnumValueInfo>,
+    pub union_members: Vec<String>,
+    pub via: Vec<String>,
+    pub expanded_types: Vec<ExpandedType>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FieldDetail {
+    pub type_name: String,
+    pub field_name: String,
+    pub return_type: String,
+    pub description: Option<String>,
+    pub arg_count: usize,
+    pub args: Vec<ArgInfo>,
+    pub via: Vec<String>,
+    pub input_expansions: Vec<ExpandedType>,
+    pub return_expansion: Option<ExpandedType>,
+    pub is_deprecated: bool,
+    pub deprecation_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FieldSummary {
+    pub name: String,
+    pub return_type: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FieldInfo {
+    pub name: String,
+    pub return_type: String,
+    pub description: Option<String>,
+    pub is_deprecated: bool,
+    pub deprecation_reason: Option<String>,
+    pub arg_count: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EnumValueInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub is_deprecated: bool,
+    pub deprecation_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ArgInfo {
+    pub name: String,
+    pub arg_type: String,
+    pub description: Option<String>,
+    pub default_value: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ExpandedType {
+    pub name: String,
+    pub kind: TypeKind,
+    pub fields: Vec<FieldInfo>,
+    pub enum_values: Vec<EnumValueInfo>,
+    pub union_members: Vec<String>,
+    pub implements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TypeKind {
+    Object,
+    Input,
+    Enum,
+    Interface,
+    Union,
+    Scalar,
+}
+
+impl TypeKind {
+    pub const fn label(&self) -> &'static str {
+        match self {
+            TypeKind::Object => "object",
+            TypeKind::Input => "input",
+            TypeKind::Enum => "enum",
+            TypeKind::Interface => "interface",
+            TypeKind::Union => "union",
+            TypeKind::Scalar => "scalar",
+        }
+    }
+}
+
+impl std::fmt::Display for TypeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+/// Generate a schema overview.
+pub fn overview(schema: &Schema, graph_ref: &str) -> SchemaOverview {
+    let mut total_fields = 0usize;
+    let mut total_deprecated = 0usize;
+    let mut objects = Vec::new();
+    let mut inputs = Vec::new();
+    let mut enums = Vec::new();
+    let mut interfaces = Vec::new();
+    let mut unions = Vec::new();
+    let mut scalars = Vec::new();
+
+    let builtin_scalars = ["String", "Int", "Float", "Boolean", "ID"];
+
+    for (name, ty) in &schema.types {
+        let name_str = name.to_string();
+        // Skip built-in types
+        if name_str.starts_with("__") || builtin_scalars.contains(&name_str.as_str()) {
+            continue;
+        }
+        match ty {
+            ExtendedType::Object(obj) => {
+                let fc = obj.fields.len();
+                let dc = count_deprecated_fields_obj(obj);
+                total_fields += fc;
+                total_deprecated += dc;
+                if name_str != "Query" && name_str != "Mutation" && name_str != "Subscription" {
+                    objects.push(name_str);
+                }
+            }
+            ExtendedType::InputObject(inp) => {
+                total_fields += inp.fields.len();
+                inputs.push(name_str);
+            }
+            ExtendedType::Enum(e) => {
+                let dc = e
+                    .values
+                    .values()
+                    .filter(|v| is_deprecated_directive(&v.directives))
+                    .count();
+                total_deprecated += dc;
+                enums.push(name_str);
+            }
+            ExtendedType::Interface(iface) => {
+                let fc = iface.fields.len();
+                let dc = count_deprecated_fields_iface(iface);
+                total_fields += fc;
+                total_deprecated += dc;
+                interfaces.push(name_str);
+            }
+            ExtendedType::Union(_) => {
+                unions.push(name_str);
+            }
+            ExtendedType::Scalar(_) => {
+                scalars.push(name_str);
+            }
+        }
+    }
+
+    objects.sort();
+    inputs.sort();
+    enums.sort();
+    interfaces.sort();
+    unions.sort();
+    scalars.sort();
+
+    let user_types = objects.len()
+        + inputs.len()
+        + enums.len()
+        + interfaces.len()
+        + unions.len()
+        + scalars.len()
+        + count_root_types(schema);
+
+    let query_fields = get_root_fields(schema, "Query");
+    let mutation_fields = get_root_fields(schema, "Mutation");
+
+    // Add Query/Mutation fields to total
+    total_fields += query_fields.len();
+    total_fields += mutation_fields.len();
+
+    SchemaOverview {
+        graph_ref: graph_ref.to_string(),
+        total_types: user_types,
+        total_fields,
+        total_deprecated,
+        query_fields,
+        mutation_fields,
+        objects,
+        inputs,
+        enums,
+        interfaces,
+        unions,
+        scalars,
+    }
+}
+
+/// Generate detailed info for a type.
+pub fn type_detail(
+    schema: &Schema,
+    type_name: &str,
+    include_deprecated: bool,
+    depth: usize,
+) -> Result<TypeDetail, SchemaError> {
+    let ty = schema
+        .types
+        .get(type_name)
+        .ok_or_else(|| SchemaError::TypeNotFound(type_name.to_string()))?;
+
+    let via_paths = root_paths::find_root_paths(schema, type_name);
+    let via: Vec<String> = via_paths.iter().map(|p| p.format_via()).collect();
+
+    match ty {
+        ExtendedType::Object(obj) => {
+            let description = obj.description.as_ref().map(|d| d.to_string());
+            let implements: Vec<String> = obj
+                .implements_interfaces
+                .iter()
+                .map(|i| i.to_string())
+                .collect();
+            let all_fields: Vec<FieldInfo> = obj
+                .fields
+                .iter()
+                .map(|(name, field)| field_to_info(name.as_str(), field))
+                .collect();
+            let (fields, field_count, deprecated_count, expanded_types) =
+                process_fields(schema, all_fields, include_deprecated, depth);
+            Ok(TypeDetail {
+                name: type_name.to_string(),
+                kind: TypeKind::Object,
+                description,
+                field_count,
+                deprecated_count,
+                implements,
+                fields,
+                enum_values: Vec::new(),
+                union_members: Vec::new(),
+                via,
+                expanded_types,
+            })
+        }
+        ExtendedType::Interface(iface) => {
+            let description = iface.description.as_ref().map(|d| d.to_string());
+            let implements: Vec<String> = iface
+                .implements_interfaces
+                .iter()
+                .map(|i| i.to_string())
+                .collect();
+            let all_fields: Vec<FieldInfo> = iface
+                .fields
+                .iter()
+                .map(|(name, field)| field_to_info(name.as_str(), field))
+                .collect();
+            let (fields, field_count, deprecated_count, expanded_types) =
+                process_fields(schema, all_fields, include_deprecated, depth);
+            let implementors = find_implementors(schema, type_name);
+            Ok(TypeDetail {
+                name: type_name.to_string(),
+                kind: TypeKind::Interface,
+                description,
+                field_count,
+                deprecated_count,
+                implements,
+                fields,
+                enum_values: Vec::new(),
+                union_members: implementors,
+                via,
+                expanded_types,
+            })
+        }
+        ExtendedType::InputObject(inp) => {
+            let description = inp.description.as_ref().map(|d| d.to_string());
+            let fields: Vec<FieldInfo> = inp
+                .fields
+                .iter()
+                .map(|(name, field)| input_field_to_info(name.as_str(), field))
+                .collect();
+            let field_count = fields.len();
+            Ok(TypeDetail {
+                name: type_name.to_string(),
+                kind: TypeKind::Input,
+                description,
+                field_count,
+                deprecated_count: 0,
+                implements: Vec::new(),
+                fields,
+                enum_values: Vec::new(),
+                union_members: Vec::new(),
+                via,
+                expanded_types: Vec::new(),
+            })
+        }
+        ExtendedType::Enum(e) => {
+            let description = e.description.as_ref().map(|d| d.to_string());
+            let all_values: Vec<EnumValueInfo> = e
+                .values
+                .iter()
+                .map(|(name, val)| EnumValueInfo {
+                    name: name.to_string(),
+                    description: val.description.as_ref().map(|d| d.to_string()),
+                    is_deprecated: is_deprecated_directive(&val.directives),
+                    deprecation_reason: get_deprecation_reason(&val.directives),
+                })
+                .collect();
+            let total_count = all_values.len();
+            let deprecated_count = all_values.iter().filter(|v| v.is_deprecated).count();
+            let values = if include_deprecated {
+                all_values
+            } else {
+                all_values
+                    .into_iter()
+                    .filter(|v| !v.is_deprecated)
+                    .collect()
+            };
+            Ok(TypeDetail {
+                name: type_name.to_string(),
+                kind: TypeKind::Enum,
+                description,
+                field_count: total_count,
+                deprecated_count,
+                implements: Vec::new(),
+                fields: Vec::new(),
+                enum_values: values,
+                union_members: Vec::new(),
+                via,
+                expanded_types: Vec::new(),
+            })
+        }
+        ExtendedType::Union(u) => {
+            let description = u.description.as_ref().map(|d| d.to_string());
+            let members: Vec<String> = u.members.iter().map(|m| m.to_string()).collect();
+            Ok(TypeDetail {
+                name: type_name.to_string(),
+                kind: TypeKind::Union,
+                description,
+                field_count: 0,
+                deprecated_count: 0,
+                implements: Vec::new(),
+                fields: Vec::new(),
+                enum_values: Vec::new(),
+                union_members: members,
+                via,
+                expanded_types: Vec::new(),
+            })
+        }
+        ExtendedType::Scalar(s) => {
+            let description = s.description.as_ref().map(|d| d.to_string());
+            Ok(TypeDetail {
+                name: type_name.to_string(),
+                kind: TypeKind::Scalar,
+                description,
+                field_count: 0,
+                deprecated_count: 0,
+                implements: Vec::new(),
+                fields: Vec::new(),
+                enum_values: Vec::new(),
+                union_members: Vec::new(),
+                via,
+                expanded_types: Vec::new(),
+            })
+        }
+    }
+}
+
+/// Generate detailed info for a specific field.
+pub fn field_detail(schema: &Schema, coord: &SchemaCoordinate) -> Result<FieldDetail, SchemaError> {
+    let (type_name, field_name) = match coord {
+        SchemaCoordinate::TypeAttribute(tac) => (tac.ty.as_str(), tac.attribute.as_str()),
+        _ => {
+            return Err(SchemaError::InvalidCoordinate(
+                "field_detail requires a Type.field coordinate".into(),
+            ));
+        }
+    };
+
+    let ty = schema
+        .types
+        .get(type_name)
+        .ok_or_else(|| SchemaError::TypeNotFound(type_name.to_string()))?;
+
+    let field = match ty {
+        ExtendedType::Object(obj) => obj.fields.get(field_name),
+        ExtendedType::Interface(iface) => iface.fields.get(field_name),
+        _ => None,
+    }
+    .ok_or_else(|| SchemaError::FieldNotFound {
+        type_name: type_name.to_string(),
+        field: field_name.to_string(),
+    })?;
+
+    let return_type = field.ty.to_string();
+    let description = field.description.as_ref().map(|d| d.to_string());
+    let is_deprecated = is_deprecated_directive(&field.directives);
+    let deprecation_reason = get_deprecation_reason(&field.directives);
+
+    let args: Vec<ArgInfo> = field
+        .arguments
+        .iter()
+        .map(|arg| ArgInfo {
+            name: arg.name.to_string(),
+            arg_type: arg.ty.to_string(),
+            description: arg.description.as_ref().map(|d| d.to_string()),
+            default_value: arg.default_value.as_ref().map(|v| v.to_string()),
+        })
+        .collect();
+
+    let via_paths = root_paths::find_root_paths(schema, type_name);
+    let via: Vec<String> = via_paths
+        .iter()
+        .map(|p| format!("{} {ARROW} {}.{}", p.format_via(), type_name, field_name))
+        .collect();
+
+    // Expand input types used as arguments
+    let mut input_expansions = Vec::new();
+    for arg in &args {
+        let arg_type_name = unwrap_type_name(&arg.arg_type);
+        if let Some(expanded) = expand_single_type(schema, &arg_type_name, true)
+            && expanded.kind == TypeKind::Input
+        {
+            input_expansions.push(expanded);
+        }
+    }
+
+    // Expand return type
+    let return_type_name = unwrap_type_name(&return_type);
+    let return_expansion = expand_single_type(schema, &return_type_name, true);
+
+    Ok(FieldDetail {
+        type_name: type_name.to_string(),
+        field_name: field_name.to_string(),
+        return_type,
+        description,
+        arg_count: args.len(),
+        args,
+        via,
+        input_expansions,
+        return_expansion,
+        is_deprecated,
+        deprecation_reason,
+    })
+}
+
+// Helper functions
+
+/// Process field list: count deprecated, filter if needed, expand referenced types.
+fn process_fields(
+    schema: &Schema,
+    all_fields: Vec<FieldInfo>,
+    include_deprecated: bool,
+    depth: usize,
+) -> (Vec<FieldInfo>, usize, usize, Vec<ExpandedType>) {
+    let deprecated_count = all_fields.iter().filter(|f| f.is_deprecated).count();
+    let field_count = all_fields.len();
+    let fields = if include_deprecated {
+        all_fields
+    } else {
+        all_fields
+            .into_iter()
+            .filter(|f| !f.is_deprecated)
+            .collect()
+    };
+    let expanded_types = if depth > 0 {
+        expand_referenced_types(schema, &fields, depth, include_deprecated)
+    } else {
+        Vec::new()
+    };
+    (fields, field_count, deprecated_count, expanded_types)
+}
+
+fn field_to_info(name: &str, field: &FieldDefinition) -> FieldInfo {
+    FieldInfo {
+        name: name.to_string(),
+        return_type: field.ty.to_string(),
+        description: field.description.as_ref().map(|d| d.to_string()),
+        is_deprecated: is_deprecated_directive(&field.directives),
+        deprecation_reason: get_deprecation_reason(&field.directives),
+        arg_count: field.arguments.len(),
+    }
+}
+
+fn input_field_to_info(name: &str, field: &InputValueDefinition) -> FieldInfo {
+    FieldInfo {
+        name: name.to_string(),
+        return_type: field.ty.to_string(),
+        description: field.description.as_ref().map(|d| d.to_string()),
+        is_deprecated: is_deprecated_directive(&field.directives),
+        deprecation_reason: get_deprecation_reason(&field.directives),
+        arg_count: 0,
+    }
+}
+
+fn is_deprecated_directive(directives: &apollo_compiler::ast::DirectiveList) -> bool {
+    directives.get("deprecated").is_some()
+}
+
+fn get_deprecation_reason(directives: &apollo_compiler::ast::DirectiveList) -> Option<String> {
+    directives.get("deprecated").and_then(|d| {
+        d.arguments
+            .iter()
+            .find(|arg| arg.name == "reason")
+            .and_then(|arg| {
+                if let apollo_compiler::ast::Value::String(s) = &*arg.value {
+                    Some(s.to_string())
+                } else {
+                    None
+                }
+            })
+    })
+}
+
+fn get_root_fields(schema: &Schema, root_name: &str) -> Vec<FieldSummary> {
+    if let Some(ExtendedType::Object(obj)) = schema.types.get(root_name) {
+        obj.fields
+            .iter()
+            .map(|(name, field)| FieldSummary {
+                name: name.to_string(),
+                return_type: field.ty.to_string(),
+            })
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
+fn count_root_types(schema: &Schema) -> usize {
+    ["Query", "Mutation", "Subscription"]
+        .into_iter()
+        .filter(|name| schema.types.contains_key(*name))
+        .count()
+}
+
+fn count_deprecated_fields_obj(obj: &apollo_compiler::schema::ObjectType) -> usize {
+    obj.fields
+        .values()
+        .filter(|f| is_deprecated_directive(&f.directives))
+        .count()
+}
+
+fn count_deprecated_fields_iface(iface: &apollo_compiler::schema::InterfaceType) -> usize {
+    iface
+        .fields
+        .values()
+        .filter(|f| is_deprecated_directive(&f.directives))
+        .count()
+}
+
+fn find_implementors(schema: &Schema, interface_name: &str) -> Vec<String> {
+    let mut implementors = Vec::new();
+    for (name, ty) in &schema.types {
+        if let ExtendedType::Object(obj) = ty
+            && obj
+                .implements_interfaces
+                .iter()
+                .any(|i| i.as_str() == interface_name)
+        {
+            implementors.push(name.to_string());
+        }
+    }
+    implementors.sort();
+    implementors
+}
+
+pub fn expand_single_type(
+    schema: &Schema,
+    type_name: &str,
+    include_deprecated: bool,
+) -> Option<ExpandedType> {
+    let ty = schema.types.get(type_name)?;
+    match ty {
+        ExtendedType::Object(obj) => {
+            let fields: Vec<FieldInfo> = obj
+                .fields
+                .iter()
+                .filter(|(_, f)| include_deprecated || !is_deprecated_directive(&f.directives))
+                .map(|(name, field)| field_to_info(name.as_str(), field))
+                .collect();
+            let implements: Vec<String> = obj
+                .implements_interfaces
+                .iter()
+                .map(|i| i.to_string())
+                .collect();
+            Some(expand_fielded_type(
+                schema,
+                type_name,
+                TypeKind::Object,
+                fields,
+                implements,
+            ))
+        }
+        ExtendedType::Interface(iface) => {
+            let fields: Vec<FieldInfo> = iface
+                .fields
+                .iter()
+                .filter(|(_, f)| include_deprecated || !is_deprecated_directive(&f.directives))
+                .map(|(name, field)| field_to_info(name.as_str(), field))
+                .collect();
+            Some(expand_fielded_type(
+                schema,
+                type_name,
+                TypeKind::Interface,
+                fields,
+                Vec::new(),
+            ))
+        }
+        ExtendedType::InputObject(inp) => {
+            let fields: Vec<FieldInfo> = inp
+                .fields
+                .iter()
+                .map(|(name, field)| input_field_to_info(name.as_str(), field))
+                .collect();
+            Some(ExpandedType {
+                name: type_name.to_string(),
+                kind: TypeKind::Input,
+                fields,
+                enum_values: Vec::new(),
+                union_members: Vec::new(),
+                implements: Vec::new(),
+            })
+        }
+        ExtendedType::Enum(e) => {
+            let values: Vec<EnumValueInfo> = e
+                .values
+                .iter()
+                .filter(|(_, v)| include_deprecated || !is_deprecated_directive(&v.directives))
+                .map(|(name, val)| EnumValueInfo {
+                    name: name.to_string(),
+                    description: val.description.as_ref().map(|d| d.to_string()),
+                    is_deprecated: is_deprecated_directive(&val.directives),
+                    deprecation_reason: get_deprecation_reason(&val.directives),
+                })
+                .collect();
+            Some(ExpandedType {
+                name: type_name.to_string(),
+                kind: TypeKind::Enum,
+                fields: Vec::new(),
+                enum_values: values,
+                union_members: Vec::new(),
+                implements: Vec::new(),
+            })
+        }
+        ExtendedType::Union(u) => {
+            let members: Vec<String> = u.members.iter().map(|m| m.to_string()).collect();
+            Some(ExpandedType {
+                name: type_name.to_string(),
+                kind: TypeKind::Union,
+                fields: Vec::new(),
+                enum_values: Vec::new(),
+                union_members: members,
+                implements: Vec::new(),
+            })
+        }
+        ExtendedType::Scalar(_) => None,
+    }
+}
+
+/// Shared logic for expanding Object and Interface types.
+fn expand_fielded_type(
+    schema: &Schema,
+    type_name: &str,
+    kind: TypeKind,
+    fields: Vec<FieldInfo>,
+    implements: Vec<String>,
+) -> ExpandedType {
+    let union_members = if kind == TypeKind::Interface {
+        find_implementors(schema, type_name)
+    } else {
+        Vec::new()
+    };
+    ExpandedType {
+        name: type_name.to_string(),
+        kind,
+        fields,
+        enum_values: Vec::new(),
+        union_members,
+        implements,
+    }
+}
+
+fn expand_referenced_types(
+    schema: &Schema,
+    fields: &[FieldInfo],
+    depth: usize,
+    include_deprecated: bool,
+) -> Vec<ExpandedType> {
+    if depth == 0 {
+        return Vec::new();
+    }
+
+    let builtin_scalars = ["String", "Int", "Float", "Boolean", "ID"];
+    let mut seen = std::collections::HashSet::new();
+    let mut result = Vec::new();
+
+    for field in fields {
+        let type_name = unwrap_type_name(&field.return_type);
+        if builtin_scalars.contains(&type_name.as_str()) || type_name.starts_with("__") {
+            continue;
+        }
+        if seen.contains(&type_name) {
+            continue;
+        }
+        seen.insert(type_name.clone());
+        if let Some(expanded) = expand_single_type(schema, &type_name, include_deprecated) {
+            result.push(expanded);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_schema() -> Schema {
+        let sdl = include_str!("test_fixtures/test_schema.graphql");
+        match Schema::parse(sdl, "test.graphql") {
+            Ok(s) => s,
+            Err(e) => e.partial,
+        }
+    }
+
+    #[test]
+    fn overview_type_counts() {
+        let schema = test_schema();
+        let ov = overview(&schema, "test@current");
+        assert!(ov.total_types > 0);
+        assert!(!ov.query_fields.is_empty());
+        assert!(!ov.mutation_fields.is_empty());
+        assert!(!ov.objects.is_empty());
+        assert!(!ov.enums.is_empty());
+        assert!(!ov.interfaces.is_empty());
+        assert!(!ov.inputs.is_empty());
+    }
+
+    #[test]
+    fn overview_excludes_builtins() {
+        let schema = test_schema();
+        let ov = overview(&schema, "test@current");
+        assert!(!ov.objects.contains(&"__Schema".to_string()));
+        assert!(!ov.scalars.contains(&"String".to_string()));
+    }
+
+    #[test]
+    fn overview_excludes_root_types_from_objects() {
+        let schema = test_schema();
+        let ov = overview(&schema, "test@current");
+        assert!(!ov.objects.contains(&"Query".to_string()));
+        assert!(!ov.objects.contains(&"Mutation".to_string()));
+    }
+
+    #[test]
+    fn type_detail_object() {
+        let schema = test_schema();
+        let detail = type_detail(&schema, "Post", true, 0).unwrap();
+        assert_eq!(detail.name, "Post");
+        assert_eq!(detail.kind, TypeKind::Object);
+        assert!(detail.field_count > 0);
+        assert!(!detail.implements.is_empty()); // Post implements Node & Timestamped
+    }
+
+    #[test]
+    fn type_detail_enum() {
+        let schema = test_schema();
+        let detail = type_detail(&schema, "DigestFrequency", true, 0).unwrap();
+        assert_eq!(detail.kind, TypeKind::Enum);
+        assert_eq!(detail.enum_values.len(), 3); // DAILY, WEEKLY, NEVER
+    }
+
+    #[test]
+    fn type_detail_interface() {
+        let schema = test_schema();
+        let detail = type_detail(&schema, "Timestamped", true, 0).unwrap();
+        assert_eq!(detail.kind, TypeKind::Interface);
+        assert!(detail.union_members.contains(&"Post".to_string()));
+        assert!(detail.union_members.contains(&"Comment".to_string()));
+    }
+
+    #[test]
+    fn type_detail_input() {
+        let schema = test_schema();
+        let detail = type_detail(&schema, "CreatePostInput", true, 0).unwrap();
+        assert_eq!(detail.kind, TypeKind::Input);
+        assert!(detail.fields.iter().any(|f| f.name == "title"));
+    }
+
+    #[test]
+    fn type_detail_union() {
+        let schema = test_schema();
+        let detail = type_detail(&schema, "ContentItem", true, 0).unwrap();
+        assert_eq!(detail.kind, TypeKind::Union);
+        assert!(detail.union_members.contains(&"Post".to_string()));
+        assert!(detail.union_members.contains(&"Comment".to_string()));
+    }
+
+    #[test]
+    fn type_detail_not_found() {
+        let schema = test_schema();
+        let result = type_detail(&schema, "NonExistent", true, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn type_detail_with_depth_expands_referenced_types() {
+        let schema = test_schema();
+        let detail = type_detail(&schema, "Post", true, 1).unwrap();
+        assert!(!detail.expanded_types.is_empty());
+        assert!(detail.expanded_types.iter().any(|t| t.name == "User"));
+    }
+
+    #[test]
+    fn type_detail_deprecated_fields_filtered() {
+        let schema = test_schema();
+        let with_deprecated = type_detail(&schema, "User", true, 0).unwrap();
+        let without_deprecated = type_detail(&schema, "User", false, 0).unwrap();
+        assert!(with_deprecated.fields.len() > without_deprecated.fields.len());
+        assert!(with_deprecated.deprecated_count > 0);
+    }
+
+    #[test]
+    fn field_detail_with_args() {
+        let schema = test_schema();
+        let coord: SchemaCoordinate = "User.posts".parse().unwrap();
+        let detail = field_detail(&schema, &coord).unwrap();
+        assert_eq!(detail.type_name, "User");
+        assert_eq!(detail.field_name, "posts");
+        assert!(detail.arg_count > 0); // has limit, offset args
+    }
+
+    #[test]
+    fn field_detail_not_found() {
+        let schema = test_schema();
+        let coord: SchemaCoordinate = "Post.nonExistent".parse().unwrap();
+        let result = field_detail(&schema, &coord);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn field_detail_deprecated() {
+        let schema = test_schema();
+        let coord: SchemaCoordinate = "Post.oldSlug".parse().unwrap();
+        let detail = field_detail(&schema, &coord).unwrap();
+        assert!(detail.is_deprecated);
+        assert!(detail.deprecation_reason.is_some());
+    }
+
+    #[test]
+    fn type_detail_enum_deprecated_values() {
+        let schema = test_schema();
+        let with = type_detail(&schema, "SortOrder", true, 0).unwrap();
+        assert_eq!(with.enum_values.len(), 4);
+        assert_eq!(with.deprecated_count, 1);
+        let deprecated_val = with
+            .enum_values
+            .iter()
+            .find(|v| v.name == "RELEVANCE")
+            .unwrap();
+        assert!(deprecated_val.is_deprecated);
+        assert_eq!(
+            deprecated_val.deprecation_reason.as_deref(),
+            Some("Use TOP instead")
+        );
+
+        let without = type_detail(&schema, "SortOrder", false, 0).unwrap();
+        assert_eq!(without.enum_values.len(), 3);
+        assert!(!without.enum_values.iter().any(|v| v.name == "RELEVANCE"));
+    }
+
+    #[test]
+    fn field_detail_expands_input_types() {
+        let schema = test_schema();
+        let coord: SchemaCoordinate = "Mutation.createPost".parse().unwrap();
+        let detail = field_detail(&schema, &coord).unwrap();
+        assert!(!detail.input_expansions.is_empty());
+        assert!(
+            detail
+                .input_expansions
+                .iter()
+                .any(|t| t.name == "CreatePostInput")
+        );
+    }
+}

--- a/crates/rover-schema/src/error.rs
+++ b/crates/rover-schema/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SchemaError {
+    #[error("Failed to parse schema: {0}")]
+    ParseError(String),
+
+    #[error("Type not found: {0}")]
+    TypeNotFound(String),
+
+    #[error("Field '{field}' not found on type '{type_name}'")]
+    FieldNotFound { type_name: String, field: String },
+
+    #[error("Invalid coordinate: {0}")]
+    InvalidCoordinate(String),
+}

--- a/crates/rover-schema/src/format/compact.rs
+++ b/crates/rover-schema/src/format/compact.rs
@@ -1,0 +1,361 @@
+use itertools::Itertools;
+
+use super::{DASH, HOOK_ARROW};
+use crate::describe::{
+    DescribeResult, ExpandedType, FieldDetail, SchemaOverview, TypeDetail, TypeKind,
+};
+/// Format a DescribeResult in compact (token-efficient) notation.
+pub fn format_describe_compact(result: &DescribeResult) -> String {
+    match result {
+        DescribeResult::Overview(overview) => format_overview_compact(overview),
+        DescribeResult::TypeDetail(detail) => format_type_detail_compact(detail),
+        DescribeResult::FieldDetail(detail) => format_field_detail_compact(detail),
+    }
+}
+
+fn format_overview_compact(ov: &SchemaOverview) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "S:{}:{}t,{}f",
+        ov.graph_ref, ov.total_types, ov.total_fields
+    ));
+    if ov.total_deprecated > 0 {
+        out.push_str(&format!(",{}d", ov.total_deprecated));
+    }
+    out.push('\n');
+
+    if !ov.query_fields.is_empty() {
+        let fields = ov
+            .query_fields
+            .iter()
+            .map(|f| format!("{}:{}", f.name, abbreviate_type(&f.return_type)))
+            .join(",");
+        out.push_str(&format!("Q:{fields}\n"));
+    }
+    if !ov.mutation_fields.is_empty() {
+        let fields = ov
+            .mutation_fields
+            .iter()
+            .map(|f| format!("{}:{}", f.name, abbreviate_type(&f.return_type)))
+            .join(",");
+        out.push_str(&format!("M:{fields}\n"));
+    }
+
+    out.trim_end().to_string()
+}
+
+fn format_type_detail_compact(detail: &TypeDetail) -> String {
+    let mut out = String::new();
+
+    let prefix = kind_prefix(detail.kind);
+    out.push_str(prefix);
+    out.push_str(&detail.name);
+
+    // For interfaces, show implementing types
+    if detail.kind == TypeKind::Interface && !detail.union_members.is_empty() {
+        out.push_str(&format!("<{}>", detail.union_members.join(",")));
+    }
+
+    // For unions, show member types
+    if detail.kind == TypeKind::Union && !detail.union_members.is_empty() {
+        out.push_str(&format!("<{}>", detail.union_members.join(",")));
+    }
+
+    // Fields
+    if !detail.fields.is_empty() {
+        out.push(':');
+        out.push_str(
+            &detail
+                .fields
+                .iter()
+                .map(|f| {
+                    let prefix = if f.is_deprecated { "~" } else { "" };
+                    format!("{}{}:{}", prefix, f.name, abbreviate_type(&f.return_type))
+                })
+                .join(","),
+        );
+    }
+
+    // Enum values
+    if !detail.enum_values.is_empty() {
+        out.push(':');
+        out.push_str(
+            &detail
+                .enum_values
+                .iter()
+                .map(|v| {
+                    if v.is_deprecated {
+                        format!("~{}", v.name)
+                    } else {
+                        v.name.clone()
+                    }
+                })
+                .join(","),
+        );
+    }
+
+    out.push('\n');
+
+    // Expanded types
+    for expanded in &detail.expanded_types {
+        format_expanded_compact(&mut out, expanded);
+    }
+
+    out.trim_end().to_string()
+}
+
+fn format_field_detail_compact(detail: &FieldDetail) -> String {
+    let mut out = String::new();
+
+    // Field line
+    let args = detail
+        .args
+        .iter()
+        .map(|a| format!("{}:{}", a.name, abbreviate_type(&a.arg_type)))
+        .join(",");
+    out.push_str(&format!(
+        "{}.{}({}):{}",
+        detail.type_name,
+        detail.field_name,
+        args,
+        abbreviate_type(&detail.return_type)
+    ));
+    out.push('\n');
+
+    // Input expansions
+    for input in &detail.input_expansions {
+        format_expanded_compact(&mut out, input);
+    }
+
+    // Return expansion
+    if let Some(ret) = &detail.return_expansion {
+        format_expanded_compact(&mut out, ret);
+    }
+
+    // Via path
+    if !detail.via.is_empty() {
+        out.push_str(&format!("{HOOK_ARROW} {}\n", detail.via[0]));
+    }
+
+    out.trim_end().to_string()
+}
+
+fn format_expanded_compact(out: &mut String, expanded: &ExpandedType) {
+    let prefix = kind_prefix(expanded.kind);
+    out.push_str(prefix);
+    out.push_str(&expanded.name);
+
+    if expanded.kind == TypeKind::Interface && !expanded.union_members.is_empty() {
+        out.push_str(&format!("<{}>", expanded.union_members.join(",")));
+    }
+
+    if !expanded.fields.is_empty() {
+        out.push(':');
+        out.push_str(
+            &expanded
+                .fields
+                .iter()
+                .map(|f| {
+                    let prefix = if f.is_deprecated { "~" } else { "" };
+                    format!("{}{}:{}", prefix, f.name, abbreviate_type(&f.return_type))
+                })
+                .join(","),
+        );
+    }
+
+    if !expanded.enum_values.is_empty() {
+        out.push(':');
+        out.push_str(
+            &expanded
+                .enum_values
+                .iter()
+                .map(|v| {
+                    if v.is_deprecated {
+                        format!("~{}", v.name)
+                    } else {
+                        v.name.clone()
+                    }
+                })
+                .join(","),
+        );
+    }
+
+    out.push('\n');
+}
+
+const fn kind_prefix(kind: TypeKind) -> &'static str {
+    match kind {
+        TypeKind::Object => "T:",
+        TypeKind::Input => "I:",
+        TypeKind::Enum => "E:",
+        TypeKind::Interface => "F:",
+        TypeKind::Union => "U:",
+        TypeKind::Scalar => "S:",
+    }
+}
+
+/// Abbreviate common scalar types for compact output.
+///
+/// Only replaces the base type name when it exactly matches a built-in scalar,
+/// preserving wrappers like `[` `]` `!`.
+pub fn abbreviate_type(type_str: &str) -> String {
+    // Strip wrappers to find the base type name
+    let base = type_str.replace(['[', ']', '!'], "");
+    let abbrev = match base.as_str() {
+        "String" => "s",
+        "Int" => "i",
+        "Float" => "f",
+        "Boolean" => "b",
+        "ID" => "d",
+        _ => return type_str.to_string(),
+    };
+    // Re-apply the original wrappers around the abbreviation
+    type_str.replacen(&base, abbrev, 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abbreviate_scalars() {
+        assert_eq!(abbreviate_type("String"), "s");
+        assert_eq!(abbreviate_type("String!"), "s!");
+        assert_eq!(abbreviate_type("[String!]!"), "[s!]!");
+        assert_eq!(abbreviate_type("Int"), "i");
+        assert_eq!(abbreviate_type("Float"), "f");
+        assert_eq!(abbreviate_type("Boolean!"), "b!");
+        assert_eq!(abbreviate_type("ID!"), "d!");
+    }
+
+    #[test]
+    fn abbreviate_preserves_custom_types() {
+        assert_eq!(abbreviate_type("Post!"), "Post!");
+        assert_eq!(abbreviate_type("[User!]!"), "[User!]!");
+    }
+
+    #[test]
+    fn abbreviate_preserves_types_containing_scalar_substrings() {
+        assert_eq!(abbreviate_type("PrintSettings!"), "PrintSettings!");
+        assert_eq!(
+            abbreviate_type("[IntegrationPoint!]!"),
+            "[IntegrationPoint!]!"
+        );
+        assert_eq!(abbreviate_type("FloatRange"), "FloatRange");
+        assert_eq!(abbreviate_type("BooleanExpression!"), "BooleanExpression!");
+        assert_eq!(abbreviate_type("StringFilter"), "StringFilter");
+        assert_eq!(abbreviate_type("ValidID!"), "ValidID!");
+    }
+
+    #[test]
+    fn kind_prefixes() {
+        assert_eq!(kind_prefix(TypeKind::Object), "T:");
+        assert_eq!(kind_prefix(TypeKind::Input), "I:");
+        assert_eq!(kind_prefix(TypeKind::Enum), "E:");
+        assert_eq!(kind_prefix(TypeKind::Interface), "F:");
+        assert_eq!(kind_prefix(TypeKind::Union), "U:");
+    }
+
+    #[test]
+    fn deprecated_field_tilde_prefix() {
+        let detail = TypeDetail {
+            name: "Post".into(),
+            kind: TypeKind::Object,
+            description: None,
+            field_count: 2,
+            deprecated_count: 1,
+            implements: Vec::new(),
+            fields: vec![
+                crate::describe::FieldInfo {
+                    name: "title".into(),
+                    return_type: "String!".into(),
+                    description: None,
+                    is_deprecated: false,
+                    deprecation_reason: None,
+                    arg_count: 0,
+                },
+                crate::describe::FieldInfo {
+                    name: "oldSlug".into(),
+                    return_type: "String".into(),
+                    description: None,
+                    is_deprecated: true,
+                    deprecation_reason: Some("Use slug instead".into()),
+                    arg_count: 0,
+                },
+            ],
+            enum_values: Vec::new(),
+            union_members: Vec::new(),
+            via: Vec::new(),
+            expanded_types: Vec::new(),
+        };
+        let output = format_type_detail_compact(&detail);
+        assert!(output.contains("title:s!"));
+        assert!(output.contains("~oldSlug:s"));
+    }
+
+    #[test]
+    fn deprecated_enum_value_tilde_prefix() {
+        let detail = TypeDetail {
+            name: "SortOrder".into(),
+            kind: TypeKind::Enum,
+            description: None,
+            field_count: 4,
+            deprecated_count: 1,
+            implements: Vec::new(),
+            fields: Vec::new(),
+            enum_values: vec![
+                crate::describe::EnumValueInfo {
+                    name: "NEWEST".into(),
+                    description: None,
+                    is_deprecated: false,
+                    deprecation_reason: None,
+                },
+                crate::describe::EnumValueInfo {
+                    name: "RELEVANCE".into(),
+                    description: None,
+                    is_deprecated: true,
+                    deprecation_reason: Some("Use TOP instead".into()),
+                },
+            ],
+            union_members: Vec::new(),
+            via: Vec::new(),
+            expanded_types: Vec::new(),
+        };
+        let output = format_type_detail_compact(&detail);
+        assert!(output.contains("NEWEST"));
+        assert!(output.contains("~RELEVANCE"));
+    }
+
+    #[test]
+    fn expanded_deprecated_field_tilde_prefix() {
+        let expanded = ExpandedType {
+            name: "User".into(),
+            kind: TypeKind::Object,
+            fields: vec![
+                crate::describe::FieldInfo {
+                    name: "id".into(),
+                    return_type: "ID!".into(),
+                    description: None,
+                    is_deprecated: false,
+                    deprecation_reason: None,
+                    arg_count: 0,
+                },
+                crate::describe::FieldInfo {
+                    name: "legacyId".into(),
+                    return_type: "String".into(),
+                    description: None,
+                    is_deprecated: true,
+                    deprecation_reason: None,
+                    arg_count: 0,
+                },
+            ],
+            enum_values: Vec::new(),
+            union_members: Vec::new(),
+            implements: Vec::new(),
+        };
+        let mut out = String::new();
+        format_expanded_compact(&mut out, &expanded);
+        assert!(out.contains("id:d!"));
+        assert!(out.contains("~legacyId:s"));
+    }
+}

--- a/crates/rover-schema/src/format/compact.rs
+++ b/crates/rover-schema/src/format/compact.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 
-use super::{DASH, HOOK_ARROW};
+use super::HOOK_ARROW;
 use crate::describe::{
     DescribeResult, ExpandedType, FieldDetail, SchemaOverview, TypeDetail, TypeKind,
 };

--- a/crates/rover-schema/src/format/description.rs
+++ b/crates/rover-schema/src/format/description.rs
@@ -1,4 +1,4 @@
-use super::{ARROW, DASH, DEPRECATED_MARKER, DOTTED, HOOK_ARROW, SEPARATOR};
+use super::{ARROW, DEPRECATED_MARKER, DOTTED, HOOK_ARROW, SEPARATOR};
 use crate::describe::{
     DescribeResult, ExpandedType, FieldDetail, FieldInfo, SchemaOverview, TypeDetail, TypeKind,
 };

--- a/crates/rover-schema/src/format/description.rs
+++ b/crates/rover-schema/src/format/description.rs
@@ -1,0 +1,702 @@
+use super::{ARROW, DASH, DEPRECATED_MARKER, DOTTED, HOOK_ARROW, SEPARATOR};
+use crate::describe::{
+    DescribeResult, ExpandedType, FieldDetail, FieldInfo, SchemaOverview, TypeDetail, TypeKind,
+};
+const MAX_WIDTH: usize = 100;
+
+/// Format a DescribeResult as human-readable description text.
+pub fn format_describe(result: &DescribeResult) -> String {
+    match result {
+        DescribeResult::Overview(overview) => format_overview(overview),
+        DescribeResult::TypeDetail(detail) => format_type_detail(detail),
+        DescribeResult::FieldDetail(detail) => format_field_detail(detail),
+    }
+}
+
+fn format_overview(ov: &SchemaOverview) -> String {
+    let mut out = String::new();
+
+    // Header line
+    out.push_str(&format!(
+        "SCHEMA {} [{} types, {} fields",
+        ov.graph_ref, ov.total_types, ov.total_fields
+    ));
+    if ov.total_deprecated > 0 {
+        out.push_str(&format!(", {} deprecated", ov.total_deprecated));
+    }
+    out.push_str("]\n");
+
+    // Query fields
+    if !ov.query_fields.is_empty() {
+        let names: Vec<&str> = ov.query_fields.iter().map(|f| f.name.as_str()).collect();
+        let preview = truncate_list(&names, 6);
+        out.push_str(&format!(
+            "  Query      {SEPARATOR} {} fields ({})\n",
+            ov.query_fields.len(),
+            preview
+        ));
+    }
+
+    // Mutation fields
+    if !ov.mutation_fields.is_empty() {
+        let names: Vec<&str> = ov.mutation_fields.iter().map(|f| f.name.as_str()).collect();
+        let preview = truncate_list(&names, 6);
+        out.push_str(&format!(
+            "  Mutation   {SEPARATOR} {} fields ({})\n",
+            ov.mutation_fields.len(),
+            preview
+        ));
+    }
+
+    out.push('\n');
+
+    // Type categories
+    if !ov.objects.is_empty() {
+        let preview = truncate_list_owned(&ov.objects, 8);
+        out.push_str(&format!(
+            "  objects    ({:>2})  {}\n",
+            ov.objects.len(),
+            preview
+        ));
+    }
+    if !ov.inputs.is_empty() {
+        let preview = truncate_list_owned(&ov.inputs, 8);
+        out.push_str(&format!(
+            "  inputs     ({:>2})  {}\n",
+            ov.inputs.len(),
+            preview
+        ));
+    }
+    if !ov.enums.is_empty() {
+        let preview = truncate_list_owned(&ov.enums, 8);
+        out.push_str(&format!(
+            "  enums      ({:>2})  {}\n",
+            ov.enums.len(),
+            preview
+        ));
+    }
+    if !ov.interfaces.is_empty() {
+        let preview = truncate_list_owned(&ov.interfaces, 8);
+        out.push_str(&format!(
+            "  interfaces ({:>2})  {}\n",
+            ov.interfaces.len(),
+            preview
+        ));
+    }
+    if !ov.unions.is_empty() {
+        let preview = truncate_list_owned(&ov.unions, 8);
+        out.push_str(&format!(
+            "  unions     ({:>2})  {}\n",
+            ov.unions.len(),
+            preview
+        ));
+    }
+    if !ov.scalars.is_empty() {
+        let preview = truncate_list_owned(&ov.scalars, 8);
+        out.push_str(&format!(
+            "  scalars    ({:>2})  {}\n",
+            ov.scalars.len(),
+            preview
+        ));
+    }
+
+    out.trim_end().to_string()
+}
+
+fn format_type_detail(detail: &TypeDetail) -> String {
+    let mut out = String::new();
+
+    // Header
+    let kind_label = match detail.kind {
+        TypeKind::Object => "TYPE",
+        TypeKind::Interface => "INTERFACE",
+        TypeKind::Input => "INPUT",
+        TypeKind::Enum => "ENUM",
+        TypeKind::Union => "UNION",
+        TypeKind::Scalar => "SCALAR",
+    };
+
+    out.push_str(&format!("{} {}", kind_label, detail.name));
+
+    match detail.kind {
+        TypeKind::Enum => {
+            out.push_str(&format!(" [{} values", detail.field_count));
+        }
+        TypeKind::Union => {
+            out.push_str(&format!(" [{} members", detail.union_members.len()));
+        }
+        _ => {
+            out.push_str(&format!(" [{} fields", detail.field_count));
+        }
+    }
+
+    if detail.deprecated_count > 0 {
+        out.push_str(&format!(", {} deprecated", detail.deprecated_count));
+    }
+    out.push(']');
+
+    if !detail.implements.is_empty() {
+        out.push_str(&format!(" implements {}", detail.implements.join(" & ")));
+    }
+
+    out.push('\n');
+
+    // Description
+    if let Some(desc) = &detail.description {
+        out.push_str(&format!("  {SEPARATOR} {}\n", desc));
+
+        // Blank line after description before fields/values
+        if !detail.fields.is_empty()
+            || !detail.enum_values.is_empty()
+            || !detail.union_members.is_empty()
+        {
+            out.push('\n');
+        }
+    }
+
+    // Fields
+    write_field_items(&mut out, &detail.fields, 2);
+
+    // Enum values
+    if !detail.enum_values.is_empty() {
+        let cols: Vec<String> = detail.enum_values.iter().map(|v| v.name.clone()).collect();
+        let col_width = compute_col_width(&cols, 2);
+        for (i, val) in detail.enum_values.iter().enumerate() {
+            write_item_line(
+                &mut out,
+                &cols[i],
+                val.description.as_deref(),
+                val.is_deprecated,
+                val.deprecation_reason.as_deref(),
+                2,
+                col_width,
+            );
+        }
+    }
+
+    // Union members
+    if !detail.union_members.is_empty() {
+        if detail.kind == TypeKind::Interface {
+            // For interfaces, show implementing types
+            out.push_str(&format!(
+                "  {SEPARATOR} implemented by {}\n",
+                detail.union_members.join(", ")
+            ));
+        } else {
+            out.push_str(&format!("  = {}\n", detail.union_members.join(" | ")));
+        }
+    }
+
+    // Hint when deprecated fields/values are hidden
+    if detail.deprecated_count > 0 {
+        let showing_deprecated = match detail.kind {
+            TypeKind::Enum => detail.enum_values.iter().any(|v| v.is_deprecated),
+            _ => detail.fields.iter().any(|f| f.is_deprecated),
+        };
+        if !showing_deprecated {
+            out.push_str(&format!(
+                "\n  Use --include-deprecated to show {} hidden deprecated {}.\n",
+                detail.deprecated_count,
+                if detail.kind == TypeKind::Enum {
+                    "values"
+                } else {
+                    "fields"
+                }
+            ));
+        }
+    }
+
+    // Expanded types (--depth)
+    for expanded in &detail.expanded_types {
+        out.push('\n');
+        format_expanded_type(&mut out, expanded);
+    }
+
+    out.trim_end().to_string()
+}
+
+fn format_field_detail(detail: &FieldDetail) -> String {
+    let mut out = String::new();
+
+    // Header
+    out.push_str(&format!(
+        "FIELD {}.{} {ARROW} {}",
+        detail.type_name, detail.field_name, detail.return_type
+    ));
+    if detail.arg_count > 0 {
+        out.push_str(&format!(
+            " [{} arg{}]",
+            detail.arg_count,
+            if detail.arg_count == 1 { "" } else { "s" }
+        ));
+    }
+    out.push('\n');
+
+    // Description
+    if let Some(desc) = &detail.description {
+        out.push_str(&format!("  {SEPARATOR} {}\n", desc));
+    }
+
+    // Via paths
+    for via in &detail.via {
+        out.push_str(&format!("  via {}\n", via));
+    }
+
+    // Deprecation
+    if detail.is_deprecated {
+        if let Some(reason) = &detail.deprecation_reason {
+            out.push_str(&format!("  {DEPRECATED_MARKER} DEPRECATED: {}\n", reason));
+        } else {
+            out.push_str(&format!("  {DEPRECATED_MARKER} DEPRECATED\n"));
+        }
+    }
+
+    // Args
+    if !detail.args.is_empty() {
+        out.push_str("\n  args:\n");
+        let arg_cols: Vec<String> = detail
+            .args
+            .iter()
+            .map(|a| format!("{}: {}", a.name, a.arg_type))
+            .collect();
+        let col_width = compute_col_width(&arg_cols, 4);
+        for (i, arg) in detail.args.iter().enumerate() {
+            write_item_line(
+                &mut out,
+                &arg_cols[i],
+                arg.description.as_deref(),
+                false,
+                None,
+                4,
+                col_width,
+            );
+        }
+    }
+
+    // Input type expansions
+    for input in &detail.input_expansions {
+        out.push_str(&format!("\n  input {}:\n", input.name));
+        write_field_items(&mut out, &input.fields, 4);
+    }
+
+    // Return type expansion
+    if let Some(ret) = &detail.return_expansion {
+        out.push_str(&format!("\n  returns {}:\n", ret.name));
+        write_field_items(&mut out, &ret.fields, 4);
+    }
+
+    out.trim_end().to_string()
+}
+
+// Helpers
+
+/// Compute column width for name columns based on the widest item.
+/// Ensures at least a 2-char gap before the › separator.
+fn compute_col_width(items: &[String], indent: usize) -> usize {
+    let longest = items.iter().map(|s| s.len()).max().unwrap_or(0);
+    let col = longest + 2; // min 2-char gap before ›
+    let max = (MAX_WIDTH - indent) / 2;
+    col.clamp(16, max)
+}
+
+/// Word-wrap description text to fit within `avail` chars per line.
+/// Continuation lines are indented to `cont_indent` spaces.
+/// Embedded newlines are reflowed (replaced with spaces) before wrapping.
+fn wrap_description(text: &str, avail: usize, cont_indent: usize) -> String {
+    // Normalize embedded newlines into spaces so we can re-wrap cleanly.
+    // Collapse any \r\n or \n followed by whitespace into a single space.
+    let mut normalized = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\r' || c == '\n' {
+            // Skip any following whitespace (including more newlines)
+            while chars.peek().is_some_and(|&ch| ch.is_whitespace()) {
+                chars.next();
+            }
+            // Replace with a single space (unless we're at the start or end)
+            if !normalized.is_empty() && chars.peek().is_some() {
+                normalized.push(' ');
+            }
+        } else {
+            normalized.push(c);
+        }
+    }
+
+    if avail == 0 || normalized.len() <= avail {
+        return normalized;
+    }
+
+    let mut result = String::new();
+    let mut remaining = normalized.as_str();
+    let mut first = true;
+
+    while !remaining.is_empty() {
+        if !first {
+            result.push('\n');
+            for _ in 0..cont_indent {
+                result.push(' ');
+            }
+        }
+
+        if remaining.len() <= avail {
+            result.push_str(remaining);
+            break;
+        }
+
+        let break_at = remaining[..avail].rfind(' ').unwrap_or(avail);
+        let after_break = remaining[break_at..].trim_start();
+        // Don't widow short trailing fragments (e.g. a lone ".")
+        if after_break.len() <= 2 {
+            result.push_str(remaining);
+            break;
+        }
+        result.push_str(&remaining[..break_at]);
+        remaining = after_break;
+        first = false;
+    }
+
+    result
+}
+
+/// Write one field/enum-value line with consistent formatting.
+///
+/// For 2-space indent, deprecated fields use `⚠` as a gutter marker replacing the first space.
+/// For 4-space indent, deprecated fields use `  ⚠ ` (⚠ replaces one inner space).
+/// If deprecated with a reason, appends a `↳ Deprecated: reason` line below.
+fn write_item_line(
+    out: &mut String,
+    name_col: &str,
+    desc: Option<&str>,
+    is_deprecated: bool,
+    dep_reason: Option<&str>,
+    indent: usize,
+    col_width: usize,
+) {
+    // Write indent with optional deprecation gutter marker
+    if is_deprecated {
+        if indent <= 2 {
+            out.push(DEPRECATED_MARKER);
+            for _ in 1..indent {
+                out.push(' ');
+            }
+        } else {
+            for _ in 0..indent.saturating_sub(2) {
+                out.push(' ');
+            }
+            out.push(DEPRECATED_MARKER);
+            out.push(' ');
+        }
+    } else {
+        for _ in 0..indent {
+            out.push(' ');
+        }
+    }
+
+    // Write name column, padded to col_width with minimum 2-char gap
+    out.push_str(name_col);
+
+    let name_len = name_col.len();
+    let pad = if name_len + 2 <= col_width {
+        col_width - name_len
+    } else {
+        2 // always at least 2 spaces before ›
+    };
+
+    if let Some(desc) = desc {
+        for _ in 0..pad {
+            out.push(' ');
+        }
+        out.push(SEPARATOR);
+        out.push(' ');
+
+        let desc_start = indent + name_len + pad + 2; // +2 for "› "
+        let avail = MAX_WIDTH.saturating_sub(desc_start);
+        let wrapped = wrap_description(desc, avail, desc_start);
+        out.push_str(&wrapped);
+    }
+    out.push('\n');
+
+    // Deprecated reason on next line, visually attached with ↳
+    if is_deprecated && let Some(reason) = dep_reason {
+        for _ in 0..indent + 2 {
+            out.push(' ');
+        }
+        out.push(HOOK_ARROW);
+        out.push_str(" Deprecated: ");
+        out.push_str(reason);
+        out.push('\n');
+    }
+}
+
+/// Write a list of FieldInfo items with computed column alignment.
+fn write_field_items(out: &mut String, fields: &[FieldInfo], indent: usize) {
+    if fields.is_empty() {
+        return;
+    }
+    let cols: Vec<String> = fields
+        .iter()
+        .map(|f| format!("{}: {}", f.name, f.return_type))
+        .collect();
+    let col_width = compute_col_width(&cols, indent);
+    for (i, field) in fields.iter().enumerate() {
+        write_item_line(
+            out,
+            &cols[i],
+            field.description.as_deref(),
+            field.is_deprecated,
+            field.deprecation_reason.as_deref(),
+            indent,
+            col_width,
+        );
+    }
+}
+
+fn format_expanded_type(out: &mut String, expanded: &ExpandedType) {
+    out.push_str(&format!("  {DOTTED} {}", expanded.name));
+    if expanded.kind == TypeKind::Interface && !expanded.union_members.is_empty() {
+        out.push_str(&format!(
+            " (interface {ARROW} {})",
+            expanded.union_members.join(", ")
+        ));
+    }
+    if !expanded.fields.is_empty() {
+        out.push_str(&format!(
+            " [{} field{}]",
+            expanded.fields.len(),
+            if expanded.fields.len() == 1 { "" } else { "s" }
+        ));
+    }
+    out.push('\n');
+
+    write_field_items(out, &expanded.fields, 4);
+}
+
+fn truncate_list(items: &[&str], max: usize) -> String {
+    if items.len() <= max {
+        items.join(", ")
+    } else {
+        format!("{}, ...", items[..max].join(", "))
+    }
+}
+
+fn truncate_list_owned(items: &[String], max: usize) -> String {
+    if items.len() <= max {
+        items.join(" ")
+    } else {
+        format!("{} ...", items[..max].join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use apollo_compiler::Schema;
+
+    use super::*;
+    use crate::describe;
+
+    fn test_schema() -> Schema {
+        let sdl = include_str!("../test_fixtures/test_schema.graphql");
+        match Schema::parse(sdl, "test.graphql") {
+            Ok(s) => s,
+            Err(e) => e.partial,
+        }
+    }
+
+    #[test]
+    fn deprecated_field_gutter_marker_with_reason() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "Post", true, 0).unwrap();
+        let output = format_type_detail(&detail);
+        // ⚠ gutter marker on the field line
+        assert!(output.contains(DEPRECATED_MARKER));
+        // Reason on the next line
+        assert!(output.contains(&format!("{HOOK_ARROW} Deprecated: Use slug instead")));
+    }
+
+    #[test]
+    fn deprecated_field_gutter_marker_without_reason() {
+        let mut out = String::new();
+        write_item_line(&mut out, "oldField: String", None, true, None, 2, 20);
+        assert!(
+            out.starts_with(DEPRECATED_MARKER),
+            "should start with ⚠ gutter marker"
+        );
+        assert!(
+            !out.contains("Deprecated:"),
+            "no reason line when reason is None"
+        );
+    }
+
+    #[test]
+    fn deprecated_enum_value_marker() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "SortOrder", true, 0).unwrap();
+        let output = format_type_detail(&detail);
+        assert!(output.contains("RELEVANCE"));
+        assert!(output.contains(DEPRECATED_MARKER));
+        assert!(output.contains(&format!("{HOOK_ARROW} Deprecated: Use TOP instead")));
+    }
+
+    #[test]
+    fn hidden_deprecated_hint_for_fields() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "Post", false, 0).unwrap();
+        let output = format_type_detail(&detail);
+        assert!(output.contains("Use --include-deprecated to show"));
+        assert!(output.contains("hidden deprecated fields"));
+        assert!(!output.contains("oldSlug"));
+    }
+
+    #[test]
+    fn hidden_deprecated_hint_for_enum_values() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "SortOrder", false, 0).unwrap();
+        let output = format_type_detail(&detail);
+        assert!(output.contains("Use --include-deprecated to show"));
+        assert!(output.contains("hidden deprecated values"));
+        assert!(!output.contains("RELEVANCE"));
+    }
+
+    #[test]
+    fn no_hint_when_deprecated_included() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "Post", true, 0).unwrap();
+        let output = format_type_detail(&detail);
+        assert!(!output.contains("Use --include-deprecated"));
+        assert!(output.contains("oldSlug"));
+    }
+
+    #[test]
+    fn no_hint_when_no_deprecated() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "Category", true, 0).unwrap();
+        let output = format_type_detail(&detail);
+        assert!(!output.contains("Use --include-deprecated"));
+    }
+
+    #[test]
+    fn expanded_type_deprecated_field_marker() {
+        let schema = test_schema();
+        // User has deprecated legacyId; expand via Post --depth 1
+        let detail = describe::type_detail(&schema, "Post", true, 1).unwrap();
+        let output = format_type_detail(&detail);
+        // The expanded User type should show the deprecated marker
+        assert!(output.contains("legacyId"));
+        assert!(output.contains(&format!("{HOOK_ARROW} Deprecated: Use id instead")));
+    }
+
+    #[test]
+    fn column_alignment_consistent() {
+        let schema = test_schema();
+        let detail = describe::type_detail(&schema, "Post", false, 0).unwrap();
+        let output = format_type_detail(&detail);
+        // Field lines (containing "name: Type") with descriptions should have
+        // at least a 2-space gap before the › separator
+        for line in output.lines() {
+            let trimmed = line.trim_start();
+            // Only check field lines: must have ":" before "›" (name: Type pattern)
+            if let (Some(colon_pos), Some(sep_pos)) = (trimmed.find(':'), trimmed.find(SEPARATOR))
+                && colon_pos < sep_pos
+            {
+                let abs_sep = line.find(SEPARATOR).unwrap();
+                let before_sep = &line[..abs_sep];
+                assert!(
+                    before_sep.ends_with("  "),
+                    "should have at least 2-space gap before ›: {:?}",
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn description_wrapping() {
+        let mut out = String::new();
+        let long_desc = "This is a very long description that should wrap to multiple lines because it exceeds the available width when combined with the field name column";
+        write_item_line(&mut out, "field: Type", Some(long_desc), false, None, 2, 20);
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines.len() > 1, "long description should wrap");
+        // Continuation lines should be indented
+        for line in &lines[1..] {
+            assert!(
+                line.starts_with("                        "),
+                "continuation should be indented: {:?}",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn compute_col_width_basics() {
+        let items = vec!["name: String!".to_string(), "id: ID!".to_string()];
+        let width = compute_col_width(&items, 2);
+        // longest is 13 ("name: String!"), so width = 15, clamped min to 16
+        assert_eq!(width, 16);
+
+        let long_items = vec!["veryLongFieldName: [SomeComplexType!]!".to_string()];
+        let width = compute_col_width(&long_items, 2);
+        // longest is 38, so width = 40, within clamp range
+        assert_eq!(width, 40);
+    }
+
+    #[test]
+    fn wrap_description_short_text() {
+        let result = wrap_description("short text", 50, 10);
+        assert_eq!(result, "short text");
+    }
+
+    #[test]
+    fn wrap_description_long_text() {
+        let text = "This is a longer description that needs wrapping";
+        let result = wrap_description(text, 25, 10);
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(lines.len() > 1);
+        // First line fits within avail
+        assert!(lines[0].len() <= 25);
+        // Continuation lines are indented
+        for line in &lines[1..] {
+            assert!(line.starts_with("          ")); // 10 spaces
+        }
+    }
+
+    #[test]
+    fn wrap_description_reflows_embedded_newlines() {
+        let text = "First line of text.\nSecond line\nThird line that keeps going.";
+        let result = wrap_description(text, 50, 10);
+        // Embedded newlines should be collapsed into spaces and re-wrapped
+        assert!(
+            !result.contains("Second line\n"),
+            "embedded newline should be reflowed: {:?}",
+            result
+        );
+        // The text should still be present, just reflowed
+        assert!(result.contains("First line of text."));
+        assert!(result.contains("Second line"));
+        assert!(result.contains("Third line"));
+    }
+
+    #[test]
+    fn deprecated_gutter_indent_2() {
+        let mut out = String::new();
+        write_item_line(&mut out, "field: Type", None, true, None, 2, 16);
+        // Should start with ⚠ (replacing first indent space) + 1 space
+        assert!(out.starts_with(&format!("{DEPRECATED_MARKER} field: Type")));
+    }
+
+    #[test]
+    fn deprecated_gutter_indent_4() {
+        let mut out = String::new();
+        write_item_line(
+            &mut out,
+            "field: Type",
+            None,
+            true,
+            Some("old field"),
+            4,
+            16,
+        );
+        // Should start with 2 spaces + ⚠ + space
+        assert!(out.starts_with(&format!("  {DEPRECATED_MARKER} field: Type")));
+        assert!(out.contains(&format!("{HOOK_ARROW} Deprecated: old field")));
+    }
+}

--- a/crates/rover-schema/src/format/mod.rs
+++ b/crates/rover-schema/src/format/mod.rs
@@ -1,0 +1,44 @@
+pub mod compact;
+pub mod description;
+pub mod sdl;
+
+// Unicode box-drawing and symbol constants used across formatters.
+pub(crate) const DEPRECATED_MARKER: char = '\u{26a0}'; // ⚠
+pub(crate) const SEPARATOR: char = '\u{203a}'; // ›
+pub(crate) const ARROW: char = '\u{2192}'; // →
+pub(crate) const DASH: char = '\u{2500}'; // ─
+pub(crate) const DOTTED: char = '\u{2508}'; // ┈
+pub(crate) const HOOK_ARROW: char = '\u{21b3}'; // ↳
+
+/// Output format for schema commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Human-readable description (default for TTY)
+    Description,
+    /// Token-efficient compact notation (default for piped output)
+    Compact,
+    /// Raw SDL
+    Sdl,
+}
+
+/// Detect whether stdout is a TTY.
+pub fn is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+}
+
+/// Select the appropriate output format based on flags and TTY detection.
+/// `is_json` comes from the global `--format json` flag, which is handled
+/// at a higher level and suppresses auto-compact.
+pub fn select_format(sdl: bool, compact: bool, is_json: bool) -> OutputFormat {
+    if sdl {
+        OutputFormat::Sdl
+    } else if compact {
+        OutputFormat::Compact
+    } else if !is_json && !is_tty() {
+        // Auto-compact when piped and not already in JSON mode
+        OutputFormat::Compact
+    } else {
+        OutputFormat::Description
+    }
+}

--- a/crates/rover-schema/src/format/mod.rs
+++ b/crates/rover-schema/src/format/mod.rs
@@ -25,19 +25,3 @@ pub fn is_tty() -> bool {
     use std::io::IsTerminal;
     std::io::stdout().is_terminal()
 }
-
-/// Select the appropriate output format based on flags and TTY detection.
-/// `is_json` comes from the global `--format json` flag, which is handled
-/// at a higher level and suppresses auto-compact.
-pub fn select_format(sdl: bool, compact: bool, is_json: bool) -> OutputFormat {
-    if sdl {
-        OutputFormat::Sdl
-    } else if compact {
-        OutputFormat::Compact
-    } else if !is_json && !is_tty() {
-        // Auto-compact when piped and not already in JSON mode
-        OutputFormat::Compact
-    } else {
-        OutputFormat::Description
-    }
-}

--- a/crates/rover-schema/src/format/mod.rs
+++ b/crates/rover-schema/src/format/mod.rs
@@ -6,7 +6,6 @@ pub mod sdl;
 pub(crate) const DEPRECATED_MARKER: char = '\u{26a0}'; // ⚠
 pub(crate) const SEPARATOR: char = '\u{203a}'; // ›
 pub(crate) const ARROW: char = '\u{2192}'; // →
-pub(crate) const DASH: char = '\u{2500}'; // ─
 pub(crate) const DOTTED: char = '\u{2508}'; // ┈
 pub(crate) const HOOK_ARROW: char = '\u{21b3}'; // ↳
 

--- a/crates/rover-schema/src/format/sdl.rs
+++ b/crates/rover-schema/src/format/sdl.rs
@@ -1,0 +1,294 @@
+use apollo_compiler::coordinate::SchemaCoordinate;
+
+/// Extract filtered SDL for a coordinate from the full schema SDL.
+/// Returns SDL containing just the targeted type (and for fields, just the parent type).
+pub fn filtered_sdl(coord: Option<&SchemaCoordinate>, sdl: &str) -> String {
+    let type_name = coord.and_then(|c| match c {
+        SchemaCoordinate::Type(tc) => Some(tc.ty.as_str()),
+        SchemaCoordinate::TypeAttribute(tac) => Some(tac.ty.as_str()),
+        SchemaCoordinate::FieldArgument(fac) => Some(fac.ty.as_str()),
+        SchemaCoordinate::Directive(_) | SchemaCoordinate::DirectiveArgument(_) => None,
+    });
+    match type_name {
+        None => sdl.to_string(),
+        Some(type_name) => extract_type_sdl(type_name, sdl),
+    }
+}
+
+/// Extract the SDL definition for a single type from the full schema SDL.
+///
+/// Searches for `type Name`, `input Name`, etc. with word-boundary checking
+/// to avoid matching `Post` when `PostEdge` appears first.
+pub fn extract_type_sdl(type_name: &str, full_sdl: &str) -> String {
+    let patterns = [
+        format!("type {type_name}"),
+        format!("input {type_name}"),
+        format!("enum {type_name}"),
+        format!("interface {type_name}"),
+        format!("union {type_name}"),
+        format!("scalar {type_name}"),
+    ];
+
+    for pattern in &patterns {
+        // Iterate through all occurrences, checking word boundary after the type name
+        let mut search_from = 0;
+        let type_pos = loop {
+            let Some(pos) = full_sdl[search_from..].find(pattern.as_str()) else {
+                break None;
+            };
+            let abs_pos = search_from + pos;
+            let next = full_sdl[abs_pos + pattern.len()..].chars().next();
+            if next.is_none_or(|c| !c.is_alphanumeric() && c != '_') {
+                break Some(abs_pos);
+            }
+            search_from = abs_pos + 1;
+        };
+        let Some(type_pos) = type_pos else {
+            continue;
+        };
+
+        let Some(end) = find_type_end(full_sdl, type_pos) else {
+            continue;
+        };
+
+        // Include a preceding `"""` description block if present
+        let before = &full_sdl[..type_pos];
+        let start = before
+            .rfind("\"\"\"")
+            .filter(|&closing_pos| {
+                // Only include if the description block is adjacent (no other type defs between)
+                full_sdl[closing_pos..type_pos].trim().ends_with("\"\"\"")
+            })
+            .and_then(|closing_pos| {
+                // Find the opening `"""` before the closing one
+                before[..closing_pos].rfind("\"\"\"")
+            })
+            .unwrap_or(type_pos);
+
+        return full_sdl[start..end].trim().to_string();
+    }
+
+    format!("# Type '{type_name}' not found in SDL")
+}
+
+fn find_type_end(sdl: &str, start: usize) -> Option<usize> {
+    let rest = &sdl[start..];
+
+    // For scalars and unions without braces on the first line: end at the newline
+    if let Some(nl) = rest.find('\n') {
+        let first_line = &rest[..nl];
+        if !first_line.contains('{') {
+            return Some(start + nl);
+        }
+    }
+
+    // For types with body: find the matching closing brace,
+    // skipping over triple-quoted (""") string literals.
+    if let Some(open) = rest.find('{') {
+        let mut depth = 0;
+        let body = &rest[open..];
+        let mut chars = body.char_indices().peekable();
+        while let Some((i, ch)) = chars.next() {
+            if ch == '"' {
+                // Check for triple-quote start
+                if body[i..].starts_with("\"\"\"") {
+                    // Skip the opening """
+                    chars.next();
+                    chars.next();
+                    // Consume until closing """
+                    while let Some((j, _)) = chars.next() {
+                        if body[j..].starts_with("\"\"\"") {
+                            chars.next();
+                            chars.next();
+                            break;
+                        }
+                    }
+                    continue;
+                }
+            }
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(start + open + i + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Some(sdl.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SDL: &str = r#""""A content post"""
+type Post implements Node & Timestamped {
+  id: ID!
+  title: String!
+  body: String!
+}
+
+type PostEdge {
+  node: Post!
+}
+
+type PostConnection {
+  edges: [PostEdge!]
+  pageInfo: PageInfo!
+}
+
+input CreatePostInput {
+  title: String!
+  body: String!
+}
+
+"""Content search types"""
+enum SearchType {
+  POST
+  USER
+  CATEGORY
+}
+
+"""An entity with a stable ID"""
+interface Node {
+  id: ID!
+}
+
+union ContentItem = Post | Comment
+
+scalar DateTime
+
+"""Email digest frequency"""
+enum DigestFrequency {
+  DAILY
+  WEEKLY
+  NEVER
+}"#;
+
+    #[test]
+    fn extract_object_type() {
+        let result = extract_type_sdl("PostEdge", TEST_SDL);
+        assert!(result.starts_with("type PostEdge"), "got: {result}");
+        assert!(result.contains("node: Post!"));
+    }
+
+    #[test]
+    fn extract_input_type() {
+        let result = extract_type_sdl("CreatePostInput", TEST_SDL);
+        assert!(result.starts_with("input CreatePostInput"), "got: {result}");
+        assert!(result.contains("title: String!"));
+    }
+
+    #[test]
+    fn extract_enum_type() {
+        let result = extract_type_sdl("SearchType", TEST_SDL);
+        assert!(
+            result.contains("enum SearchType"),
+            "should contain enum: {result}"
+        );
+        assert!(result.contains("POST"));
+    }
+
+    #[test]
+    fn extract_interface_type() {
+        let result = extract_type_sdl("Node", TEST_SDL);
+        assert!(
+            result.contains("interface Node"),
+            "should contain interface: {result}"
+        );
+        assert!(result.contains("id: ID!"));
+    }
+
+    #[test]
+    fn extract_union_type() {
+        let result = extract_type_sdl("ContentItem", TEST_SDL);
+        assert!(
+            result.starts_with("union ContentItem"),
+            "should start with union: {result}"
+        );
+        assert!(result.contains("Post | Comment"));
+    }
+
+    #[test]
+    fn extract_scalar_type() {
+        let result = extract_type_sdl("DateTime", TEST_SDL);
+        assert_eq!(result, "scalar DateTime");
+    }
+
+    #[test]
+    fn extract_type_with_description_block() {
+        let result = extract_type_sdl("Post", TEST_SDL);
+        assert!(
+            result.starts_with("\"\"\"A content post\"\"\""),
+            "should include description block: {result}"
+        );
+        assert!(result.contains("type Post"));
+    }
+
+    #[test]
+    fn extract_enum_with_description_block() {
+        let result = extract_type_sdl("DigestFrequency", TEST_SDL);
+        assert!(
+            result.starts_with("\"\"\"Email digest frequency\"\"\""),
+            "should include description: {result}"
+        );
+        assert!(result.contains("enum DigestFrequency"));
+    }
+
+    #[test]
+    fn type_name_prefix_bug_post_vs_postedge() {
+        // PostEdge appears after Post in SDL, but searching for "Post" must not match "PostEdge"
+        let result = extract_type_sdl("Post", TEST_SDL);
+        assert!(
+            result.contains("type Post implements"),
+            "should find 'type Post', not 'type PostEdge': {result}"
+        );
+        assert!(
+            !result.contains("type PostEdge"),
+            "must not contain PostEdge definition: {result}"
+        );
+    }
+
+    #[test]
+    fn type_name_prefix_bug_reversed_order() {
+        // SDL where PostEdge appears BEFORE Post — the original bug
+        let sdl = "type PostEdge {\n  node: Post!\n}\n\ntype Post {\n  id: ID!\n}\n";
+        let result = extract_type_sdl("Post", sdl);
+        assert!(
+            result.starts_with("type Post"),
+            "should find exact 'type Post', not 'type PostEdge': {result}"
+        );
+        assert!(!result.contains("PostEdge"), "must not match PostEdge");
+    }
+
+    #[test]
+    fn braces_inside_description_do_not_break_extraction() {
+        let sdl = "type Foo {\n  \"\"\"\n  Example: { bar: 1 }\n  \"\"\"\n  field: String!\n}\n\ntype Bar {\n  id: ID!\n}\n";
+        let result = extract_type_sdl("Foo", sdl);
+        assert!(
+            result.contains("field: String!"),
+            "should include Foo's field: {result}"
+        );
+        assert!(
+            !result.contains("type Bar"),
+            "should not bleed into Bar: {result}"
+        );
+    }
+
+    #[test]
+    fn not_found_fallback() {
+        let result = extract_type_sdl("NonExistent", TEST_SDL);
+        assert_eq!(result, "# Type 'NonExistent' not found in SDL");
+    }
+
+    #[test]
+    fn filtered_sdl_none_returns_full() {
+        let result = filtered_sdl(None, TEST_SDL);
+        assert_eq!(result, TEST_SDL);
+    }
+}

--- a/crates/rover-schema/src/lib.rs
+++ b/crates/rover-schema/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod describe;
+pub mod error;
+pub mod format;
+pub mod parsed_schema;
+pub mod root_paths;
+pub(crate) mod util;
+
+// Re-export main public types
+pub use apollo_compiler::coordinate::SchemaCoordinate;
+pub use describe::{DescribeResult, FieldDetail, SchemaOverview, TypeDetail};
+pub use error::SchemaError;
+pub use format::OutputFormat;
+pub use parsed_schema::ParsedSchema;

--- a/crates/rover-schema/src/parsed_schema.rs
+++ b/crates/rover-schema/src/parsed_schema.rs
@@ -1,0 +1,22 @@
+use apollo_compiler::Schema;
+
+/// Wrapper around apollo_compiler::Schema providing convenient accessors.
+pub struct ParsedSchema {
+    schema: Schema,
+}
+
+impl ParsedSchema {
+    /// Parse SDL into a schema. Uses permissive parsing (no validation)
+    /// since we want to explore schemas that may have minor issues.
+    pub fn parse(sdl: &str) -> Self {
+        let schema = match Schema::parse(sdl, "schema.graphql") {
+            Ok(schema) => schema,
+            Err(with_errors) => with_errors.partial,
+        };
+        Self { schema }
+    }
+
+    pub const fn inner(&self) -> &Schema {
+        &self.schema
+    }
+}

--- a/crates/rover-schema/src/root_paths.rs
+++ b/crates/rover-schema/src/root_paths.rs
@@ -1,0 +1,229 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use apollo_compiler::{Schema, schema::ExtendedType};
+use itertools::Itertools;
+
+use crate::{
+    format::{ARROW, SEPARATOR},
+    util::unwrap_type_name,
+};
+
+/// A path from a root type (Query/Mutation) to a target type through field references.
+#[derive(Debug, Clone)]
+pub struct RootPath {
+    /// Sequence of (type_name, field_name) pairs from root to target.
+    /// The last element's type_name is the parent of the target.
+    pub segments: Vec<PathSegment>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PathSegment {
+    pub type_name: String,
+    pub field_name: String,
+}
+
+impl RootPath {
+    pub fn format_via(&self) -> String {
+        self.segments
+            .iter()
+            .map(|seg| format!("{}.{}", seg.type_name, seg.field_name))
+            .join(&format!(" {SEPARATOR} "))
+    }
+
+    pub fn format_compact(&self) -> String {
+        self.segments
+            .iter()
+            .map(|seg| format!("{}.{}", seg.type_name, seg.field_name))
+            .join(&format!("{ARROW}"))
+    }
+
+    pub fn format_path_header(&self, target_type: &str) -> String {
+        self.segments
+            .iter()
+            .map(|seg| format!("{}.{}", seg.type_name, seg.field_name))
+            .chain(std::iter::once(target_type.to_string()))
+            .join(&format!(" {ARROW} "))
+    }
+}
+
+/// Find the shortest BFS path(s) from Query/Mutation roots to a target type.
+pub fn find_root_paths(schema: &Schema, target_type: &str) -> Vec<RootPath> {
+    let mut paths = Vec::new();
+
+    for root_name in root_type_names(schema) {
+        if root_name == target_type {
+            continue;
+        }
+        if let Some(path) = bfs_to_type(schema, &root_name, target_type) {
+            paths.push(path);
+        }
+    }
+
+    paths
+}
+
+fn root_type_names(schema: &Schema) -> Vec<String> {
+    let mut roots = Vec::new();
+    if let Some(query) = schema.schema_definition.query.as_ref() {
+        roots.push(query.to_string());
+    } else if schema.types.contains_key("Query") {
+        roots.push("Query".to_string());
+    }
+    if let Some(mutation) = schema.schema_definition.mutation.as_ref() {
+        roots.push(mutation.to_string());
+    } else if schema.types.contains_key("Mutation") {
+        roots.push("Mutation".to_string());
+    }
+    roots
+}
+
+fn bfs_to_type(schema: &Schema, start: &str, target: &str) -> Option<RootPath> {
+    let mut visited: HashSet<String> = HashSet::new();
+    // Map from type_name -> (parent_type, field_name)
+    let mut parent_map: HashMap<String, (String, String)> = HashMap::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    visited.insert(start.to_string());
+    queue.push_back(start.to_string());
+
+    const MAX_DEPTH: usize = 10;
+    let mut depth = 0;
+
+    while !queue.is_empty() && depth < MAX_DEPTH {
+        let level_size = queue.len();
+        for _ in 0..level_size {
+            let Some(current) = queue.pop_front() else {
+                break;
+            };
+
+            if let Some(fields) = get_object_fields(schema, &current) {
+                for (field_name, return_type) in fields {
+                    let type_name = unwrap_type_name(&return_type);
+                    if type_name == target {
+                        parent_map.insert(type_name, (current.clone(), field_name));
+                        return Some(reconstruct_path(&parent_map, start, target));
+                    }
+                    if !visited.contains(&type_name) {
+                        visited.insert(type_name.clone());
+                        parent_map.insert(type_name.clone(), (current.clone(), field_name));
+                        queue.push_back(type_name);
+                    }
+                }
+            }
+        }
+        depth += 1;
+    }
+
+    None
+}
+
+fn reconstruct_path(
+    parent_map: &HashMap<String, (String, String)>,
+    start: &str,
+    target: &str,
+) -> RootPath {
+    let mut segments = Vec::new();
+    let mut current = target.to_string();
+
+    while current != start {
+        if let Some((parent_type, field_name)) = parent_map.get(&current) {
+            segments.push(PathSegment {
+                type_name: parent_type.clone(),
+                field_name: field_name.clone(),
+            });
+            current = parent_type.clone();
+        } else {
+            break;
+        }
+    }
+
+    segments.reverse();
+    RootPath { segments }
+}
+
+fn get_object_fields(schema: &Schema, type_name: &str) -> Option<Vec<(String, String)>> {
+    let ty = schema.types.get(type_name)?;
+    match ty {
+        ExtendedType::Object(obj) => Some(
+            obj.fields
+                .iter()
+                .map(|(name, field)| (name.to_string(), field.ty.to_string()))
+                .collect(),
+        ),
+        ExtendedType::Interface(iface) => Some(
+            iface
+                .fields
+                .iter()
+                .map(|(name, field)| (name.to_string(), field.ty.to_string()))
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_schema() -> Schema {
+        let sdl = include_str!("test_fixtures/test_schema.graphql");
+        match Schema::parse(sdl, "test.graphql") {
+            Ok(s) => s,
+            Err(e) => e.partial,
+        }
+    }
+
+    #[test]
+    fn finds_direct_path_from_query() {
+        let schema = test_schema();
+        let paths = find_root_paths(&schema, "Post");
+        assert!(!paths.is_empty());
+        let has_direct = paths.iter().any(|p| {
+            p.segments.len() == 1
+                && p.segments[0].type_name == "Query"
+                && p.segments[0].field_name == "post"
+        });
+        assert!(has_direct, "Should find direct Query.post path");
+    }
+
+    #[test]
+    fn finds_path_to_nested_type() {
+        let schema = test_schema();
+        let paths = find_root_paths(&schema, "Preferences");
+        assert!(!paths.is_empty());
+        // Preferences is reachable through Query.viewer → Viewer.preferences
+    }
+
+    #[test]
+    fn no_path_for_root_type() {
+        let schema = test_schema();
+        let paths = find_root_paths(&schema, "Query");
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn no_path_for_unreachable_scalar() {
+        let schema = test_schema();
+        let paths = find_root_paths(&schema, "URL");
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn format_via_produces_readable_output() {
+        let path = RootPath {
+            segments: vec![
+                PathSegment {
+                    type_name: "Query".into(),
+                    field_name: "user".into(),
+                },
+                PathSegment {
+                    type_name: "User".into(),
+                    field_name: "posts".into(),
+                },
+            ],
+        };
+        let via = path.format_via();
+        assert!(via.contains("Query.user"));
+        assert!(via.contains("User.posts"));
+    }
+}

--- a/crates/rover-schema/src/test_fixtures/test_schema.graphql
+++ b/crates/rover-schema/src/test_fixtures/test_schema.graphql
@@ -1,0 +1,210 @@
+"""The root query type"""
+type Query {
+  """Get a user by ID"""
+  user(id: ID!): User
+  """Get a post by ID"""
+  post(id: ID!): Post
+  """List all categories"""
+  categories: [Category!]!
+  """Search for content"""
+  search(query: String!, types: [SearchType!]!, limit: Int): SearchResults
+  """Get the currently authenticated viewer"""
+  viewer: Viewer
+}
+
+type Mutation {
+  """Create a new post"""
+  createPost(input: CreatePostInput!): CreatePostPayload
+  """Update notification preferences"""
+  updatePreferences(input: UpdatePreferencesInput): UpdatePreferencesPayload
+  """Delete a comment"""
+  deleteComment(id: ID!): DeleteCommentPayload
+}
+
+"""A registered user"""
+type User implements Node & Profile {
+  id: ID!
+  name: String!
+  """The user's email address"""
+  email: String!
+  """Posts authored by this user"""
+  posts(limit: Int, offset: Int): PostConnection
+  bio: String
+  avatarUrl: String
+  createdAt: String!
+  legacyId: String @deprecated(reason: "Use id instead")
+}
+
+"""A content post"""
+type Post implements Node & Timestamped {
+  id: ID!
+  title: String!
+  """The body content"""
+  body: String!
+  """The author of this post"""
+  author: User!
+  comments: CommentConnection!
+  category: Category!
+  tags: [Tag!]!
+  publishedAt: String
+  createdAt: String!
+  updatedAt: String!
+  viewCount: Int!
+  """The post's popularity score (0-100)"""
+  score: Int!
+  slug: String!
+  oldSlug: String @deprecated(reason: "Use slug instead")
+}
+
+"""A comment on a post"""
+type Comment implements Node & Timestamped {
+  id: ID!
+  body: String!
+  author: User!
+  post: Post!
+  createdAt: String!
+  updatedAt: String!
+  parentComment: Comment
+}
+
+"""A content category"""
+type Category implements Node {
+  id: ID!
+  name: String!
+  description: String
+  posts: PostConnection!
+  parent: Category
+}
+
+"""A tag applied to posts"""
+type Tag {
+  name: String!
+  postCount: Int!
+}
+
+"""The authenticated viewer"""
+type Viewer implements Profile {
+  id: ID!
+  name: String!
+  email: String!
+  """Notification preferences"""
+  preferences: Preferences
+  feed: PostConnection
+}
+
+type Preferences {
+  emailNotifications: Boolean!
+  digestFrequency: DigestFrequency!
+}
+
+type PostConnection {
+  edges: [PostEdge!]
+  pageInfo: PageInfo!
+}
+
+type PostEdge {
+  node: Post!
+}
+
+type CommentConnection {
+  edges: [CommentEdge!]
+  pageInfo: PageInfo!
+}
+
+type CommentEdge {
+  node: Comment!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  total: Int
+}
+
+type SearchResults {
+  posts: [Post!]
+  users: [User!]
+  categories: [Category!]
+}
+
+type CreatePostPayload {
+  post: Post
+}
+
+type UpdatePreferencesPayload {
+  preferences: Preferences
+}
+
+type DeleteCommentPayload {
+  success: Boolean!
+}
+
+# Interfaces
+
+"""An entity with a stable ID"""
+interface Node {
+  id: ID!
+}
+
+"""An entity with timestamps"""
+interface Timestamped {
+  createdAt: String!
+  updatedAt: String!
+}
+
+"""A user profile"""
+interface Profile {
+  id: ID!
+  name: String!
+}
+
+# Enums
+
+"""Content search types"""
+enum SearchType {
+  POST
+  USER
+  CATEGORY
+}
+
+"""Email digest frequency"""
+enum DigestFrequency {
+  DAILY
+  WEEKLY
+  NEVER
+}
+
+enum SortOrder {
+  NEWEST
+  OLDEST
+  TOP
+  RELEVANCE @deprecated(reason: "Use TOP instead")
+}
+
+# Inputs
+
+input CreatePostInput {
+  """The post title"""
+  title: String!
+  """The post body"""
+  body: String!
+  """Category ID"""
+  categoryId: ID!
+  """Optional tags"""
+  tags: [String!]
+}
+
+input UpdatePreferencesInput {
+  emailNotifications: Boolean
+  digestFrequency: DigestFrequency
+}
+
+# Union
+
+union ContentItem = Post | Comment
+
+# Custom scalars
+
+scalar DateTime
+scalar URL

--- a/crates/rover-schema/src/util.rs
+++ b/crates/rover-schema/src/util.rs
@@ -1,0 +1,19 @@
+/// Extract the named type from a GraphQL type reference, stripping `[`, `]`, and `!` wrappers.
+///
+/// For example: `[String!]!` → `String`, `Post` → `Post`.
+pub(crate) fn unwrap_type_name(type_str: &str) -> String {
+    type_str.replace(['[', ']', '!'], "").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_wrappers() {
+        assert_eq!(unwrap_type_name("[String!]!"), "String");
+        assert_eq!(unwrap_type_name("Post"), "Post");
+        assert_eq!(unwrap_type_name("[User!]"), "User");
+        assert_eq!(unwrap_type_name("Int!"), "Int");
+    }
+}

--- a/docs/source/commands/describe.mdx
+++ b/docs/source/commands/describe.mdx
@@ -1,0 +1,89 @@
+---
+title: Rover describe Command
+subtitle: Explore your graph schema by type or field
+description: Use the rover describe command to view schema overviews, type details, and field details from GraphOS or a running endpoint.
+---
+
+import AuthNotice from '../../shared/auth-notice.mdx';
+
+## Overview
+
+The `rover describe` command provides structured descriptions of your graph's schema. Start with a full schema overview, then zoom into individual types and fields.
+
+<AuthNotice />
+
+## Usage
+
+```bash
+rover describe <GRAPH_REF>[:<COORDINATE>] [OPTIONS]
+```
+
+| Form | What you get |
+|---|---|
+| `graph@variant` | Schema overview |
+| `graph@variant:Type` | Type description |
+| `graph@variant:Type.field` | Field description and return type |
+
+## Examples
+
+### Schema overview
+
+```bash
+rover describe my-graph@my-variant
+```
+
+This displays the full schema summary including type counts, Query and Mutation fields, and all user-defined types grouped by kind.
+
+### Type description
+
+```bash
+rover describe my-graph@my-variant:Post
+```
+
+Shows the type's fields, descriptions, interfaces it implements, and the shortest path to reach it from Query or Mutation.
+
+### Field description
+
+```bash
+rover describe my-graph@my-variant:User.posts
+```
+
+Shows the field's arguments, input type expansion, and return type expansion — everything you need to write a query using this field.
+
+### Depth expansion
+
+```bash
+rover describe my-graph@my-variant:Post --depth 1
+```
+
+The `--depth` flag expands referenced types by N levels, showing their fields inline. This lets you explore the type graph without viewing the entire schema.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `-d, --depth <N>` | Expand referenced types N levels deep (default: 0) |
+| `--include-deprecated` | Show deprecated fields and types |
+| `--sdl` | Output raw SDL instead of structured description |
+| `--compact` | Output token-efficient compact notation |
+| `--no-cache` | Skip the local schema cache |
+| `--profile <NAME>` | Name of configuration profile to use |
+
+## Output formats
+
+By default, `rover describe` outputs a structured human-readable description. Three alternatives are available:
+
+- **`--sdl`**: Raw SDL, filtered to just the coordinate you asked for
+- **`--compact`**: Token-efficient notation (~40% fewer tokens than SDL)
+- **`--format json`** (global): Structured JSON output
+
+When output is piped (stdout is not a TTY), compact format is auto-selected unless `--sdl` or `--format json` is specified.
+
+```bash
+# Auto-compacts when piped
+rover describe my-graph@my-variant:Post | cat
+```
+
+## Schema source
+
+By default, `rover describe` fetches the schema from GraphOS using your `APOLLO_KEY`. The schema is cached locally for 5 minutes.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -203,7 +203,11 @@ impl Rover {
                     .await
             }
             Command::Contract(command) => command.run(self.get_client_config()?).await,
-            Command::Describe(command) => command.run(self.get_client_config()?).await,
+            Command::Describe(command) => {
+                command
+                    .run(self.get_client_config()?, self.output_opts.format_kind)
+                    .await
+            }
             Command::Dev(command) => {
                 command
                     .run(
@@ -466,6 +470,8 @@ pub enum RoverOutputFormatKind {
     #[default]
     Plain,
     Json,
+    Compact,
+    Sdl,
 }
 
 impl Display for RoverOutputFormatKind {
@@ -473,6 +479,8 @@ impl Display for RoverOutputFormatKind {
         match self {
             RoverOutputFormatKind::Plain => write!(f, "plain"),
             RoverOutputFormatKind::Json => write!(f, "json"),
+            RoverOutputFormatKind::Compact => write!(f, "compact"),
+            RoverOutputFormatKind::Sdl => write!(f, "sdl"),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -203,6 +203,7 @@ impl Rover {
                     .await
             }
             Command::Contract(command) => command.run(self.get_client_config()?).await,
+            Command::Describe(command) => command.run(self.get_client_config()?).await,
             Command::Dev(command) => {
                 command
                     .run(
@@ -401,6 +402,9 @@ pub enum Command {
 
     /// Contract configuration commands
     Contract(command::Contract),
+
+    /// Describe a graph's schema by type or field
+    Describe(command::Describe),
 
     /// Run a supergraph locally to develop and test subgraph changes
     ///

--- a/src/command/describe/mod.rs
+++ b/src/command/describe/mod.rs
@@ -9,8 +9,8 @@ use rover_schema::{
 use serde::Serialize;
 
 use crate::{
-    RoverOutput, RoverResult, command::schema_cache, options::ProfileOpt,
-    utils::client::StudioClientConfig,
+    RoverOutput, RoverResult, cli::RoverOutputFormatKind, command::schema_cache,
+    options::ProfileOpt, utils::client::StudioClientConfig,
 };
 
 #[derive(Debug, Serialize, Parser)]
@@ -25,7 +25,7 @@ use crate::{
         rover describe my-graph@my-variant:Post\n    \
         rover describe my-graph@my-variant:Post --depth 1\n    \
         rover describe my-graph@my-variant:User.posts\n    \
-        rover describe my-graph@my-variant:Post --sdl")]
+        rover describe my-graph@my-variant:Post --format sdl")]
 pub struct Describe {
     /// <NAME>@<VARIANT>[:<COORDINATE>]
     ///
@@ -44,14 +44,6 @@ pub struct Describe {
     #[arg(long = "include-deprecated")]
     include_deprecated: bool,
 
-    /// Output raw SDL
-    #[arg(long = "sdl")]
-    sdl: bool,
-
-    /// Output token-efficient compact notation
-    #[arg(long = "compact")]
-    compact: bool,
-
     /// Skip reading from the local schema cache (still writes to cache)
     #[arg(long = "no-cache")]
     no_cache: bool,
@@ -61,7 +53,11 @@ pub struct Describe {
 }
 
 impl Describe {
-    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+    pub async fn run(
+        &self,
+        client_config: StudioClientConfig,
+        format_kind: RoverOutputFormatKind,
+    ) -> RoverResult<RoverOutput> {
         let (graph_ref, coordinate) = parse_graph_ref_and_coordinate(&self.graph_ref_and_coord)?;
 
         // Fetch SDL (with caching)
@@ -78,9 +74,20 @@ impl Describe {
         let schema = parsed.inner();
 
         // Determine output format
-        let output_format = format::select_format(self.sdl, self.compact, false);
+        let output_format = match format_kind {
+            RoverOutputFormatKind::Sdl => OutputFormat::Sdl,
+            RoverOutputFormatKind::Compact => OutputFormat::Compact,
+            RoverOutputFormatKind::Json => OutputFormat::Description,
+            RoverOutputFormatKind::Plain => {
+                if format::is_tty() {
+                    OutputFormat::Description
+                } else {
+                    OutputFormat::Compact
+                }
+            }
+        };
 
-        // If --sdl, output filtered SDL
+        // If --format sdl, output filtered SDL
         if output_format == OutputFormat::Sdl {
             let sdl_output = sdl::filtered_sdl(coordinate.as_ref(), &sdl_string);
             return Ok(RoverOutput::DescribeResponse {

--- a/src/command/describe/mod.rs
+++ b/src/command/describe/mod.rs
@@ -1,0 +1,250 @@
+use std::str::FromStr;
+
+use clap::Parser;
+use rover_client::shared::GraphRef;
+use rover_schema::{
+    ParsedSchema, SchemaCoordinate, describe,
+    format::{self, OutputFormat, compact, description, sdl},
+};
+use serde::Serialize;
+
+use crate::{
+    RoverOutput, RoverResult, command::schema_cache, options::ProfileOpt,
+    utils::client::StudioClientConfig,
+};
+
+#[derive(Debug, Serialize, Parser)]
+/// Describe a graph's schema by type or field
+///
+/// Displays a structured description of your graph's schema. Start with an
+/// overview, then zoom into individual types and fields.
+///
+/// Piped output defaults to --compact.
+#[command(after_help = "EXAMPLES:\n    \
+        rover describe my-graph@my-variant\n    \
+        rover describe my-graph@my-variant:Post\n    \
+        rover describe my-graph@my-variant:Post --depth 1\n    \
+        rover describe my-graph@my-variant:User.posts\n    \
+        rover describe my-graph@my-variant:Post --sdl")]
+pub struct Describe {
+    /// <NAME>@<VARIANT>[:<COORDINATE>]
+    ///
+    /// graph@variant            Schema overview
+    /// graph@variant:Type       Describe a type
+    /// graph@variant:Type.field Describe a field
+    #[arg(value_name = "GRAPH_REF")]
+    #[serde(skip_serializing)]
+    graph_ref_and_coord: String,
+
+    /// Expand referenced types N levels deep
+    #[arg(long = "depth", short = 'd', default_value_t = 0)]
+    depth: usize,
+
+    /// Show deprecated fields and types
+    #[arg(long = "include-deprecated")]
+    include_deprecated: bool,
+
+    /// Output raw SDL
+    #[arg(long = "sdl")]
+    sdl: bool,
+
+    /// Output token-efficient compact notation
+    #[arg(long = "compact")]
+    compact: bool,
+
+    /// Skip reading from the local schema cache (still writes to cache)
+    #[arg(long = "no-cache")]
+    no_cache: bool,
+
+    #[clap(flatten)]
+    profile: ProfileOpt,
+}
+
+impl Describe {
+    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        let (graph_ref, coordinate) = parse_graph_ref_and_coordinate(&self.graph_ref_and_coord)?;
+
+        // Fetch SDL (with caching)
+        let sdl_string = schema_cache::fetch_sdl_cached(
+            &graph_ref,
+            &self.profile,
+            &client_config,
+            self.no_cache,
+        )
+        .await?;
+
+        // Parse
+        let parsed = ParsedSchema::parse(&sdl_string);
+        let schema = parsed.inner();
+
+        // Determine output format
+        let output_format = format::select_format(self.sdl, self.compact, false);
+
+        // If --sdl, output filtered SDL
+        if output_format == OutputFormat::Sdl {
+            let sdl_output = sdl::filtered_sdl(coordinate.as_ref(), &sdl_string);
+            return Ok(RoverOutput::DescribeResponse {
+                content: sdl_output,
+                json_data: serde_json::Value::Null,
+            });
+        }
+
+        // Generate describe result
+        let result = match &coordinate {
+            None => {
+                let overview = describe::overview(schema, &graph_ref.to_string());
+                describe::DescribeResult::Overview(overview)
+            }
+            Some(SchemaCoordinate::Type(tc)) => {
+                let detail = describe::type_detail(
+                    schema,
+                    tc.ty.as_str(),
+                    self.include_deprecated,
+                    self.depth,
+                )
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                describe::DescribeResult::TypeDetail(detail)
+            }
+            Some(coord @ SchemaCoordinate::TypeAttribute(_)) => {
+                let detail =
+                    describe::field_detail(schema, coord).map_err(|e| anyhow::anyhow!("{}", e))?;
+                describe::DescribeResult::FieldDetail(detail)
+            }
+            Some(other) => {
+                return Err(
+                    anyhow::anyhow!("unsupported coordinate for describe: '{other}'").into(),
+                );
+            }
+        };
+
+        let json_data = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+
+        let content = match output_format {
+            OutputFormat::Description => description::format_describe(&result),
+            OutputFormat::Compact => compact::format_describe_compact(&result),
+            OutputFormat::Sdl => unreachable!(),
+        };
+
+        Ok(RoverOutput::DescribeResponse { content, json_data })
+    }
+}
+
+/// Parse a combined `GRAPH_REF:COORDINATE` string.
+///
+/// The heuristic: find the `@variant` portion first. Then look for a `:` after
+/// the variant where the text following starts with an uppercase letter (GraphQL
+/// type names are PascalCase). This handles variants that contain `:`.
+fn parse_graph_ref_and_coordinate(
+    input: &str,
+) -> RoverResult<(GraphRef, Option<SchemaCoordinate>)> {
+    // Find the @ that separates graph name from variant
+    let at_pos = input.find('@');
+
+    if let Some(at_pos) = at_pos {
+        // Look for a coordinate after the variant
+        let after_at = &input[at_pos + 1..];
+
+        // Find the last `:` where the following char is uppercase (a type name)
+        let mut coord_split = None;
+        for (i, _) in after_at.match_indices(':') {
+            let remaining = &after_at[i + 1..];
+            if remaining.starts_with(|c: char| c.is_ascii_uppercase()) {
+                coord_split = Some(at_pos + 1 + i);
+                break;
+            }
+        }
+
+        if let Some(split_pos) = coord_split {
+            let graph_ref_str = &input[..split_pos];
+            let coord_str = &input[split_pos + 1..];
+            let graph_ref =
+                GraphRef::from_str(graph_ref_str).map_err(|e| anyhow::anyhow!("{}", e))?;
+            let coordinate = coord_str
+                .parse::<SchemaCoordinate>()
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+            Ok((graph_ref, Some(coordinate)))
+        } else {
+            // No coordinate — entire string is the graph ref
+            let graph_ref = GraphRef::from_str(input).map_err(|e| anyhow::anyhow!("{}", e))?;
+            Ok((graph_ref, None))
+        }
+    } else {
+        // No @, but check for a coordinate (`:` followed by uppercase type name)
+        if let Some(colon_pos) = input.find(':') {
+            let remaining = &input[colon_pos + 1..];
+            if remaining.starts_with(|c: char| c.is_ascii_uppercase()) {
+                let graph_ref_str = &input[..colon_pos];
+                let coord_str = remaining;
+                let graph_ref =
+                    GraphRef::from_str(graph_ref_str).map_err(|e| anyhow::anyhow!("{}", e))?;
+                let coordinate = coord_str
+                    .parse::<SchemaCoordinate>()
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                return Ok((graph_ref, Some(coordinate)));
+            }
+        }
+        // No coordinate — entire string is the graph ref (gets default variant)
+        let graph_ref = GraphRef::from_str(input).map_err(|e| anyhow::anyhow!("{}", e))?;
+        Ok((graph_ref, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_graph_ref_only() {
+        let (graph_ref, coord) = parse_graph_ref_and_coordinate("my-graph@current").unwrap();
+        assert_eq!(graph_ref.name, "my-graph");
+        assert_eq!(graph_ref.variant, "current");
+        assert!(coord.is_none());
+    }
+
+    #[test]
+    fn parse_graph_ref_with_type() {
+        let (graph_ref, coord) = parse_graph_ref_and_coordinate("my-graph@current:Post").unwrap();
+        assert_eq!(graph_ref.name, "my-graph");
+        assert_eq!(graph_ref.variant, "current");
+        assert_eq!(coord, Some("Post".parse::<SchemaCoordinate>().unwrap()));
+    }
+
+    #[test]
+    fn parse_graph_ref_with_field() {
+        let (graph_ref, coord) =
+            parse_graph_ref_and_coordinate("my-graph@current:User.posts").unwrap();
+        assert_eq!(graph_ref.name, "my-graph");
+        assert_eq!(graph_ref.variant, "current");
+        assert_eq!(
+            coord,
+            Some("User.posts".parse::<SchemaCoordinate>().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_graph_ref_no_variant() {
+        let (graph_ref, coord) = parse_graph_ref_and_coordinate("mygraph").unwrap();
+        assert_eq!(graph_ref.name, "mygraph");
+        assert_eq!(graph_ref.variant, "current");
+        assert!(coord.is_none());
+    }
+
+    #[test]
+    fn parse_graph_ref_no_variant_with_type() {
+        let (graph_ref, coord) = parse_graph_ref_and_coordinate("my-graph:Post").unwrap();
+        assert_eq!(graph_ref.name, "my-graph");
+        assert_eq!(graph_ref.variant, "current");
+        assert_eq!(coord, Some("Post".parse::<SchemaCoordinate>().unwrap()));
+    }
+
+    #[test]
+    fn parse_graph_ref_no_variant_with_field() {
+        let (graph_ref, coord) = parse_graph_ref_and_coordinate("my-graph:User.posts").unwrap();
+        assert_eq!(graph_ref.name, "my-graph");
+        assert_eq!(graph_ref.variant, "current");
+        assert_eq!(
+            coord,
+            Some("User.posts".parse::<SchemaCoordinate>().unwrap())
+        );
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -5,6 +5,7 @@ mod config;
 #[cfg(feature = "composition-js")]
 pub mod connector;
 mod contract;
+mod describe;
 mod dev;
 mod docs;
 mod explain;
@@ -18,6 +19,7 @@ mod lsp;
 pub(crate) mod output;
 mod persisted_queries;
 mod readme;
+pub(crate) mod schema_cache;
 pub(crate) mod subgraph;
 #[cfg(feature = "composition-js")]
 pub(crate) mod supergraph;
@@ -31,6 +33,7 @@ pub use config::Config;
 #[cfg(feature = "composition-js")]
 pub use connector::Connector;
 pub use contract::Contract;
+pub use describe::Describe;
 pub use dev::Dev;
 pub use docs::Docs;
 pub use explain::Explain;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -113,6 +113,10 @@ pub enum RoverOutput {
         graph_id: String,
         jwt: String,
     },
+    DescribeResponse {
+        content: String,
+        json_data: serde_json::Value,
+    },
     EmptySuccess,
     CloudConfigFetchResponse {
         config: String,
@@ -525,6 +529,7 @@ impl RoverOutput {
                 stderrln!("Success!")?;
                 Some(jwt.to_string())
             }
+            RoverOutput::DescribeResponse { content, .. } => Some(content.clone()),
             RoverOutput::EmptySuccess => None,
             RoverOutput::CloudConfigFetchResponse { config } => Some(config.to_string()),
             RoverOutput::MessageResponse { msg } => Some(msg.into()),
@@ -676,6 +681,7 @@ impl RoverOutput {
             } => {
                 json!({ "readme": new_content, "last_updated_time": last_updated_time })
             }
+            RoverOutput::DescribeResponse { json_data, .. } => json_data.clone(),
             RoverOutput::EmptySuccess => json!(null),
             RoverOutput::PersistedQueriesPublishResponse(response) => {
                 json!({
@@ -814,6 +820,7 @@ impl RoverOutput {
             RoverOutput::Introspection(_) => Some("Introspection Response"),
             RoverOutput::ReadmeFetchResponse { .. } => Some("Readme"),
             RoverOutput::GraphPublishResponse { .. } => Some("Schema Hash"),
+            RoverOutput::DescribeResponse { .. } => None,
             _ => None,
         }
     }

--- a/src/command/schema_cache.rs
+++ b/src/command/schema_cache.rs
@@ -1,0 +1,164 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Result as AnyResult;
+use camino::{Utf8Path, Utf8PathBuf};
+use rover_client::{
+    operations::graph::fetch::{self, GraphFetchInput},
+    shared::GraphRef,
+};
+use rover_std::Fs;
+use serde::{Deserialize, Serialize};
+
+use crate::{RoverResult, options::ProfileOpt, utils::client::StudioClientConfig};
+
+const CACHE_TTL: Duration = Duration::from_secs(300);
+const CACHE_DIR_NAME: &str = "schema-cache";
+
+#[derive(Serialize, Deserialize)]
+struct CacheEntry {
+    sdl: String,
+    cached_at_epoch_secs: u64,
+}
+
+/// Fetch SDL for a graph ref, using a local file cache with 5-min TTL.
+///
+/// When `no_cache` is `true`, always fetches from the registry but still
+/// writes the result to cache for subsequent calls.
+pub async fn fetch_sdl_cached(
+    graph_ref: &GraphRef,
+    profile: &ProfileOpt,
+    client_config: &StudioClientConfig,
+    no_cache: bool,
+) -> RoverResult<String> {
+    let cache_dir = cache_dir_for(client_config);
+    let cache_file = cache_file_for(&cache_dir, graph_ref);
+
+    if !no_cache && let Some(sdl) = read_cache(&cache_file) {
+        return Ok(sdl);
+    }
+
+    let client = client_config.get_authenticated_client(profile)?;
+    let resp = fetch::run(
+        GraphFetchInput {
+            graph_ref: graph_ref.clone(),
+        },
+        &client,
+    )
+    .await?;
+    let sdl = resp.sdl.contents;
+
+    // Best-effort — don't fail the command on cache write errors
+    let _ = write_cache(&cache_dir, &cache_file, &sdl);
+
+    Ok(sdl)
+}
+
+fn cache_dir_for(config: &StudioClientConfig) -> Utf8PathBuf {
+    config.config.home.join(CACHE_DIR_NAME)
+}
+
+fn cache_file_for(dir: &Utf8Path, graph_ref: &GraphRef) -> Utf8PathBuf {
+    dir.join(format!("{}@{}.json", graph_ref.name, graph_ref.variant))
+}
+
+fn read_cache(path: &Utf8Path) -> Option<String> {
+    let contents = Fs::read_file(path).ok()?;
+    let entry: CacheEntry = serde_json::from_str(&contents).ok()?;
+
+    let age = Duration::from_secs(now_epoch_secs().saturating_sub(entry.cached_at_epoch_secs));
+    if age > CACHE_TTL {
+        return None;
+    }
+
+    Some(entry.sdl)
+}
+
+fn write_cache(dir: &Utf8Path, path: &Utf8Path, sdl: &str) -> AnyResult<()> {
+    Fs::create_dir_all(dir)?;
+    let entry = CacheEntry {
+        sdl: sdl.to_string(),
+        cached_at_epoch_secs: now_epoch_secs(),
+    };
+    Fs::write_file(path, serde_json::to_string(&entry)?)?;
+    Ok(())
+}
+
+fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_cache_dir() -> Utf8PathBuf {
+        let dir = std::env::temp_dir().join(format!("rover-cache-test-{}", std::process::id()));
+        Utf8PathBuf::try_from(dir).expect("temp dir should be valid UTF-8")
+    }
+
+    fn cleanup(dir: &Utf8Path) {
+        let _ = std::fs::remove_dir_all(dir.as_std_path());
+    }
+
+    #[test]
+    fn cache_file_for_correct_path() {
+        let dir = Utf8PathBuf::from("/tmp/cache");
+        let graph_ref = GraphRef {
+            name: "my-graph".to_string(),
+            variant: "prod".to_string(),
+        };
+        let path = cache_file_for(&dir, &graph_ref);
+        assert_eq!(path, Utf8PathBuf::from("/tmp/cache/my-graph@prod.json"));
+    }
+
+    #[test]
+    fn read_cache_missing_file() {
+        let result = read_cache(Utf8Path::new("/tmp/nonexistent-rover-cache-file.json"));
+        assert!(result.is_none(), "missing file should return None");
+    }
+
+    #[test]
+    fn read_cache_expired_ttl() {
+        let dir = temp_cache_dir().join("expired");
+        let _ = std::fs::create_dir_all(dir.as_std_path());
+        let file = dir.join("test.json");
+
+        let entry = CacheEntry {
+            sdl: "type Query { hello: String }".to_string(),
+            cached_at_epoch_secs: 0, // epoch = definitely expired
+        };
+        std::fs::write(file.as_std_path(), serde_json::to_string(&entry).unwrap()).unwrap();
+
+        let result = read_cache(&file);
+        assert!(result.is_none(), "expired cache should return None");
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn read_cache_valid_cache() {
+        let dir = temp_cache_dir().join("valid");
+        let file = dir.join("test.json");
+
+        write_cache(&dir, &file, "type Query { hi: String }").unwrap();
+
+        let result = read_cache(&file);
+        assert_eq!(result, Some("type Query { hi: String }".to_string()));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn read_cache_malformed_json() {
+        let dir = temp_cache_dir().join("malformed");
+        let _ = std::fs::create_dir_all(dir.as_std_path());
+        let file = dir.join("test.json");
+
+        std::fs::write(file.as_std_path(), "not valid json!!!").unwrap();
+
+        let result = read_cache(&file);
+        assert!(result.is_none(), "malformed JSON should return None");
+        cleanup(&dir);
+    }
+}

--- a/src/options/output.rs
+++ b/src/options/output.rs
@@ -22,7 +22,9 @@ impl RoverPrinter for RoverOutput {
     fn write_or_print(self, output_opts: &OutputOpts) -> RoverResult<()> {
         // Format the RoverOutput as either plain text or JSON.
         let output = match output_opts.format_kind {
-            RoverOutputFormatKind::Plain => self.get_stdout(),
+            RoverOutputFormatKind::Plain
+            | RoverOutputFormatKind::Compact
+            | RoverOutputFormatKind::Sdl => self.get_stdout(),
             RoverOutputFormatKind::Json => Ok(Some(JsonOutput::from(self.clone()).to_string())),
         };
 
@@ -58,7 +60,9 @@ impl RoverPrinter for RoverOutput {
 impl RoverPrinter for RoverError {
     fn write_or_print(self, output_opts: &OutputOpts) -> RoverResult<()> {
         match output_opts.format_kind {
-            RoverOutputFormatKind::Plain => self.print(),
+            RoverOutputFormatKind::Plain
+            | RoverOutputFormatKind::Compact
+            | RoverOutputFormatKind::Sdl => self.print(),
             RoverOutputFormatKind::Json => {
                 let json = JsonOutput::from(self);
                 match &output_opts.output_file {


### PR DESCRIPTION
## Summary

Adds `rover describe`, a coordinate-driven command for exploring a GraphQL schema locally.

```bash
rover describe my-graph@current              # schema overview
rover describe my-graph@current:Post         # one type
rover describe my-graph@current:User.posts   # one field
```

Schema exploration capabilities currently live exclusively in the Apollo MCP Server. Skills are built around CLI tools (`Bash(rover:*)`), so they can't leverage schema intelligence without requiring users to set up an MCP server. This command closes that gap.

## `rover describe`

```
rover describe <GRAPH_REF>[:<COORDINATE>] [OPTIONS]
```

| Form | Output |
|---|---|
| `graphRef` | Schema overview (type counts, root fields, type lists by kind) |
| `graphRef:Type` | Type detail (fields, descriptions, implements, `via` path from roots) |
| `graphRef:Type.field` | Field detail (args, input expansion, return type expansion) |

Key features:
- Summary-first headers: `SCHEMA [80 types, 343 fields]`, `TYPE Track [17 fields, 1 deprecated]`
- `--depth N` expands referenced types N levels deep
- Deprecated hidden by default (count in header, `--include-deprecated` to show)
- `via` lines show how to reach a type from Query/Mutation roots
- Output: `--sdl`, `--compact`, `--json`

**Schema overview:**

```
$ rover describe my-graph@current

SCHEMA my-graph@current [29 types, 86 fields, 3 deprecated]
  Query      › 5 fields (user, post, categories, search, viewer)
  Mutation   › 3 fields (createPost, updatePreferences, deleteComment)

  objects    (16)  Category Comment CommentConnection CommentEdge CreatePostPayload ...
  inputs     ( 2)  CreatePostInput UpdatePreferencesInput
  enums      ( 3)  DigestFrequency SearchType SortOrder
  interfaces ( 3)  Node Profile Timestamped
  unions     ( 1)  ContentItem
  scalars    ( 2)  DateTime URL
```

**Type detail:**

```
$ rover describe my-graph@current:Post

TYPE Post [14 fields, 1 deprecated] implements Node & Timestamped
  › A content post

  id: ID!
  title: String!
  body: String!                 › The body content
  author: User!                 › The author of this post
  comments: CommentConnection!
  category: Category!
  tags: [Tag!]!
  publishedAt: String
  createdAt: String!
  updatedAt: String!
  viewCount: Int!
  score: Int!                   › The post's popularity score (0-100)
  slug: String!

  Use --include-deprecated to show 1 hidden deprecated fields.
```

**Type detail with `--include-deprecated --depth 1`:**

```
$ rover describe my-graph@current:Post --include-deprecated --depth 1

TYPE Post [14 fields, 1 deprecated] implements Node & Timestamped
  › A content post

  id: ID!
  title: String!
  ...
⚠ oldSlug: String
    ↳ Deprecated: Use slug instead

  ┈ User [8 fields]
    id: ID!
    name: String!
    ...
  ⚠ legacyId: String
      ↳ Deprecated: Use id instead
```

**Field detail:**

```
$ rover describe my-graph@current:Query.search

FIELD Query.search → SearchResults [3 args]
  › Search for content

  args:
    query: String!
    types: [SearchType!]!
    limit: Int

  returns SearchResults:
    posts: [Post!]
    users: [User!]
    categories: [Category!]
```

## Shared behavior

These features are shared with the `rover search` command that is implemented in #3048.

- **Schema cache** — local temp dir, keyed by graph ref + variant, 5-min TTL, `--no-cache` to bypass
- **TTY detection** — description format on TTY, `--compact` auto-selected when piped
- **Schema source** — GraphOS registry via `APOLLO_KEY` (default), or `--endpoint <URL>` for introspection

## Implementation

New `rover-schema` crate:
- `describe.rs` — core describe engine (overview, type detail, field detail)
- `root_paths.rs` — BFS path construction from roots
- `format/` — description, compact, and SDL output formatters
- `coordinate.rs` — schema coordinate parsing (re-exported from `apollo_compiler`)

CLI integration reuses existing Rover infrastructure (`GraphRefOpt`, `StudioClientConfig`, `RoverOutput`).