### PR TITLE
Add `rover search` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -175,13 +175,13 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.31.0"
+version = "1.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66f8eefe0ed21932dcc31eeca614cc8337bdc9ec7d4b2fb200b2a1539ba5c92"
+checksum = "09e0b71d829a6eec7900cab1ef14791290a3b2edf201dbc7c56cae5ef001475d"
 dependencies = [
  "ahash 0.8.12",
- "apollo-parser 0.8.4",
- "ariadne 0.5.1",
+ "apollo-parser 0.8.5",
+ "ariadne",
  "futures",
  "indexmap 2.13.0",
  "rowan 0.16.1",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ff8173456a624ef6b708fea22a951070f6d3dbfe921d6f7c004feb3a98e91f"
+checksum = "eca9a79b988aa51410fcfbf6cc56aad6c2d7ef72d4d0121952140df77610ba80"
 dependencies = [
  "apollo-compiler",
  "derive_more",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6679082f0b059e51d482af1bba9559a55bd76d3a6643b8f855b67de68421b1c"
+checksum = "e98457125e9d8e17efc2dabd344a868c8449080534e6843e1f0882c3b6a19262"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -267,7 +267,7 @@ checksum = "2f51b3195b80b17e8d720906f3865b32fff80a93b80145d000ab788e168e2370"
 dependencies = [
  "apollo-compiler",
  "apollo-federation-types",
- "apollo-parser 0.8.4",
+ "apollo-parser 0.8.5",
  "debounced",
  "futures",
  "indexmap 2.13.0",
@@ -298,13 +298,13 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f05cbc7da3c2e3bb2f86e985aad5f72571d2e2cd26faf8caa7782131576f84"
+checksum = "947e21ff51879f8a40d7519dfe619268de2afba4042a8a43878276de3cb910f0"
 dependencies = [
  "memchr",
  "rowan 0.16.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -314,14 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
-name = "ariadne"
-version = "0.5.1"
+name = "arc-swap"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
- "concolor",
- "unicode-width 0.1.14",
- "yansi",
+ "rustversion",
 ]
 
 [[package]]
@@ -330,6 +328,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
 dependencies = [
+ "concolor",
  "unicode-width 0.2.2",
  "yansi",
 ]
@@ -388,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -461,7 +460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.116",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -502,7 +501,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -536,7 +535,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -563,7 +562,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -580,7 +579,7 @@ checksum = "e8b5778837666541195063243828c5b6139221b47dc4ec3ba81738e532469ab1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -751,6 +750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +798,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -840,7 +848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "str_inflector",
- "syn 2.0.116",
+ "syn 2.0.117",
  "try_match",
 ]
 
@@ -855,6 +863,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -901,7 +915,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -975,6 +989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +1014,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1077,7 +1097,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1299,7 +1319,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strict",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1370,7 +1390,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1384,6 +1404,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1447,7 +1473,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1461,7 +1487,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1474,7 +1500,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1485,7 +1511,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1496,7 +1522,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1507,7 +1533,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1541,17 +1567,18 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1562,7 +1589,7 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1583,7 +1610,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1593,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1615,7 +1642,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1694,7 +1721,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1710,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
  "objc2",
@@ -1726,7 +1753,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1755,6 +1782,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duct"
@@ -1839,7 +1872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1882,6 +1915,12 @@ checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
 dependencies = [
  "ascii_utils",
 ]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -1987,6 +2026,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,7 +2125,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2155,20 +2204,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -2182,7 +2231,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2312,7 +2361,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2323,7 +2372,7 @@ checksum = "b684c77d1b5f9c6006068852e0e0e80c6df3ef85c24fe81ef26fbadbd595af77"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2466,6 +2515,12 @@ dependencies = [
  "toml",
  "tracing",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -2840,10 +2895,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
+name = "instant"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -2863,7 +2930,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2871,6 +2938,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2930,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3050,7 +3126,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3078,6 +3154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,21 +3184,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.12"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "libc",
@@ -3144,9 +3233,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3196,7 +3285,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3218,6 +3307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3333,12 @@ dependencies = [
  "serde_repr",
  "url",
 ]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
 name = "lzma-rust2"
@@ -3262,10 +3366,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "measure_time"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbefd235b0aadd181626f281e1d684e116972988c14c264e42069d5e8a5775cc"
+dependencies = [
+ "instant",
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3283,7 +3406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df4051db13d0816cf23196d3baa216385ae099339f5d0645a8d9ff2305e82b8"
 dependencies = [
  "lazy_static",
- "lru",
+ "lru 0.7.8",
  "memoize-inner",
 ]
 
@@ -3365,7 +3488,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3399,6 +3522,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nix"
@@ -3490,7 +3619,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3591,6 +3720,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3604,9 +3744,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -3783,6 +3923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "opener"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,7 +3985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3856,6 +4002,15 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "ownedbytes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "parking"
@@ -3947,7 +4102,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3993,29 +4148,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -4030,6 +4185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4039,7 +4200,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4129,16 +4290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4160,7 +4321,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4235,9 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4247,6 +4408,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -4310,6 +4477,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_regex"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4396,7 +4573,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4439,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regressions"
@@ -4585,7 +4762,7 @@ dependencies = [
  "anyhow",
  "apollo-federation-types",
  "apollo-language-server",
- "apollo-parser 0.8.4",
+ "apollo-parser 0.8.5",
  "assert-json-diff",
  "assert_cmd",
  "assert_fs",
@@ -4672,7 +4849,7 @@ dependencies = [
  "tracing-test",
  "url",
  "uuid",
- "which 8.0.0",
+ "which 8.0.1",
 ]
 
 [[package]]
@@ -4682,8 +4859,8 @@ dependencies = [
  "anyhow",
  "apollo-encoder",
  "apollo-federation-types",
- "apollo-parser 0.8.4",
- "ariadne 0.6.0",
+ "apollo-parser 0.8.5",
+ "ariadne",
  "backon",
  "buildstructor",
  "camino",
@@ -4781,6 +4958,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tantivy",
  "thiserror 2.0.18",
 ]
 
@@ -4886,8 +5064,18 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4932,22 +5120,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -4997,7 +5185,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5091,7 +5279,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5125,14 +5313,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77253fb2d4451418d07025826028bcb96ee42d3e58859689a70ce62908009db6"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
@@ -5143,9 +5331,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5188,7 +5376,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5199,7 +5387,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5260,7 +5448,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5286,9 +5474,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -5296,14 +5484,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5333,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -5348,13 +5536,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5511,6 +5699,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5555,12 +5752,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5678,7 +5875,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5727,9 +5924,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5753,7 +5950,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5763,6 +5960,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
 dependencies = [
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools 0.12.1",
+ "levenshtein_automata",
+ "log",
+ "lru 0.12.5",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284899c2325d6832203ac6ff5891b297fc5239c3dc754c5bc1977855b23c10df"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12722224ffbe346c7fec3275c699e508fd0d4710e629e933d5736ec524a1f44e"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.12.1",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8019e3cabcfd20a1380b491e13ff42f57bb38bf97c3d5fa5c07e50816e0621f4"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c69578242e8e9fc989119f522ba5b49a38ac20f576fc778035b96cc94f41f98e"
+dependencies = [
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56d6ff5591fc332739b3ce7035b57995a3ce29a93ffd6012660e0949c956ea8"
+dependencies = [
+ "murmurhash32",
+ "rand_distr",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0dcade25819a89cfe6f17d932c9cedff11989936bf6dd4f336d50392053b04"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5794,15 +6132,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5878,7 +6216,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5889,7 +6227,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5917,6 +6255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "libc",
  "num-conv",
@@ -5924,6 +6263,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -5931,6 +6271,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -5959,9 +6309,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -5976,13 +6326,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6053,7 +6403,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -6069,6 +6419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6077,9 +6436,21 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
  "winnow",
 ]
 
@@ -6188,7 +6559,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6231,7 +6602,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6305,7 +6676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6341,7 +6712,7 @@ checksum = "b9c81686f7ab4065ccac3df7a910c4249f8c0f3fb70421d6ddec19b9311f63f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6359,7 +6730,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -6471,6 +6842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6484,11 +6861,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6592,9 +6969,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6605,9 +6982,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6619,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6629,22 +7006,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -6685,9 +7062,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6726,12 +7103,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "3a824aeba0fbb27264f815ada4cff43d65b1741b7a4ed7629ff9089148c4a4e0"
 dependencies = [
  "env_home",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -6757,7 +7134,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6787,7 +7164,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6798,7 +7175,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7058,9 +7435,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -7111,7 +7488,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7127,7 +7504,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7188,7 +7565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -7217,7 +7594,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "which 8.0.0",
+ "which 8.0.1",
  "zip",
 ]
 
@@ -7255,28 +7632,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7296,7 +7673,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7317,7 +7694,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7350,7 +7727,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7383,9 +7760,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ thiserror = "2"
 tap = "1"
 tar = "0.4"
 termimad = "0.34"
+tantivy = "0.22"
 tempfile = "3"
 tokio = { version = "1", features = ["signal", "io-std"] }
 tokio-stream = "0.1"

--- a/crates/rover-schema/Cargo.toml
+++ b/crates/rover-schema/Cargo.toml
@@ -7,11 +7,16 @@ version = "0.0.0"
 
 publish = false
 
+[features]
+default = ["search"]
+search = ["tantivy"]
+
 [dependencies]
 apollo-compiler = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tantivy = { workspace = true, optional = true }
 heck = { workspace = true }
 itertools = { workspace = true }
 

--- a/crates/rover-schema/src/error.rs
+++ b/crates/rover-schema/src/error.rs
@@ -13,4 +13,8 @@ pub enum SchemaError {
 
     #[error("Invalid coordinate: {0}")]
     InvalidCoordinate(String),
+
+    #[cfg(feature = "search")]
+    #[error("Search index error: {0}")]
+    SearchError(#[from] tantivy::TantivyError),
 }

--- a/crates/rover-schema/src/format/compact.rs
+++ b/crates/rover-schema/src/format/compact.rs
@@ -4,6 +4,9 @@ use super::HOOK_ARROW;
 use crate::describe::{
     DescribeResult, ExpandedType, FieldDetail, SchemaOverview, TypeDetail, TypeKind,
 };
+#[cfg(feature = "search")]
+use crate::search::SearchResult;
+
 /// Format a DescribeResult in compact (token-efficient) notation.
 pub fn format_describe_compact(result: &DescribeResult) -> String {
     match result {
@@ -135,6 +138,25 @@ fn format_field_detail_compact(detail: &FieldDetail) -> String {
     // Via path
     if !detail.via.is_empty() {
         out.push_str(&format!("{HOOK_ARROW} {}\n", detail.via[0]));
+    }
+
+    out.trim_end().to_string()
+}
+
+/// Format search results in compact notation.
+#[cfg(feature = "search")]
+pub fn format_search_compact(results: &[SearchResult]) -> String {
+    let mut out = String::new();
+
+    for result in results {
+        out.push_str(&format!(
+            "{DASH}{DASH} {} {DASH}{DASH}\n",
+            result.path_header
+        ));
+        for expanded in &result.types {
+            format_expanded_compact(&mut out, expanded);
+        }
+        out.push('\n');
     }
 
     out.trim_end().to_string()

--- a/crates/rover-schema/src/format/compact.rs
+++ b/crates/rover-schema/src/format/compact.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 
-use super::HOOK_ARROW;
+use super::{DASH, HOOK_ARROW};
 use crate::describe::{
     DescribeResult, ExpandedType, FieldDetail, SchemaOverview, TypeDetail, TypeKind,
 };

--- a/crates/rover-schema/src/format/description.rs
+++ b/crates/rover-schema/src/format/description.rs
@@ -2,6 +2,9 @@ use super::{ARROW, DEPRECATED_MARKER, DOTTED, HOOK_ARROW, SEPARATOR};
 use crate::describe::{
     DescribeResult, ExpandedType, FieldDetail, FieldInfo, SchemaOverview, TypeDetail, TypeKind,
 };
+#[cfg(feature = "search")]
+use crate::search::SearchResult;
+
 const MAX_WIDTH: usize = 100;
 
 /// Format a DescribeResult as human-readable description text.
@@ -283,6 +286,45 @@ fn format_field_detail(detail: &FieldDetail) -> String {
     if let Some(ret) = &detail.return_expansion {
         out.push_str(&format!("\n  returns {}:\n", ret.name));
         write_field_items(&mut out, &ret.fields, 4);
+    }
+
+    out.trim_end().to_string()
+}
+
+/// Format a search result in description format.
+#[cfg(feature = "search")]
+pub fn format_search(results: &[SearchResult], query: &str) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!(
+        "SEARCH \"{}\" [{} path{}]\n",
+        query,
+        results.len(),
+        if results.len() == 1 { "" } else { "s" }
+    ));
+
+    for result in results {
+        out.push_str(&format!(
+            "\n{DASH}{DASH} {} {DASH}{DASH}\n\n",
+            result.path_header
+        ));
+
+        for expanded in &result.types {
+            out.push_str(&format!("  {}", expanded.name));
+            if !expanded.union_members.is_empty() && expanded.kind == TypeKind::Interface {
+                out.push_str(&format!(
+                    " (interface {ARROW} {})",
+                    expanded.union_members.join(", ")
+                ));
+            }
+            if !expanded.fields.is_empty() {
+                out.push_str(&format!(" [{} fields]", expanded.fields.len()));
+            }
+            out.push('\n');
+
+            write_field_items(&mut out, &expanded.fields, 4);
+            out.push('\n');
+        }
     }
 
     out.trim_end().to_string()

--- a/crates/rover-schema/src/format/description.rs
+++ b/crates/rover-schema/src/format/description.rs
@@ -1,4 +1,4 @@
-use super::{ARROW, DEPRECATED_MARKER, DOTTED, HOOK_ARROW, SEPARATOR};
+use super::{ARROW, DASH, DEPRECATED_MARKER, DOTTED, HOOK_ARROW, SEPARATOR};
 use crate::describe::{
     DescribeResult, ExpandedType, FieldDetail, FieldInfo, SchemaOverview, TypeDetail, TypeKind,
 };

--- a/crates/rover-schema/src/format/mod.rs
+++ b/crates/rover-schema/src/format/mod.rs
@@ -6,6 +6,7 @@ pub mod sdl;
 pub(crate) const DEPRECATED_MARKER: char = '\u{26a0}'; // ⚠
 pub(crate) const SEPARATOR: char = '\u{203a}'; // ›
 pub(crate) const ARROW: char = '\u{2192}'; // →
+pub(crate) const DASH: char = '\u{2500}'; // ─
 pub(crate) const DOTTED: char = '\u{2508}'; // ┈
 pub(crate) const HOOK_ARROW: char = '\u{21b3}'; // ↳
 

--- a/crates/rover-schema/src/lib.rs
+++ b/crates/rover-schema/src/lib.rs
@@ -3,6 +3,8 @@ pub mod error;
 pub mod format;
 pub mod parsed_schema;
 pub mod root_paths;
+#[cfg(feature = "search")]
+pub mod search;
 pub(crate) mod util;
 
 // Re-export main public types

--- a/crates/rover-schema/src/search/index.rs
+++ b/crates/rover-schema/src/search/index.rs
@@ -1,0 +1,273 @@
+use tantivy::{
+    Index, IndexWriter, TantivyDocument,
+    collector::TopDocs,
+    query::QueryParser,
+    schema::{self as tantivy_schema, STORED, TEXT, Value},
+};
+
+use super::tokenizer::prepare_for_index;
+use crate::error::SchemaError;
+
+/// Schema element stored in the search index.
+#[derive(Debug, Clone)]
+pub struct IndexedElement {
+    pub element_type: ElementType,
+    pub type_name: String,
+    pub field_name: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementType {
+    Type,
+    Field,
+    Argument,
+    EnumValue,
+}
+
+/// In-memory search index built from a schema.
+pub struct SchemaIndex {
+    index: Index,
+    name_field: tantivy_schema::Field,
+    description_field: tantivy_schema::Field,
+    type_name_field: tantivy_schema::Field,
+    field_name_field: tantivy_schema::Field,
+    element_type_field: tantivy_schema::Field,
+}
+
+impl SchemaIndex {
+    pub fn build(elements: Vec<IndexedElement>) -> Result<Self, SchemaError> {
+        let mut schema_builder = tantivy_schema::Schema::builder();
+        let name_field = schema_builder.add_text_field("name", TEXT | STORED);
+        let description_field = schema_builder.add_text_field("description", TEXT);
+        let type_name_field = schema_builder.add_text_field("type_name", STORED);
+        let field_name_field = schema_builder.add_text_field("field_name", STORED);
+        let element_type_field = schema_builder.add_text_field("element_type", STORED);
+        let schema = schema_builder.build();
+
+        let index = Index::create_in_ram(schema);
+        let mut writer: IndexWriter = index.writer(15_000_000)?;
+
+        for elem in &elements {
+            let mut doc = TantivyDocument::new();
+
+            let name_text = match &elem.field_name {
+                Some(field) => format!(
+                    "{} {}",
+                    prepare_for_index(&elem.type_name),
+                    prepare_for_index(field)
+                ),
+                None => prepare_for_index(&elem.type_name),
+            };
+            doc.add_text(name_field, &name_text);
+
+            if let Some(desc) = &elem.description {
+                doc.add_text(description_field, prepare_for_index(desc));
+            }
+
+            doc.add_text(type_name_field, &elem.type_name);
+            doc.add_text(field_name_field, elem.field_name.as_deref().unwrap_or(""));
+            doc.add_text(
+                element_type_field,
+                match elem.element_type {
+                    ElementType::Type => "type",
+                    ElementType::Field => "field",
+                    ElementType::Argument => "argument",
+                    ElementType::EnumValue => "enum_value",
+                },
+            );
+
+            writer.add_document(doc)?;
+        }
+
+        writer.commit()?;
+
+        Ok(Self {
+            index,
+            name_field,
+            description_field,
+            type_name_field,
+            field_name_field,
+            element_type_field,
+        })
+    }
+
+    /// Search the index, returning matched elements ranked by relevance.
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<IndexedElement>, SchemaError> {
+        let reader = self.index.reader()?;
+        let searcher = reader.searcher();
+
+        let query_parser =
+            QueryParser::for_index(&self.index, vec![self.name_field, self.description_field]);
+
+        let prepared_query = prepare_for_index(query);
+        let parsed_query = query_parser
+            .parse_query(&prepared_query)
+            .map_err(|e| SchemaError::SearchError(e.into()))?;
+
+        let top_docs = searcher.search(&parsed_query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::new();
+        for (_score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_address)?;
+
+            let type_name = doc
+                .get_first(self.type_name_field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let field_name = doc
+                .get_first(self.field_name_field)
+                .and_then(|v| v.as_str())
+                .and_then(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some(s.to_string())
+                    }
+                });
+            let element_type_str = doc
+                .get_first(self.element_type_field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("type");
+            let element_type = match element_type_str {
+                "field" => ElementType::Field,
+                "argument" => ElementType::Argument,
+                "enum_value" => ElementType::EnumValue,
+                _ => ElementType::Type,
+            };
+
+            results.push(IndexedElement {
+                element_type,
+                type_name,
+                field_name,
+                description: None,
+            });
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_element(
+        element_type: ElementType,
+        type_name: &str,
+        field_name: Option<&str>,
+        description: Option<&str>,
+    ) -> IndexedElement {
+        IndexedElement {
+            element_type,
+            type_name: type_name.to_string(),
+            field_name: field_name.map(|s| s.to_string()),
+            description: description.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn build_and_search_by_name() {
+        let elements = vec![
+            make_element(ElementType::Type, "User", None, None),
+            make_element(ElementType::Type, "Post", None, None),
+        ];
+        let index = SchemaIndex::build(elements).unwrap();
+        let results = index.search("user", 10).unwrap();
+        assert!(
+            results.iter().any(|r| r.type_name == "User"),
+            "should find User by name"
+        );
+    }
+
+    #[test]
+    fn search_by_description() {
+        let elements = vec![
+            make_element(
+                ElementType::Type,
+                "User",
+                None,
+                Some("A registered user of the platform"),
+            ),
+            make_element(ElementType::Type, "Post", None, Some("A blog post")),
+        ];
+        let index = SchemaIndex::build(elements).unwrap();
+        let results = index.search("registered", 10).unwrap();
+        assert!(
+            results.iter().any(|r| r.type_name == "User"),
+            "should find User via description"
+        );
+    }
+
+    #[test]
+    fn search_camel_case_in_description() {
+        let elements = vec![make_element(
+            ElementType::Type,
+            "Mutation",
+            None,
+            Some("Use createPost to make a new post"),
+        )];
+        let index = SchemaIndex::build(elements).unwrap();
+        let results = index.search("create", 10).unwrap();
+        assert!(
+            results.iter().any(|r| r.type_name == "Mutation"),
+            "should match camelCase identifier in description"
+        );
+    }
+
+    #[test]
+    fn search_respects_limit() {
+        let elements: Vec<IndexedElement> = (0..10)
+            .map(|i| make_element(ElementType::Type, &format!("Item{i}"), None, Some("common")))
+            .collect();
+        let index = SchemaIndex::build(elements).unwrap();
+        let results = index.search("common", 2).unwrap();
+        assert!(results.len() <= 2, "should respect limit=2");
+    }
+
+    #[test]
+    fn search_empty_results() {
+        let elements = vec![make_element(ElementType::Type, "User", None, None)];
+        let index = SchemaIndex::build(elements).unwrap();
+        let results = index.search("nonexistent", 10).unwrap();
+        assert!(results.is_empty(), "should return empty for no matches");
+    }
+
+    #[test]
+    fn element_type_round_trip() {
+        let elements = vec![
+            make_element(ElementType::Type, "User", None, None),
+            make_element(ElementType::Field, "User", Some("email"), None),
+            make_element(ElementType::Argument, "Query", Some("id"), None),
+            make_element(ElementType::EnumValue, "Status", Some("ACTIVE"), None),
+        ];
+        let index = SchemaIndex::build(elements).unwrap();
+
+        let results = index.search("user", 10).unwrap();
+        let types: Vec<ElementType> = results.iter().map(|r| r.element_type).collect();
+        assert!(types.contains(&ElementType::Type) || types.contains(&ElementType::Field));
+
+        // Verify enum_value round-trips
+        let results = index.search("active", 10).unwrap();
+        assert!(
+            results
+                .iter()
+                .any(|r| r.element_type == ElementType::EnumValue)
+        );
+    }
+
+    #[test]
+    fn field_name_stored_correctly() {
+        let elements = vec![make_element(
+            ElementType::Field,
+            "User",
+            Some("email"),
+            None,
+        )];
+        let index = SchemaIndex::build(elements).unwrap();
+        let results = index.search("email", 10).unwrap();
+        assert!(!results.is_empty());
+        assert_eq!(results[0].field_name.as_deref(), Some("email"));
+    }
+}

--- a/crates/rover-schema/src/search/mod.rs
+++ b/crates/rover-schema/src/search/mod.rs
@@ -1,0 +1,442 @@
+pub mod index;
+pub mod tokenizer;
+
+use apollo_compiler::{Schema, schema::ExtendedType};
+
+use self::index::{ElementType, IndexedElement, SchemaIndex};
+use crate::{
+    describe::{self, ExpandedType},
+    error::SchemaError,
+    format::ARROW,
+    root_paths,
+};
+
+/// A single search result: a path from root to match with expanded types.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SearchResult {
+    pub path_header: String,
+    pub types: Vec<ExpandedType>,
+    pub matched_type: String,
+    pub matched_field: Option<String>,
+}
+
+/// Search a schema for the given terms.
+pub fn search(
+    schema: &Schema,
+    query: &str,
+    limit: usize,
+    include_deprecated: bool,
+) -> Result<Vec<SearchResult>, SchemaError> {
+    // Build index
+    let elements = extract_elements(schema, include_deprecated);
+    let index = SchemaIndex::build(elements)?;
+
+    // Search
+    let matches = index.search(query, limit * 3)?; // Over-fetch to account for dedup
+
+    // Build paths for each match
+    let mut results = Vec::new();
+    let mut seen_paths = std::collections::HashSet::new();
+
+    for matched in &matches {
+        let target_type = &matched.type_name;
+        let paths = root_paths::find_root_paths(schema, target_type);
+
+        if paths.is_empty() {
+            // Type might be a root type itself or unreachable
+            if is_root_type(schema, target_type) {
+                let path_header = format_root_match(target_type, &matched.field_name);
+                if seen_paths.contains(&path_header) {
+                    continue;
+                }
+                seen_paths.insert(path_header.clone());
+
+                let types = build_result_types(schema, &[], target_type, include_deprecated);
+                results.push(SearchResult {
+                    path_header,
+                    types,
+                    matched_type: target_type.clone(),
+                    matched_field: matched.field_name.clone(),
+                });
+            }
+            continue;
+        }
+
+        for path in &paths {
+            let path_header = if let Some(field) = &matched.field_name {
+                format!(
+                    "{} {ARROW} {}.{}",
+                    path.format_path_header(target_type),
+                    target_type,
+                    field
+                )
+            } else {
+                path.format_path_header(target_type)
+            };
+
+            if seen_paths.contains(&path_header) {
+                continue;
+            }
+            seen_paths.insert(path_header.clone());
+
+            let types = build_result_types(schema, &path.segments, target_type, include_deprecated);
+            results.push(SearchResult {
+                path_header,
+                types,
+                matched_type: target_type.clone(),
+                matched_field: matched.field_name.clone(),
+            });
+
+            if results.len() >= limit {
+                break;
+            }
+        }
+
+        if results.len() >= limit {
+            break;
+        }
+    }
+
+    results.truncate(limit);
+    Ok(results)
+}
+
+fn extract_elements(schema: &Schema, include_deprecated: bool) -> Vec<IndexedElement> {
+    let mut elements = Vec::new();
+    let builtin_scalars = ["String", "Int", "Float", "Boolean", "ID"];
+
+    for (name, ty) in &schema.types {
+        let name_str = name.to_string();
+        if name_str.starts_with("__") || builtin_scalars.contains(&name_str.as_str()) {
+            continue;
+        }
+
+        // Index the type itself
+        let type_desc = match ty {
+            ExtendedType::Object(obj) => obj.description.as_ref().map(|d| d.to_string()),
+            ExtendedType::Interface(iface) => iface.description.as_ref().map(|d| d.to_string()),
+            ExtendedType::InputObject(inp) => inp.description.as_ref().map(|d| d.to_string()),
+            ExtendedType::Enum(e) => e.description.as_ref().map(|d| d.to_string()),
+            ExtendedType::Union(u) => u.description.as_ref().map(|d| d.to_string()),
+            ExtendedType::Scalar(s) => s.description.as_ref().map(|d| d.to_string()),
+        };
+
+        elements.push(IndexedElement {
+            element_type: ElementType::Type,
+            type_name: name_str.clone(),
+            field_name: None,
+            description: type_desc,
+        });
+
+        // Index fields
+        let fields: Vec<(&str, Option<String>, bool)> = match ty {
+            ExtendedType::Object(obj) => obj
+                .fields
+                .iter()
+                .map(|(n, f)| {
+                    (
+                        n.as_str(),
+                        f.description.as_ref().map(|d| d.to_string()),
+                        f.directives.get("deprecated").is_some(),
+                    )
+                })
+                .collect(),
+            ExtendedType::Interface(iface) => iface
+                .fields
+                .iter()
+                .map(|(n, f)| {
+                    (
+                        n.as_str(),
+                        f.description.as_ref().map(|d| d.to_string()),
+                        f.directives.get("deprecated").is_some(),
+                    )
+                })
+                .collect(),
+            ExtendedType::InputObject(inp) => inp
+                .fields
+                .iter()
+                .map(|(n, f)| {
+                    (
+                        n.as_str(),
+                        f.description.as_ref().map(|d| d.to_string()),
+                        f.directives.get("deprecated").is_some(),
+                    )
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+
+        for (field_name, desc, is_deprecated) in fields {
+            if !include_deprecated && is_deprecated {
+                continue;
+            }
+            elements.push(IndexedElement {
+                element_type: ElementType::Field,
+                type_name: name_str.clone(),
+                field_name: Some(field_name.to_string()),
+                description: desc,
+            });
+        }
+
+        // Index enum values
+        if let ExtendedType::Enum(e) = ty {
+            for (val_name, val) in &e.values {
+                let is_deprecated = val.directives.get("deprecated").is_some();
+                if !include_deprecated && is_deprecated {
+                    continue;
+                }
+                elements.push(IndexedElement {
+                    element_type: ElementType::EnumValue,
+                    type_name: name_str.clone(),
+                    field_name: Some(val_name.to_string()),
+                    description: val.description.as_ref().map(|d| d.to_string()),
+                });
+            }
+        }
+    }
+
+    elements
+}
+
+fn is_root_type(schema: &Schema, type_name: &str) -> bool {
+    let query_name = schema
+        .schema_definition
+        .query
+        .as_ref()
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "Query".to_string());
+    let mutation_name = schema
+        .schema_definition
+        .mutation
+        .as_ref()
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "Mutation".to_string());
+
+    type_name == query_name || type_name == mutation_name
+}
+
+fn format_root_match(type_name: &str, field_name: &Option<String>) -> String {
+    if let Some(field) = field_name {
+        format!("{type_name}.{field}")
+    } else {
+        type_name.to_string()
+    }
+}
+
+fn build_result_types(
+    schema: &Schema,
+    path_segments: &[root_paths::PathSegment],
+    target_type: &str,
+    include_deprecated: bool,
+) -> Vec<ExpandedType> {
+    let mut types = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    // Add intermediate types from the path (depth 1 — just their fields)
+    for seg in path_segments {
+        if seen.contains(&seg.type_name) {
+            continue;
+        }
+        seen.insert(seg.type_name.clone());
+        if let Some(expanded) =
+            describe::expand_single_type(schema, &seg.type_name, include_deprecated)
+        {
+            types.push(expanded);
+        }
+    }
+
+    // Add the target type
+    if !seen.contains(target_type)
+        && let Some(expanded) =
+            describe::expand_single_type(schema, target_type, include_deprecated)
+    {
+        types.push(expanded);
+    }
+
+    types
+}
+
+#[cfg(test)]
+mod tests {
+    use apollo_compiler::Schema;
+
+    use super::*;
+    use crate::search::index::ElementType;
+
+    fn test_schema() -> Schema {
+        let sdl = include_str!("../test_fixtures/test_schema.graphql");
+        match Schema::parse(sdl, "test.graphql") {
+            Ok(s) => s,
+            Err(e) => e.partial,
+        }
+    }
+
+    #[test]
+    fn search_finds_type_by_name() {
+        let schema = test_schema();
+        let results = search(&schema, "post", 5, false).unwrap();
+        assert!(
+            results.iter().any(|r| r.matched_type == "Post"),
+            "should find Post type: {results:?}"
+        );
+    }
+
+    #[test]
+    fn search_finds_by_field_name() {
+        let schema = test_schema();
+        let results = search(&schema, "email", 5, false).unwrap();
+        assert!(
+            results
+                .iter()
+                .any(|r| r.matched_type == "User" || r.matched_field.as_deref() == Some("email")),
+            "should find User/email: {results:?}"
+        );
+    }
+
+    #[test]
+    fn extract_elements_filters_builtins() {
+        let schema = test_schema();
+        let elements = extract_elements(&schema, false);
+        let builtin_names = ["String", "Int", "Float", "Boolean", "ID"];
+        for elem in &elements {
+            assert!(
+                !builtin_names.contains(&elem.type_name.as_str()),
+                "should not contain builtin scalar: {}",
+                elem.type_name
+            );
+            assert!(
+                !elem.type_name.starts_with("__"),
+                "should not contain introspection type: {}",
+                elem.type_name
+            );
+        }
+    }
+
+    #[test]
+    fn extract_elements_includes_all_kinds() {
+        let schema = test_schema();
+        let elements = extract_elements(&schema, false);
+        let types: Vec<ElementType> = elements.iter().map(|e| e.element_type).collect();
+        assert!(
+            types.contains(&ElementType::Type),
+            "should have Type elements"
+        );
+        assert!(
+            types.contains(&ElementType::Field),
+            "should have Field elements"
+        );
+        assert!(
+            types.contains(&ElementType::EnumValue),
+            "should have EnumValue elements"
+        );
+    }
+
+    #[test]
+    fn extract_elements_deprecated_filtering() {
+        let schema = test_schema();
+
+        // Without deprecated: should not include oldSlug or legacyId
+        let elements = extract_elements(&schema, false);
+        let field_names: Vec<&str> = elements
+            .iter()
+            .filter_map(|e| e.field_name.as_deref())
+            .collect();
+        assert!(
+            !field_names.contains(&"oldSlug"),
+            "should exclude deprecated oldSlug"
+        );
+        assert!(
+            !field_names.contains(&"legacyId"),
+            "should exclude deprecated legacyId"
+        );
+
+        // With deprecated: should include them
+        let elements = extract_elements(&schema, true);
+        let field_names: Vec<&str> = elements
+            .iter()
+            .filter_map(|e| e.field_name.as_deref())
+            .collect();
+        assert!(
+            field_names.contains(&"oldSlug"),
+            "should include deprecated oldSlug"
+        );
+        assert!(
+            field_names.contains(&"legacyId"),
+            "should include deprecated legacyId"
+        );
+    }
+
+    #[test]
+    fn is_root_type_works() {
+        let schema = test_schema();
+        assert!(is_root_type(&schema, "Query"));
+        assert!(is_root_type(&schema, "Mutation"));
+        assert!(!is_root_type(&schema, "Post"));
+        assert!(!is_root_type(&schema, "User"));
+    }
+
+    #[test]
+    fn search_deduplicates_paths() {
+        let schema = test_schema();
+        let results = search(&schema, "post", 10, false).unwrap();
+        let headers: Vec<&str> = results.iter().map(|r| r.path_header.as_str()).collect();
+        let unique: std::collections::HashSet<&&str> = headers.iter().collect();
+        assert_eq!(
+            headers.len(),
+            unique.len(),
+            "should have no duplicate path_header values"
+        );
+    }
+
+    #[test]
+    fn search_respects_limit() {
+        let schema = test_schema();
+        let results = search(&schema, "post", 1, false).unwrap();
+        assert!(results.len() <= 1, "should respect limit=1");
+    }
+
+    /// End-to-end: parse SDL → search → extract SDL for matched types.
+    /// Exercises the full pipeline that `search --sdl` uses.
+    #[test]
+    fn search_sdl_end_to_end() {
+        use crate::format::sdl::extract_type_sdl;
+
+        let sdl_string = include_str!("../test_fixtures/test_schema.graphql");
+        let parsed = crate::ParsedSchema::parse(sdl_string);
+        let schema = parsed.inner();
+
+        let results = search(schema, "post", 5, false).unwrap();
+        assert!(!results.is_empty(), "should have search results");
+
+        // Replicate the search --sdl output logic
+        let mut seen = std::collections::HashSet::new();
+        let mut sdl_blocks = Vec::new();
+        for result in &results {
+            for expanded in &result.types {
+                if seen.insert(&expanded.name) {
+                    sdl_blocks.push(extract_type_sdl(&expanded.name, sdl_string));
+                }
+            }
+        }
+        let output = sdl_blocks.join("\n\n");
+
+        // Should contain actual SDL definitions, not "not found" messages
+        assert!(
+            !output.contains("# Type '"),
+            "should not have not-found markers: {output}"
+        );
+        // Should contain the Post type definition
+        assert!(
+            output.contains("type Post"),
+            "should include Post SDL: {output}"
+        );
+        // Should contain at least one other type from the path (e.g. Query)
+        assert!(
+            output.contains("type Query"),
+            "should include Query SDL from the path: {output}"
+        );
+        // Each type should appear only once
+        let post_count = output.matches("type Post").count();
+        assert_eq!(post_count, 1, "Post should appear exactly once");
+    }
+}

--- a/crates/rover-schema/src/search/tokenizer.rs
+++ b/crates/rover-schema/src/search/tokenizer.rs
@@ -1,0 +1,68 @@
+/// Split a camelCase or PascalCase identifier into lowercase words.
+///
+/// Examples:
+/// - `getUserById` → `["get", "user", "by", "id"]`
+/// - `HTMLParser` → `["html", "parser"]`
+/// - `PostConnection` → `["post", "connection"]`
+pub fn split_camel_case(s: &str) -> Vec<String> {
+    use heck::ToSnakeCase;
+    s.to_snake_case()
+        .split('_')
+        .filter(|w| !w.is_empty())
+        .map(|w| w.to_string())
+        .collect()
+}
+
+/// Prepare text for indexing: split camelCase, join with spaces.
+pub fn prepare_for_index(name: &str) -> String {
+    split_camel_case(name).join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_camel_case() {
+        assert_eq!(
+            split_camel_case("getUserById"),
+            vec!["get", "user", "by", "id"]
+        );
+    }
+
+    #[test]
+    fn pascal_case() {
+        assert_eq!(
+            split_camel_case("CreatePostInput"),
+            vec!["create", "post", "input"]
+        );
+    }
+
+    #[test]
+    fn uppercase_run() {
+        assert_eq!(split_camel_case("HTMLParser"), vec!["html", "parser"]);
+    }
+
+    #[test]
+    fn single_word() {
+        assert_eq!(split_camel_case("name"), vec!["name"]);
+    }
+
+    #[test]
+    fn all_uppercase() {
+        assert_eq!(split_camel_case("ID"), vec!["id"]);
+    }
+
+    #[test]
+    fn snake_case() {
+        assert_eq!(
+            split_camel_case("get_user_by_id"),
+            vec!["get", "user", "by", "id"]
+        );
+    }
+
+    #[test]
+    fn prepare_for_index_works() {
+        assert_eq!(prepare_for_index("CreatePostInput"), "create post input");
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,9 @@ ignore = [
     # security risk to us at present, and when/if `apollo-federation-types` decides to move their YAML
     # library else where we can remove this.
     "RUSTSEC-2024-0320",
+    # `instant` is unmaintained (replaced by `web-time`), pulled in transitively by `tantivy`.
+    # No security risk — `instant` is only used for timing on non-wasm targets.
+    "RUSTSEC-2024-0384",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/docs/source/commands/search.mdx
+++ b/docs/source/commands/search.mdx
@@ -1,0 +1,75 @@
+---
+title: Rover search Command
+subtitle: Search your graph schema by keyword
+description: Use the rover search command to find types, fields, and operations in your GraphQL schema by keyword.
+---
+
+import AuthNotice from '../../shared/auth-notice.mdx';
+
+## Overview
+
+The `rover search` command finds schema elements by keyword. Search matches against type names, field names, argument names, and descriptions. Each result includes a complete path from a Query or Mutation root, with all intermediate types.
+
+<AuthNotice />
+
+## Usage
+
+```bash
+rover search <GRAPH_REF> <TERMS> [OPTIONS]
+```
+
+## Examples
+
+### Basic search
+
+```bash
+rover search my-graph@my-variant "search terms"
+```
+
+Returns matching paths with all intermediate types expanded, so you have enough context to write a query from a single search result.
+
+### Limiting results
+
+```bash
+rover search my-graph@my-variant "search terms" --limit 3
+```
+
+## Options
+
+| Option | Description |
+|---|---|
+| `-l, --limit <N>` | Maximum number of result paths (default: 5) |
+| `--include-deprecated` | Include deprecated fields in results |
+| `--sdl` | Output raw SDL instead of structured description |
+| `--compact` | Output token-efficient compact notation |
+| `--no-cache` | Skip the local schema cache |
+| `--profile <NAME>` | Name of configuration profile to use |
+
+## Output formats
+
+By default, `rover search` outputs human-readable results with full paths from Query/Mutation roots. Three alternatives are available:
+
+- **`--sdl`**: Raw SDL for matched types
+- **`--compact`**: Token-efficient notation
+- **`--format json`** (global): Structured JSON output
+
+When output is piped (stdout is not a TTY), compact format is auto-selected.
+
+```bash
+# Auto-compacts when piped
+rover search my-graph@my-variant "search terms" | cat
+```
+
+## How search works
+
+Search uses full-text indexing with:
+
+- **camelCase splitting**: `PostConnection` is searchable as "post connection"
+- **English stemming**: "creating" matches "create" and "created"
+- **BM25 scoring**: Results ranked by relevance across names and descriptions
+
+Each result includes a BFS-discovered shortest path from Query or Mutation roots, with intermediate types expanded at depth 1.
+
+## Schema source
+
+By default, `rover search` fetches the schema from GraphOS using your `APOLLO_KEY`. The schema is cached locally for 5 minutes.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -262,7 +262,11 @@ impl Rover {
             }
             Command::Info(command) => command.run(),
             Command::Explain(command) => command.run(),
-            Command::Search(command) => command.run(self.get_client_config()?).await,
+            Command::Search(command) => {
+                command
+                    .run(self.get_client_config()?, self.output_opts.format_kind)
+                    .await
+            }
             Command::PersistedQueries(command) => command.run(self.get_client_config()?).await,
             Command::License(command) => command.run(self.get_client_config()?).await,
             #[cfg(feature = "composition-js")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -262,6 +262,7 @@ impl Rover {
             }
             Command::Info(command) => command.run(),
             Command::Explain(command) => command.run(),
+            Command::Search(command) => command.run(self.get_client_config()?).await,
             Command::PersistedQueries(command) => command.run(self.get_client_config()?).await,
             Command::License(command) => command.run(self.get_client_config()?).await,
             #[cfg(feature = "composition-js")]
@@ -431,6 +432,9 @@ pub enum Command {
 
     /// Readme commands
     Readme(command::Readme),
+
+    /// Search a graph's schema by keyword
+    Search(command::Search),
 
     /// Subgraph schema commands
     Subgraph(command::Subgraph),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod output;
 mod persisted_queries;
 mod readme;
 pub(crate) mod schema_cache;
+mod search;
 pub(crate) mod subgraph;
 #[cfg(feature = "composition-js")]
 pub(crate) mod supergraph;
@@ -47,6 +48,7 @@ pub use lsp::Lsp;
 pub use output::RoverOutput;
 pub use persisted_queries::PersistedQueries;
 pub use readme::Readme;
+pub use search::Search;
 pub use subgraph::Subgraph;
 #[cfg(feature = "composition-js")]
 pub use supergraph::Supergraph;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -117,6 +117,10 @@ pub enum RoverOutput {
         content: String,
         json_data: serde_json::Value,
     },
+    SearchResponse {
+        content: String,
+        json_data: serde_json::Value,
+    },
     EmptySuccess,
     CloudConfigFetchResponse {
         config: String,
@@ -530,6 +534,7 @@ impl RoverOutput {
                 Some(jwt.to_string())
             }
             RoverOutput::DescribeResponse { content, .. } => Some(content.clone()),
+            RoverOutput::SearchResponse { content, .. } => Some(content.clone()),
             RoverOutput::EmptySuccess => None,
             RoverOutput::CloudConfigFetchResponse { config } => Some(config.to_string()),
             RoverOutput::MessageResponse { msg } => Some(msg.into()),
@@ -682,6 +687,7 @@ impl RoverOutput {
                 json!({ "readme": new_content, "last_updated_time": last_updated_time })
             }
             RoverOutput::DescribeResponse { json_data, .. } => json_data.clone(),
+            RoverOutput::SearchResponse { json_data, .. } => json_data.clone(),
             RoverOutput::EmptySuccess => json!(null),
             RoverOutput::PersistedQueriesPublishResponse(response) => {
                 json!({
@@ -821,6 +827,7 @@ impl RoverOutput {
             RoverOutput::ReadmeFetchResponse { .. } => Some("Readme"),
             RoverOutput::GraphPublishResponse { .. } => Some("Schema Hash"),
             RoverOutput::DescribeResponse { .. } => None,
+            RoverOutput::SearchResponse { .. } => None,
             _ => None,
         }
     }

--- a/src/command/search/mod.rs
+++ b/src/command/search/mod.rs
@@ -1,0 +1,103 @@
+use clap::Parser;
+use rover_client::shared::GraphRef;
+use rover_schema::{
+    ParsedSchema,
+    format::{self, OutputFormat, compact, description, sdl},
+    search,
+};
+use serde::Serialize;
+
+use crate::{
+    RoverOutput, RoverResult, command::schema_cache, options::ProfileOpt,
+    utils::client::StudioClientConfig,
+};
+
+#[derive(Debug, Serialize, Parser)]
+/// Search a graph's schema by keyword
+///
+/// Find types, fields, and operations by name or description. Results include
+/// complete paths from Query/Mutation roots with all intermediate types.
+///
+/// Piped output defaults to --compact.
+#[command(after_help = "EXAMPLES:\n    \
+        rover search my-graph@my-variant \"search terms\"\n    \
+        rover search my-graph@my-variant \"create post\"")]
+pub struct Search {
+    /// <NAME>@<VARIANT> of graph in Apollo Studio.
+    /// @<VARIANT> may be left off, defaulting to @current
+    #[arg(value_name = "GRAPH_REF")]
+    #[serde(skip_serializing)]
+    graph_ref: GraphRef,
+
+    /// Search terms
+    #[arg(value_name = "TERMS")]
+    #[serde(skip_serializing)]
+    terms: String,
+
+    /// Max result paths
+    #[arg(long = "limit", default_value_t = 5)]
+    limit: usize,
+
+    /// Show deprecated fields in results
+    #[arg(long = "include-deprecated")]
+    include_deprecated: bool,
+
+    /// Output raw SDL
+    #[arg(long = "sdl")]
+    sdl: bool,
+
+    /// Output token-efficient compact notation
+    #[arg(long = "compact")]
+    compact: bool,
+
+    /// Skip reading from the local schema cache (still writes to cache)
+    #[arg(long = "no-cache")]
+    no_cache: bool,
+
+    #[clap(flatten)]
+    profile: ProfileOpt,
+}
+
+impl Search {
+    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+        // Fetch SDL (with caching)
+        let sdl_string = schema_cache::fetch_sdl_cached(
+            &self.graph_ref,
+            &self.profile,
+            &client_config,
+            self.no_cache,
+        )
+        .await?;
+
+        // Parse
+        let parsed = ParsedSchema::parse(&sdl_string);
+        let schema = parsed.inner();
+
+        // Search
+        let results = search::search(schema, &self.terms, self.limit, self.include_deprecated)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+        let json_data = serde_json::to_value(&results).unwrap_or(serde_json::Value::Null);
+
+        // Format
+        let output_format = format::select_format(self.sdl, self.compact, false);
+        let content = match output_format {
+            OutputFormat::Description => description::format_search(&results, &self.terms),
+            OutputFormat::Compact => compact::format_search_compact(&results),
+            OutputFormat::Sdl => {
+                let mut seen = std::collections::HashSet::new();
+                let mut sdl_blocks = Vec::new();
+                for result in &results {
+                    for expanded in &result.types {
+                        if seen.insert(&expanded.name) {
+                            sdl_blocks.push(sdl::extract_type_sdl(&expanded.name, &sdl_string));
+                        }
+                    }
+                }
+                sdl_blocks.join("\n\n")
+            }
+        };
+
+        Ok(RoverOutput::SearchResponse { content, json_data })
+    }
+}

--- a/src/command/search/mod.rs
+++ b/src/command/search/mod.rs
@@ -8,8 +8,8 @@ use rover_schema::{
 use serde::Serialize;
 
 use crate::{
-    RoverOutput, RoverResult, command::schema_cache, options::ProfileOpt,
-    utils::client::StudioClientConfig,
+    RoverOutput, RoverResult, cli::RoverOutputFormatKind, command::schema_cache,
+    options::ProfileOpt, utils::client::StudioClientConfig,
 };
 
 #[derive(Debug, Serialize, Parser)]
@@ -42,14 +42,6 @@ pub struct Search {
     #[arg(long = "include-deprecated")]
     include_deprecated: bool,
 
-    /// Output raw SDL
-    #[arg(long = "sdl")]
-    sdl: bool,
-
-    /// Output token-efficient compact notation
-    #[arg(long = "compact")]
-    compact: bool,
-
     /// Skip reading from the local schema cache (still writes to cache)
     #[arg(long = "no-cache")]
     no_cache: bool,
@@ -59,7 +51,11 @@ pub struct Search {
 }
 
 impl Search {
-    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+    pub async fn run(
+        &self,
+        client_config: StudioClientConfig,
+        format_kind: RoverOutputFormatKind,
+    ) -> RoverResult<RoverOutput> {
         // Fetch SDL (with caching)
         let sdl_string = schema_cache::fetch_sdl_cached(
             &self.graph_ref,
@@ -80,7 +76,18 @@ impl Search {
         let json_data = serde_json::to_value(&results).unwrap_or(serde_json::Value::Null);
 
         // Format
-        let output_format = format::select_format(self.sdl, self.compact, false);
+        let output_format = match format_kind {
+            RoverOutputFormatKind::Sdl => OutputFormat::Sdl,
+            RoverOutputFormatKind::Compact => OutputFormat::Compact,
+            RoverOutputFormatKind::Json => OutputFormat::Description,
+            RoverOutputFormatKind::Plain => {
+                if format::is_tty() {
+                    OutputFormat::Description
+                } else {
+                    OutputFormat::Compact
+                }
+            }
+        };
         let content = match output_format {
             OutputFormat::Description => description::format_search(&results, &self.terms),
             OutputFormat::Compact => compact::format_search_compact(&results),


### PR DESCRIPTION
## Summary

Adds `rover search`, a keyword-driven command for discovering types and fields in a GraphQL schema. Builds on the `rover-schema` crate introduced in the rover-describe PR.

```bash
rover search my-graph@current "playback"
rover search my-graph@current "user email" --limit 10
```

Note: `rover search` depends on the `rover-schema` crate and shared infrastructure (`schema_cache`, TTY detection, output formats) introduced in that PR. Once `rover-describe` merges to `main`, this PR will be retargeted to `main`.

## `rover search`

```
rover search <GRAPH_REF> <TERMS> [OPTIONS]
```

Fuzzy keyword search across type names, field names, and descriptions. Each result is a **complete path** from a Query/Mutation root to the match with all intermediate types included — enough context to write a query from a single search.

Key features:
- Tantivy full-text index with BM25 ranking and camelCase tokenization via `heck`
- BFS path construction from roots, scored by path length and match position
- Deprecated items hidden by default (`--include-deprecated` to include)
- `--limit N` controls max result paths (default 5)
- Output: `--sdl`, `--compact`, `--json`

**Example:**

```
$ rover search my-graph@current "post" --limit 2

SEARCH "post" [2 paths]

── Query.post → Post ──

  Query [5 fields]
    user: User                › Get a user by ID
    post: Post                › Get a post by ID
    categories: [Category!]!  › List all categories
    search: SearchResults     › Search for content
    viewer: Viewer            › Get the currently authenticated viewer

  Post [13 fields]
    id: ID!
    title: String!
    body: String!                 › The body content
    author: User!                 › The author of this post
    comments: CommentConnection!
    category: Category!
    tags: [Tag!]!
    publishedAt: String
    createdAt: String!
    updatedAt: String!
    viewCount: Int!
    score: Int!                   › The post's popularity score (0-100)
    slug: String!


── Mutation.createPost → CreatePostPayload.post → Post ──

  Mutation [3 fields]
    createPost: CreatePostPayload                › Create a new post
    updatePreferences: UpdatePreferencesPayload  › Update notification preferences
    deleteComment: DeleteCommentPayload          › Delete a comment

  CreatePostPayload [1 fields]
    post: Post

  Post [13 fields]
    ...
```

## Implementation

Adds a `search/` module to the `rover-schema` crate:
- `search/index.rs` — Tantivy schema index, element extraction, BM25 search
- `search/tokenizer.rs` — camelCase splitting via `heck::ToSnakeCase`
- `search/mod.rs` — path construction, result tree-shaking, deduplication
- `format/description.rs` + `format/compact.rs` — search result formatters

### Why Tantivy?

`apollo-mcp-server` (`crates/apollo-schema-index`) uses Tantivy for the same purpose — this follows the established pattern across Apollo schema tooling. Tantivy provides BM25 ranking and boolean query parsing that simpler fuzzy matchers can't replicate, and it's behind a `search = ["tantivy"]` feature gate so it's only compiled when needed.