### PR TITLE
Resync windows installer with the code it was copied from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,8 +731,9 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
- "winapi",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6812,6 +6813,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7076,16 +7088,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/installers/binstall/Cargo.toml
+++ b/installers/binstall/Cargo.toml
@@ -30,8 +30,9 @@ url = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cc = "1"
-winapi = "0.3"
-winreg = "0.55"
+windows-registry = "0.6"
+windows-result = "0.4"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
 
 [dev-dependencies]
 assert_fs = { workspace = true }

--- a/installers/binstall/src/error.rs
+++ b/installers/binstall/src/error.rs
@@ -48,4 +48,8 @@ pub enum InstallerError {
 
     #[error(transparent)]
     FileDownloadError(BoxError),
+
+    #[cfg(windows)]
+    #[error(transparent)]
+    WindowsError(#[from] windows_result::Error),
 }

--- a/installers/binstall/src/system/windows.rs
+++ b/installers/binstall/src/system/windows.rs
@@ -1,16 +1,16 @@
 // most of this code is taken wholesale from this:
 // https://github.com/rust-lang/rustup/blob/master/src/cli/self_update/windows.rs
-use std::io;
+use windows_registry::{CURRENT_USER, HSTRING};
 
 use crate::{Installer, InstallerError};
 
 /// Adds the downloaded binary in Installer to a Windows PATH
 pub fn add_binary_to_path(installer: &Installer) -> Result<(), InstallerError> {
     let windows_path = get_windows_path_var()?;
-    let bin_path = installer.get_bin_dir_path()?.to_string();
+    let bin_path = HSTRING::from(installer.get_bin_dir_path()?.as_std_path());
     if let Some(old_path) = windows_path {
-        if let Some(new_path) = add_to_path(&old_path, &bin_path) {
-            apply_new_path(&new_path)?;
+        if let Some(new_path) = add_to_path(old_path, bin_path) {
+            apply_new_path(new_path)?;
         }
     }
 
@@ -25,98 +25,61 @@ pub fn add_binary_to_path(installer: &Installer) -> Result<(), InstallerError> {
 // Get the windows PATH variable out of the registry as a String. If
 // this returns None then the PATH variable is not unicode and we
 // should not mess with it.
-fn get_windows_path_var() -> Result<Option<String>, InstallerError> {
-    use winreg::{
-        enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
-        RegKey,
-    };
+fn get_windows_path_var() -> Result<Option<HSTRING>, InstallerError> {
+    use windows_result::HRESULT;
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_INVALID_DATA};
 
-    let root = RegKey::predef(HKEY_CURRENT_USER);
-    let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)?;
+    let environment = CURRENT_USER.create("Environment")?;
 
-    let reg_value = environment.get_raw_value("PATH");
+    let reg_value = environment.get_hstring("PATH");
     match reg_value {
-        Ok(val) => {
-            if let Some(s) = string_from_winreg_value(&val) {
-                Ok(Some(s))
-            } else {
-                eprintln!(
-                    "warn: the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. \
-                       Not modifying the PATH variable"
-                );
-                Ok(None)
-            }
+        Ok(val) => Ok(Some(val)),
+        Err(e) if e.code() == HRESULT::from_win32(ERROR_INVALID_DATA) => {
+            eprintln!(
+                "warn: the registry key HKEY_CURRENT_USER\\Environment\\PATH is not a string. \
+                   Not modifying the PATH variable"
+            );
+            Ok(None)
         }
-        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(Some(String::new())),
+        Err(e) if e.code() == HRESULT::from_win32(ERROR_FILE_NOT_FOUND) => Ok(Some(HSTRING::new())),
         Err(e) => Err(e.into()),
-    }
-}
-
-// This is used to decode the value of HKCU\Environment\PATH. If that
-// key is not unicode (or not REG_SZ | REG_EXPAND_SZ) then this
-// returns None.  The winreg library itself does a lossy unicode
-// conversion.
-fn string_from_winreg_value(val: &winreg::RegValue) -> Option<String> {
-    use std::slice;
-
-    use winreg::enums::RegType;
-
-    match val.vtype {
-        RegType::REG_SZ | RegType::REG_EXPAND_SZ => {
-            // Copied from winreg
-            let words = unsafe {
-                #[allow(clippy::cast_ptr_alignment)]
-                slice::from_raw_parts(val.bytes.as_ptr().cast::<u16>(), val.bytes.len() / 2)
-            };
-            String::from_utf16(words).ok().map(|mut s| {
-                while s.ends_with('\u{0}') {
-                    s.pop();
-                }
-                s
-            })
-        }
-        _ => None,
     }
 }
 
 // Returns None if the existing old_path does not need changing, otherwise
 // prepends the path_str to old_path, handling empty old_path appropriately.
-fn add_to_path(old_path: &str, path_str: &str) -> Option<String> {
+fn add_to_path(old_path: HSTRING, path_str: HSTRING) -> Option<HSTRING> {
     if old_path.is_empty() {
-        Some(path_str.to_string())
-    } else if old_path.contains(path_str) {
+        Some(path_str)
+    } else if old_path
+        .windows(path_str.len())
+        .any(|path| *path == *path_str)
+    {
         None
     } else {
-        let mut new_path = path_str.to_string();
-        new_path.push(';');
-        new_path.push_str(old_path);
-        Some(new_path)
+        let mut new_path = path_str.to_os_string();
+        new_path.push(";");
+        new_path.push(old_path.to_os_string());
+        Some(HSTRING::from(new_path))
     }
 }
 
-fn apply_new_path(new_path: &str) -> Result<(), InstallerError> {
+fn apply_new_path(new_path: HSTRING) -> Result<(), InstallerError> {
     use std::ptr;
 
-    use winapi::{
-        shared::minwindef::*,
-        um::winuser::{SendMessageTimeoutA, HWND_BROADCAST, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE},
-    };
-    use winreg::{
-        enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
-        RegKey, RegValue,
+    use windows_sys::Win32::{
+        Foundation::{LPARAM, WPARAM},
+        UI::WindowsAndMessaging::{
+            SendMessageTimeoutA, HWND_BROADCAST, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+        },
     };
 
-    let root = RegKey::predef(HKEY_CURRENT_USER);
-    let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)?;
+    let environment = CURRENT_USER.create("Environment")?;
 
     if new_path.is_empty() {
-        environment.delete_value("PATH")?;
+        environment.remove_value("PATH")?;
     } else {
-        let reg_value = RegValue {
-            bytes: string_to_winreg_bytes(new_path),
-            vtype: RegType::REG_EXPAND_SZ,
-        };
-        environment.set_raw_value("PATH", &reg_value)?;
+        environment.set_expand_hstring("PATH", &new_path)?;
     }
 
     // Tell other processes to update their environment
@@ -124,8 +87,8 @@ fn apply_new_path(new_path: &str) -> Result<(), InstallerError> {
         SendMessageTimeoutA(
             HWND_BROADCAST,
             WM_SETTINGCHANGE,
-            0_usize,
-            "Environment\0".as_ptr() as LPARAM,
+            0 as WPARAM,
+            c"Environment".as_ptr() as LPARAM,
             SMTO_ABORTIFHUNG,
             5000,
             ptr::null_mut(),
@@ -135,21 +98,17 @@ fn apply_new_path(new_path: &str) -> Result<(), InstallerError> {
     Ok(())
 }
 
-fn string_to_winreg_bytes(s: &str) -> Vec<u8> {
-    use std::{ffi::OsStr, os::windows::ffi::OsStrExt};
-    let v: Vec<u16> = OsStr::new(s).encode_wide().chain(Some(0)).collect();
-    unsafe { std::slice::from_raw_parts(v.as_ptr().cast::<u8>(), v.len() * 2).to_vec() }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn windows_install_does_not_add_path_twice() {
         assert_eq!(
             None,
             super::add_to_path(
-                r"c:\users\example\.mybinary\bin;foo",
-                r"c:\users\example\.mybinary\bin"
+                HSTRING::from(r"c:\users\example\.mybinary\bin;foo"),
+                HSTRING::from(r"c:\users\example\.mybinary\bin")
             )
         );
     }
@@ -157,16 +116,22 @@ mod tests {
     #[test]
     fn windows_install_does_add_path() {
         assert_eq!(
-            Some(r"c:\users\example\.mybinary\bin;foo".to_string()),
-            super::add_to_path("foo", r"c:\users\example\.mybinary\bin")
+            Some(HSTRING::from(r"c:\users\example\.mybinary\bin;foo")),
+            super::add_to_path(
+                HSTRING::from("foo"),
+                HSTRING::from(r"c:\users\example\.mybinary\bin")
+            )
         );
     }
 
     #[test]
     fn windows_install_does_add_path_no_double_semicolon() {
         assert_eq!(
-            Some(r"c:\users\example\.mybinary\bin;foo;bar;".to_string()),
-            super::add_to_path("foo;bar;", r"c:\users\example\.mybinary\bin")
+            Some(HSTRING::from(r"c:\users\example\.mybinary\bin;foo;bar;")),
+            super::add_to_path(
+                HSTRING::from("foo;bar;"),
+                HSTRING::from(r"c:\users\example\.mybinary\bin")
+            )
         );
     }
 }


### PR DESCRIPTION
Since we originally copied this, official Windows crates have been published by Microsoft. The upstream code we based this off of has switched to them and we should too as it simplifies the code a good bit and leaves our only unsafe block the actual system call to reload the PATH.
