### PR TITLE
Remove dependencies from `rover` npm package

### DIFF
--- a/.mise/scripts/install_pnpm.sh
+++ b/.mise/scripts/install_pnpm.sh
@@ -11,7 +11,7 @@ echo "Installed pnpm"
 # The choice of version here is arbitrary (we just need something we know exists) so that we can test if the
 # installer works, given an existing version. This way we're not at the mercy of whether the binary that corresponds
 # to the latest commit exists.
-npm --prefix "$INSTALLERS_DIR" version --allow-same-version 0.23.0
+npm --prefix "$INSTALLERS_DIR" version --allow-same-version 0.37.2
 echo "Temporarily patched package.json to fixed stable binary"
 # Install dependencies of the package first
 (cd "$INSTALLERS_DIR" && pnpm install)

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -7,6 +7,7 @@ const { existsSync, mkdirSync, rmSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
 const { Readable } = require("stream");
+const { ProxyAgent, fetch } = require("undici");
 
 const error = (msg) => {
   console.error(msg);
@@ -23,35 +24,35 @@ const supportedPlatforms = [
     ARCHITECTURE: "x64",
     RUST_TARGET: "x86_64-pc-windows-msvc",
     BINARY_NAME: `${name}-${version}.exe`,
-    RAW_NAME: `${name}.exe`
+    RAW_NAME: `${name}.exe`,
   },
   {
     TYPE: "Linux",
     ARCHITECTURE: "x64",
     RUST_TARGET: "x86_64-unknown-linux-gnu",
     BINARY_NAME: `${name}-${version}`,
-    RAW_NAME: `${name}`
+    RAW_NAME: `${name}`,
   },
   {
     TYPE: "Linux",
     ARCHITECTURE: "arm64",
     RUST_TARGET: "aarch64-unknown-linux-gnu",
     BINARY_NAME: `${name}-${version}`,
-    RAW_NAME: `${name}`
+    RAW_NAME: `${name}`,
   },
   {
     TYPE: "Darwin",
     ARCHITECTURE: "x64",
     RUST_TARGET: "x86_64-apple-darwin",
     BINARY_NAME: `${name}-${version}`,
-    RAW_NAME: `${name}`
+    RAW_NAME: `${name}`,
   },
   {
     TYPE: "Darwin",
     ARCHITECTURE: "arm64",
     RUST_TARGET: "aarch64-apple-darwin",
     BINARY_NAME: `${name}-${version}`,
-    RAW_NAME: `${name}`
+    RAW_NAME: `${name}`,
   },
 ];
 
@@ -66,7 +67,7 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
           "Downloading musl binary that does not include `rover supergraph compose`.";
         if (libc.isNonGlibcLinuxSync()) {
           console.warn(
-            "This operating system does not support dynamic linking to glibc."
+            "This operating system does not support dynamic linking to glibc.",
           );
           console.warn(musl_warning);
           supportedPlatform.RUST_TARGET = "x86_64-unknown-linux-musl";
@@ -82,7 +83,7 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
             libc_minor_version < min_minor_version
           ) {
             console.warn(
-              `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
+              `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`,
             );
             console.warn(musl_warning);
             supportedPlatform.RUST_TARGET = "x86_64-unknown-linux-musl";
@@ -94,17 +95,24 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
   }
 
   error(
-    `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${supportedPlatforms.map(p => `  ${p.TYPE} ${p.ARCHITECTURE} (${p.RUST_TARGET})`).join("\n")}`
+    `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${supportedPlatforms.map((p) => `  ${p.TYPE} ${p.ARCHITECTURE} (${p.RUST_TARGET})`).join("\n")}`,
   );
 };
 
 const getProxyUrl = (urlString) => {
   const { protocol, hostname } = new URL(urlString);
   const noProxy = process.env.NO_PROXY || process.env.no_proxy || "";
-  if (noProxy === "*") return null;
-  if (noProxy && noProxy.split(",").some(h => hostname.endsWith(h.trim()))) return null;
-  if (protocol === "https:") return process.env.HTTPS_PROXY || process.env.https_proxy || null;
-  if (protocol === "http:") return process.env.HTTP_PROXY || process.env.http_proxy || null;
+  if (!noProxy) {
+    // fall through to proxy lookup
+  } else if (noProxy === "*" || /^(true|1)$/i.test(noProxy)) {
+    return null;
+  } else if (noProxy.split(",").some((h) => hostname.endsWith(h.trim()))) {
+    return null;
+  }
+  if (protocol === "https:")
+    return process.env.HTTPS_PROXY || process.env.https_proxy || null;
+  if (protocol === "http:")
+    return process.env.HTTP_PROXY || process.env.http_proxy || null;
   return null;
 };
 
@@ -131,7 +139,7 @@ class Binary {
     if (errors.length > 0) {
       let errorMsg =
         "One or more of the parameters you passed to the Binary constructor are invalid:\n";
-      errors.forEach(error => {
+      errors.forEach((error) => {
         errorMsg += error;
       });
       errorMsg +=
@@ -158,7 +166,7 @@ class Binary {
     if (this.exists()) {
       if (!suppressLogs) {
         console.error(
-          `${this.name} is already installed, skipping installation.`
+          `${this.name} is already installed, skipping installation.`,
         );
       }
       return Promise.resolve();
@@ -176,39 +184,41 @@ class Binary {
 
     const proxyUrl = getProxyUrl(this.url);
 
-    let fetchPromise;
-    if (proxyUrl) {
-      const { ProxyAgent, fetch: undiciFetch } = require("undici");
-      fetchPromise = undiciFetch(this.url, { dispatcher: new ProxyAgent(proxyUrl) });
-    } else {
-      fetchPromise = fetch(this.url);
-    }
+    const agent = proxyUrl ? new ProxyAgent(proxyUrl) : null;
+    const fetchPromise = fetch(this.url, agent ? { dispatcher: agent } : {});
 
     return fetchPromise
-      .then(res => {
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(
+            `Failed to download binary from ${this.url}: HTTP ${res.status} ${res.statusText}`,
+          );
+        }
         return new Promise((resolve, reject) => {
           const sink = Readable.fromWeb(res.body).pipe(
-            tar.x({ strip: 1, C: this.installDirectory })
+            tar.x({ strip: 1, C: this.installDirectory }),
           );
           sink.on("finish", () => resolve());
-          sink.on("error", err => reject(err));
+          sink.on("error", (err) => reject(err));
         });
       })
       .then(() => {
-        fs.renameSync(join(this.installDirectory, this.raw_name), this.binaryPath);
+        fs.renameSync(
+          join(this.installDirectory, this.raw_name),
+          this.binaryPath,
+        );
         if (!suppressLogs) {
           console.error(`${this.name} has been installed!`);
         }
       })
-      .catch(e => {
+      .finally(() => agent && agent.close())
+      .catch((e) => {
         error(`Error fetching release: ${e.message}`);
       });
   }
 
   run() {
-    const promise = !this.exists()
-      ? this.install(true)
-      : Promise.resolve();
+    const promise = !this.exists() ? this.install(true) : Promise.resolve();
 
     promise
       .then(() => {
@@ -224,7 +234,7 @@ class Binary {
 
         process.exit(result.status);
       })
-      .catch(e => {
+      .catch((e) => {
         error(e.message);
         process.exit(1);
       });
@@ -232,17 +242,25 @@ class Binary {
 }
 
 const getBinary = (overrideInstallDirectory, platform = getPlatform()) => {
-  const download_host = process.env.npm_config_apollo_rover_download_host || process.env.APOLLO_ROVER_DOWNLOAD_HOST || 'https://rover.apollo.dev'
+  const download_host =
+    process.env.npm_config_apollo_rover_download_host ||
+    process.env.APOLLO_ROVER_DOWNLOAD_HOST ||
+    "https://rover.apollo.dev";
   // the url for this binary is constructed from values in `package.json`
   // https://rover.apollo.dev/tar/rover/x86_64-unknown-linux-gnu/v0.4.8
   const url = `${download_host}/tar/${name}/${platform.RUST_TARGET}/v${version}`;
-  const { dirname } = require('path');
+  const { dirname } = require("path");
   const appDir = dirname(require.main.filename);
   let installDirectory = join(appDir, "binary");
   if (overrideInstallDirectory != null && overrideInstallDirectory !== "") {
-    installDirectory = overrideInstallDirectory
+    installDirectory = overrideInstallDirectory;
   }
-  let binary = new Binary(platform.BINARY_NAME, platform.RAW_NAME, url, installDirectory);
+  let binary = new Binary(
+    platform.BINARY_NAME,
+    platform.RAW_NAME,
+    url,
+    installDirectory,
+  );
 
   // setting this allows us to extract supergraph plugins to the proper directory
   // the variable itself is read in Rust code
@@ -256,10 +274,10 @@ const install = (suppressLogs = false) => {
   // for the curl installer.
   if (!suppressLogs) {
     console.error(
-      "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=true"
+      "If you would like to disable Rover's anonymized usage collection, you can set APOLLO_TELEMETRY_DISABLED=true",
     );
     console.error(
-      "You can check out our documentation at https://go.apollo.dev/r/docs."
+      "You can check out our documentation at https://go.apollo.dev/r/docs.",
     );
   }
 

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -3,6 +3,7 @@
 const libc = require("detect-libc");
 const os = require("os");
 const tar = require("tar");
+const { Console } = require("node:console");
 const { existsSync, mkdirSync, rmSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -94,9 +95,12 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
     }
   }
 
-  error(
-    `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${supportedPlatforms.map((p) => `  ${p.TYPE} ${p.ARCHITECTURE} (${p.RUST_TARGET})`).join("\n")}`,
+  const stderr = new Console(process.stderr);
+  stderr.log(
+    `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.`,
   );
+  stderr.table(supportedPlatforms);
+  process.exit(1);
 };
 
 const getProxyUrl = (urlString) => {

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const axios = require("axios");
-const cTable = require("console.table");
 const libc = require("detect-libc");
 const os = require("os");
 const tar = require("tar");
@@ -96,9 +95,7 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
   }
 
   error(
-    `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${cTable.getTable(
-      supportedPlatforms
-    )}`
+    `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${supportedPlatforms.map(p => `  ${p.TYPE} ${p.ARCHITECTURE} (${p.RUST_TARGET})`).join("\n")}`
   );
 };
 

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -103,21 +103,53 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
   process.exit(1);
 };
 
-const getProxyUrl = (urlString) => {
-  const { protocol, hostname } = new URL(urlString);
+/*! Copyright (c) 2022 Mitchell Alderson - MIT License */
+export const getProxyEnv = (requestURL) => {
   const noProxy = process.env.NO_PROXY || process.env.no_proxy || "";
-  if (!noProxy) {
-    // fall through to proxy lookup
-  } else if (noProxy === "*" || /^(true|1)$/i.test(noProxy)) {
-    return null;
-  } else if (noProxy.split(",").some((h) => hostname.endsWith(h.trim()))) {
+
+  // if the noProxy is a wildcard then return null
+  if (noProxy === "*") {
     return null;
   }
-  if (protocol === "https:")
-    return process.env.HTTPS_PROXY || process.env.https_proxy || null;
-  if (protocol === "http:")
+
+  // if the noProxy is not empty and the uri is found, return null
+  if (noProxy !== "" && urlInNoProxy(requestURL, noProxy)) {
+    return null;
+  }
+
+  // get proxy based on request url's protocol
+  if (requestURL.protocol == "http:") {
     return process.env.HTTP_PROXY || process.env.http_proxy || null;
+  }
+
+  if (requestURL.protocol == "https:") {
+    return process.env.HTTPS_PROXY || process.env.https_proxy || null;
+  }
+
+  // not a supported protocol...
   return null;
+};
+
+/*! Copyright (c) 2022 Mitchell Alderson - MIT License */
+const urlInNoProxy = (requestURL, noProxy) => {
+  const port =
+    requestURL.port || (requestURL.protocol === "https:" ? "443" : "80");
+  const hostname = formatHostName(requestURL.hostname);
+  //testing: internal.example.com,internal2.example.com
+  const noProxyList = noProxy.split(",");
+
+  return noProxyList.map(parseNoProxyZone).some((noProxyZone) => {
+    const isMatchedAt = hostname.indexOf(noProxyZone.hostname);
+    const hostnameMatched =
+      isMatchedAt > -1 &&
+      isMatchedAt === hostname.length - noProxyZone.hostname.length;
+
+    if (noProxyZone.hasPort) {
+      return port === noProxyZone.port && hostnameMatched;
+    }
+
+    return hostnameMatched;
+  });
 };
 
 /*! Copyright (c) 2019 Avery Harnish - MIT License */
@@ -186,7 +218,7 @@ class Binary {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    const proxyUrl = getProxyUrl(this.url);
+    const proxyUrl = getProxyEnv(this.url);
 
     const agent = proxyUrl ? new ProxyAgent(proxyUrl) : null;
     const fetchPromise = fetch(this.url, agent ? { dispatcher: agent } : {});
@@ -195,7 +227,7 @@ class Binary {
       .then((res) => {
         if (!res.ok) {
           throw new Error(
-            `Failed to download binary from ${this.url}: HTTP ${res.status} ${res.statusText}`,
+            `Failed to download binary: HTTP ${res.status} ${res.statusText}`,
           );
         }
         return new Promise((resolve, reject) => {

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -1,13 +1,12 @@
 "use strict";
 
-const axios = require("axios");
 const libc = require("detect-libc");
 const os = require("os");
 const tar = require("tar");
-const { configureProxy } = require("axios-proxy-builder");
 const { existsSync, mkdirSync, rmSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
+const { Readable } = require("stream");
 
 const error = (msg) => {
   console.error(msg);
@@ -99,6 +98,16 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
   );
 };
 
+const getProxyUrl = (urlString) => {
+  const { protocol, hostname } = new URL(urlString);
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy || "";
+  if (noProxy === "*") return null;
+  if (noProxy && noProxy.split(",").some(h => hostname.endsWith(h.trim()))) return null;
+  if (protocol === "https:") return process.env.HTTPS_PROXY || process.env.https_proxy || null;
+  if (protocol === "http:") return process.env.HTTP_PROXY || process.env.http_proxy || null;
+  return null;
+};
+
 /*! Copyright (c) 2019 Avery Harnish - MIT License */
 class Binary {
   constructor(name, raw_name, url, installDirectory) {
@@ -145,7 +154,7 @@ class Binary {
     return existsSync(this.binaryPath);
   }
 
-  install(fetchOptions, suppressLogs = false) {
+  install(suppressLogs = false) {
     if (this.exists()) {
       if (!suppressLogs) {
         console.error(
@@ -165,10 +174,20 @@ class Binary {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
+    const proxyUrl = getProxyUrl(this.url);
+
+    let fetchPromise;
+    if (proxyUrl) {
+      const { ProxyAgent, fetch: undiciFetch } = require("undici");
+      fetchPromise = undiciFetch(this.url, { dispatcher: new ProxyAgent(proxyUrl) });
+    } else {
+      fetchPromise = fetch(this.url);
+    }
+
+    return fetchPromise
       .then(res => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
+          const sink = Readable.fromWeb(res.body).pipe(
             tar.x({ strip: 1, C: this.installDirectory })
           );
           sink.on("finish", () => resolve());
@@ -186,9 +205,9 @@ class Binary {
       });
   }
 
-  run(fetchOptions) {
+  run() {
     const promise = !this.exists()
-      ? this.install(fetchOptions, true)
+      ? this.install(true)
       : Promise.resolve();
 
     promise
@@ -233,7 +252,6 @@ const getBinary = (overrideInstallDirectory, platform = getPlatform()) => {
 
 const install = (suppressLogs = false) => {
   const binary = getBinary();
-  const proxy = configureProxy(binary.url);
   // these messages are duplicated in `src/command/install/mod.rs`
   // for the curl installer.
   if (!suppressLogs) {
@@ -245,7 +263,7 @@ const install = (suppressLogs = false) => {
     );
   }
 
-  return binary.install(proxy, suppressLogs);
+  return binary.install(suppressLogs);
 };
 
 const run = () => {

--- a/installers/npm/binary.js
+++ b/installers/npm/binary.js
@@ -104,7 +104,7 @@ const getPlatform = (type = os.type(), architecture = os.arch()) => {
 };
 
 /*! Copyright (c) 2022 Mitchell Alderson - MIT License */
-export const getProxyEnv = (requestURL) => {
+const getProxyEnv = (requestURL) => {
   const noProxy = process.env.NO_PROXY || process.env.no_proxy || "";
 
   // if the noProxy is a wildcard then return null
@@ -283,7 +283,7 @@ const getBinary = (overrideInstallDirectory, platform = getPlatform()) => {
     process.env.APOLLO_ROVER_DOWNLOAD_HOST ||
     "https://rover.apollo.dev";
   // the url for this binary is constructed from values in `package.json`
-  // https://rover.apollo.dev/tar/rover/x86_64-unknown-linux-gnu/v0.4.8
+  // https://rover.apollo.dev/tar/rover/x86_64-unknown-linux-gnu/vx.x.x
   const url = `${download_host}/tar/${name}/${platform.RUST_TARGET}/v${version}`;
   const { dirname } = require("path");
   const appDir = dirname(require.main.filename);

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "detect-libc": "^2.0.0",
+        "detect-libc": "2.1.2",
         "tar": "^7.0.0",
         "undici": "^7.0.0"
       },

--- a/installers/npm/package-lock.json
+++ b/installers/npm/package-lock.json
@@ -10,24 +10,20 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.13.1",
-        "axios-proxy-builder": "^0.1.1",
-        "console.table": "^0.10.0",
         "detect-libc": "^2.0.0",
-        "tar": "^7.0.0"
+        "tar": "^7.0.0",
+        "undici": "^7.0.0"
       },
       "bin": {
         "rover": "run.js"
       },
       "devDependencies": {
-        "axios-mock-adapter": "2.1.0",
         "jest": "30.3.0",
         "jest-junit": "16.0.0",
         "prettier": "3.8.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1570,46 +1566,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios-mock-adapter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
-      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "is-buffer": "^2.0.5"
-      },
-      "peerDependencies": {
-        "axios": ">= 0.17.0"
-      }
-    },
-    "node_modules/axios-proxy-builder": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/axios-proxy-builder/-/axios-proxy-builder-0.1.2.tgz",
-      "integrity": "sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "^0.0.6"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
@@ -1790,19 +1746,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1981,16 +1924,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2029,36 +1962,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/console.table": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/console.table/-/console.table-0.10.0.tgz",
-      "integrity": "sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g==",
-      "license": "MIT",
-      "dependencies": {
-        "easy-table": "1.1.0"
-      },
-      "engines": {
-        "node": "> 0.10"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2125,28 +2034,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2166,35 +2053,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/easy-table": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
-      "integrity": "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "wcwidth": ">=1.0.1"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
@@ -2231,51 +2095,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2371,13 +2190,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2409,26 +2221,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2444,22 +2236,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2484,15 +2260,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2513,30 +2280,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2545,19 +2288,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2595,18 +2325,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2622,45 +2340,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/html-escaper": {
@@ -2735,30 +2414,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -3664,42 +3319,12 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -4074,15 +3699,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pure-rand": {
@@ -4543,15 +4159,6 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4573,6 +4180,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4681,16 +4297,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/which": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
-    "detect-libc": "^2.0.0",
+    "detect-libc": "2.1.2",
     "tar": "^7.0.0",
     "undici": "^7.0.0"
   },

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -29,18 +29,15 @@
     "url": "https://github.com/apollographql/rover/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=6"
+    "node": ">=20"
   },
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {
-    "axios": "^1.13.1",
-    "axios-proxy-builder": "^0.1.1",
     "detect-libc": "^2.0.0",
-    "tar": "^7.0.0"
+    "tar": "^7.0.0",
+    "undici": "^7.0.0"
   },
   "devDependencies": {
-    "axios-mock-adapter": "2.1.0",
     "jest": "30.3.0",
     "jest-junit": "16.0.0",
     "prettier": "3.8.1"

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/apollographql/rover/issues"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.18.1"
   },
   "homepage": "https://github.com/apollographql/rover#readme",
   "dependencies": {

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "axios": "^1.13.1",
     "axios-proxy-builder": "^0.1.1",
-    "console.table": "^0.10.0",
     "detect-libc": "^2.0.0",
     "tar": "^7.0.0"
   },

--- a/installers/npm/tests/binary.test.js
+++ b/installers/npm/tests/binary.test.js
@@ -4,26 +4,28 @@ const path = require("path");
 const pjson = require("../package.json");
 const fs = require("node:fs");
 const crypto = require("node:crypto");
-const MockAdapter = require("axios-mock-adapter");
-const axios = require("axios");
+const { MockAgent, setGlobalDispatcher, getGlobalDispatcher } = require("undici");
 const {getPlatform} = require("../binary");
 
-var mock = new MockAdapter(axios);
-mock.onGet(new RegExp("https://rover\.apollo\.dev/tar/rover/x86_64-pc-windows-msvc/.*")).reply(function (_) {
-  return [
-    200,
-    fs.createReadStream(
-        path.join(__dirname, "fake_tarballs", "rover-fake-windows.tar.gz"),
-    ),
-  ];
+let originalDispatcher;
+
+beforeAll(() => {
+  originalDispatcher = getGlobalDispatcher();
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+
+  const mockPool = mockAgent.get("https://rover.apollo.dev");
+  mockPool.intercept({ path: /\/tar\/rover\/x86_64-pc-windows-msvc\/.*/, method: "GET" })
+    .reply(200, fs.readFileSync(path.join(__dirname, "fake_tarballs", "rover-fake-windows.tar.gz")))
+    .persist();
+  mockPool.intercept({ path: /\/tar\/rover\/.*/, method: "GET" })
+    .reply(200, fs.readFileSync(path.join(__dirname, "fake_tarballs", "rover-fake.tar.gz")))
+    .persist();
 });
-mock.onGet(new RegExp("https://rover\.apollo\.dev/tar/rover/.*")).reply(function (_) {
-  return [
-    200,
-    fs.createReadStream(
-        path.join(__dirname, "fake_tarballs", "rover-fake.tar.gz"),
-    ),
-  ];
+
+afterAll(() => {
+  setGlobalDispatcher(originalDispatcher);
 });
 
 
@@ -80,7 +82,7 @@ test("install doesn't do anything if a binary already exists", () => {
 
   const binary_name = `rover-${pjson.version}`;
   fs.writeFileSync(path.join(directory, binary_name), "foobarbash");
-  bin.install({}, true);
+  bin.install(true);
   const file_contents = fs.readFileSync(path.join(directory, binary_name));
   expect(file_contents.toString()).toBe("foobarbash");
 });
@@ -94,7 +96,7 @@ test("install recreates an existing directory if it exists", () => {
     path.join(directory, "i-am-a-different-new-file.txt"),
     "binboobaznar",
   );
-  bin.install({}, true);
+  bin.install(true);
 
   const directory_entries = fs.readdirSync(directory, { withFileTypes: true });
   expect(
@@ -107,7 +109,7 @@ test("install downloads a binary if none exists", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rover-tests-"));
   const bin = binary.getBinary(directory);
   //
-  const directory_entries = await bin.install({}, true).then(async () => {
+  const directory_entries = await bin.install(true).then(async () => {
     return fs.readdirSync(directory, { withFileTypes: true });
   });
   const filtered_directory_entries = directory_entries.filter(
@@ -129,7 +131,7 @@ test("install renames binary properly", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rover-tests-"));
   // Create a Binary object
   const bin = binary.getBinary(directory);
-  const directory_entries = await bin.install({}, true).then(async () => {
+  const directory_entries = await bin.install(true).then(async () => {
     return fs.readdirSync(directory, { withFileTypes: true });
   });
   expect(
@@ -144,7 +146,7 @@ test("install renames binary properly (Windows)", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rover-tests-"));
   // Create a Binary object
   const bin = binary.getBinary(directory, getPlatform("Windows_NT", "x64"));
-  const directory_entries = await bin.install({}, true).then(async () => {
+  const directory_entries = await bin.install(true).then(async () => {
     return fs.readdirSync(directory, { withFileTypes: true });
   });
   expect(
@@ -171,7 +173,7 @@ test("install adds a new binary if another version exists", async () => {
   // Create a Binary object
   const bin = binary.getBinary(directory);
   // Install the binary
-  let new_directory_entries = await bin.install({}, true).then(() => {
+  let new_directory_entries = await bin.install(true).then(() => {
     // Grab the directory entries again
     return fs.readdirSync(directory, { withFileTypes: true });
   });

--- a/installers/npm/tests/binary.test.js
+++ b/installers/npm/tests/binary.test.js
@@ -4,8 +4,12 @@ const path = require("path");
 const pjson = require("../package.json");
 const fs = require("node:fs");
 const crypto = require("node:crypto");
-const { MockAgent, setGlobalDispatcher, getGlobalDispatcher } = require("undici");
-const {getPlatform} = require("../binary");
+const {
+  MockAgent,
+  setGlobalDispatcher,
+  getGlobalDispatcher,
+} = require("undici");
+const { getPlatform } = require("../binary");
 
 let originalDispatcher;
 
@@ -16,18 +20,32 @@ beforeAll(() => {
   setGlobalDispatcher(mockAgent);
 
   const mockPool = mockAgent.get("https://rover.apollo.dev");
-  mockPool.intercept({ path: /\/tar\/rover\/x86_64-pc-windows-msvc\/.*/, method: "GET" })
-    .reply(200, fs.readFileSync(path.join(__dirname, "fake_tarballs", "rover-fake-windows.tar.gz")))
+  mockPool
+    .intercept({
+      path: /\/tar\/rover\/x86_64-pc-windows-msvc\/.*/,
+      method: "GET",
+    })
+    .reply(
+      200,
+      fs.readFileSync(
+        path.join(__dirname, "fake_tarballs", "rover-fake-windows.tar.gz"),
+      ),
+    )
     .persist();
-  mockPool.intercept({ path: /\/tar\/rover\/.*/, method: "GET" })
-    .reply(200, fs.readFileSync(path.join(__dirname, "fake_tarballs", "rover-fake.tar.gz")))
+  mockPool
+    .intercept({ path: /\/tar\/rover\/.*/, method: "GET" })
+    .reply(
+      200,
+      fs.readFileSync(
+        path.join(__dirname, "fake_tarballs", "rover-fake.tar.gz"),
+      ),
+    )
     .persist();
 });
 
 afterAll(() => {
   setGlobalDispatcher(originalDispatcher);
 });
-
 
 test("getBinary should be created with correct name and URL", () => {
   fs.mkdtempSync(path.join(os.tmpdir(), "rover-tests-"));
@@ -117,12 +135,7 @@ test("install downloads a binary if none exists", async () => {
   );
   expect(filtered_directory_entries).toHaveLength(1);
   expect(
-    fs.statSync(
-      path.join(
-        filtered_directory_entries[0].path,
-        filtered_directory_entries[0].name,
-      ),
-    ).size,
+    fs.statSync(path.join(directory, filtered_directory_entries[0].name)).size,
   ).toBe(0);
 });
 
@@ -150,9 +163,9 @@ test("install renames binary properly (Windows)", async () => {
     return fs.readdirSync(directory, { withFileTypes: true });
   });
   expect(
-      directory_entries.filter(
-          (d) => d.isFile() && d.name === `rover-${pjson.version}.exe`,
-      ),
+    directory_entries.filter(
+      (d) => d.isFile() && d.name === `rover-${pjson.version}.exe`,
+    ),
   ).toHaveLength(1);
 });
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 lychee = "0.23.0"
-node = "24"
+node = "20.18.1"
 "cargo:cargo-deny" = "0.19"
 
 [tasks.check]


### PR DESCRIPTION
This drops the dependencies `axios`, `axios-proxy-builder` and `console.table` and introduces `undici` as a dependency.

It also pins `detect-libc` to a fixed version that we know works and has no further dependencies - this should be safer.

This PR is best reviewed commit by commit and we could also end up just choosing one or two of the commits instead of all of them.