### PR TITLE
Fix RNG in test subgraph ID generation

### DIFF
--- a/tests/e2e/subgraph/publish.rs
+++ b/tests/e2e/subgraph/publish.rs
@@ -44,7 +44,7 @@ async fn e2e_test_rover_subgraph_publish(
     // 3.2 * 10^115 possibilities for identifiers, so I think for practical purposes we can
     // consider these as unique.
     let mut rng = rand::rng();
-    let id_regex = rand_regex::Regex::compile("[a-zA-Z][a-zA-Z0-9_-]{0,63}", 100)
+    let id_regex = rand_regex::Regex::compile("[a-zA-Z][a-zA-Z0-9_-]{63}", 0)
         .expect("Could not compile regex");
     let id: String = rng.sample::<String, &rand_regex::Regex>(&id_regex);
     let schema_path = test_artifacts_directory.join("subgraph/perfSubgraph01.graphql");


### PR DESCRIPTION
This regex had a minimum length of zero which meant we could improbably fail tests when it decided to select a short enough string to collide with the existing data. In particular, I saw a test failure where it selected the single letter "N" as its ID which of course matched existing data.

