### PR TITLE
Suppress apt interactive prompts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ commands:
                 command: ldd --version
             - run:
                 name: Install OpenSSL
-                command: sudo apt-get install -y libssl-dev
+                command: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev
 
       - when:
           condition:


### PR DESCRIPTION
Suppress apt interactive prompts

Failing workflow: https://app.circleci.com/pipelines/github/apollographql/rover/12019/workflows/eb44d881-2f49-4f8a-ab55-b0a7de1a4525/jobs/102098