### PR TITLE
Run install tests serially with retries to reduce network issues

### DIFF
--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 use rstest::{fixture, rstest};
 use sealed_test::prelude::*;
 use serde_json::Value;
+use serial_test::serial;
 use speculoos::prelude::*;
 use tracing_test::traced_test;
 
@@ -20,6 +21,7 @@ use tracing_test::traced_test;
 #[case::installs_apollo_mcp_server_at_latest(Vec::from(["install", "--plugin", "apollo-mcp-server@latest", "--client-timeout", "120"]), "apollo-mcp-server")]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
+#[serial]
 #[sealed_test(env = [("APOLLO_ELV2_LICENSE", "accept")])]
 async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_name: &str) {
     // GIVEN
@@ -71,6 +73,7 @@ fn temp_dir() -> Utf8PathBuf {
 #[case::force_installs_router(Vec::from(["install", "--force", "--plugin", "router@=1.0.0", "--log", "debug"]), "router",  "router-v1.0.0")]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
+#[serial]
 #[sealed_test(env = [("APOLLO_ELV2_LICENSE", "accept")])]
 async fn e2e_test_rover_install_plugin_with_force_opt(
     #[case] args: Vec<&str>,
@@ -143,6 +146,7 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
 #[case::supergraph_latest_2("supergraph", "latest-2")]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
+#[serial]
 #[sealed_test(env = [("APOLLO_ELV2_LICENSE", "accept")], files = ["latest_plugin_versions.json"])]
 async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     #[case] binary_name: &str,

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -5,7 +5,6 @@ use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 use regex::Regex;
 use rstest::{fixture, rstest};
-use sealed_test::prelude::*;
 use serde_json::Value;
 use serial_test::serial;
 use speculoos::prelude::*;
@@ -22,7 +21,6 @@ use tracing_test::traced_test;
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[serial]
-#[sealed_test(env = [("APOLLO_ELV2_LICENSE", "accept")])]
 async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_name: &str) {
     // GIVEN
     //   - an install command for the supergraph binary that forces replacement; sometimes this
@@ -34,6 +32,7 @@ async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_n
     let bin_path = temp_dir.join(".rover/bin");
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.env("APOLLO_HOME", temp_dir);
+    cmd.env("APOLLO_ELV2_LICENSE", "accept");
     cmd.args(args);
     let output = cmd.output().expect("Could not run command");
 
@@ -74,7 +73,6 @@ fn temp_dir() -> Utf8PathBuf {
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[serial]
-#[sealed_test(env = [("APOLLO_ELV2_LICENSE", "accept")])]
 async fn e2e_test_rover_install_plugin_with_force_opt(
     #[case] args: Vec<&str>,
     #[case] binary: &str,
@@ -93,6 +91,7 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     // FIRST INSTALLATION, NO FORCE
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.env("APOLLO_HOME", temp_dir.clone());
+    cmd.env("APOLLO_ELV2_LICENSE", "accept");
     cmd.args(args_without_force_option.clone());
     let output = cmd.output().expect("Could not run command");
     let stderr = std::str::from_utf8(&output.stderr).expect("failed to convert bytes to a str");
@@ -113,6 +112,7 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     // SECOND INSTALLATION, NO FORCE, USES EXISTING BINARY
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.env("APOLLO_HOME", temp_dir.clone());
+    cmd.env("APOLLO_ELV2_LICENSE", "accept");
     cmd.args(args_without_force_option.clone());
     let output = cmd.output().expect("Could not run command");
     let stderr = std::str::from_utf8(&output.stderr).expect("failed to convert bytes to a str");
@@ -133,6 +133,7 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     // THIRD INSTALLATION, USES FORCE, BINARY EXISTS
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.env("APOLLO_HOME", temp_dir.clone());
+    cmd.env("APOLLO_ELV2_LICENSE", "accept");
     cmd.args(forced_args);
     let output = cmd.output().expect("Could not run command");
     let stderr = std::str::from_utf8(&output.stderr).expect("failed to convert bytes to a str");
@@ -147,7 +148,6 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[serial]
-#[sealed_test(env = [("APOLLO_ELV2_LICENSE", "accept")], files = ["latest_plugin_versions.json"])]
 async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     #[case] binary_name: &str,
     #[case] config_version_name: &str,
@@ -156,10 +156,10 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     let bin_path = temp_dir.join(".rover/bin");
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
 
-    let config_file_contents = std::fs::read_to_string("latest_plugin_versions.json")
-        .expect("Should have been able to read the file");
+    let config_file_contents =
+        include_str!("../../../latest_plugin_versions.json");
 
-    let versions: Value = serde_json::from_str(&config_file_contents)
+    let versions: Value = serde_json::from_str(config_file_contents)
         .expect("failed to get json out of latest_plugin_versions.json");
 
     let latest_version_from_config_file = &versions[binary_name]["versions"][config_version_name]
@@ -167,6 +167,7 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
         .replace("\"", "");
 
     cmd.env("APOLLO_HOME", temp_dir);
+    cmd.env("APOLLO_ELV2_LICENSE", "accept");
     cmd.args([
         "install",
         "--plugin",

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -156,8 +156,7 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
     let bin_path = temp_dir.join(".rover/bin");
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
 
-    let config_file_contents =
-        include_str!("../../../latest_plugin_versions.json");
+    let config_file_contents = include_str!("../../../latest_plugin_versions.json");
 
     let versions: Value = serde_json::from_str(config_file_contents)
         .expect("failed to get json out of latest_plugin_versions.json");

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -171,6 +171,8 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
         "install",
         "--plugin",
         &format!("{binary_name}@{latest_version_from_config_file}"),
+        "--client-timeout",
+        "120",
     ]);
     cmd.output().expect("Could not run command");
 

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -1,4 +1,4 @@
-use std::{process::Command, str::from_utf8};
+use std::{process::Command, str::from_utf8, thread, time::Duration};
 
 use assert_cmd::cargo;
 use assert_fs::TempDir;
@@ -10,14 +10,34 @@ use serial_test::serial;
 use speculoos::prelude::*;
 use tracing_test::traced_test;
 
+/// Runs a rover install command with retries to handle transient network failures in CI.
+/// Returns the output of the first successful attempt, or the output of the last attempt
+/// if all retries are exhausted.
+fn run_with_retries(cmd_fn: impl Fn() -> Command, max_attempts: u32) -> std::process::Output {
+    let mut last_output = None;
+    for attempt in 1..=max_attempts {
+        let output = cmd_fn().output().expect("Could not run command");
+        if output.status.success() || attempt == max_attempts {
+            return output;
+        }
+        eprintln!(
+            "attempt {attempt}/{max_attempts} failed (exit {}), retrying in 5s...",
+            output.status
+        );
+        last_output = Some(output);
+        thread::sleep(Duration::from_secs(5));
+    }
+    last_output.unwrap()
+}
+
 #[rstest]
-#[case::installs_supergraph_at_pinned_version(Vec::from(["install", "--plugin", "supergraph@=2.8.0", "--client-timeout", "120"]), "supergraph-v2.8.0")]
-#[case::installs_supergraph_at_latest(Vec::from(["install", "--plugin", "supergraph@latest-2", "--client-timeout", "120"]), "supergraph-")]
-#[case::installs_supergraph_at_latest_0(Vec::from(["install", "--plugin", "supergraph@latest-0", "--client-timeout", "120"]), "supergraph-")]
-#[case::installs_router_at_pinned_version(Vec::from(["install", "--plugin", "router@=1.0.0", "--client-timeout", "120"]), "router-v1.0.0")]
-#[case::installs_router_at_latest(Vec::from(["install", "--plugin", "router@latest", "--client-timeout", "120"]), "router-")]
-#[case::installs_router_2x(Vec::from(["install", "--plugin", "router@2", "--client-timeout", "120"]), "router-")]
-#[case::installs_apollo_mcp_server_at_latest(Vec::from(["install", "--plugin", "apollo-mcp-server@latest", "--client-timeout", "120"]), "apollo-mcp-server")]
+#[case::installs_supergraph_at_pinned_version(Vec::from(["install", "--plugin", "supergraph@=2.8.0"]), "supergraph-v2.8.0")]
+#[case::installs_supergraph_at_latest(Vec::from(["install", "--plugin", "supergraph@latest-2"]), "supergraph-")]
+#[case::installs_supergraph_at_latest_0(Vec::from(["install", "--plugin", "supergraph@latest-0"]), "supergraph-")]
+#[case::installs_router_at_pinned_version(Vec::from(["install", "--plugin", "router@=1.0.0"]), "router-v1.0.0")]
+#[case::installs_router_at_latest(Vec::from(["install", "--plugin", "router@latest"]), "router-")]
+#[case::installs_router_2x(Vec::from(["install", "--plugin", "router@2"]), "router-")]
+#[case::installs_apollo_mcp_server_at_latest(Vec::from(["install", "--plugin", "apollo-mcp-server@latest"]), "apollo-mcp-server")]
 #[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[serial]
@@ -30,11 +50,18 @@ async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_n
     //   - it's run
     let temp_dir = Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap();
     let bin_path = temp_dir.join(".rover/bin");
-    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
-    cmd.env("APOLLO_HOME", temp_dir);
-    cmd.env("APOLLO_ELV2_LICENSE", "accept");
-    cmd.args(args);
-    let output = cmd.output().expect("Could not run command");
+    let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let temp_dir_clone = temp_dir.clone();
+    let output = run_with_retries(
+        || {
+            let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_ELV2_LICENSE", "accept");
+            cmd.args(&args_owned);
+            cmd
+        },
+        3,
+    );
 
     asserting(&format!(
         "Was expecting success but instead got: {}",
@@ -81,19 +108,26 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
 ) {
     let bin_path = temp_dir.join(".rover/bin");
 
-    let forced_args = args.clone();
-    let args_without_force_option: Vec<&str> = args
+    let forced_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let args_without_force_option: Vec<String> = args
         .iter()
         .filter(|opt| *opt != &"--force")
-        .map(|opt| opt.to_owned())
+        .map(|s| s.to_string())
         .collect();
 
     // FIRST INSTALLATION, NO FORCE
-    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
-    cmd.env("APOLLO_HOME", temp_dir.clone());
-    cmd.env("APOLLO_ELV2_LICENSE", "accept");
-    cmd.args(args_without_force_option.clone());
-    let output = cmd.output().expect("Could not run command");
+    let temp_dir_clone = temp_dir.clone();
+    let args_clone = args_without_force_option.clone();
+    let output = run_with_retries(
+        || {
+            let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_ELV2_LICENSE", "accept");
+            cmd.args(&args_clone);
+            cmd
+        },
+        3,
+    );
     let stderr = std::str::from_utf8(&output.stderr).expect("failed to convert bytes to a str");
     assert_that!(stderr).contains(format!("the '{binary}' plugin was successfully installed"));
 
@@ -131,11 +165,18 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     assert_that!(installed).is_true();
 
     // THIRD INSTALLATION, USES FORCE, BINARY EXISTS
-    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
-    cmd.env("APOLLO_HOME", temp_dir.clone());
-    cmd.env("APOLLO_ELV2_LICENSE", "accept");
-    cmd.args(forced_args);
-    let output = cmd.output().expect("Could not run command");
+    let temp_dir_clone = temp_dir.clone();
+    let forced_args_clone = forced_args.clone();
+    let output = run_with_retries(
+        || {
+            let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_ELV2_LICENSE", "accept");
+            cmd.args(&forced_args_clone);
+            cmd
+        },
+        3,
+    );
     let stderr = std::str::from_utf8(&output.stderr).expect("failed to convert bytes to a str");
     let re = Regex::new(&format!("the '{binary}' plugin was successfully installed")).unwrap();
     assert_that!(re.is_match(stderr)).is_true();
@@ -154,7 +195,6 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
 ) {
     let temp_dir = Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap();
     let bin_path = temp_dir.join(".rover/bin");
-    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
 
     let config_file_contents = include_str!("../../../latest_plugin_versions.json");
 
@@ -165,16 +205,25 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
         .to_string()
         .replace("\"", "");
 
-    cmd.env("APOLLO_HOME", temp_dir);
-    cmd.env("APOLLO_ELV2_LICENSE", "accept");
-    cmd.args([
-        "install",
-        "--plugin",
-        &format!("{binary_name}@{latest_version_from_config_file}"),
-        "--client-timeout",
-        "120",
-    ]);
-    cmd.output().expect("Could not run command");
+    let plugin_arg = format!("{binary_name}@{latest_version_from_config_file}");
+    let temp_dir_clone = temp_dir.clone();
+    let output = run_with_retries(
+        || {
+            let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_ELV2_LICENSE", "accept");
+            cmd.args(["install", "--plugin", &plugin_arg]);
+            cmd
+        },
+        3,
+    );
+
+    asserting(&format!(
+        "Was expecting success but instead got: {}",
+        from_utf8(output.stderr.as_slice()).unwrap()
+    ))
+    .that(&output.status.success())
+    .is_true();
 
     // THEN
     //   - it successfully installs

--- a/tests/e2e/install/plugin.rs
+++ b/tests/e2e/install/plugin.rs
@@ -51,11 +51,10 @@ async fn e2e_test_rover_install_plugin(#[case] args: Vec<&str>, #[case] binary_n
     let temp_dir = Utf8PathBuf::try_from(TempDir::new().unwrap().path().to_path_buf()).unwrap();
     let bin_path = temp_dir.join(".rover/bin");
     let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-    let temp_dir_clone = temp_dir.clone();
     let output = run_with_retries(
         || {
             let mut cmd = Command::new(cargo::cargo_bin!("rover"));
-            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_HOME", &temp_dir);
             cmd.env("APOLLO_ELV2_LICENSE", "accept");
             cmd.args(&args_owned);
             cmd
@@ -147,7 +146,7 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.env("APOLLO_HOME", temp_dir.clone());
     cmd.env("APOLLO_ELV2_LICENSE", "accept");
-    cmd.args(args_without_force_option.clone());
+    cmd.args(args_without_force_option);
     let output = cmd.output().expect("Could not run command");
     let stderr = std::str::from_utf8(&output.stderr).expect("failed to convert bytes to a str");
     let re = Regex::new("exists, skipping install").unwrap();
@@ -165,14 +164,12 @@ async fn e2e_test_rover_install_plugin_with_force_opt(
     assert_that!(installed).is_true();
 
     // THIRD INSTALLATION, USES FORCE, BINARY EXISTS
-    let temp_dir_clone = temp_dir.clone();
-    let forced_args_clone = forced_args.clone();
     let output = run_with_retries(
         || {
             let mut cmd = Command::new(cargo::cargo_bin!("rover"));
-            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_HOME", temp_dir.as_path());
             cmd.env("APOLLO_ELV2_LICENSE", "accept");
-            cmd.args(&forced_args_clone);
+            cmd.args(&forced_args);
             cmd
         },
         3,
@@ -206,11 +203,10 @@ async fn e2e_test_rover_install_plugins_from_latest_plugin_config_file(
         .replace("\"", "");
 
     let plugin_arg = format!("{binary_name}@{latest_version_from_config_file}");
-    let temp_dir_clone = temp_dir.clone();
     let output = run_with_retries(
         || {
             let mut cmd = Command::new(cargo::cargo_bin!("rover"));
-            cmd.env("APOLLO_HOME", &temp_dir_clone);
+            cmd.env("APOLLO_HOME", &temp_dir);
             cmd.env("APOLLO_ELV2_LICENSE", "accept");
             cmd.args(["install", "--plugin", &plugin_arg]);
             cmd


### PR DESCRIPTION
These tests all running concurrently is possibly overloading the network stack in the minimal glibc tests, which is why they frequently encounter transient errors.

I let Claude run against this PR until we got consistent passing runs.
