### PR TITLE
sputnik: fix 'occured' -> 'occurred' in error.rs doc comment

### DIFF
--- a/crates/sputnik/src/error.rs
+++ b/crates/sputnik/src/error.rs
@@ -3,7 +3,7 @@ use std::io;
 use rover_std::RoverStdError;
 use thiserror::Error;
 
-/// SputnikError is the type of Error that occured.
+/// SputnikError is the type of Error that occurred.
 #[derive(Error, Debug)]
 pub enum SputnikError {
     /// io::Error occurs when any given std::io::Error arises.


### PR DESCRIPTION
Doc comment in `crates/sputnik/src/error.rs` line 6 reads `Error that occured`. Fixed to `occurred`. Comment-only change.