### PR TITLE
Restore retry-until-ready behavior for unavailable subgraphs

### DIFF
--- a/crates/rover-client/src/operations/subgraph/check/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check/runner.rs
@@ -1,8 +1,8 @@
-use crate::RoverClientError;
 use crate::blocking::StudioClient;
 use crate::operations::config::is_federated::{self, IsFederatedInput};
 use crate::operations::subgraph::check::types::{MutationResponseData, SubgraphCheckAsyncInput};
 use crate::shared::CheckRequestSuccessResult;
+use crate::RoverClientError;
 
 use graphql_client::*;
 use rover_studio::types::GraphRef;

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -346,13 +346,13 @@ impl CompositionPipeline<state::Run> {
     > {
         tracing::debug!("generate_lazy_and_fully_resolved_supergraph_configs");
         // Get the two different kinds of resolutions (we know that the fully_resolved will be a non-proper subset of the lazily_resolved)
-        let (mut lazily_resolved_supergraph_config, _) = self
+        let (lazily_resolved_supergraph_config, _) = self
             .state
             .resolver
             .lazily_resolve_subgraphs(&self.state.supergraph_root)
             .await?;
         debug!(
-            "Initial Lazily Resolved Config is: {:?}",
+            "Lazily Resolved Config is: {:?}",
             lazily_resolved_supergraph_config
         );
         let (fully_resolved_supergraph_config, full_resolution_errors) = self
@@ -365,15 +365,14 @@ impl CompositionPipeline<state::Run> {
             )
             .await?;
         debug!(
-            "Initial Fully Resolved Config is: {:?}",
+            "Fully Resolved Config is: {:?}",
             fully_resolved_supergraph_config
         );
-        // Generate the correct lazily_resolved config, by removing all the things that cannot fully resolve
-        lazily_resolved_supergraph_config
-            .filter_subgraphs(full_resolution_errors.keys().cloned().collect());
-        debug!("Final Config is: {:?}", lazily_resolved_supergraph_config);
 
-        // Merge all the errors together and give all three back
+        // Note: subgraphs that failed full resolution (e.g. unreachable introspection endpoints)
+        // are intentionally kept in the lazily-resolved config so that watchers are created for
+        // them. Those watchers will keep polling and trigger recomposition once the subgraphs
+        // become available.
         Ok((
             lazily_resolved_supergraph_config,
             fully_resolved_supergraph_config,


### PR DESCRIPTION
Previously, subgraphs that failed introspection at startup were removed from the lazily-resolved config via `filter_subgraphs`, so no watcher was created for them. With no watcher polling the endpoint, `rover dev` would print the initial composition error and exit, never recovering when the subgraph later came online.

This is fixed by keeping all subgraphs in the lazily-resolved config regardless of whether full resolution succeeded. The introspection watcher's existing polling loop will handle transient failures and will trigger recomposition once connectivity is restored

JIRA: https://apollographql.atlassian.net/browse/ROVER-370

### Testing
Before this fix:
- Call `rover dev`, subgraph is not running
- After 10 seconds start the subgraph 
```
➜  rover git:(main) target/release/rover dev --supergraph-config supergraph.yaml
merging supergraph schema files
what URL is your subgraph running on?:  http://localhost:4001
what is the name of this subgraph?: ellie
error: Error occurred when composing supergraph
Error resolving subgraphs:
Unable to resolve subgraphs.
ellie: Failed to introspect the subgraph "ellie": Upstream service error: Unexpected(reqwest::Error { kind: Request, url: "http://localhost:4001/", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", 127.0.0.1:4001, Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) })
error: Composition Events Stream closed before supergraph schema could successfully compose
```

After implementing the fix:
- Call `rover dev`, subgraph is not running
- After 10 seconds start the subgraph 
```
➜  rover git:(dmallare/subgraphs-not-required-to-be-online) target/release/rover dev --supergraph-config supergraph.yaml
merging supergraph schema files
what URL is your subgraph running on?: http://localhost:4001
what is the name of this subgraph?: ellie-test
starting a session with the 'ellie-test' subgraph
polling http://localhost:4001/ every 1 seconds
error: Error occurred when composing supergraph
Error resolving subgraphs:
Unable to resolve subgraphs.
ellie-test: Failed to introspect the subgraph "ellie-test": Upstream service error: Unexpected(reqwest::Error { kind: Request, url: "http://localhost:4001/", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", 127.0.0.1:4001, Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) })
==> Connectivity restored for subgraph "ellie-test".
==> Schema change detected for subgraph: ellie-test
composing supergraph with Federation 2.13.3
==> Composition successful.
==> Attempting to start router at http://localhost:4000.
==> Health check exposed at http://127.0.0.1:8088/health
WARN: Connector debugging is enabled, this may expose sensitive information.
==> Your supergraph is running! head to http://localhost:4000 to query your supergraph
```

