### PR TITLE
Add --use-example-schema to publish commands for subgraph bootstrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 📚 Documentation -->
 
+# [Unreleased]
+
+## 🚀 Features
+
+- **Add `--use-example-schema` flag to `subgraph publish`**
+
+  Allows publishing a placeholder schema without needing to provide your own schema file. This is useful for setting up your graph structure before your actual schemas are ready. The placeholder schema is `type Query { helloWorld: String }` with a routing URL of `https://example.com`.
+
 # [0.38.1] - 2026-04-22
 
 ## 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🚀 Features
 
-- **Add `--use-example-schema` flag to `subgraph publish`**
+- **Add `--use-example-schema` flag to `subgraph publish` - @samaanghani PR #3218**
 
   Allows publishing a placeholder schema without needing to provide your own schema file. This is useful for setting up your graph structure before your actual schemas are ready. The placeholder schema is `type Query { helloWorld: String }` with a routing URL of `https://example.com`.
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -202,7 +202,7 @@ Alternatively, you can provide `-`, in which case the command uses an SDL string
 
 **Required unless `--schema` is provided.** Publish using a placeholder example schema (`type Query { helloWorld: String }`) and routing URL (`https://example.com`) instead of providing your own.
 
-This helps you set up your graph structure before your actual schemas are ready—for example, when creating a new supergraph and its initial subgraphs, or adding a new subgraph to an existing supergraph.
+Use this option to set up your graph structure before your actual schemas are ready, such as when you create a new supergraph and its initial subgraphs.
 
 </td>
 </tr>

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -184,9 +184,25 @@ Options include:
 </td>
 <td>
 
-**Required.** The path to a local `.graphql` or `.gql` file, in SDL format.
+**Required unless `--use-example-schema` is provided.** The path to a local `.graphql` or `.gql` file, in SDL format.
 
 Alternatively, you can provide `-`, in which case the command uses an SDL string piped to `stdin` instead (see [Using `stdin`](../conventions#using-stdin)).
+
+</td>
+</tr>
+
+<tr class="required">
+<td>
+
+###### `--use-example-schema`
+
+</td>
+
+<td>
+
+**Required unless `--schema` is provided.** Publish using a placeholder example schema (`type Query { helloWorld: String }`) and routing URL (`https://example.com`) instead of providing your own.
+
+This helps you set up your graph structure before your actual schemas are ready—for example, when creating a new supergraph and its initial subgraphs, or adding a new subgraph to an existing supergraph.
 
 </td>
 </tr>

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -41,7 +41,8 @@ pub struct Publish {
 
     /// Url of a running subgraph that a supergraph can route operations to
     /// (often a deployed subgraph). May be left empty ("") or a placeholder url
-    /// if not running a gateway or router in managed federation mode
+    /// if not running a gateway or router in managed federation mode.
+    /// Not required if `--use-example-schema` is provided.
     #[arg(long)]
     #[serde(skip_serializing)]
     routing_url: Option<String>,

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use crate::{
     RoverError, RoverErrorSuggestion, RoverOutput, RoverResult,
-    options::{GraphRefOpt, ProfileOpt, SchemaOpt, SubgraphOpt},
+    options::{GraphRefOpt, OptionalSchemaOpt, ProfileOpt, SubgraphOpt},
     utils::client::StudioClientConfig,
 };
 
@@ -33,7 +33,7 @@ pub struct Publish {
 
     #[clap(flatten)]
     #[serde(skip_serializing)]
-    schema: SchemaOpt,
+    schema: OptionalSchemaOpt,
 
     /// Indicate whether to convert a non-federated graph into a subgraph
     #[arg(short, long)]
@@ -66,25 +66,38 @@ impl Publish {
     ) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
 
-        let url = Self::determine_routing_url(
-            self.no_url,
-            &self.routing_url,
-            self.allow_invalid_routing_url,
-            || async {
-                Ok(routing_url::run(
-                    SubgraphRoutingUrlInput {
-                        graph_ref: self.graph.graph_ref.clone(),
-                        subgraph_name: self.subgraph.subgraph_name.clone(),
-                    },
-                    &client,
-                )
-                .await?)
-            },
-            &mut io::stderr(),
-            &mut io::stdin(),
-            io::stderr().is_terminal() && io::stdin().is_terminal(),
-        )
-        .await?;
+        let (url, schema) = if self.schema.is_using_example_schema() {
+            (
+                Some(OptionalSchemaOpt::example_url().to_string()),
+                OptionalSchemaOpt::example_schema().to_string(),
+            )
+        } else {
+            let url = Self::determine_routing_url(
+                self.no_url,
+                &self.routing_url,
+                self.allow_invalid_routing_url,
+                || async {
+                    Ok(routing_url::run(
+                        SubgraphRoutingUrlInput {
+                            graph_ref: self.graph.graph_ref.clone(),
+                            subgraph_name: self.subgraph.subgraph_name.clone(),
+                        },
+                        &client,
+                    )
+                    .await?)
+                },
+                &mut io::stderr(),
+                &mut io::stdin(),
+                io::stderr().is_terminal() && io::stdin().is_terminal(),
+            )
+            .await?;
+
+            let schema = self
+                .schema
+                .read_file_descriptor("SDL", &mut std::io::stdin())?;
+
+            (url, schema)
+        };
 
         eprintln!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
@@ -92,10 +105,6 @@ impl Publish {
             Style::Link.paint(&self.subgraph.subgraph_name),
             Style::Command.paint(&self.profile.profile_name)
         );
-
-        let schema = self
-            .schema
-            .read_file_descriptor("SDL", &mut std::io::stdin())?;
 
         tracing::debug!("Publishing \n{}", &schema);
 

--- a/src/options/schema.rs
+++ b/src/options/schema.rs
@@ -1,9 +1,11 @@
 use clap::Parser;
-
 use crate::{
     RoverResult,
     utils::{effect::read_stdin::ReadStdin, parsers::FileDescriptorType},
 };
+
+const EXAMPLE_SCHEMA: &str = "type Query { helloWorld: String }";
+const EXAMPLE_URL: &str = "https://example.com";
 
 #[derive(Debug, Parser)]
 pub struct SchemaOpt {
@@ -45,5 +47,144 @@ impl SchemaOpt {
             }),
             Err(e) => Err(e),
         }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct OptionalSchemaOpt {
+    /// The schema file to publish. You can pass `-` to use stdin instead of a file.
+    #[arg(
+        long,
+        short = 's',
+        required_unless_present = "use_example_schema",
+        conflicts_with = "use_example_schema"
+    )]
+    schema: Option<FileDescriptorType>,
+
+    #[arg(long)]
+    use_example_schema: bool,
+}
+
+impl OptionalSchemaOpt {
+    pub fn is_using_example_schema(&self) -> bool {
+        self.use_example_schema
+    }
+
+    pub fn example_schema() -> &'static str {
+        EXAMPLE_SCHEMA
+    }
+
+    pub fn example_url() -> &'static str {
+        EXAMPLE_URL
+    }
+
+    pub(crate) fn read_file_descriptor(
+        &self,
+        file_description: &str,
+        read_stdin_impl: &mut impl ReadStdin,
+    ) -> RoverResult<String> {
+        self.schema
+            .as_ref()
+            .expect("schema is required unless use_example_schema is set")
+            .read_file_descriptor(file_description, read_stdin_impl)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[derive(Debug, Parser)]
+    struct TestCmd {
+        #[clap(flatten)]
+        schema: OptionalSchemaOpt,
+
+        #[arg(long)]
+        name: String,
+    }
+
+    #[test]
+    fn test_use_example_schema_returns_correct_values() {
+        let cmd = TestCmd::try_parse_from([
+            "test",
+            "--name",
+            "my-subgraph",
+            "--use-example-schema",
+        ])
+        .unwrap();
+
+        assert!(cmd.schema.is_using_example_schema());
+        assert_eq!(
+            OptionalSchemaOpt::example_schema(),
+            "type Query { helloWorld: String }"
+        );
+        assert_eq!(OptionalSchemaOpt::example_url(), "https://example.com");
+        assert_eq!(cmd.name, "my-subgraph");
+    }
+
+    #[test]
+    fn test_schema_flag_works_without_example() {
+        let cmd = TestCmd::try_parse_from([
+            "test",
+            "--name",
+            "my-subgraph",
+            "--schema",
+            "./my-schema.graphql",
+        ])
+        .unwrap();
+
+        assert!(!cmd.schema.is_using_example_schema());
+        assert!(cmd.schema.schema.is_some());
+        assert_eq!(cmd.name, "my-subgraph");
+    }
+
+    #[test]
+    fn test_error_when_both_schema_and_use_example_schema_provided() {
+        let result = TestCmd::try_parse_from([
+            "test",
+            "--name",
+            "my-subgraph",
+            "--schema",
+            "./my-schema.graphql",
+            "--use-example-schema",
+        ]);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("cannot be used with"),
+            "Expected conflict error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_error_when_neither_schema_nor_use_example_schema_provided() {
+        let result = TestCmd::try_parse_from(["test", "--name", "my-subgraph"]);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--schema") || err.contains("required"),
+            "Expected missing argument error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_both_options_appear_in_help() {
+        let help = TestCmd::command().render_help().to_string();
+
+        assert!(
+            help.contains("--schema"),
+            "Help should contain --schema option"
+        );
+        assert!(
+            help.contains("--use-example-schema"),
+            "Help should contain --use-example-schema option"
+        );
+        assert!(
+            help.contains("-s"),
+            "Help should contain -s short option for schema"
+        );
     }
 }

--- a/src/options/schema.rs
+++ b/src/options/schema.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+
 use crate::{
     RoverResult,
     utils::{effect::read_stdin::ReadStdin, parsers::FileDescriptorType},
@@ -53,6 +54,7 @@ impl SchemaOpt {
 #[derive(Debug, Parser)]
 pub struct OptionalSchemaOpt {
     /// The schema file to publish. You can pass `-` to use stdin instead of a file.
+    /// Not required if `--use-example-schema` is provided.
     #[arg(
         long,
         short = 's',
@@ -61,20 +63,22 @@ pub struct OptionalSchemaOpt {
     )]
     schema: Option<FileDescriptorType>,
 
+    /// Publish using a placeholder example schema instead of providing your own.
+    /// Useful for setting up your graph structure before your actual schema is ready.
     #[arg(long)]
     use_example_schema: bool,
 }
 
 impl OptionalSchemaOpt {
-    pub fn is_using_example_schema(&self) -> bool {
+    pub const fn is_using_example_schema(&self) -> bool {
         self.use_example_schema
     }
 
-    pub fn example_schema() -> &'static str {
+    pub const fn example_schema() -> &'static str {
         EXAMPLE_SCHEMA
     }
 
-    pub fn example_url() -> &'static str {
+    pub const fn example_url() -> &'static str {
         EXAMPLE_URL
     }
 
@@ -92,8 +96,9 @@ impl OptionalSchemaOpt {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use clap::{CommandFactory, Parser};
+
+    use super::*;
 
     #[derive(Debug, Parser)]
     struct TestCmd {
@@ -106,13 +111,9 @@ mod tests {
 
     #[test]
     fn test_use_example_schema_returns_correct_values() {
-        let cmd = TestCmd::try_parse_from([
-            "test",
-            "--name",
-            "my-subgraph",
-            "--use-example-schema",
-        ])
-        .unwrap();
+        let cmd =
+            TestCmd::try_parse_from(["test", "--name", "my-subgraph", "--use-example-schema"])
+                .unwrap();
 
         assert!(cmd.schema.is_using_example_schema());
         assert_eq!(

--- a/src/options/schema.rs
+++ b/src/options/schema.rs
@@ -52,15 +52,11 @@ impl SchemaOpt {
 }
 
 #[derive(Debug, Parser)]
+#[group(required = true, multiple = false)]
 pub struct OptionalSchemaOpt {
     /// The schema file to publish. You can pass `-` to use stdin instead of a file.
     /// Not required if `--use-example-schema` is provided.
-    #[arg(
-        long,
-        short = 's',
-        required_unless_present = "use_example_schema",
-        conflicts_with = "use_example_schema"
-    )]
+    #[arg(long, short = 's')]
     schema: Option<FileDescriptorType>,
 
     /// Publish using a placeholder example schema instead of providing your own.

--- a/tests/e2e/subgraph/publish.rs
+++ b/tests/e2e/subgraph/publish.rs
@@ -4,6 +4,7 @@ use assert_cmd::cargo;
 use rand::RngExt;
 use rstest::rstest;
 use serde::Deserialize;
+use serde_json::Value;
 use speculoos::{assert_that, iter::ContainingIntoIterAssertions};
 use tracing::{error, info};
 use tracing_test::traced_test;
@@ -113,6 +114,133 @@ async fn e2e_test_rover_subgraph_publish(
     // left with subgraphs lying around. In the future we should move to something like
     // test-context (https://docs.rs/test-context/latest/test_context/) so that we get cleanup
     // for free. Until then we can manually clean up if it becomes necessary.
+    let mut subgraph_delete_cmd = Command::new(cargo::cargo_bin!("rover"));
+    subgraph_delete_cmd.args([
+        "subgraph",
+        "delete",
+        "--name",
+        &id,
+        "--confirm",
+        "--client-timeout",
+        "120",
+        &remote_supergraph_publish_test_variant_graphref,
+    ]);
+
+    let delete_output = subgraph_delete_cmd.output().expect("Could not run command");
+
+    if !delete_output.status.success() {
+        error!("{}", String::from_utf8(delete_output.stderr).unwrap());
+        panic!("Command did not complete successfully");
+    }
+}
+
+#[rstest]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+async fn e2e_test_rover_subgraph_publish_with_example_schema(
+    remote_supergraph_publish_test_variant_graphref: String,
+) {
+    // Generate a unique identifier for the subgraph name
+    let mut rng = rand::rng();
+    let id_regex = rand_regex::Regex::compile("[a-zA-Z][a-zA-Z0-9_-]{63}", 0)
+        .expect("Could not compile regex");
+    let id: String = rng.sample::<String, &rand_regex::Regex>(&id_regex);
+    info!("Using name {} for subgraph with example schema", &id);
+
+    // Grab the initial list of subgraphs to check that what we want doesn't already exist
+    let mut subgraph_list_cmd = Command::new(cargo::cargo_bin!("rover"));
+    subgraph_list_cmd.args([
+        "subgraph",
+        "list",
+        &remote_supergraph_publish_test_variant_graphref,
+        "--format",
+        "json",
+    ]);
+    let list_cmd_output = subgraph_list_cmd
+        .output()
+        .expect("Could not run initial list command");
+    let resp: SubgraphListResponse = serde_json::from_slice(list_cmd_output.stdout.as_slice())
+        .unwrap_or_else(|_| {
+            panic!(
+                "Could not parse response to struct - Raw: {}",
+                from_utf8(list_cmd_output.stdout.as_slice()).unwrap()
+            )
+        });
+    let initial_subgraphs = resp.get_subgraph_names();
+    assert_that(&initial_subgraphs).does_not_contain(&id);
+
+    // Publish a subgraph using --use-example-schema instead of --schema and --routing-url
+    info!("Creating subgraph with name {} using example schema", &id);
+    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+    cmd.args([
+        "subgraph",
+        "publish",
+        "--name",
+        &id,
+        "--use-example-schema",
+        "--client-timeout",
+        "120",
+        "--format",
+        "json",
+        &remote_supergraph_publish_test_variant_graphref,
+    ]);
+    let output = cmd.output().expect("Could not run command");
+
+    if !output.status.success() {
+        error!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        error!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("Command did not complete successfully");
+    }
+
+    // Verify stderr contains expected message about subgraph creation
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("was created") || stderr.contains("published"),
+        "Expected stderr to contain creation/publish message, got: {}",
+        stderr
+    );
+
+    // Parse JSON response and verify subgraph_was_created and no build errors
+    let json_response: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+        panic!(
+            "Could not parse publish response as JSON - Raw: {}",
+            from_utf8(&output.stdout).unwrap()
+        )
+    });
+
+    let data = json_response
+        .get("data")
+        .expect("Response should have 'data' field");
+
+    assert_eq!(
+        data.get("subgraph_was_created"),
+        Some(&Value::Bool(true)),
+        "Expected subgraph_was_created to be true"
+    );
+
+    // Verify build_errors is empty (null or empty array)
+    let build_errors = data.get("build_errors");
+    assert!(
+        build_errors.is_none()
+            || build_errors == Some(&Value::Null)
+            || build_errors == Some(&Value::Array(vec![])),
+        "Expected no build errors, got: {:?}",
+        build_errors
+    );
+
+    // Also verify via list that the subgraph was created
+    let post_creation_output = subgraph_list_cmd
+        .output()
+        .expect("Could not run list command after creating new variant");
+    let post_creation_resp: SubgraphListResponse =
+        serde_json::from_slice(post_creation_output.stdout.as_slice())
+            .expect("Could not parse response to struct");
+    let final_subgraphs = post_creation_resp.get_subgraph_names();
+    assert_that(&final_subgraphs).contains(&id);
+
+    // Clean up by deleting the subgraph
+    info!("Deleting subgraph with name {}", &id);
     let mut subgraph_delete_cmd = Command::new(cargo::cargo_bin!("rover"));
     subgraph_delete_cmd.args([
         "subgraph",

--- a/tests/e2e/subgraph/publish.rs
+++ b/tests/e2e/subgraph/publish.rs
@@ -193,11 +193,11 @@ async fn e2e_test_rover_subgraph_publish_with_example_schema(
         panic!("Command did not complete successfully");
     }
 
-    // Verify stderr contains expected message about subgraph creation
+    // Verify stderr contains expected message about publishing
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("was created") || stderr.contains("published"),
-        "Expected stderr to contain creation/publish message, got: {}",
+        stderr.contains("Publishing SDL"),
+        "Expected stderr to contain 'Publishing SDL' message, got: {}",
         stderr
     );
 


### PR DESCRIPTION
### Summary
Adds a new --use-example-schema flag to rover subgraph publish command. This allows users to publish a placeholder schema without needing to provide their own schema file.

Use case: Customers often want to set up their subgraph structure before their actual schemas are ready. This flag lets them scaffold their graph infrastructure first, then replace the placeholders with real schemas later.

When using `--use-example-schema`:

Schema: type Query { helloWorld: String }
Routing URL (subgraph only): https://example.com

### Changes

- src/options/schema.rs: Added OptionalSchemaOpt struct with conditional --schema and --use-example-schema flags
- src/utils/parsers.rs: Moved FileWithMetadata and read_file_descriptor_with_metadata to FileDescriptorType
- src/command/subgraph/publish.rs: Updated to use OptionalSchemaOpt
- docs/source/commands/subgraphs.mdx: Added documentation for new flag
- tests/e2e/subgraph/publish.rs: Added e2e test for --use-example-schema

### Test Plan

- Unit tests for OptionalSchemaOpt argument parsing added + pass (`cargo test options::schema::tests`)
- Existing subgraph publish unit tests pass (`cargo test command::subgraph::publish::tests`)
- E2E tests added + pass (`cargo test e2e -- --ignored`)
- `cargo check` passes
- `cargo clippy `passes
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->
