### PR TITLE
feat(client extract): wire rover client extract command

### DIFF
--- a/src/command/client/extract/file.rs
+++ b/src/command/client/extract/file.rs
@@ -1,0 +1,176 @@
+use camino::{Utf8Path, Utf8PathBuf};
+use rover_std::{Fs, RoverStdError};
+
+use super::{
+    documents::{ExtractDocuments, SkippedDocument},
+    language::{ExtractLanguage, UnsupportedExtractExtension},
+    types::MaterializedFile,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum MaterializeFileError {
+    #[error("Failed to detect a file extension for path: {}", .path)]
+    NoExtension { path: Utf8PathBuf },
+    #[error(transparent)]
+    UnsupportedExtension(#[from] UnsupportedExtractExtension),
+    #[error("Failed to read file: {}. {}", .path, .err)]
+    FileReadError {
+        path: Utf8PathBuf,
+        err: RoverStdError,
+    },
+    #[error("Failed to write file: {}. {}", .path, .err)]
+    FileWriteError {
+        path: Utf8PathBuf,
+        err: RoverStdError,
+    },
+    #[error("No documents found in file: {}", .path)]
+    NoDocuments {
+        path: Utf8PathBuf,
+        skipped: Vec<SkippedDocument>,
+    },
+}
+
+#[derive(Clone, Debug, bon::Builder)]
+pub struct MaterializeFileOptions {
+    overwrite: bool,
+    out_dir: Utf8PathBuf,
+}
+
+#[derive(Clone, Debug, bon::Builder)]
+pub struct ExtractFile {
+    root_dir: Utf8PathBuf,
+    path: Utf8PathBuf,
+}
+
+impl ExtractFile {
+    pub fn materialize(
+        &self,
+        options: &MaterializeFileOptions,
+    ) -> Result<(MaterializedFile, Vec<SkippedDocument>), MaterializeFileError> {
+        let language = self
+            .path
+            .extension()
+            .ok_or_else(|| MaterializeFileError::NoExtension {
+                path: self.path.clone(),
+            })
+            .and_then(|ext| {
+                ExtractLanguage::from_extension(ext).map_err(MaterializeFileError::from)
+            })?;
+        let contents =
+            Fs::read_file(&self.path).map_err(|err| MaterializeFileError::FileReadError {
+                path: self.path.clone(),
+                err,
+            })?;
+        let result = language.extract_documents(&contents);
+        if result.documents.is_empty() {
+            Err(MaterializeFileError::NoDocuments {
+                path: self.path.clone(),
+                skipped: result.skipped,
+            })
+        } else {
+            let relative = relative_to_root(&self.path, &self.root_dir);
+            let target = options.out_dir.join(relative).with_extension("graphql");
+            let target = resolve_target(&target, options.overwrite);
+            if let Some(parent) = target.parent() {
+                let _ = Fs::create_dir_all(parent);
+            }
+            let body = result
+                .documents
+                .iter()
+                .map(|doc| doc.content.clone())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            Fs::write_file(&target, body).map_err(|err| MaterializeFileError::FileWriteError {
+                path: self.path.clone(),
+                err,
+            })?;
+            Ok((
+                MaterializedFile {
+                    source: self.path.clone(),
+                    target,
+                    documents_count: result.documents.len(),
+                },
+                result.skipped,
+            ))
+        }
+    }
+}
+
+fn resolve_target(target: &Utf8Path, overwrite: bool) -> Utf8PathBuf {
+    if overwrite {
+        return target.to_path_buf();
+    }
+    match Fs::metadata(target) {
+        Ok(_) => {
+            let mut generated = target.to_path_buf();
+            if let Some(stem) = target.file_stem() {
+                let parent = target.parent().unwrap_or(target);
+                generated = parent.join(format!("{stem}.generated.graphql"));
+            }
+            generated
+        }
+        Err(_) => target.to_path_buf(),
+    }
+}
+
+fn relative_to_root(file: &Utf8Path, root: &Utf8Path) -> Utf8PathBuf {
+    if let Ok(rel) = file.strip_prefix(root) {
+        return rel.to_path_buf();
+    }
+    if let (Ok(canon_file), Ok(canon_root)) = (file.canonicalize_utf8(), root.canonicalize_utf8())
+        && let Ok(rel) = canon_file.strip_prefix(&canon_root)
+    {
+        return rel.to_path_buf();
+    }
+    file.file_name()
+        .map(Utf8PathBuf::from)
+        .unwrap_or_else(|| file.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use speculoos::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn resolve_target_with_overwrite_returns_original_path() {
+        let target = Utf8PathBuf::from("/nonexistent/path/query.graphql");
+        assert_that!(resolve_target(&target, true)).is_equal_to(target);
+    }
+
+    #[test]
+    fn resolve_target_without_overwrite_nonexistent_file_returns_original_path() {
+        let target = Utf8PathBuf::from("/nonexistent/path/query.graphql");
+        assert_that!(resolve_target(&target, false)).is_equal_to(target);
+    }
+
+    #[test]
+    fn resolve_target_without_overwrite_existing_file_appends_generated_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("query.graphql");
+        std::fs::write(&path, "").unwrap();
+        let target = Utf8PathBuf::from_path_buf(path).unwrap();
+
+        let result = resolve_target(&target, false);
+
+        assert_that!(result.as_str()).contains("query.generated.graphql");
+    }
+
+    #[test]
+    fn relative_to_root_strips_prefix_for_file_under_root() {
+        let root = Utf8PathBuf::from("/project/src");
+        let file = Utf8PathBuf::from("/project/src/components/Query.ts");
+
+        assert_that!(relative_to_root(&file, &root))
+            .is_equal_to(Utf8PathBuf::from("components/Query.ts"));
+    }
+
+    #[test]
+    fn relative_to_root_falls_back_to_filename_when_not_under_root() {
+        let root = Utf8PathBuf::from("/other/path");
+        let file = Utf8PathBuf::from("/project/src/Query.ts");
+
+        assert_that!(relative_to_root(&file, &root)).is_equal_to(Utf8PathBuf::from("Query.ts"));
+    }
+}

--- a/src/command/client/extract/file.rs
+++ b/src/command/client/extract/file.rs
@@ -2,9 +2,9 @@ use camino::{Utf8Path, Utf8PathBuf};
 use rover_std::{Fs, RoverStdError};
 
 use super::{
+    MaterializedFile,
     documents::{ExtractDocuments, SkippedDocument},
     language::{ExtractLanguage, UnsupportedExtractExtension},
-    MaterializedFile,
 };
 
 #[derive(thiserror::Error, Debug)]

--- a/src/command/client/extract/file.rs
+++ b/src/command/client/extract/file.rs
@@ -4,7 +4,7 @@ use rover_std::{Fs, RoverStdError};
 use super::{
     documents::{ExtractDocuments, SkippedDocument},
     language::{ExtractLanguage, UnsupportedExtractExtension},
-    types::MaterializedFile,
+    MaterializedFile,
 };
 
 #[derive(thiserror::Error, Debug)]

--- a/src/command/client/extract/file.rs
+++ b/src/command/client/extract/file.rs
@@ -74,24 +74,25 @@ impl ExtractFile {
             if let Some(parent) = target.parent() {
                 let _ = Fs::create_dir_all(parent);
             }
+            let output = (
+                MaterializedFile {
+                    source: self.path.clone(),
+                    target: target.clone(),
+                    documents_count: result.documents.len(),
+                },
+                result.skipped,
+            );
             let body = result
                 .documents
-                .iter()
-                .map(|doc| doc.content.clone())
+                .into_iter()
+                .map(|doc| doc.content)
                 .collect::<Vec<_>>()
                 .join("\n\n");
             Fs::write_file(&target, body).map_err(|err| MaterializeFileError::FileWriteError {
                 path: self.path.clone(),
                 err,
             })?;
-            Ok((
-                MaterializedFile {
-                    source: self.path.clone(),
-                    target,
-                    documents_count: result.documents.len(),
-                },
-                result.skipped,
-            ))
+            Ok(output)
         }
     }
 }

--- a/src/command/client/extract/mod.rs
+++ b/src/command/client/extract/mod.rs
@@ -1,12 +1,19 @@
-#![allow(dead_code)]
-
 mod documents;
+mod file;
 mod graphql;
 mod language;
+mod output;
 
-use camino::Utf8PathBuf;
+use anyhow::anyhow;
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::{Parser, ValueEnum};
 use documents::SkippedDocument;
+use file::{ExtractFile, MaterializeFileError, MaterializeFileOptions};
+use itertools::{Either, Itertools};
+use rover_std::FileSearch;
 use serde::Serialize;
+
+use crate::{RoverError, RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize)]
 pub struct ExtractedDocument {
@@ -34,4 +41,172 @@ pub struct ExtractionSummary {
     pub source_files_with_graphql: usize,
     pub documents_extracted: usize,
     pub documents_skipped: usize,
+}
+
+#[derive(Debug, Serialize, Parser)]
+pub struct Extract {
+    /// Glob patterns to include (e.g. `src/**/*.ts`). Defaults to all supported extensions.
+    #[arg(long = "include", value_name = "PATTERN", action = clap::ArgAction::Append)]
+    include: Vec<String>,
+
+    /// Glob patterns to exclude (e.g. `**/__generated__/**`).
+    #[arg(long = "exclude", value_name = "PATTERN", action = clap::ArgAction::Append)]
+    exclude: Vec<String>,
+
+    /// Restrict extraction to these languages.
+    #[arg(
+        long = "language",
+        value_enum,
+        action = clap::ArgAction::Append,
+        value_name = "LANG"
+    )]
+    language: Vec<LanguageOpt>,
+
+    /// Root directory to scan. Defaults to the current working directory.
+    #[arg(long = "root-dir", value_name = "DIR")]
+    root_dir: Option<Utf8PathBuf>,
+
+    /// Output directory for .graphql files.
+    #[arg(long = "out-dir", value_name = "DIR", default_value = "graphql")]
+    out_dir: Utf8PathBuf,
+
+    /// Overwrite existing .graphql files when conflicts occur.
+    #[arg(long = "overwrite")]
+    overwrite: bool,
+}
+
+#[derive(Clone, Debug, Serialize, ValueEnum)]
+pub enum LanguageOpt {
+    Ts,
+    Swift,
+    Kotlin,
+}
+
+impl LanguageOpt {
+    const fn extensions(&self) -> &'static [&'static str] {
+        match self {
+            LanguageOpt::Ts => &["ts", "tsx"],
+            LanguageOpt::Swift => &["swift"],
+            LanguageOpt::Kotlin => &["kt", "kts"],
+        }
+    }
+}
+
+impl Extract {
+    pub async fn run(&self) -> RoverResult<RoverOutput> {
+        let root = match &self.root_dir {
+            Some(r) => r.clone(),
+            None => {
+                let cwd = std::env::current_dir()?;
+                Utf8PathBuf::from_path_buf(cwd)
+                    .map_err(|_| RoverError::new(anyhow!("current directory is not utf-8")))?
+            }
+        };
+        let out_dir = absolutize(&root, &self.out_dir);
+
+        let extensions: Vec<&str> = if self.language.is_empty() {
+            all_languages()
+        } else {
+            self.language
+                .iter()
+                .flat_map(LanguageOpt::extensions)
+                .copied()
+                .collect()
+        };
+
+        let files = FileSearch::builder()
+            .root(root.clone())
+            .includes(self.include.clone())
+            .excludes(self.exclude.clone())
+            .build()
+            .find(&extensions)?;
+
+        let mut summary = ExtractionSummary {
+            out_dir: out_dir.clone(),
+            source_files_processed: files.len(),
+            ..Default::default()
+        };
+
+        let options = MaterializeFileOptions::builder()
+            .overwrite(self.overwrite)
+            .out_dir(out_dir)
+            .build();
+
+        let (successes, failures): (Vec<_>, Vec<_>) = files.iter().partition_map(|file| {
+            match ExtractFile::builder()
+                .root_dir(root.clone())
+                .path(file.clone())
+                .build()
+                .materialize(&options)
+            {
+                Ok((materialized, skipped)) => Either::Left((file.clone(), materialized, skipped)),
+                Err(err) => Either::Right((file.clone(), err)),
+            }
+        });
+
+        let mut materialized = Vec::new();
+        let mut skipped = Vec::new();
+
+        for (path, mat, doc_skipped) in successes {
+            summary.source_files_with_graphql += 1;
+            summary.documents_extracted += mat.documents_count;
+            summary.documents_skipped += doc_skipped.len();
+            skipped.extend(doc_skipped.into_iter().map(|s| (path.clone(), s)));
+            materialized.push(mat);
+        }
+
+        for (path, err) in failures {
+            if let MaterializeFileError::NoDocuments {
+                skipped: doc_skipped,
+                ..
+            } = err
+            {
+                summary.documents_skipped += doc_skipped.len();
+                skipped.extend(doc_skipped.into_iter().map(|s| (path.clone(), s)));
+            } else {
+                tracing::info!("skipping {path}: {err}");
+            }
+        }
+
+        Ok(RoverOutput::CliOutput(Box::new(
+            output::ClientExtractOutput {
+                summary,
+                files: materialized,
+                skipped,
+            },
+        )))
+    }
+}
+
+fn absolutize(root: &Utf8Path, path: &Utf8Path) -> Utf8PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn all_languages() -> Vec<&'static str> {
+    vec!["ts", "tsx", "swift", "kt", "kts"]
+}
+
+#[cfg(test)]
+mod tests {
+    use speculoos::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn absolutize_returns_absolute_path_unchanged() {
+        let root = Utf8PathBuf::from("/project");
+        let path = Utf8PathBuf::from("/other/absolute/path");
+        assert_that!(absolutize(&root, &path)).is_equal_to(path);
+    }
+
+    #[test]
+    fn absolutize_joins_relative_path_with_root() {
+        let root = Utf8PathBuf::from("/project");
+        let path = Utf8PathBuf::from("graphql");
+        assert_that!(absolutize(&root, &path)).is_equal_to(Utf8PathBuf::from("/project/graphql"));
+    }
 }

--- a/src/command/client/extract/output.rs
+++ b/src/command/client/extract/output.rs
@@ -1,0 +1,166 @@
+use camino::Utf8PathBuf;
+use serde::Serialize;
+use serde_json::json;
+
+use super::{
+    documents::SkippedDocument,
+    types::{ExtractionSummary, MaterializedFile},
+};
+use crate::command::CliOutput;
+
+#[derive(Debug, Serialize)]
+pub struct ClientExtractOutput {
+    pub summary: ExtractionSummary,
+    pub files: Vec<MaterializedFile>,
+    pub skipped: Vec<(Utf8PathBuf, SkippedDocument)>,
+}
+
+impl CliOutput for ClientExtractOutput {
+    fn text(&self) -> String {
+        let out_dir = self
+            .summary
+            .out_dir
+            .canonicalize_utf8()
+            .unwrap_or_else(|_| self.summary.out_dir.clone());
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "Processed {} source files; {} contained GraphQL.",
+            self.summary.source_files_processed, self.summary.source_files_with_graphql
+        ));
+        if !self.files.is_empty() {
+            lines.push(format!(
+                "Wrote {} documents to {}",
+                self.summary.documents_extracted, out_dir
+            ));
+        }
+        if !self.skipped.is_empty() {
+            lines.push("Skipped documents:".to_string());
+            for (file, s) in &self.skipped {
+                let full_path = file.canonicalize_utf8().unwrap_or_else(|_| file.clone());
+                lines.push(format!("  {}:{} {}", full_path, s.line, s.reason));
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        let out_dir = self
+            .summary
+            .out_dir
+            .canonicalize_utf8()
+            .unwrap_or_else(|_| self.summary.out_dir.clone());
+        Ok(json!({
+            "client_extract": {
+                "out_dir": out_dir,
+                "source_files_processed": self.summary.source_files_processed,
+                "source_files_with_graphql": self.summary.source_files_with_graphql,
+                "documents_extracted": self.summary.documents_extracted,
+                "documents_skipped": self.summary.documents_skipped,
+                "files": self.files.iter().map(|f| json!({
+                    "source": f.source,
+                    "target": f.target,
+                    "documents": f.documents_count
+                })).collect::<Vec<_>>(),
+                "skipped": self.skipped.iter().map(|(source, s)| {
+                    let full_path = source
+                        .canonicalize_utf8()
+                        .unwrap_or_else(|_| source.clone());
+                    json!({
+                        "source": full_path,
+                        "line": s.line,
+                        "reason": s.reason.to_string(),
+                    })
+                }).collect::<Vec<_>>(),
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use speculoos::prelude::*;
+
+    use super::*;
+    use crate::command::client::extract::{
+        documents::{SkipReason, SkippedDocument},
+        types::{ExtractionSummary, MaterializedFile},
+    };
+
+    fn make_output(
+        files: Vec<MaterializedFile>,
+        skipped: Vec<(Utf8PathBuf, SkippedDocument)>,
+    ) -> ClientExtractOutput {
+        let documents_extracted: usize = files.iter().map(|f| f.documents_count).sum();
+        let documents_skipped = skipped.len();
+        ClientExtractOutput {
+            summary: ExtractionSummary {
+                out_dir: Utf8PathBuf::from("graphql"),
+                source_files_processed: 5,
+                source_files_with_graphql: files.len(),
+                documents_extracted,
+                documents_skipped,
+            },
+            files,
+            skipped,
+        }
+    }
+
+    #[test]
+    fn text_includes_source_file_counts() {
+        let output = make_output(vec![], vec![]);
+        let text = output.text();
+
+        assert_that!(&text).contains("5 source files");
+        assert_that!(&text).contains("0 contained GraphQL");
+    }
+
+    #[test]
+    fn text_includes_skipped_document_details_when_present() {
+        let skipped = vec![(
+            Utf8PathBuf::from("src/Query.ts"),
+            SkippedDocument {
+                line: 3,
+                reason: SkipReason::UnsupportedInterpolation,
+            },
+        )];
+        let output = make_output(vec![], skipped);
+        let text = output.text();
+
+        assert_that!(&text).contains("Skipped documents:");
+        assert_that!(&text).contains("src/Query.ts");
+        assert_that!(&text).contains(
+            "contains a template interpolation (${...}); only static strings can be extracted",
+        );
+    }
+
+    #[test]
+    fn json_contains_expected_top_level_keys() {
+        let output = make_output(vec![], vec![]);
+        let json_result = output.json();
+        let value = assert_that!(json_result).is_ok().subject;
+
+        let extract = &value["client_extract"];
+        assert_that!(&extract["source_files_processed"]).is_equal_to(serde_json::json!(5));
+        assert_that!(&extract["source_files_with_graphql"]).is_equal_to(serde_json::json!(0));
+        assert_that!(&extract["documents_extracted"]).is_equal_to(serde_json::json!(0));
+        assert_that!(&extract["out_dir"]).is_equal_to(serde_json::json!("graphql"));
+    }
+
+    #[test]
+    fn json_files_array_contains_source_and_target() {
+        let files = vec![MaterializedFile {
+            source: Utf8PathBuf::from("src/Query.ts"),
+            target: Utf8PathBuf::from("graphql/src/Query.graphql"),
+            documents_count: 2,
+        }];
+        let output = make_output(files, vec![]);
+        let json_result = output.json();
+        let value = assert_that!(json_result).is_ok().subject;
+
+        let files_arr = &value["client_extract"]["files"];
+        assert_that!(&files_arr[0]["source"]).is_equal_to(serde_json::json!("src/Query.ts"));
+        assert_that!(&files_arr[0]["target"])
+            .is_equal_to(serde_json::json!("graphql/src/Query.graphql"));
+        assert_that!(&files_arr[0]["documents"]).is_equal_to(serde_json::json!(2));
+    }
+}

--- a/src/command/client/extract/output.rs
+++ b/src/command/client/extract/output.rs
@@ -2,11 +2,7 @@ use camino::Utf8PathBuf;
 use serde::Serialize;
 use serde_json::json;
 
-use super::{
-    documents::SkippedDocument,
-    ExtractionSummary,
-    MaterializedFile,
-};
+use super::{ExtractionSummary, MaterializedFile, documents::SkippedDocument};
 use crate::command::CliOutput;
 
 #[derive(Debug, Serialize)]
@@ -83,9 +79,8 @@ mod tests {
 
     use super::*;
     use crate::command::client::extract::{
+        ExtractionSummary, MaterializedFile,
         documents::{SkipReason, SkippedDocument},
-        ExtractionSummary,
-        MaterializedFile,
     };
 
     fn make_output(

--- a/src/command/client/extract/output.rs
+++ b/src/command/client/extract/output.rs
@@ -4,7 +4,8 @@ use serde_json::json;
 
 use super::{
     documents::SkippedDocument,
-    types::{ExtractionSummary, MaterializedFile},
+    ExtractionSummary,
+    MaterializedFile,
 };
 use crate::command::CliOutput;
 
@@ -83,7 +84,8 @@ mod tests {
     use super::*;
     use crate::command::client::extract::{
         documents::{SkipReason, SkippedDocument},
-        types::{ExtractionSummary, MaterializedFile},
+        ExtractionSummary,
+        MaterializedFile,
     };
 
     fn make_output(

--- a/src/command/client/mod.rs
+++ b/src/command/client/mod.rs
@@ -18,6 +18,9 @@ pub struct Client {
 pub enum Command {
     /// Validate operations in .graphql files against a graph
     Check(check::Check),
+
+    /// Extract GraphQL documents from source files into .graphql files
+    Extract(extract::Extract),
 }
 
 impl Client {
@@ -28,6 +31,7 @@ impl Client {
     ) -> RoverResult<RoverOutput> {
         match &self.command {
             Command::Check(command) => command.run(client_config, git_context).await,
+            Command::Extract(command) => command.run().await,
         }
     }
 }


### PR DESCRIPTION
## Summary

This is the second of three stacked PRs introducing `rover client extract`. It builds on the extraction engine from PR 1 and adds the CLI surface that makes it a runnable command.

**What's here:**

- `file.rs` — `ExtractFile::materialize()` reads a source file, runs the appropriate extractor, and writes the resulting documents to a `.graphql` file under `--out-dir`. Preserves relative directory structure from `--root-dir`. Conflict resolution: without `--overwrite`, an existing file gets a `.generated.graphql` suffix rather than being clobbered.
- `mod.rs` — the `Extract` clap struct (`--root-dir`, `--out-dir`, `--language`, `--include`, `--exclude`, `--overwrite`), file discovery via `FileSearch`, result aggregation (successes vs. files with no documents vs. hard errors), and wiring into the `rover client` command enum.
- `output.rs` — `CliOutput` implementation for both text and JSON. Text output canonicalizes paths so users see absolute paths regardless of where they invoked the command. JSON output follows the standard rover envelope (`json_version`, `data`, `error`) with a `client_extract` block containing counts, a `files` array, and a `skipped` array with per-document skip reasons rendered via their `Display` impl.
- `client/mod.rs` — registers `Extract` as a subcommand of `rover client`.

**Decisions worth reviewing:**

- Files with no extractable documents (all skipped or no tags at all) are not treated as errors — they produce entries in `skipped` but the command exits 0. Only hard I/O failures surface as errors.
- Overwrite conflict resolution produces a `.generated.graphql` suffix rather than failing, so a second run never destroys existing output.
- Skip reasons use `thiserror`'s `Display` in JSON output rather than `Debug`, so the messages are user-readable rather than variant names.

40 unit tests total (29 from PR 1 + 11 new covering file materialization, output formatting, path canonicalization, and overwrite behavior).
