### PR TITLE
Respect `--insecure-accept-invalid-certs` in `rover init --mcp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "apollo-parser 0.8.5",
  "ariadne",
  "backon",
+ "bon",
  "buildstructor",
  "camino",
  "chrono",

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -16,6 +16,7 @@ apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
 apollo-encoder = { workspace = true }
 backon = { workspace = true }
+bon = { workspace = true }
 buildstructor = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 comfy-table = { workspace = true, features = ["custom_styling"]}

--- a/crates/rover-client/src/operations/init/github/mod.rs
+++ b/crates/rover-client/src/operations/init/github/mod.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin};
 
 use reqwest::Client;
 use serde::Deserialize;
-use tower::{Service, util::BoxCloneService};
+use tower::{util::BoxCloneService, Service};
 
 use crate::error::RoverClientError;
 

--- a/crates/rover-client/src/operations/init/github/mod.rs
+++ b/crates/rover-client/src/operations/init/github/mod.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin};
 
 use reqwest::Client;
 use serde::Deserialize;
-use tower::{util::BoxCloneService, Service};
+use tower::{Service, util::BoxCloneService};
 
 use crate::error::RoverClientError;
 
@@ -29,7 +29,6 @@ impl From<GitHubServiceError> for RoverClientError {
 pub struct GitHubService {
     client: Client,
     base_url: String,
-    pub accept_invalid_certs: bool,
 }
 
 #[bon::bon]
@@ -43,11 +42,7 @@ impl GitHubService {
             .danger_accept_invalid_certs(accept_invalid_certs)
             .build()
             .expect("Failed to build HTTP client");
-        Self {
-            client,
-            base_url,
-            accept_invalid_certs,
-        }
+        Self { client, base_url }
     }
 }
 

--- a/crates/rover-client/src/operations/init/github/mod.rs
+++ b/crates/rover-client/src/operations/init/github/mod.rs
@@ -36,10 +36,8 @@ pub struct GitHubService {
 impl GitHubService {
     #[builder]
     pub fn new(
-        #[builder(default = "https://api.github.com".to_string())]
-        base_url: String,
-        #[builder(default)]
-        accept_invalid_certs: bool,
+        #[builder(default = "https://api.github.com".to_string())] base_url: String,
+        #[builder(default)] accept_invalid_certs: bool,
     ) -> Self {
         let client = Client::builder()
             .danger_accept_invalid_certs(accept_invalid_certs)

--- a/crates/rover-client/src/operations/init/github/mod.rs
+++ b/crates/rover-client/src/operations/init/github/mod.rs
@@ -29,26 +29,26 @@ impl From<GitHubServiceError> for RoverClientError {
 pub struct GitHubService {
     client: Client,
     base_url: String,
+    pub accept_invalid_certs: bool,
 }
 
-impl Default for GitHubService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
+#[bon::bon]
 impl GitHubService {
-    pub fn new() -> Self {
+    #[builder]
+    pub fn new(
+        #[builder(default = "https://api.github.com".to_string())]
+        base_url: String,
+        #[builder(default)]
+        accept_invalid_certs: bool,
+    ) -> Self {
+        let client = Client::builder()
+            .danger_accept_invalid_certs(accept_invalid_certs)
+            .build()
+            .expect("Failed to build HTTP client");
         Self {
-            client: Client::new(),
-            base_url: "https://api.github.com".to_string(),
-        }
-    }
-
-    pub fn with_base_url(base_url: String) -> Self {
-        Self {
-            client: Client::new(),
+            client,
             base_url,
+            accept_invalid_certs,
         }
     }
 }
@@ -190,7 +190,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_tar() {
-        let mut service = GitHubService::new();
+        let mut service = GitHubService::builder().build();
         let request = GetTarRequest::new(
             "apollographql".to_string(),
             "rover-init-starters".to_string(),

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -214,7 +214,10 @@ impl Init {
         };
 
         let creation_confirmed = match use_case_selected
-            .select_template(&self.project_template)
+            .select_template(
+                &self.project_template,
+                client_config.accept_invalid_certs(),
+            )
             .await?
             .enter_project_name(&self.project_name)?
             .confirm_graph_id(&self.graph_id)?
@@ -785,7 +788,8 @@ impl Init {
 
         // Fetch raw files from the add-mcp directory
         let branch_ref = "release/v3";
-        let mut template_fetcher = InitTemplateFetcher::new();
+        let mut template_fetcher =
+            InitTemplateFetcher::new(client_config.accept_invalid_certs());
         let template_options = template_fetcher.call(branch_ref).await?;
 
         // Extract files directly from the add-mcp directory (no examples to remove)
@@ -1312,7 +1316,8 @@ This MCP server provides AI-accessible tools for your Apollo graph.
 
         // Fetch base template + add-mcp using the existing fetch_mcp_template method
         let branch_ref = "release/v3";
-        let mut template_fetcher = InitTemplateFetcher::new();
+        let mut template_fetcher =
+            InitTemplateFetcher::new(client_config.accept_invalid_certs());
         let mut selected_template = template_fetcher
             .fetch_mcp_template(base_template_id, branch_ref)
             .await?;

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -214,10 +214,7 @@ impl Init {
         };
 
         let creation_confirmed = match use_case_selected
-            .select_template(
-                &self.project_template,
-                client_config.accept_invalid_certs(),
-            )
+            .select_template(&self.project_template, client_config.accept_invalid_certs())
             .await?
             .enter_project_name(&self.project_name)?
             .confirm_graph_id(&self.graph_id)?
@@ -788,8 +785,7 @@ impl Init {
 
         // Fetch raw files from the add-mcp directory
         let branch_ref = "release/v3";
-        let mut template_fetcher =
-            InitTemplateFetcher::new(client_config.accept_invalid_certs());
+        let mut template_fetcher = InitTemplateFetcher::new(client_config.accept_invalid_certs());
         let template_options = template_fetcher.call(branch_ref).await?;
 
         // Extract files directly from the add-mcp directory (no examples to remove)
@@ -1316,8 +1312,7 @@ This MCP server provides AI-accessible tools for your Apollo graph.
 
         // Fetch base template + add-mcp using the existing fetch_mcp_template method
         let branch_ref = "release/v3";
-        let mut template_fetcher =
-            InitTemplateFetcher::new(client_config.accept_invalid_certs());
+        let mut template_fetcher = InitTemplateFetcher::new(client_config.accept_invalid_certs());
         let mut selected_template = template_fetcher
             .fetch_mcp_template(base_template_id, branch_ref)
             .await?;

--- a/src/command/init/states.rs
+++ b/src/command/init/states.rs
@@ -165,6 +165,7 @@ pub struct MCPOrganizationSelected {
     pub organization: OrganizationId,
     pub setup_type: MCPSetupType,
     pub data_source_type: MCPDataSourceType,
+    pub accept_invalid_certs: bool,
 }
 
 #[derive(Debug)]

--- a/src/command/init/template_fetcher.rs
+++ b/src/command/init/template_fetcher.rs
@@ -184,13 +184,15 @@ impl InitTemplateOptions {
 
 #[derive(Debug)]
 pub struct InitTemplateFetcher {
-    service: GitHubService,
+    pub(crate) service: GitHubService,
 }
 
 impl InitTemplateFetcher {
-    pub fn new() -> Self {
+    pub fn new(accept_invalid_certs: bool) -> Self {
         Self {
-            service: GitHubService::new(),
+            service: GitHubService::builder()
+                .accept_invalid_certs(accept_invalid_certs)
+                .build(),
         }
     }
 
@@ -377,7 +379,9 @@ impl SelectedTemplateState {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use serde_json;
+    use speculoos::prelude::*;
 
     use super::*;
 

--- a/src/command/init/template_fetcher.rs
+++ b/src/command/init/template_fetcher.rs
@@ -184,7 +184,7 @@ impl InitTemplateOptions {
 
 #[derive(Debug)]
 pub struct InitTemplateFetcher {
-    pub(crate) service: GitHubService,
+    service: GitHubService,
 }
 
 impl InitTemplateFetcher {
@@ -379,9 +379,7 @@ impl SelectedTemplateState {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
     use serde_json;
-    use speculoos::prelude::*;
 
     use super::*;
 

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -228,10 +228,11 @@ impl UseCaseSelected {
     pub async fn select_template(
         self,
         options: &ProjectTemplateOpt,
+        accept_invalid_certs: bool,
     ) -> RoverResult<TemplateSelected> {
         // Fetch the template to get the list of files
         let repo_ref = "release/v3";
-        let mut template_fetcher = InitTemplateFetcher::new();
+        let mut template_fetcher = InitTemplateFetcher::new(accept_invalid_certs);
         let template_options = template_fetcher.call(repo_ref).await?;
 
         // MCP flow is handled in separate state machine, should not reach here with --mcp flag
@@ -854,6 +855,7 @@ impl MCPDataSourceSelected {
             organization,
             setup_type: self.setup_type,
             data_source_type: self.data_source_type,
+            accept_invalid_certs: client_config.accept_invalid_certs(),
         })
     }
 }
@@ -867,7 +869,7 @@ impl MCPOrganizationSelected {
         };
 
         let repo_ref = "release/v3";
-        let mut template_fetcher = InitTemplateFetcher::new();
+        let mut template_fetcher = InitTemplateFetcher::new(self.accept_invalid_certs);
 
         // Select template based on data source type
         let template_id = match self.data_source_type {

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -204,7 +204,7 @@ impl StudioClientConfig {
         Ok(service)
     }
 
-    pub fn accept_invalid_certs(&self) -> bool {
+    pub const fn accept_invalid_certs(&self) -> bool {
         self.client_builder.accept_invalid_certs
     }
 

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -204,6 +204,10 @@ impl StudioClientConfig {
         Ok(service)
     }
 
+    pub fn accept_invalid_certs(&self) -> bool {
+        self.client_builder.accept_invalid_certs
+    }
+
     pub const fn retry_period(&self) -> Duration {
         self.client_timeout.get_duration()
     }


### PR DESCRIPTION
Fixes an issue where `allow_invalid_certs` isn't passed along to clients created in this command.