### PR TITLE
Pin release toolchain via mise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,16 +199,7 @@ jobs:
           pattern: artifacts-*
           merge-multiple: true
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm for trusted publishing support
-        # npm trusted publishing (OIDC) requires npm >= 11.5.1
-        # due to a bug (https://github.com/nodejs/node/issues/62425#issuecomment-4200715930)
-        # NPM 10 has to be installed first for NPM 11 to successfully install
-        run: npm install -g npm@10.9.8 && npm install -g npm@11
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Resolve release parameters
         id: params

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -36,12 +36,12 @@ commits previous to it. Preparing it involves several phases:
 
 ### Create a release PR
 
-1. Make sure you have both `npm`, `cargo` and `graphql_client_cli` installed on your machine and in your `PATH`.
+1. Make sure you have [`mise`](https://mise.jdx.dev/) installed on your machine and in your `PATH`, then run `mise install` from the repo root. This installs the pinned `rust`, `cargo` (both sourced from [`rust-toolchain.toml`](./rust-toolchain.toml)), `node`, `npm`, and `graphql_client_cli`.
 2. Create a new branch "#.#.#" where "#.#.#" is this release's version
 3. Update the version in [`./Cargo.toml`](./Cargo.toml), workspace crates like `rover-client` should remain untouched.
 4. Update the installer versions in [`docs/source/getting-started.mdx`](./docs/source/getting-started.mdx) and [`docs/source/ci-cd.mdx`](./docs/source/ci-cd.mdx). (eventually this should be automated).
 5. Run `cargo run -- help` and copy the output to the "Command-line Options" section in [`README.md`](./README.md#command-line-options).
-6. Run `cargo xtask prep` (this will require `npm` to be installed).
+6. Run `mise run prep`.
 7. Push up all of your local changes. The commit message should be "release: v#.#.#"
 8. Open a Pull Request from the branch you pushed.
 9. Add the release pull request to the milestone you opened.
@@ -78,11 +78,11 @@ These are releases that usually proceed a standard release as a way of getting f
 
 ### Create a release PR
 
-1. Make sure you have both `npm`, `cargo` and `graphql_client_cli` installed on your machine and in your `PATH`.
+1. Make sure you have [`mise`](https://mise.jdx.dev/) installed on your machine and in your `PATH`, then run `mise install` from the repo root. This installs the pinned `rust` (sourced from [`rust-toolchain.toml`](./rust-toolchain.toml), which provides `cargo`), `node` (which provides `npm`), and `graphql_client_cli` declared in [`mise.toml`](./mise.toml).
 2. Create a new branch "#.#.#-rc.#" where "#.#.#" is this release's version, and the final `#` is the number of the release candidate (this starts at 0 and increments by 1 for each subsequent release candidate)
 3. Update the version in [`./Cargo.toml`](./Cargo.toml), workspace crates like `rover-client` should remain untouched.
 4. Run `cargo run -- help` and copy the output to the "Command-line Options" section in [`README.md`](./README.md#command-line-options).
-5. Run `cargo xtask prep` (this will require `npm` to be installed).
+5. Run `mise run prep` (this wraps `cargo xtask prep` with the pinned toolchain from [`mise.toml`](./mise.toml)).
 6. Push up all of your local changes. The commit message should be "release: v#.#.#-rc.#"
 7. Open a Pull Request from the branch you pushed. The description for this PR should include the salient changes in this release candidate, and what testing should be applied to it.
 8. Paste the changelog entry into the description of the Pull Request.
@@ -125,11 +125,11 @@ Sometimes it's necessary to create a `rover` release from an arbitrary branch, t
 
 ### Create a release branch
 
-1. Make sure you have both `npm`, `cargo` and `graphql_client_cli` installed on your machine and in your `PATH`.
+1. Make sure you have [`mise`](https://mise.jdx.dev/) installed on your machine and in your `PATH`, then run `mise install` from the repo root. This installs the pinned `rust` (sourced from [`rust-toolchain.toml`](./rust-toolchain.toml), which provides `cargo`), `node` (which provides `npm`), and `graphql_client_cli` declared in [`mise.toml`](./mise.toml).
 2. Create a new branch `#.#.#-<<IDENTIFIER>>` where "#.#.#" is this release's version.
    1. `IDENTIFIER` can be any series of valid [Semver identifiers separated by dots](https://semver.org/#spec-item-9)
 3. Update the version in [`./Cargo.toml`](./Cargo.toml), workspace crates like `rover-client` should remain untouched.
-4. Run `cargo xtask prep` (this will require `npm` to be installed).
+4. Run `mise run prep` (this wraps `cargo xtask prep` with the pinned toolchain from [`mise.toml`](./mise.toml)).
 5. Push up all of your local changes.
 
 ### Tag and build release

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ idiomatic_version_file_enable_tools = ["rust"]
 [tools]
 "github:lycheeverse/lychee" = { version = "0.24.2", version_prefix = "lychee-v" }
 node = "22.14.0"
+"npm:npm" = "11.5.1"
 "cargo:cargo-deny" = "0.19"
 "cargo:graphql_client_cli" = "0.14.0"
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,19 @@
+[settings]
+idiomatic_version_file_enable_tools = ["rust"]
+
 [tools]
 "github:lycheeverse/lychee" = { version = "0.24.2", version_prefix = "lychee-v" }
 node = "22.14.0"
 "cargo:cargo-deny" = "0.19"
+"cargo:graphql_client_cli" = "0.14.0"
 
 [tasks.check]
 description = "Run the same checks as CI"
 depends = ["clippy", "format-check", "test"]
+
+[tasks.prep]
+description = "Prepare a release: regenerate template schemas/queries and bump the npm installer version"
+run = "cargo xtask prep"
 
 [tasks.format-check]
 run = "cargo +nightly fmt --all -- --check"

--- a/src/error/metadata/codes/E029.md
+++ b/src/error/metadata/codes/E029.md
@@ -1,5 +1,3 @@
 This error occurs when you propose a subgraph schema that could not be built.
 
 There are many reasons why you may run into build errors. This error should include information about _why_ the proposed subgraph schema could not be composed. Error code references can be found [here](https://www.apollographql.com/docs/federation/errors/).
-
-Some build errors are part of normal workflows. For instance, you may need to publish a subgraph that does not compose if you are trying to [migrate an entity or field](https://www.apollographql.com/docs/federation/entities/#migrating-entities-and-fields-advanced).

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -16,6 +16,6 @@ You can run `cargo xtask dist` to build Rover's binary like it would be built in
 
 The most important xtask command you'll need to run locally is `cargo xtask prep`. This command prepares Rover for a new release. You'll want to update the version in `Cargo.toml`, and run `cargo xtask prep` as a part of making the PR for a new release.
 
-You must have `volta` [installed](https://docs.volta.sh/guide/getting-started) in order to ensure the proper node versions are used for the multiple packages in this repo.
+Run `mise install` from the repo root to get the pinned `node`, `npm`, and `graphql_client_cli` versions declared in [`mise.toml`](../mise.toml), then run `mise run prep` (which wraps `cargo xtask prep`).
 
 These steps are outlined in more detail in the [release checklist](../RELEASE_CHECKLIST.md).

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -2,7 +2,6 @@ use std::str;
 
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
-use which::which;
 
 use crate::{
     tools::Runner,
@@ -43,10 +42,7 @@ impl NpmRunner {
     }
 
     /// prepares our npm installer package for release
-    /// you must have volta installed to run this command
     pub(crate) fn prepare_package(&self) -> Result<()> {
-        self.require_volta()?;
-
         self.update_dependency_tree()
             .with_context(|| "Could not update the dependency tree.")?;
 
@@ -60,12 +56,6 @@ impl NpmRunner {
             .with_context(|| "Publish dry-run failed.")?;
 
         Ok(())
-    }
-
-    fn require_volta(&self) -> Result<()> {
-        which("volta")
-            .map(|_| ())
-            .map_err(|_| anyhow!("You must have `volta` installed to run this command."))
     }
 
     fn update_dependency_tree(&self) -> Result<()> {


### PR DESCRIPTION
## Summary
- Pin the tools used during release prep (`node`/`npm`, `graphql_client_cli`, and `rust`/`cargo`) so releases are reproducible. `rust-toolchain.toml` remains the single source of truth for the Rust version; mise picks it up automatically via `idiomatic_version_file_enable_tools = ["rust"]`.
- Add a `mise run prep` task that wraps `cargo xtask prep` with the pinned toolchain on `PATH`.
- Drop the unused `volta` presence check from `xtask/src/tools/npm.rs` — mise now owns Node/npm pinning, so the guard was redundant.
- Replace "make sure you have npm, cargo, graphql_client_cli installed" in `RELEASE_CHECKLIST.md` and `xtask/README.md` with `mise install` + `mise run prep`.