### PR TITLE
Add canonical subgraph lint action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,8 @@ jobs:
         include:
           - src: install
             dest: install-rover
+          - src: subgraph-lint
+            dest: rover-subgraph-lint 
     steps:
       - name: Mint installation token
         id: app-token

--- a/actions/subgraph-lint/README.md
+++ b/actions/subgraph-lint/README.md
@@ -1,0 +1,48 @@
+# Apollo Rover Subgraph Lint
+
+GitHub Action that runs [`rover subgraph lint`](https://www.apollographql.com/docs/rover/commands/subgraphs#subgraph-lint) inside the official `ghcr.io/apollographql/rover` container. No separate install step is required — the action bundles a pinned Rover version.
+
+> **Note:** This is a Docker container action and runs only on Linux runners (`ubuntu-*`). For Windows or macOS workflows, use [`install-rover`](https://github.com/apollographql-gh-actions/install-rover) plus a `run:` step that invokes `rover subgraph lint` directly.
+
+## Inputs
+
+| Name | Description | Required |
+| ---- | ----------- | :------: |
+| `apollo-key` | Apollo Studio API key. Use a Subgraph or Graph API key in shared environments. | ✓ |
+| `graph-ref` | `<NAME>@<VARIANT>` of the graph in Apollo Studio. | ✓ |
+| `name` | The name of the subgraph being linted. | ✓ |
+| `schema` | Path (inside the workspace) to the schema file to lint. | ✓ |
+| `ignore-existing-lint-violations` | Set to `true` to only flag violations introduced in the diff against the published schema. | |
+| `log` | Rover log level. See [Rover docs: Logging](https://www.apollographql.com/docs/rover/configuring#logging) for available levels and the default. | |
+| `format` | Rover log format. See [Rover docs: Configuring output](https://www.apollographql.com/docs/rover/configuring#configuring-output) for available values and the default. | |
+| `client-timeout` | Timeout in seconds for HTTP(S) requests. Defaults to Rover's built-in default. | |
+
+## Usage
+
+```yaml
+- uses: apollographql-gh-actions/rover-subgraph-lint@rover-v0.38.1
+  with:
+    apollo-key: ${{ secrets.APOLLO_KEY }}
+    graph-ref: ${{ vars.APOLLO_GRAPH_REF }}
+    name: subgraph-name
+    schema: ./path/to/schema.graphql
+```
+
+## Versioning
+
+Action releases are pinned in lockstep with Rover releases. Lockstep tags use a `rover-` prefix.
+
+- `@rover-v0.X.Y` — runs Rover `0.X.Y` exactly. Both this action and Rover use immutable releases so no SHA pinning is required.
+- `@v1` — pre-lockstep composite action. This does not guarantee immutability and should be used only in cases where pinning a specific version is not desirable.
+
+## Migrating from `@v1`
+
+The behavior is the same, but:
+
+- No `install-rover` step required — the action is self-contained.
+- Linux runners only (was cross-platform). See note at the top for the Windows/macOS workaround.
+- `apollo-key` is still passed via `with:` and translated to `APOLLO_KEY` inside the container.
+
+## Source
+
+This action is generated from [`actions/subgraph-lint/action.yml`](https://github.com/apollographql/rover/blob/main/actions/subgraph-lint/action.yml) in the Rover repo and republished here on every Rover release.

--- a/actions/subgraph-lint/action.yml
+++ b/actions/subgraph-lint/action.yml
@@ -1,0 +1,60 @@
+name: "Run Rover Subgraph Lint"
+description: "Run the `rover subgraph lint` command."
+author: "Apollo GraphQL"
+branding:
+  icon: "terminal"
+
+inputs:
+  # required
+  apollo-key:
+    description: "Your Apollo Studio API key."
+    required: true
+  graph-ref:
+    description: "<NAME>@<VARIANT> of graph in Apollo Studio."
+    required: true
+  name:
+    description: "The name of the subgraph."
+    required: true
+  schema:
+    description: "The schema file to lint."
+    required: true
+
+  # optional
+  ignore-existing-lint-violations:
+    description: "(Optional) If `true`, the linter only flags violations present in the diff between the local schema and the published schema. By default, all violations in the local schema are flagged."
+
+  # common
+  log:
+    description: "Specify Rover's log level."
+  format:
+    description: "Specify Rover's log format type [plain|json]."
+  client-timeout:
+    description: "Configure the timeout length (in seconds) when performing HTTP(S) requests."
+
+runs:
+  using: "docker"
+  # The image tag is rewritten by `cargo xtask prep` so each release tag pins
+  # the action to the matching Rover version. Do not edit by hand.
+  image: "docker://ghcr.io/apollographql/rover:0.38.1"
+  entrypoint: "/bin/bash"
+  args:
+    - "-c"
+    # Inputs flow through env (not template-inlined) so values containing shell
+    # metacharacters cannot break out of quoting and execute arbitrary commands.
+    - |
+      set -euo pipefail
+      ARGS=("$INPUT_GRAPH_REF" --name "$INPUT_NAME" --schema "$INPUT_SCHEMA")
+      [ "${INPUT_IGNORE_EXISTING_LINT_VIOLATIONS:-}" = "true" ] && ARGS+=(--ignore-existing-lint-violations)
+      [ -n "${INPUT_LOG:-}" ] && ARGS+=(--log "$INPUT_LOG")
+      [ -n "${INPUT_FORMAT:-}" ] && ARGS+=(--format "$INPUT_FORMAT")
+      [ -n "${INPUT_CLIENT_TIMEOUT:-}" ] && ARGS+=(--client-timeout "$INPUT_CLIENT_TIMEOUT")
+      exec rover --skip-update-check subgraph lint "${ARGS[@]}"
+  env:
+    APOLLO_KEY: ${{ inputs.apollo-key }}
+    INPUT_GRAPH_REF: ${{ inputs.graph-ref }}
+    INPUT_NAME: ${{ inputs.name }}
+    INPUT_SCHEMA: ${{ inputs.schema }}
+    INPUT_IGNORE_EXISTING_LINT_VIOLATIONS: ${{ inputs.ignore-existing-lint-violations }}
+    INPUT_LOG: ${{ inputs.log }}
+    INPUT_FORMAT: ${{ inputs.format }}
+    INPUT_CLIENT_TIMEOUT: ${{ inputs.client-timeout }}

--- a/xtask/src/commands/prep/container_actions.rs
+++ b/xtask/src/commands/prep/container_actions.rs
@@ -1,0 +1,70 @@
+use std::fs;
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use regex::Regex;
+
+use crate::utils::{PKG_PROJECT_ROOT, PKG_VERSION};
+
+/// Subdirectory of the project root that holds the container action
+/// definitions. Each subdirectory's `action.yml` gets shipped to the matching
+/// `apollographql-gh-actions/<repo>` at release time.
+const CONTAINER_ACTIONS_DIR: &str = "actions";
+
+/// Rewrites the `image:` line in each container `action.yml` so the published
+/// release tag pins the action to the matching Rover Docker image. Walks
+/// `actions/*/action.yml` so adding a new action is purely a matter of
+/// dropping its directory in. Non-container action.yml files (composite,
+/// JavaScript) are silently skipped.
+pub(crate) fn update_versions() -> Result<()> {
+    crate::info!("updating container action image tags.");
+    let actions_root = PKG_PROJECT_ROOT.join(CONTAINER_ACTIONS_DIR);
+    let entries = fs::read_dir(actions_root.as_path())
+        .with_context(|| format!("Could not read {}", &actions_root))?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| Utf8PathBuf::from_path_buf(entry.path()).ok())
+        .filter(|path| path.is_dir())
+        .map(|dir| dir.join("action.yml"))
+        .filter(|action_file| action_file.is_file());
+
+    for action_file in entries {
+        update_action_image(&action_file)?;
+    }
+    Ok(())
+}
+
+/// Captures and updates the version segment of a line shaped like
+///
+/// ```yaml
+///   image: "docker://ghcr.io/apollographql/rover:<version>"
+/// ```
+///
+/// The double-quote delimiters and `image:` prefix are part of the match so
+/// the rewrite only touches the actual image-pin line, even if other text in
+/// the file happens to contain the same version string.
+fn update_action_image(action_file: &Utf8Path) -> Result<()> {
+    let old_contents = fs::read_to_string(action_file)
+        .with_context(|| format!("Could not read contents of {} to a String", action_file))?;
+
+    let version_regex =
+        Regex::new(r#"(image:\s*"docker://ghcr\.io/apollographql/rover:)([^"]+)(")"#)
+            .context("Could not create regex for container action image tag")?;
+    let Some(captures) = version_regex.captures(&old_contents) else {
+        // Composite / JavaScript action — nothing to pin.
+        return Ok(());
+    };
+    // Group 2 is guaranteed non-empty by the regex (uses `+`), so the
+    // capture's presence implies a present version.
+    let old_version = &captures[2];
+
+    if old_version == PKG_VERSION.as_str() {
+        return Ok(());
+    }
+
+    crate::info!("updating image tag in `{}`.", action_file);
+    let replacement = format!("${{1}}{}${{3}}", *PKG_VERSION);
+    let new_contents = version_regex.replace_all(&old_contents, replacement.as_str());
+    fs::write(action_file, new_contents.as_ref())
+        .with_context(|| format!("Could not write updated image tag to {}", action_file))?;
+    Ok(())
+}

--- a/xtask/src/commands/prep/mod.rs
+++ b/xtask/src/commands/prep/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     tools::{CargoRunner, NpmRunner},
 };
 
+mod container_actions;
 mod docs;
 mod installers;
 mod main_schema;
@@ -36,6 +37,7 @@ impl Prep {
         let cargo_runner = CargoRunner::new()?;
         cargo_runner.update_deps()?;
         installers::update_versions()?;
+        container_actions::update_versions()?;
         let docs_runner = DocsRunner::new()?;
         docs_runner
             .build_error_code_reference()


### PR DESCRIPTION
This includes an xtask to automatically manage the action's docker version
