### PR TITLE
Plumb through remote subgraphs on hot reloads

### DIFF
--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -317,6 +317,7 @@ impl CompositionPipeline<state::Run> {
             .map_err(CompositionPipelineError::ResolveSubgraphs)?
             .setup_supergraph_config_watcher(
                 lazily_resolved_supergraph_config,
+                self.state.resolver.remote_subgraphs().clone(),
                 self.state.fetch_remote_subgraph_factory.clone(),
                 self.state.resolve_introspect_subgraph_factory.clone(),
             )

--- a/src/composition/runner/mod.rs
+++ b/src/composition/runner/mod.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::Debug,
 };
 
+use apollo_federation_types::config::SubgraphConfig;
 use camino::Utf8PathBuf;
 use futures::stream::{BoxStream, StreamExt, select};
 use rover_http::HttpService;
@@ -102,6 +103,7 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
     pub fn setup_supergraph_config_watcher(
         self,
         supergraph_config: LazilyResolvedSupergraphConfig,
+        remote_subgraphs: BTreeMap<String, SubgraphConfig>,
         fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
         resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory,
     ) -> Runner<state::SetupCompositionWatcher> {
@@ -122,6 +124,7 @@ impl Runner<state::SetupSupergraphConfigWatcher> {
             let watcher = SupergraphConfigWatcher::new(
                 f,
                 supergraph_config.clone(),
+                remote_subgraphs,
                 fetch_remote_subgraph_factory,
                 resolve_introspect_subgraph_factory,
             );

--- a/src/composition/supergraph/config/resolver/mod.rs
+++ b/src/composition/supergraph/config/resolver/mod.rs
@@ -46,6 +46,28 @@ pub mod fetch_remote_subgraph;
 pub mod fetch_remote_subgraphs;
 mod state;
 
+/// Merges YAML-defined subgraphs over a base of remote (`--graph-ref`) subgraphs.
+///
+/// YAML entries win, but their `routing_url` falls back to the remote entry's when unset.
+/// Remote-only subgraphs are preserved.
+pub(crate) fn merge_yaml_over_remote_subgraphs(
+    mut merged: BTreeMap<String, SubgraphConfig>,
+    yaml_subgraphs: BTreeMap<String, SubgraphConfig>,
+) -> BTreeMap<String, SubgraphConfig> {
+    for (name, subgraph_config) in yaml_subgraphs {
+        let subgraph_config = SubgraphConfig {
+            routing_url: subgraph_config.routing_url.or_else(|| {
+                merged
+                    .get(&name)
+                    .and_then(|remote_config| remote_config.routing_url.clone())
+            }),
+            schema: subgraph_config.schema,
+        };
+        merged.insert(name, subgraph_config);
+    }
+    merged
+}
+
 /// This is a state-based resolver for the different stages of resolving a supergraph config
 pub struct SupergraphConfigResolver<State> {
     state: State,
@@ -142,26 +164,21 @@ impl SupergraphConfigResolver<state::LoadSupergraphConfig> {
                 .state
                 .federation_version_resolver
                 .from_supergraph_config(Some(&supergraph_config));
-            let mut merged_subgraphs = self.state.subgraphs;
-            for (name, subgraph_config) in supergraph_config.subgraphs {
-                let subgraph_config = SubgraphConfig {
-                    routing_url: subgraph_config.routing_url.or_else(|| {
-                        merged_subgraphs
-                            .get(&name)
-                            .and_then(|remote_config| remote_config.routing_url.clone())
-                    }),
-                    schema: subgraph_config.schema,
-                };
-                merged_subgraphs.insert(name, subgraph_config);
-            }
+            let remote_subgraphs = self.state.subgraphs;
+            let merged_subgraphs = merge_yaml_over_remote_subgraphs(
+                remote_subgraphs.clone(),
+                supergraph_config.subgraphs,
+            );
             Ok(SupergraphConfigResolver {
                 state: state::DefineDefaultSubgraph {
                     origin_path,
                     federation_version_resolver,
                     subgraphs: merged_subgraphs,
+                    remote_subgraphs,
                 },
             })
         } else {
+            let remote_subgraphs = self.state.subgraphs.clone();
             Ok(SupergraphConfigResolver {
                 state: state::DefineDefaultSubgraph {
                     origin_path: None,
@@ -170,6 +187,7 @@ impl SupergraphConfigResolver<state::LoadSupergraphConfig> {
                         .federation_version_resolver
                         .from_supergraph_config(None),
                     subgraphs: self.state.subgraphs,
+                    remote_subgraphs,
                 },
             })
         }
@@ -233,6 +251,7 @@ impl SupergraphConfigResolver<state::DefineDefaultSubgraph> {
                 origin_path: self.state.origin_path,
                 federation_version_resolver: self.state.federation_version_resolver,
                 subgraphs: self.state.subgraphs,
+                remote_subgraphs: self.state.remote_subgraphs,
             },
         })
     }
@@ -244,6 +263,7 @@ impl SupergraphConfigResolver<state::DefineDefaultSubgraph> {
                 origin_path: self.state.origin_path,
                 federation_version_resolver: self.state.federation_version_resolver,
                 subgraphs: self.state.subgraphs,
+                remote_subgraphs: self.state.remote_subgraphs,
             },
         }
     }
@@ -280,6 +300,13 @@ pub enum ResolveSupergraphConfigError {
 pub type InitializedSupergraphConfigResolver = SupergraphConfigResolver<state::ResolveSubgraphs>;
 
 impl SupergraphConfigResolver<state::ResolveSubgraphs> {
+    /// Returns the subgraphs that were originally loaded via `--graph-ref`. This is the
+    /// pre-merge snapshot used to re-apply remote subgraphs when the local supergraph config
+    /// file is hot-reloaded.
+    pub const fn remote_subgraphs(&self) -> &BTreeMap<String, SubgraphConfig> {
+        &self.state.remote_subgraphs
+    }
+
     /// Fully resolves the subgraph configurations in the supergraph config file to their SDLs
     pub async fn fully_resolve_subgraphs(
         &self,

--- a/src/composition/supergraph/config/resolver/state.rs
+++ b/src/composition/supergraph/config/resolver/state.rs
@@ -19,6 +19,9 @@ pub struct DefineDefaultSubgraph {
     pub origin_path: Option<Utf8PathBuf>,
     pub federation_version_resolver: FederationVersionResolverFromSubgraphs,
     pub subgraphs: BTreeMap<String, SubgraphConfig>,
+    /// Subgraphs fetched from the `--graph-ref` flag, preserved separately from the merged
+    /// `subgraphs` set so they can be re-applied when the local `supergraph.yaml` is hot-reloaded.
+    pub remote_subgraphs: BTreeMap<String, SubgraphConfig>,
 }
 
 /// In this stage, we attempt to resolve subgraphs lazily: making sure file paths are correct
@@ -27,4 +30,7 @@ pub struct ResolveSubgraphs {
     pub origin_path: Option<Utf8PathBuf>,
     pub federation_version_resolver: FederationVersionResolverFromSubgraphs,
     pub subgraphs: BTreeMap<String, SubgraphConfig>,
+    /// Subgraphs fetched from the `--graph-ref` flag, preserved separately from the merged
+    /// `subgraphs` set so they can be re-applied when the local `supergraph.yaml` is hot-reloaded.
+    pub remote_subgraphs: BTreeMap<String, SubgraphConfig>,
 }

--- a/src/composition/watchers/watcher/supergraph_config.rs
+++ b/src/composition/watchers/watcher/supergraph_config.rs
@@ -25,7 +25,9 @@ use crate::{
             federation::FederationVersionResolver,
             full::{FullyResolvedSupergraphConfig, introspect::ResolveIntrospectSubgraphFactory},
             lazy::LazilyResolvedSupergraphConfig,
-            resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory,
+            resolver::{
+                fetch_remote_subgraph::FetchRemoteSubgraphFactory, merge_yaml_over_remote_subgraphs,
+            },
             unresolved::UnresolvedSupergraphConfig,
         },
         watchers::watcher::supergraph_config::SupergraphConfigSerialisationError::DeserializingConfigError,
@@ -39,6 +41,11 @@ use crate::{
 pub(crate) struct SupergraphConfigWatcher {
     file_watcher: FileWatcher,
     supergraph_config: SupergraphConfigYaml,
+    /// Subgraphs originally loaded via `--graph-ref`. Merged into the freshly-read YAML on each
+    /// hot-reload so they are preserved across edits to the local supergraph config (matching the
+    /// merge precedence used at startup in
+    /// `SupergraphConfigResolver::load_from_file_descriptor`).
+    remote_subgraphs: BTreeMap<String, SubgraphConfig>,
     fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
     resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory,
 }
@@ -47,12 +54,14 @@ impl SupergraphConfigWatcher {
     pub fn new(
         file_watcher: FileWatcher,
         supergraph_config: LazilyResolvedSupergraphConfig,
+        remote_subgraphs: BTreeMap<String, SubgraphConfig>,
         fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
         resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory,
     ) -> SupergraphConfigWatcher {
         SupergraphConfigWatcher {
             file_watcher,
             supergraph_config: supergraph_config.into(),
+            remote_subgraphs,
             fetch_remote_subgraph_factory,
             resolve_introspect_subgraph_factory,
         }
@@ -127,6 +136,16 @@ impl SupergraphConfigWatcher {
                     debug!("Current supergraph config is: {:?}", latest_supergraph_config);
                     match Self::read_supergraph_config(&contents) {
                         Ok(supergraph_config) => {
+                            // Re-apply the startup-time merge so subgraphs originally loaded
+                            // from `--graph-ref` survive edits to the local YAML file.
+                            let merged_subgraphs = merge_yaml_over_remote_subgraphs(
+                                self.remote_subgraphs.clone(),
+                                supergraph_config.subgraphs,
+                            );
+                            let supergraph_config = SupergraphConfigYaml {
+                                subgraphs: merged_subgraphs,
+                                federation_version: supergraph_config.federation_version,
+                            };
                             let unresolved_supergraph_config = UnresolvedSupergraphConfig {
                                 origin_path: Some(supergraph_config_path.clone()),
                                 federation_version_resolver: Some(FederationVersionResolver::default().from_supergraph_config(Some( &supergraph_config))),
@@ -320,6 +339,77 @@ mod tests {
 
     use super::{SupergraphConfigDiff, *};
     use crate::composition::watchers::watcher::supergraph_config::SupergraphConfigWatcher;
+
+    // Regression test for ROVER-377: when `rover dev` is run with both `--graph-ref` and a
+    // local supergraph.yaml, editing the YAML file at runtime previously dropped every
+    // graph-ref-only subgraph from the session because the watcher only re-read the YAML and
+    // discarded the remote subgraphs that had been merged in at startup.
+    #[test]
+    fn test_hot_reload_preserves_graph_ref_subgraphs() {
+        fn sdl(value: &str) -> SubgraphConfig {
+            SubgraphConfig {
+                routing_url: Some(format!("http://localhost/{value}")),
+                schema: SchemaSource::Sdl {
+                    sdl: value.to_string(),
+                },
+            }
+        }
+        fn remote(name: &str) -> SubgraphConfig {
+            SubgraphConfig {
+                routing_url: Some(format!("http://localhost/{name}")),
+                schema: SchemaSource::Subgraph {
+                    graphref: "graph@variant".to_string(),
+                    subgraph: name.to_string(),
+                },
+            }
+        }
+
+        // Subgraphs that came from `--graph-ref` at startup.
+        let remote_subgraphs = BTreeMap::from([
+            ("accounts".to_string(), remote("accounts")),
+            ("products".to_string(), remote("products")),
+            ("billing".to_string(), remote("billing")),
+        ]);
+
+        // The user's initial supergraph.yaml only overrides "test".
+        let initial_yaml_subgraphs = BTreeMap::from([("test".to_string(), sdl("test-v1"))]);
+        let initial_merged =
+            merge_yaml_over_remote_subgraphs(remote_subgraphs.clone(), initial_yaml_subgraphs);
+        // Sanity-check the startup merge.
+        assert_eq!(initial_merged.len(), 4);
+
+        // The user edits supergraph.yaml — only the local "test" entry changes.
+        let new_yaml_subgraphs = BTreeMap::from([("test".to_string(), sdl("test-v2"))]);
+        let post_reload_merged =
+            merge_yaml_over_remote_subgraphs(remote_subgraphs, new_yaml_subgraphs);
+
+        // The graph-ref subgraphs must still be present after the hot-reload merge.
+        for name in ["accounts", "products", "billing"] {
+            assert!(
+                post_reload_merged.contains_key(name),
+                "expected graph-ref subgraph `{name}` to be preserved across hot-reload"
+            );
+        }
+
+        let old = SupergraphConfigYaml {
+            subgraphs: initial_merged,
+            ..Default::default()
+        };
+        let new = SupergraphConfigYaml {
+            subgraphs: post_reload_merged,
+            ..Default::default()
+        };
+        let diff = SupergraphConfigDiff::new(old, new, BTreeMap::default(), false).unwrap();
+
+        assert!(
+            diff.removed().is_empty(),
+            "no graph-ref subgraphs should be reported as removed, got: {:?}",
+            diff.removed()
+        );
+        assert!(diff.added().is_empty());
+        assert_eq!(diff.changed().len(), 1);
+        assert_eq!(diff.changed()[0].0, "test");
+    }
 
     #[test]
     fn test_supergraph_config_diff() {


### PR DESCRIPTION
Resolves ROVER-377: when `rover dev` was run with both `--graph-ref` and a local supergraph.yaml, editing the YAML file at runtime previously dropped every graph-ref-only subgraph from the session because the watcher only re-read the YAML and discarded the remote subgraphs that had been merged in at startup.
