### PR TITLE
Batch subgraph changes for supergraph.yaml hot reloads

### DIFF
--- a/src/composition/watchers/composition.rs
+++ b/src/composition/watchers/composition.rs
@@ -27,7 +27,9 @@ use crate::{
             install::{InstallSupergraph, InstallSupergraphError},
         },
         watchers::{
-            composition::CompositionInputEvent::{Federation, Passthrough, Recompose, Subgraph},
+            composition::CompositionInputEvent::{
+                Federation, Passthrough, Recompose, Subgraph, SubgraphBatch,
+            },
             subgraphs::SubgraphEvent,
         },
     },
@@ -39,8 +41,11 @@ use crate::{
 /// Event to represent an input to the CompositionWatcher, depending on the source the event comes
 /// from. This is really like a Union type over multiple disparate events
 pub enum CompositionInputEvent {
-    /// Variant to represent if the change comes from a change to subgraphs
+    /// A single change to one subgraph
     Subgraph(SubgraphEvent),
+    /// A collection of subgraph changes that all originate from the same supergraph.yaml
+    /// change and must compose as a single unit
+    SubgraphBatch(Vec<SubgraphEvent>),
     /// Variant to represent if the change comes from a change in the Federation Version
     Federation(FederationVersion),
     /// Variant to represent if we need to recompose quickly without other changes
@@ -48,6 +53,59 @@ pub enum CompositionInputEvent {
     /// Variant to something that we do not want to perform Composition on but needs to be passed
     /// through to the final stream of Composition Events.
     Passthrough(CompositionEvent),
+}
+
+/// Apply a single subgraph event to the in-memory supergraph config and emit
+/// any user-visible side-effect events. Returns `true` when the change should
+/// trigger a recomposition.
+fn apply_subgraph_event(
+    sg_event: SubgraphEvent,
+    supergraph_config: &mut FullyResolvedSupergraphConfig,
+    sender: &UnboundedSender<CompositionEvent>,
+) -> bool {
+    match sg_event {
+        SubgraphEvent::SubgraphSchemaChanged(subgraph_schema_changed) => {
+            let name = subgraph_schema_changed.name().clone();
+            let schema_source = subgraph_schema_changed.schema_source().clone();
+            let message = format!("Schema change detected for subgraph: {}", &name);
+            infoln!("{}", message);
+            tracing::info!(message);
+            if supergraph_config
+                .update_subgraph_schema(name.clone(), subgraph_schema_changed.into())
+                .is_none()
+            {
+                let _ = sender
+                    .send(CompositionEvent::SubgraphAdded(CompositionSubgraphAdded {
+                        name,
+                        schema_source,
+                    }))
+                    .tap_err(|err| error!("{:?}", err));
+            }
+            true
+        }
+        SubgraphEvent::RoutingUrlChanged(routing_url_changed) => {
+            let name = routing_url_changed.name();
+            info!("Change of routing_url detected for subgraph '{}'", name);
+            supergraph_config
+                .update_routing_url(name, routing_url_changed.routing_url().clone())
+                .is_some()
+        }
+        SubgraphEvent::SubgraphRemoved(subgraph_removed) => {
+            let name = subgraph_removed.name();
+            let resolution_error = subgraph_removed.resolution_error().clone();
+            info!("Subgraph removed: {}", name);
+            supergraph_config.remove_subgraph(name);
+            let _ = sender
+                .send(CompositionEvent::SubgraphRemoved(
+                    CompositionSubgraphRemoved {
+                        name: name.clone(),
+                        resolution_error,
+                    },
+                ))
+                .tap_err(|err| error!("{:?}", err));
+            true
+        }
+    }
 }
 
 #[derive(Builder, Debug)]
@@ -124,48 +182,22 @@ where
             cancellation_token.run_until_cancelled(async {
                 while let Some(event) = input.next().await {
                     match event {
-                        Subgraph(SubgraphEvent::SubgraphSchemaChanged(subgraph_schema_changed)) => {
-                            let name = subgraph_schema_changed.name().clone();
-                            let schema_source = subgraph_schema_changed.schema_source().clone();
-                            let message = format!("Schema change detected for subgraph: {}", &name);
-                            infoln!("{}", message);
-                            tracing::info!(message);
-                            if supergraph_config
-                                .update_subgraph_schema(
-                                    name.clone(),
-                                    subgraph_schema_changed.into(),
-                                )
-                                .is_none()
-                            {
-                                let _ = sender
-                                    .send(CompositionEvent::SubgraphAdded(
-                                        CompositionSubgraphAdded {
-                                            name,
-                                            schema_source
-                                        },
-                                    ))
-                                    .tap_err(|err| error!("{:?}", err));
-                            };
-                        }
-                        Subgraph(SubgraphEvent::RoutingUrlChanged(routing_url_changed)) => {
-                            let name = routing_url_changed.name();
-                            info!("Change of routing_url detected for subgraph '{}'", name);
-                            if supergraph_config.update_routing_url(name, routing_url_changed.routing_url().clone()).is_none() {
-                                // If we get None back then continue, as we don't need to recompose
-                                continue
+                        Subgraph(sg_event) => {
+                            if !apply_subgraph_event(sg_event, &mut supergraph_config, &sender) {
+                                continue;
                             }
-                        }
-                        Subgraph(SubgraphEvent::SubgraphRemoved(subgraph_removed)) => {
-                            let name = subgraph_removed.name();
-                            let resolution_error = subgraph_removed.resolution_error().clone();
-                            info!("Subgraph removed: {}", name);
-                            supergraph_config.remove_subgraph(name);
-                            let _ = sender
-                                .send(CompositionEvent::SubgraphRemoved(
-                                    CompositionSubgraphRemoved { name: name.clone(), resolution_error },
-                                ))
-                                .tap_err(|err| error!("{:?}", err));
-                        }
+                        },
+                        SubgraphBatch(sg_events) => {
+                            let mut subgraph_changed = false;
+                            for sg_event in sg_events {
+                                if apply_subgraph_event(sg_event, &mut supergraph_config, &sender) {
+                                    subgraph_changed = true;
+                                }
+                            }
+                            if !subgraph_changed {
+                                continue;
+                            }
+                        },
                         Federation(fed_version) => {
                             if let Some(federation_updater_config) = self.federation_updater_config.clone() {
                                 info!("Attempting to change supergraph version to {:?}", fed_version);
@@ -458,6 +490,96 @@ mod tests {
                 CompositionEvent::Error(..)
             ));
         }
+
+        cancellation_token.cancel();
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_runcomposition_subgraph_batch_runs_one_composition() -> Result<()> {
+        use crate::composition::watchers::composition::CompositionInputEvent::SubgraphBatch;
+
+        let temp_dir = assert_fs::TempDir::new()?;
+        let temp_dir_path = Utf8PathBuf::from_path_buf(temp_dir.to_path_buf()).unwrap();
+
+        let federation_version = Version::from_str("2.8.0").unwrap();
+        let subgraphs = FullyResolvedSupergraphConfig::builder()
+            .subgraphs(BTreeMap::new())
+            .federation_version(FederationVersion::ExactFedTwo(federation_version.clone()))
+            .build();
+        let supergraph_version = SupergraphVersion::new(federation_version.clone());
+        let supergraph_binary = SupergraphBinary::builder()
+            .version(supergraph_version)
+            .exe(Utf8PathBuf::from_str("some/binary").unwrap())
+            .build();
+
+        let composition_output = serde_json::to_string(&default_composition_json()).unwrap();
+        let mut mock_exec = MockExecCommand::new();
+        mock_exec
+            .expect_exec_command()
+            .times(1)
+            .returning(move |_| {
+                Ok(Output {
+                    status: ExitStatus::default(),
+                    stdout: composition_output.as_bytes().into(),
+                    stderr: Vec::default(),
+                })
+            });
+
+        let mut mock_write_file = MockWriteFile::new();
+        mock_write_file
+            .expect_write_file()
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let composition_handler = CompositionWatcher::builder()
+            .initial_supergraph_config(subgraphs)
+            .supergraph_binary(Ok(supergraph_binary))
+            .exec_command(mock_exec)
+            .write_file(mock_write_file)
+            .temp_dir(temp_dir_path)
+            .compose_on_initialisation(false)
+            .build();
+
+        let subgraph_sdl = "type Query { test: String! }".to_string();
+        let inner: Vec<SubgraphEvent> = (0..3)
+            .map(|i| {
+                SubgraphEvent::SubgraphSchemaChanged(SubgraphSchemaChanged::new(
+                    format!("subgraph-{i}"),
+                    subgraph_sdl.clone(),
+                    "https://example.com".to_string(),
+                    SchemaSource::Sdl {
+                        sdl: subgraph_sdl.clone(),
+                    },
+                ))
+            })
+            .collect();
+        let event_stream: BoxStream<CompositionInputEvent> =
+            once(async { SubgraphBatch(inner) }).boxed();
+
+        let (mut composition_messages, composition_subtask) = Subtask::new(composition_handler);
+        let cancellation_token = CancellationToken::new();
+        composition_subtask.run(event_stream, Some(cancellation_token.clone()));
+
+        let mut subgraph_added = 0;
+        let mut started = 0;
+        let mut success = 0;
+        let mut error = 0;
+        while let Some(ev) = composition_messages.next().await {
+            match ev {
+                CompositionEvent::SubgraphAdded(_) => subgraph_added += 1,
+                CompositionEvent::Started => started += 1,
+                CompositionEvent::Success(_) => success += 1,
+                CompositionEvent::Error(_) => error += 1,
+                _ => {}
+            }
+        }
+
+        assert_that!(subgraph_added).is_equal_to(3);
+        assert_that!(started).is_equal_to(1);
+        assert_that!(success).is_equal_to(1);
+        assert_that!(error).is_equal_to(0);
 
         cancellation_token.cancel();
         Ok(())

--- a/src/composition/watchers/subgraphs.rs
+++ b/src/composition/watchers/subgraphs.rs
@@ -23,7 +23,10 @@ use crate::{
             resolver::fetch_remote_subgraph::FetchRemoteSubgraphFactory,
         },
         watchers::{
-            composition::{CompositionInputEvent, CompositionInputEvent::Subgraph},
+            composition::{
+                CompositionInputEvent,
+                CompositionInputEvent::{Subgraph, SubgraphBatch},
+            },
             watcher::supergraph_config::SupergraphConfigSerialisationError,
         },
     },
@@ -195,43 +198,55 @@ impl SubtaskHandleStream for SubgraphWatchers {
             cancellation_token.run_until_cancelled(async move {
                 while let Some(diff) = input.next().await {
                     if let Ok(diff) = diff {
-                            // If we detect additional diffs, start a new subgraph subtask.
-                            // Adding the abort handle to the current collection of handles.
-                            for (subgraph_name, subgraph_config) in diff.added() {
-                                let _ = subgraph_handles.add(
-                                    subgraph_name,
-                                    subgraph_config,
-                                    self.introspection_polling_interval
-                                ).await.tap_err(|err| error!("{:?}", err));
-                            }
+                        // Collect every event that originated from this single
+                        // supergraph.yaml diff so the composition watcher applies
+                        // them as one atomic change.
+                        let mut batch: Vec<SubgraphEvent> = Vec::new();
 
-                            for (subgraph_name, subgraph_config) in diff.changed() {
-                                let _ = subgraph_handles.update(
-                                    subgraph_name,
-                                    subgraph_config,
-                                    self.introspection_polling_interval
-                                ).await.tap_err(|err| error!("{:?}", err));
-                            }
-
-                            // If we detect removal diffs, stop the subtask for the removed subgraph.
-                            for (subgraph_name, potential_error) in diff.removed() {
-                                match potential_error {
-                                    None => eprintln!("Removing subgraph from session: `{subgraph_name}`"),
-                                    Some(err) =>  {
-                                        errln!("Error detected with the config for {}\n{:?}. \nRemoving it from the session.", subgraph_name, err)
-                                    },
-                                }
-                                subgraph_handles.remove(subgraph_name, potential_error.clone());
-                            }
-
-                            // If a diff is empty, but the previous version of the supergraph.yaml
-                            // was broken we need to force a recomposition of anything that's
-                            // changed.
-                            if *diff.previously_broken() && diff.is_empty() {
-                                let _ = sender.send(CompositionInputEvent::Recompose()).tap_err(|err| error!("{:?}", err));
+                        for (subgraph_name, subgraph_config) in diff.added() {
+                            match subgraph_handles.add(
+                                subgraph_name,
+                                subgraph_config,
+                                self.introspection_polling_interval
+                            ).await {
+                                Ok(events) => batch.extend(events),
+                                Err(err) => error!("{:?}", err),
                             }
                         }
+
+                        for (subgraph_name, subgraph_config) in diff.changed() {
+                            match subgraph_handles.update(
+                                subgraph_name,
+                                subgraph_config,
+                                self.introspection_polling_interval
+                            ).await {
+                                Ok(events) => batch.extend(events),
+                                Err(err) => error!("{:?}", err),
+                            }
+                        }
+
+                        for (subgraph_name, potential_error) in diff.removed() {
+                            match potential_error {
+                                None => eprintln!("Removing subgraph from session: `{subgraph_name}`"),
+                                Some(err) =>  {
+                                    errln!("Error detected with the config for {}\n{:?}. \nRemoving it from the session.", subgraph_name, err)
+                                },
+                            }
+                            batch.push(subgraph_handles.remove(subgraph_name, potential_error.clone()));
+                        }
+
+                        if !batch.is_empty() {
+                            let _ = sender.send(SubgraphBatch(batch)).tap_err(|err| error!("{:?}", err));
+                        }
+
+                        // If a diff is empty, but the previous version of the supergraph.yaml
+                        // was broken we need to force a recomposition of anything that's
+                        // changed.
+                        if *diff.previously_broken() && diff.is_empty() {
+                            let _ = sender.send(CompositionInputEvent::Recompose()).tap_err(|err| error!("{:?}", err));
+                        }
                     }
+                }
             }).await
         });
     }
@@ -296,7 +311,7 @@ impl SubgraphHandles {
         subgraph: &str,
         subgraph_config: &SubgraphConfig,
         introspection_polling_interval: u64,
-    ) -> Result<(), ResolveSubgraphError> {
+    ) -> Result<Vec<SubgraphEvent>, ResolveSubgraphError> {
         eprintln!("Adding subgraph to session: `{subgraph}`");
         let lazily_resolved_subgraph = LazilyResolvedSubgraph::resolve(
             &self.supergraph_config_root,
@@ -320,18 +335,18 @@ impl SubgraphHandles {
         // want to spin up watchers; rather, we emit a SubgraphSchemaChanged event with
         // either what we fetch from Studio (for Subgraphs) or what the SupergraphConfig
         // has for Sdls
-        if let SubgraphWatcherKind::Once(subgraph_config) = subgraph_watcher.watcher() {
+        let event = if let SubgraphWatcherKind::Once(subgraph_config) = subgraph_watcher.watcher() {
             self.add_oneshot_subgraph_to_session(subgraph, subgraph_config.clone())
-                .await;
+                .await
         } else {
             // When we have a SchemaSource that's watchable, we start a new subtask
             // and add it to our list of subtasks
-            let _ = self
-                .add_streaming_subgraph_to_session(subgraph_watcher)
+            self.add_streaming_subgraph_to_session(subgraph_watcher)
                 .await
-                .tap_err(|err| tracing::error!("{:?}", err));
-        }
-        Ok(())
+                .tap_err(|err| tracing::error!("{:?}", err))
+                .ok()
+        };
+        Ok(event.into_iter().collect())
     }
 
     pub async fn update(
@@ -339,7 +354,7 @@ impl SubgraphHandles {
         subgraph: &str,
         subgraph_config: &SubgraphConfig,
         introspection_polling_interval: u64,
-    ) -> Result<(), ResolveSubgraphError> {
+    ) -> Result<Vec<SubgraphEvent>, ResolveSubgraphError> {
         eprintln!("Change detected for subgraph: `{subgraph}`");
         let lazily_resolved_subgraph = LazilyResolvedSubgraph::resolve(
             &self.supergraph_config_root.clone(),
@@ -359,20 +374,16 @@ impl SubgraphHandles {
             introspection_polling_interval,
             subgraph.to_string(),
         );
-        if let SubgraphWatcherKind::Once(non_repeating_fetch) = subgraph_watcher.watcher() {
-            let _ = non_repeating_fetch
+
+        let mut events: Vec<SubgraphEvent> = Vec::new();
+        if let SubgraphWatcherKind::Once(non_repeating_fetch) = subgraph_watcher.watcher()
+            && let Ok(subgraph) = non_repeating_fetch
                 .clone()
                 .run()
                 .await
                 .tap_err(|err| tracing::error!("failed to get {subgraph}'s SDL: {err:?}"))
-                .map(|subgraph| {
-                    let _ = self
-                        .sender
-                        .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
-                            subgraph.into(),
-                        )))
-                        .tap_err(|err| tracing::error!("{:?}", err));
-                });
+        {
+            events.push(SubgraphEvent::SubgraphSchemaChanged(subgraph.into()));
         }
 
         // It's possible that the routing_url was updated at this point so we need to update that
@@ -399,66 +410,54 @@ impl SubgraphHandles {
             },
             a => a,
         };
-        let _ = self.sender.send(Subgraph(SubgraphEvent::RoutingUrlChanged(
+        events.push(SubgraphEvent::RoutingUrlChanged(
             SubgraphRoutingUrlChanged {
                 name: subgraph.to_string(),
                 routing_url,
             },
-        )));
-        Ok(())
+        ));
+        Ok(events)
     }
 
-    pub fn remove(&mut self, subgraph: &str, potential_error: Option<ResolveSubgraphError>) {
+    pub fn remove(
+        &mut self,
+        subgraph: &str,
+        potential_error: Option<ResolveSubgraphError>,
+    ) -> SubgraphEvent {
         if let Some(cancellation_token) = self.cancellation_tokens.get(subgraph) {
             cancellation_token.cancel();
             self.cancellation_tokens.remove(subgraph);
         }
 
-        let _ = self
-            .sender
-            .send(Subgraph(SubgraphEvent::SubgraphRemoved(
-                SubgraphSchemaRemoved {
-                    name: subgraph.to_string(),
-                    resolution_error: potential_error,
-                },
-            )))
-            .tap_err(|err| error!("{:?}", err));
+        SubgraphEvent::SubgraphRemoved(SubgraphSchemaRemoved {
+            name: subgraph.to_string(),
+            resolution_error: potential_error,
+        })
     }
 
     async fn add_oneshot_subgraph_to_session(
         &mut self,
         subgraph: &str,
         non_repeating_fetch: NonRepeatingFetch,
-    ) {
-        let _ = non_repeating_fetch
+    ) -> Option<SubgraphEvent> {
+        non_repeating_fetch
             .run()
             .await
             .tap_err(|err| tracing::error!("failed to get {subgraph}'s SDL: {err:?}"))
-            .map(|subgraph| {
-                let _ = self
-                    .sender
-                    .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
-                        subgraph.into(),
-                    )))
-                    .tap_err(|err| tracing::error!("{:?}", err));
-            });
+            .ok()
+            .map(|subgraph| SubgraphEvent::SubgraphSchemaChanged(subgraph.into()))
     }
 
     async fn add_streaming_subgraph_to_session(
         &mut self,
         subgraph_watcher: SubgraphWatcher,
-    ) -> Result<(), ResolveSubgraphError> {
+    ) -> Result<SubgraphEvent, ResolveSubgraphError> {
         let fetch = subgraph_watcher.watcher().clone();
         let subgraph = fetch.fetch().await?;
         let cancellation_token = CancellationToken::new();
         let (mut messages, subtask) =
             Subtask::<SubgraphWatcher, FullyResolvedSubgraph>::new(subgraph_watcher);
-        let _ = self
-            .sender
-            .send(Subgraph(SubgraphEvent::SubgraphSchemaChanged(
-                subgraph.clone().into(),
-            )))
-            .tap_err(|err| tracing::error!("{:?}", err));
+        let initial_event = SubgraphEvent::SubgraphSchemaChanged(subgraph.clone().into());
 
         tokio::spawn({
             let sender = self.sender.clone();
@@ -480,7 +479,7 @@ impl SubgraphHandles {
         subtask.run(Some(cancellation_token.clone()));
         self.cancellation_tokens
             .insert(subgraph.name().to_string(), cancellation_token);
-        Ok(())
+        Ok(initial_event)
     }
 }
 


### PR DESCRIPTION
This resolves ROVER-378: When `supergraph.yaml` changes at runtime, `rover dev` processes each subgraph removal as an individual event and recomposes after each one. If a removed subgraph defines fields referenced via `@external` in other subgraphs, the intermediate composition fails and that failed state persists as the final result without ever recovering.
