### PR TITLE
Fix release tagging and release checklist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,8 +355,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: target
 
-      - name: Skip if release tag already exists on target
-        id: tag-check
+      - name: Check existing tag and release on target
+        id: state
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEST: ${{ matrix.dest }}
@@ -364,14 +364,20 @@ jobs:
           # legacy `v1`/`v1.0.0` tags inherited from the pre-lockstep era.
           ACTION_TAG: rover-${{ github.ref_name }}
         run: |
-          if gh api "repos/apollographql-gh-actions/${DEST}/git/refs/tags/${ACTION_TAG}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if gh api "repos/apollographql-gh-actions/${DEST}/git/ref/tags/${ACTION_TAG}" >/dev/null 2>&1; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+          if gh api "repos/apollographql-gh-actions/${DEST}/releases/tags/${ACTION_TAG}" >/dev/null 2>&1; then
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Stage mastered files
-        if: steps.tag-check.outputs.exists == 'false'
+        if: steps.state.outputs.tag_exists == 'false'
         env:
           SRC: ${{ matrix.src }}
         run: |
@@ -386,7 +392,7 @@ jobs:
           fi
 
       - name: Commit, tag, and push
-        if: steps.tag-check.outputs.exists == 'false'
+        if: steps.state.outputs.tag_exists == 'false'
         working-directory: target
         env:
           ROVER_TAG: ${{ github.ref_name }}
@@ -406,7 +412,7 @@ jobs:
           git push origin "$ACTION_TAG"
 
       - name: Create GitHub release on action repo
-        if: steps.tag-check.outputs.exists == 'false'
+        if: steps.state.outputs.release_exists == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEST: ${{ matrix.dest }}

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -64,8 +64,9 @@ This part of the release process is handled by GitHub Actions, and our binaries 
 6. Wait for CI to pass.
 7. Watch the release show up on the [releases page](https://github.com/apollographql/rover/releases)
 8. Verify that all of the [actions repos](https://github.com/search?q=org%3Aapollographql-gh-actions+rover&type=repositories) had releases created.
-8. Click `Edit`, paste the release notes from the changelog, and save the changes to the release.
-9. Close the milestone for this release.
+   - For each repo, open the new release on that repo, click `Edit`, then `Update release` to push the new version to the Marketplace. Releases created via the API don't auto-publish when authored by a GitHub App token (see https://github.com/orgs/community/discussions/7941).
+9. Click `Edit`, paste the release notes from the changelog, and save the changes to the release.
+10. Close the milestone for this release.
 
 ### Verify The Release
 

--- a/actions/install/action.yml
+++ b/actions/install/action.yml
@@ -1,8 +1,9 @@
-name: "Install Rover CLI"
+name: "Install Apollo Rover CLI"
 description: "Install the Rover CLI on the runner. The version installed is pinned to the version of this action."
 author: "Apollo GraphQL"
 branding:
   icon: "terminal"
+  color: "blue"
 
 # This action takes no inputs by design: it invokes the canonical installer
 # scripts, which have the rover version baked in by `cargo xtask prep` at

--- a/actions/persisted-queries-publish/action.yml
+++ b/actions/persisted-queries-publish/action.yml
@@ -1,8 +1,9 @@
-name: "Run Rover Persisted Queries Publish"
+name: "Run Apollo Rover CLI Persisted Queries Publish"
 description: "Run the `rover persisted-queries publish` command."
 author: "Apollo GraphQL"
 branding:
   icon: "terminal"
+  color: "blue"
 
 inputs:
   # required

--- a/actions/subgraph-check/action.yml
+++ b/actions/subgraph-check/action.yml
@@ -1,8 +1,9 @@
-name: "Run Rover Subgraph Check"
+name: "Run Apollo Rover CLI Subgraph Check"
 description: "Run the `rover subgraph check` command."
 author: "Apollo GraphQL"
 branding:
   icon: "terminal"
+  color: "blue"
 
 inputs:
   # required

--- a/actions/subgraph-lint/action.yml
+++ b/actions/subgraph-lint/action.yml
@@ -1,8 +1,9 @@
-name: "Run Rover Subgraph Lint"
+name: "Run Apollo Rover CLI Subgraph Lint"
 description: "Run the `rover subgraph lint` command."
 author: "Apollo GraphQL"
 branding:
   icon: "terminal"
+  color: "blue"
 
 inputs:
   # required

--- a/actions/subgraph-publish/action.yml
+++ b/actions/subgraph-publish/action.yml
@@ -1,8 +1,9 @@
-name: "Run Rover Subgraph Publish"
+name: "Run Apollo Rover CLI Subgraph Publish"
 description: "Run the `rover subgraph publish` command."
 author: "Apollo GraphQL"
 branding:
   icon: "terminal"
+  color: "blue"
 
 inputs:
   # required


### PR DESCRIPTION
Refs checks were using the wrong GitHub API which was fuzzy matching and caused us to mistakenly no-op because it found the release candidate tags. GitHub Actions publishing to Marketplace requries a human 2FA in the loop, so the release checklist is updated to note this unfortunate manual step.

Changing the names of the workflows also changed the marketplace URL/SEO discoverability, so reverted those back to what they used to be.