### PR TITLE
feat(schema): add 'rover schema search' subcommand

### DIFF
--- a/crates/rover-schema/src/search/match_score.rs
+++ b/crates/rover-schema/src/search/match_score.rs
@@ -35,6 +35,19 @@ impl MatchScore {
             .or_else(|| Self::maybe_description(description, terms))
     }
 
+    /// Returns the best tier across multiple OR'd clauses — the strongest
+    /// score from any clause that matches, or `None` if no clause does.
+    pub(super) fn best_of_clauses(
+        name: &str,
+        description: Option<&str>,
+        clauses: &[Vec<String>],
+    ) -> Option<Self> {
+        clauses
+            .iter()
+            .filter_map(|terms| Self::new(name, description, terms))
+            .min()
+    }
+
     fn maybe_exact(name: &str, words: &[String], terms: &[String]) -> Option<Self> {
         let name = name.to_lowercase();
         let exact_hit = terms

--- a/crates/rover-schema/src/search/mod.rs
+++ b/crates/rover-schema/src/search/mod.rs
@@ -6,18 +6,16 @@ pub use result::{ElementKind, SearchResult};
 use crate::ParsedSchema;
 
 impl ParsedSchema {
-    /// Search the schema for elements whose name or description matches all of the given terms.
+    /// Search the schema for elements whose name or description matches the query.
     ///
-    /// Terms are whitespace-separated. Matching is case-insensitive substring search after
-    /// splitting camelCase / snake_case names into words. Results are sorted by relevance
-    /// (name matches rank above description matches) then alphabetically by coordinate.
+    /// The query is comma-separated into OR'd clauses; within a clause, terms are
+    /// whitespace-separated and all must match. Matching is case-insensitive
+    /// substring search after splitting camelCase / snake_case names into words.
+    /// Results are sorted by relevance (name matches rank above description matches)
+    /// then alphabetically by coordinate.
     pub fn search(&self, query: &str, limit: usize, include_deprecated: bool) -> Vec<SearchResult> {
-        let terms: Vec<String> = query
-            .split_whitespace()
-            .map(|t| t.to_lowercase())
-            .filter(|t| !t.is_empty())
-            .collect();
-        if terms.is_empty() {
+        let clauses = parse_query(query);
+        if clauses.is_empty() {
             return Vec::new();
         }
 
@@ -27,7 +25,7 @@ impl ParsedSchema {
             .iter()
             .filter(|(type_name, _)| !type_name.starts_with("__"))
             .flat_map(|(type_name, ty)| {
-                SearchResult::from_extended_type(self, type_name, ty, &terms, include_deprecated)
+                SearchResult::from_extended_type(self, type_name, ty, &clauses, include_deprecated)
             })
             .collect();
 
@@ -39,6 +37,23 @@ impl ParsedSchema {
         results.truncate(limit);
         results
     }
+}
+
+/// Parses a query into OR'd clauses of AND'd terms.
+///
+/// `"create post, delete"` → `[["create","post"], ["delete"]]`.
+/// Empty clauses (from `,,` or trailing/leading `,`) are dropped.
+fn parse_query(query: &str) -> Vec<Vec<String>> {
+    query
+        .split(',')
+        .map(|clause| {
+            clause
+                .split_whitespace()
+                .map(|t| t.to_lowercase())
+                .collect::<Vec<_>>()
+        })
+        .filter(|terms| !terms.is_empty())
+        .collect()
 }
 
 #[cfg(test)]
@@ -171,5 +186,44 @@ mod tests {
         if let (Some(e), Some(f)) = (exact.first(), fuzzy.first()) {
             assert_that!(e.score()).is_less_than(f.score());
         }
+    }
+
+    #[rstest]
+    fn test_search_comma_or_clauses_union_results(schema: ParsedSchema) {
+        // "email" matches User.email; "creating" stems to "creat" → Mutation.createPost.
+        // The two clauses are OR'd, so both should appear in the result set.
+        let results = schema.search("email, creating", 10, false);
+        assert_that!(&results).matching_contains(|r| r.coordinate.to_string() == "User.email");
+        assert_that!(&results)
+            .matching_contains(|r| r.coordinate.to_string() == "Mutation.createPost");
+    }
+
+    #[rstest]
+    fn test_search_clause_picks_best_tier_across_clauses(schema: ParsedSchema) {
+        // For Mutation.createPost: clause "create" matches Exact; clause "creating"
+        // matches Stem. The score should be the best (Exact) — sort order proves it
+        // when compared against a sibling that only matches at Stem.
+        let results = schema.search("create, creating", 10, false);
+        let create_post = results
+            .iter()
+            .find(|r| r.coordinate.to_string() == "Mutation.createPost")
+            .expect("Mutation.createPost should appear");
+        // Stem-only sibling for comparison
+        let stem_only = schema.search("creating", 10, false);
+        let stem_score = stem_only
+            .iter()
+            .find(|r| r.coordinate.to_string() == "Mutation.createPost")
+            .map(|r| r.score())
+            .expect("Mutation.createPost should appear in stem-only search");
+        // Exact (from "create" clause) outranks Stem (from "creating" clause).
+        assert_that!(create_post.score()).is_less_than(stem_score);
+    }
+
+    #[rstest]
+    fn test_search_empty_clauses_are_dropped(schema: ParsedSchema) {
+        // Leading/trailing/double commas produce empty clauses which should be
+        // ignored; the rest of the query still works.
+        let results = schema.search(", email,,", 10, false);
+        assert_that!(&results).matching_contains(|r| r.coordinate.to_string() == "User.email");
     }
 }

--- a/crates/rover-schema/src/search/result.rs
+++ b/crates/rover-schema/src/search/result.rs
@@ -100,11 +100,14 @@ impl SearchResult {
     /// Collect all matching results from a single top-level schema type:
     /// the type itself (if it matches) plus any matching fields, input
     /// fields, or enum values it owns.
+    ///
+    /// `clauses` is a list of OR'd term groups — a candidate matches if any
+    /// single clause's terms all match it.
     pub(super) fn from_extended_type(
         schema: &ParsedSchema,
         type_name: &Name,
         ty: &ExtendedType,
-        terms: &[String],
+        clauses: &[Vec<String>],
         include_deprecated: bool,
     ) -> Vec<Self> {
         let mut out = Vec::new();
@@ -112,7 +115,7 @@ impl SearchResult {
             ExtendedType::Object(obj) => {
                 let via = schema.find_root_paths(type_name);
                 let desc = obj.description.as_ref().map(|d| d.to_string());
-                out.extend(Self::from_type_match(type_name, desc, via.clone(), terms));
+                out.extend(Self::from_type_match(type_name, desc, via.clone(), clauses));
                 for (field_name, field) in &obj.fields {
                     if include_deprecated || !field.is_deprecated() {
                         let fdesc = field.description.as_ref().map(|d| d.to_string());
@@ -122,7 +125,7 @@ impl SearchResult {
                             ElementKind::Field,
                             fdesc,
                             via.clone(),
-                            terms,
+                            clauses,
                         ));
                     }
                 }
@@ -130,7 +133,7 @@ impl SearchResult {
             ExtendedType::Interface(iface) => {
                 let via = schema.find_root_paths(type_name);
                 let desc = iface.description.as_ref().map(|d| d.to_string());
-                out.extend(Self::from_type_match(type_name, desc, via.clone(), terms));
+                out.extend(Self::from_type_match(type_name, desc, via.clone(), clauses));
                 for (field_name, field) in &iface.fields {
                     if include_deprecated || !field.is_deprecated() {
                         let fdesc = field.description.as_ref().map(|d| d.to_string());
@@ -140,14 +143,14 @@ impl SearchResult {
                             ElementKind::Field,
                             fdesc,
                             via.clone(),
-                            terms,
+                            clauses,
                         ));
                     }
                 }
             }
             ExtendedType::InputObject(inp) => {
                 let desc = inp.description.as_ref().map(|d| d.to_string());
-                out.extend(Self::from_type_match(type_name, desc, Vec::new(), terms));
+                out.extend(Self::from_type_match(type_name, desc, Vec::new(), clauses));
                 for (field_name, field) in &inp.fields {
                     if include_deprecated || !field.is_deprecated() {
                         let fdesc = field.description.as_ref().map(|d| d.to_string());
@@ -157,7 +160,7 @@ impl SearchResult {
                             ElementKind::InputField,
                             fdesc,
                             Vec::new(),
-                            terms,
+                            clauses,
                         ));
                     }
                 }
@@ -165,7 +168,7 @@ impl SearchResult {
             ExtendedType::Enum(e) => {
                 let via = schema.find_root_paths(type_name);
                 let desc = e.description.as_ref().map(|d| d.to_string());
-                out.extend(Self::from_type_match(type_name, desc, via.clone(), terms));
+                out.extend(Self::from_type_match(type_name, desc, via.clone(), clauses));
                 for (val_name, val) in &e.values {
                     if include_deprecated || !val.is_deprecated() {
                         let vdesc = val.description.as_ref().map(|d| d.to_string());
@@ -175,7 +178,7 @@ impl SearchResult {
                             ElementKind::EnumValue,
                             vdesc,
                             via.clone(),
-                            terms,
+                            clauses,
                         ));
                     }
                 }
@@ -183,25 +186,26 @@ impl SearchResult {
             ExtendedType::Union(u) => {
                 let desc = u.description.as_ref().map(|d| d.to_string());
                 let via = schema.find_root_paths(type_name);
-                out.extend(Self::from_type_match(type_name, desc, via, terms));
+                out.extend(Self::from_type_match(type_name, desc, via, clauses));
             }
             ExtendedType::Scalar(s) => {
                 let desc = s.description.as_ref().map(|d| d.to_string());
-                out.extend(Self::from_type_match(type_name, desc, Vec::new(), terms));
+                out.extend(Self::from_type_match(type_name, desc, Vec::new(), clauses));
             }
         }
         out
     }
 
-    /// Build a result for a top-level type when its name or description
-    /// matches every term. Returns `None` when no tier matches.
+    /// Build a result for a top-level type when any clause's terms all match
+    /// the name or description. Returns `None` when no clause matches.
     fn from_type_match(
         type_name: &Name,
         description: Option<String>,
         via: Vec<RootPath>,
-        terms: &[String],
+        clauses: &[Vec<String>],
     ) -> Option<Self> {
-        let score = MatchScore::new(type_name.as_str(), description.as_deref(), terms)?;
+        let score =
+            MatchScore::best_of_clauses(type_name.as_str(), description.as_deref(), clauses)?;
         Some(
             Self::for_type()
                 .type_name(type_name)
@@ -213,16 +217,17 @@ impl SearchResult {
     }
 
     /// Build a result for a single attribute — field, input field, or enum
-    /// value — when its name or description matches every term.
+    /// value — when any clause's terms all match its name or description.
     fn from_attribute_match(
         type_name: &Name,
         attribute: &Name,
         kind: ElementKind,
         description: Option<String>,
         via: Vec<RootPath>,
-        terms: &[String],
+        clauses: &[Vec<String>],
     ) -> Option<Self> {
-        let score = MatchScore::new(attribute.as_str(), description.as_deref(), terms)?;
+        let score =
+            MatchScore::best_of_clauses(attribute.as_str(), description.as_deref(), clauses)?;
         Some(
             Self::for_attribute()
                 .type_name(type_name)
@@ -257,8 +262,9 @@ mod tests {
         ParsedSchema::parse(sdl, "test_schema.graphql")
     }
 
-    fn terms(s: &str) -> Vec<String> {
-        s.split_whitespace().map(str::to_lowercase).collect()
+    /// Builds a single-clause input from a whitespace-separated string.
+    fn terms(s: &str) -> Vec<Vec<String>> {
+        vec![s.split_whitespace().map(str::to_lowercase).collect()]
     }
 
     fn ty_of<'a>(schema: &'a ParsedSchema, type_name: &Name) -> &'a ExtendedType {

--- a/src/command/schema/mod.rs
+++ b/src/command/schema/mod.rs
@@ -1,4 +1,5 @@
 mod describe;
+mod search;
 
 use clap::Parser;
 use serde::Serialize;
@@ -16,12 +17,15 @@ pub struct Schema {
 pub enum Command {
     /// Describe a graph's schema by type or field
     Describe(describe::Describe),
+    /// Search a schema for types and fields by keyword
+    Search(search::Search),
 }
 
 impl Schema {
     pub async fn run(&self, _client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
         match &self.command {
             Command::Describe(command) => command.run().await,
+            Command::Search(command) => command.run().await,
         }
     }
 }

--- a/src/command/schema/search/mod.rs
+++ b/src/command/schema/search/mod.rs
@@ -1,0 +1,131 @@
+use std::{
+    io::{self, Read},
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use itertools::Itertools;
+use rover_schema::{ParsedSchema, SearchResult, root_paths::RootPath};
+use rover_std::Fs;
+use serde::Serialize;
+
+use crate::{RoverOutput, RoverResult, command::CliOutput};
+
+#[derive(Debug, Serialize, Parser)]
+/// Search a GraphQL schema for types and fields by keyword
+///
+/// Searches names (with camelCase / snake_case splitting) and descriptions.
+/// All terms must match. Results are ranked: name matches above description matches.
+///
+/// Pass - as FILE to read from stdin.
+#[command(after_help = "EXAMPLES:\n    \
+    rover schema search schema.graphql email\n    \
+    rover schema search schema.graphql \"create post\"\n    \
+    cat schema.graphql | rover schema search - user\n    \
+    rover schema search schema.graphql author --limit 20\n    \
+    rover schema search schema.graphql id --include-deprecated")]
+pub struct Search {
+    /// SDL file to read. Pass - to read from stdin.
+    #[arg(value_name = "FILE")]
+    file: PathBuf,
+
+    /// Search terms. All terms must match (space-separated or quoted).
+    #[arg(value_name = "TERMS", required = true)]
+    terms: Vec<String>,
+
+    /// Maximum number of results to return.
+    #[arg(long, short = 'n', default_value_t = 10)]
+    limit: usize,
+
+    /// Include deprecated fields and enum values in results.
+    #[arg(long)]
+    include_deprecated: bool,
+}
+
+impl Search {
+    pub async fn run(&self) -> RoverResult<RoverOutput> {
+        let (sdl, _label) = self.read_sdl()?;
+        let query = self.terms.join(" ");
+        let schema = ParsedSchema::parse(&sdl, "<input>");
+        let results = schema.search(&query, self.limit, self.include_deprecated);
+        Ok(RoverOutput::CliOutput(Box::new(SearchOutput { query, results })))
+    }
+
+    fn read_sdl(&self) -> RoverResult<(String, String)> {
+        if self.file == Path::new("-") {
+            if io::IsTerminal::is_terminal(&io::stdin()) {
+                return Err(anyhow::anyhow!(
+                    "stdin is a terminal — pipe a schema file or pass a file path instead of -"
+                )
+                .into());
+            }
+            let mut sdl = String::new();
+            io::stdin()
+                .read_to_string(&mut sdl)
+                .map_err(|e| anyhow::anyhow!("failed to read from stdin: {}", e))?;
+            return Ok((sdl, "<stdin>".to_string()));
+        }
+
+        let utf8_path = camino::Utf8PathBuf::try_from(self.file.clone()).map_err(|p| {
+            anyhow::anyhow!("path '{}' contains invalid UTF-8", p.as_path().display())
+        })?;
+        let label = utf8_path.to_string();
+        Ok((Fs::read_file(utf8_path)?, label))
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchOutput {
+    query: String,
+    results: Vec<SearchResult>,
+}
+
+impl CliOutput for SearchOutput {
+    fn text(&self) -> String {
+        if self.results.is_empty() {
+            return format!("No results for \"{}\"", self.query);
+        }
+
+        let header = format!(
+            "{} result{} for \"{}\"",
+            self.results.len(),
+            if self.results.len() == 1 { "" } else { "s" },
+            self.query
+        );
+
+        let items = self
+            .results
+            .iter()
+            .map(format_result)
+            .join("\n\n");
+
+        format!("{header}\n\n{items}")
+    }
+
+    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+fn format_result(r: &SearchResult) -> String {
+    let first_line = match &r.description {
+        Some(desc) => format!("{} — {}", r.coordinate, desc),
+        None => r.coordinate.to_string(),
+    };
+
+    let kind_line = if r.via.is_empty() {
+        format!("  {}", r.kind)
+    } else {
+        let paths = r.via.iter().map(format_root_path).join(", ");
+        format!("  {}  ·  via {}", r.kind, paths)
+    };
+
+    format!("{first_line}\n{kind_line}")
+}
+
+fn format_root_path(p: &RootPath) -> String {
+    p.segments
+        .iter()
+        .map(|s| format!("{}.{}", s.type_name, s.field_name))
+        .join(" -> ")
+}

--- a/src/command/schema/search/mod.rs
+++ b/src/command/schema/search/mod.rs
@@ -48,7 +48,10 @@ impl Search {
         let query = self.terms.join(" ");
         let schema = ParsedSchema::parse(&sdl, "<input>");
         let results = schema.search(&query, self.limit, self.include_deprecated);
-        Ok(RoverOutput::CliOutput(Box::new(SearchOutput { query, results })))
+        Ok(RoverOutput::CliOutput(Box::new(SearchOutput {
+            query,
+            results,
+        })))
     }
 
     fn read_sdl(&self) -> RoverResult<(String, String)> {
@@ -93,11 +96,7 @@ impl CliOutput for SearchOutput {
             self.query
         );
 
-        let items = self
-            .results
-            .iter()
-            .map(format_result)
-            .join("\n\n");
+        let items = self.results.iter().map(format_result).join("\n\n");
 
         format!("{header}\n\n{items}")
     }

--- a/src/command/schema/search/mod.rs
+++ b/src/command/schema/search/mod.rs
@@ -16,13 +16,22 @@ use crate::{RoverOutput, RoverResult};
 #[derive(Debug, Serialize, Parser)]
 /// Search a GraphQL schema for types and fields by keyword
 ///
-/// Searches names (with camelCase / snake_case splitting) and descriptions.
-/// All terms must match. Results are ranked: name matches above description matches.
+/// Queries are comma-separated clauses; a result matches if any clause matches.
+/// Within a clause, all terms must match (space-separated). Names are split on
+/// camelCase / snake_case; matching is case-insensitive. Results are ranked by
+/// match tier (strongest first), then alphabetically by coordinate:
 ///
-/// Pass - as FILE to read from stdin.
+///   Exact        substring of the name or a name token
+///   Stem         shares an English stem with a name token
+///   Fuzzy        within one edit of a name token (terms ≥ 4 chars;
+///                shorter terms must match a token exactly)
+///   Description  appears in the SDL description (with no name match)
+///
+/// Pass `-` as FILE to read an SDL as a file from stdin.
 #[command(after_help = "EXAMPLES:\n    \
     rover schema search schema.graphql email\n    \
     rover schema search schema.graphql \"create post\"\n    \
+    rover schema search schema.graphql \"email, displayName\"\n    \
     cat schema.graphql | rover schema search - user\n    \
     rover schema search schema.graphql author --limit 20\n    \
     rover schema search schema.graphql id --include-deprecated")]

--- a/src/command/schema/search/mod.rs
+++ b/src/command/schema/search/mod.rs
@@ -1,15 +1,17 @@
+mod output;
+
 use std::{
     io::{self, Read},
     path::{Path, PathBuf},
 };
 
 use clap::Parser;
-use itertools::Itertools;
-use rover_schema::{ParsedSchema, SearchResult, root_paths::RootPath};
+use rover_schema::ParsedSchema;
 use rover_std::Fs;
 use serde::Serialize;
 
-use crate::{RoverOutput, RoverResult, command::CliOutput};
+use self::output::SearchOutput;
+use crate::{RoverOutput, RoverResult};
 
 #[derive(Debug, Serialize, Parser)]
 /// Search a GraphQL schema for types and fields by keyword
@@ -75,56 +77,4 @@ impl Search {
         let label = utf8_path.to_string();
         Ok((Fs::read_file(utf8_path)?, label))
     }
-}
-
-#[derive(Debug, Serialize)]
-pub struct SearchOutput {
-    query: String,
-    results: Vec<SearchResult>,
-}
-
-impl CliOutput for SearchOutput {
-    fn text(&self) -> String {
-        if self.results.is_empty() {
-            return format!("No results for \"{}\"", self.query);
-        }
-
-        let header = format!(
-            "{} result{} for \"{}\"",
-            self.results.len(),
-            if self.results.len() == 1 { "" } else { "s" },
-            self.query
-        );
-
-        let items = self.results.iter().map(format_result).join("\n\n");
-
-        format!("{header}\n\n{items}")
-    }
-
-    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
-        serde_json::to_value(self)
-    }
-}
-
-fn format_result(r: &SearchResult) -> String {
-    let first_line = match &r.description {
-        Some(desc) => format!("{} — {}", r.coordinate, desc),
-        None => r.coordinate.to_string(),
-    };
-
-    let kind_line = if r.via.is_empty() {
-        format!("  {}", r.kind)
-    } else {
-        let paths = r.via.iter().map(format_root_path).join(", ");
-        format!("  {}  ·  via {}", r.kind, paths)
-    };
-
-    format!("{first_line}\n{kind_line}")
-}
-
-fn format_root_path(p: &RootPath) -> String {
-    p.segments
-        .iter()
-        .map(|s| format!("{}.{}", s.type_name, s.field_name))
-        .join(" -> ")
 }

--- a/src/command/schema/search/mod.rs
+++ b/src/command/schema/search/mod.rs
@@ -46,9 +46,9 @@ pub struct Search {
 
 impl Search {
     pub async fn run(&self) -> RoverResult<RoverOutput> {
-        let (sdl, _label) = self.read_sdl()?;
+        let (sdl, label) = self.read_sdl()?;
         let query = self.terms.join(" ");
-        let schema = ParsedSchema::parse(&sdl, "<input>");
+        let schema = ParsedSchema::parse(&sdl, &label);
         let results = schema.search(&query, self.limit, self.include_deprecated);
         Ok(RoverOutput::CliOutput(Box::new(SearchOutput {
             query,

--- a/src/command/schema/search/output.rs
+++ b/src/command/schema/search/output.rs
@@ -1,0 +1,57 @@
+use itertools::Itertools;
+use rover_schema::{SearchResult, root_paths::RootPath};
+use serde::Serialize;
+
+use crate::command::CliOutput;
+
+#[derive(Debug, Serialize)]
+pub struct SearchOutput {
+    pub query: String,
+    pub results: Vec<SearchResult>,
+}
+
+impl CliOutput for SearchOutput {
+    fn text(&self) -> String {
+        if self.results.is_empty() {
+            return format!("No results for \"{}\"", self.query);
+        }
+
+        let header = format!(
+            "{} result{} for \"{}\"",
+            self.results.len(),
+            if self.results.len() == 1 { "" } else { "s" },
+            self.query
+        );
+
+        let items = self.results.iter().map(format_result).join("\n\n");
+
+        format!("{header}\n\n{items}")
+    }
+
+    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+fn format_result(r: &SearchResult) -> String {
+    let first_line = match &r.description {
+        Some(desc) => format!("{} — {}", r.coordinate, desc),
+        None => r.coordinate.to_string(),
+    };
+
+    let kind_line = if r.via.is_empty() {
+        format!("  {}", r.kind)
+    } else {
+        let paths = r.via.iter().map(format_root_path).join(", ");
+        format!("  {}  ·  via {}", r.kind, paths)
+    };
+
+    format!("{first_line}\n{kind_line}")
+}
+
+fn format_root_path(p: &RootPath) -> String {
+    p.segments
+        .iter()
+        .map(|s| format!("{}.{}", s.type_name, s.field_name))
+        .join(" -> ")
+}

--- a/tests/fixtures/schema-search/schema.graphql
+++ b/tests/fixtures/schema-search/schema.graphql
@@ -1,0 +1,50 @@
+"""Root query type"""
+type Query {
+  """Get a user by ID"""
+  user(id: ID!): User
+  """Get a post by ID"""
+  post(id: ID!): Post
+}
+
+type Mutation {
+  """Create a new post"""
+  createPost(input: CreatePostInput!): Post
+}
+
+"""A registered user"""
+type User implements Node {
+  id: ID!
+  """The user's email address"""
+  email: String!
+  displayName: String!
+  """Posts authored by this user"""
+  posts: [Post!]!
+  legacyId: String @deprecated(reason: "Use id instead")
+}
+
+"""A content post"""
+type Post implements Node {
+  id: ID!
+  title: String!
+  """The author of this post"""
+  author: User!
+  body: String!
+}
+
+"""An entity with a stable ID"""
+interface Node {
+  id: ID!
+}
+
+"""Membership tier governing access"""
+enum Role {
+  ADMIN
+  USER
+  GUEST @deprecated(reason: "Use USER instead")
+}
+
+input CreatePostInput {
+  """The post title"""
+  title: String!
+  body: String!
+}

--- a/tests/integration/schema/mod.rs
+++ b/tests/integration/schema/mod.rs
@@ -1,1 +1,2 @@
 pub mod fetch;
+pub mod search;

--- a/tests/integration/schema/search.rs
+++ b/tests/integration/schema/search.rs
@@ -1,0 +1,141 @@
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use insta::assert_json_snapshot;
+use rstest::{fixture, rstest};
+use serde_json::Value;
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/schema-search")
+}
+
+#[fixture]
+fn schema_path() -> PathBuf {
+    fixtures_root().join("schema.graphql")
+}
+
+// ── Command helpers ───────────────────────────────────────────────────────────
+
+fn rover() -> Command {
+    let mut cmd = Command::cargo_bin("rover").unwrap();
+    cmd.arg("schema").arg("search");
+    cmd
+}
+
+/// Runs `rover schema search <schema> <terms...> [extra_args]` and returns its JSON output.
+fn run_search(schema: &Path, terms: &[&str], extra_args: &[&str]) -> Value {
+    let output = rover()
+        .arg(schema)
+        .args(terms)
+        .args(extra_args)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "rover schema search failed\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// A single-token name match is returned at the Exact tier.
+#[rstest]
+fn exact_name_match_returns_field(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["email"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// Multi-term query requires every token to match; both `createPost` and
+/// `CreatePostInput` qualify because their tokenized names contain both terms.
+#[rstest]
+fn multi_term_match_requires_all_terms(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["create", "post"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// `creating` stems to `creat`, matching the `create` token in `createPost`
+/// and `CreatePostInput` at the Stem tier (Exact does not match).
+#[rstest]
+fn stem_match_finds_via_english_stemming(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["creating"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// A 4+ char term within one edit of a name token matches at the Fuzzy tier.
+#[rstest]
+fn fuzzy_match_tolerates_single_edit(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["emaill"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// Short (<4 char) terms must match a token exactly — they don't get fuzzy
+/// tolerance, so `usr` does not match the `user` token.
+#[rstest]
+fn fuzzy_short_term_requires_exact_token(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["usr"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// `membership` appears only in `Role`'s description, not in any name; the
+/// result is surfaced at the Description tier.
+#[rstest]
+fn description_only_match_surfaces_result(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["membership"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// Deprecated members (`Role.GUEST`, `User.legacyId`) are filtered out by
+/// default, so a search for `guest` returns nothing.
+#[rstest]
+fn default_excludes_deprecated_members(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["guest"], &[]);
+    assert_json_snapshot!(json);
+}
+
+/// `--include-deprecated` surfaces the deprecated enum value `Role.GUEST`.
+#[rstest]
+fn include_deprecated_surfaces_deprecated_members(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["guest"], &["--include-deprecated"]);
+    assert_json_snapshot!(json);
+}
+
+/// `-n 2` truncates the result list to at most two entries.
+#[rstest]
+fn limit_caps_result_count(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["post"], &["-n", "2"]);
+    assert_json_snapshot!(json);
+}
+
+/// Passing `-` as FILE reads the schema from stdin.
+#[rstest]
+fn stdin_input_via_dash(schema_path: PathBuf) {
+    let sdl = std::fs::read_to_string(&schema_path).unwrap();
+    let output = rover()
+        .arg("-")
+        .arg("email")
+        .arg("--format")
+        .arg("json")
+        .write_stdin(sdl)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "rover schema search - failed\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_json_snapshot!(json);
+}
+
+/// A term that matches nothing in the schema yields an empty `results` array.
+#[rstest]
+fn no_matches_returns_empty_results(schema_path: PathBuf) {
+    let json = run_search(&schema_path, &["xyzzy"], &[]);
+    assert_json_snapshot!(json);
+}

--- a/tests/integration/schema/search.rs
+++ b/tests/integration/schema/search.rs
@@ -159,6 +159,16 @@ fn no_matches_returns_empty_results(schema_path: PathBuf) {
     assert_json_snapshot!(json);
 }
 
+/// Comma-separated clauses are OR'd: a result matching any clause is returned.
+#[rstest]
+fn comma_or_clauses_union_results(schema_path: PathBuf) {
+    // "email" matches User.email; "creating" stems to Mutation.createPost and
+    // CreatePostInput. Results from both clauses appear, sorted by tier then
+    // coordinate.
+    let json = run_search(&schema_path, &["email,", "creating"], &[]);
+    assert_json_snapshot!(json);
+}
+
 // ── Text-format snapshots ────────────────────────────────────────────────────
 //
 // Each test below mirrors the JSON test of the same name, asserting the
@@ -242,5 +252,11 @@ fn stdin_input_via_dash_text(schema_path: PathBuf) {
 #[rstest]
 fn no_matches_returns_empty_results_text(schema_path: PathBuf) {
     let text = run_search_text(&schema_path, &["xyzzy"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn comma_or_clauses_union_results_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["email,", "creating"], &[]);
     assert_snapshot!(text);
 }

--- a/tests/integration/schema/search.rs
+++ b/tests/integration/schema/search.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
-use insta::assert_json_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 use rstest::{fixture, rstest};
 use serde_json::Value;
 
@@ -40,6 +40,25 @@ fn run_search(schema: &Path, terms: &[&str], extra_args: &[&str]) -> Value {
         String::from_utf8_lossy(&output.stderr)
     );
     serde_json::from_slice(&output.stdout).unwrap()
+}
+
+/// Runs `rover schema search <schema> <terms...> [extra_args] --format plain` and returns
+/// its captured stdout as a String for text-format snapshot assertions.
+fn run_search_text(schema: &Path, terms: &[&str], extra_args: &[&str]) -> String {
+    let output = rover()
+        .arg(schema)
+        .args(terms)
+        .args(extra_args)
+        .arg("--format")
+        .arg("plain")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "rover schema search failed\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -138,4 +157,90 @@ fn stdin_input_via_dash(schema_path: PathBuf) {
 fn no_matches_returns_empty_results(schema_path: PathBuf) {
     let json = run_search(&schema_path, &["xyzzy"], &[]);
     assert_json_snapshot!(json);
+}
+
+// ── Text-format snapshots ────────────────────────────────────────────────────
+//
+// Each test below mirrors the JSON test of the same name, asserting the
+// human-facing plain-text formatter (`SearchOutput::text` / `format_result` /
+// `format_root_path` in src/command/schema/search/output.rs).
+
+#[rstest]
+fn exact_name_match_returns_field_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["email"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn multi_term_match_requires_all_terms_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["create", "post"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn stem_match_finds_via_english_stemming_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["creating"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn fuzzy_match_tolerates_single_edit_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["emaill"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn fuzzy_short_term_requires_exact_token_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["usr"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn description_only_match_surfaces_result_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["membership"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn default_excludes_deprecated_members_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["guest"], &[]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn include_deprecated_surfaces_deprecated_members_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["guest"], &["--include-deprecated"]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn limit_caps_result_count_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["post"], &["-n", "2"]);
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn stdin_input_via_dash_text(schema_path: PathBuf) {
+    let sdl = std::fs::read_to_string(&schema_path).unwrap();
+    let output = rover()
+        .arg("-")
+        .arg("email")
+        .arg("--format")
+        .arg("plain")
+        .write_stdin(sdl)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "rover schema search - failed\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert_snapshot!(text);
+}
+
+#[rstest]
+fn no_matches_returns_empty_results_text(schema_path: PathBuf) {
+    let text = run_search_text(&schema_path, &["xyzzy"], &[]);
+    assert_snapshot!(text);
 }

--- a/tests/integration/schema/snapshots/main__integration__schema__search__comma_or_clauses_union_results.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__comma_or_clauses_union_results.snap
@@ -1,0 +1,54 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 169
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "email, creating",
+    "results": [
+      {
+        "coordinate": "User.email",
+        "kind": "field",
+        "description": "The user's email address",
+        "via": [
+          {
+            "segments": [
+              {
+                "type_name": "Query",
+                "field_name": "user"
+              }
+            ]
+          },
+          {
+            "segments": [
+              {
+                "type_name": "Mutation",
+                "field_name": "createPost"
+              },
+              {
+                "type_name": "Post",
+                "field_name": "author"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "coordinate": "CreatePostInput",
+        "kind": "type",
+        "description": null,
+        "via": []
+      },
+      {
+        "coordinate": "Mutation.createPost",
+        "kind": "field",
+        "description": "Create a new post",
+        "via": []
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__comma_or_clauses_union_results_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__comma_or_clauses_union_results_text.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 261
+expression: text
+---
+3 results for "email, creating"
+
+User.email — The user's email address
+  field  ·  via Query.user, Mutation.createPost -> Post.author
+
+CreatePostInput
+  type
+
+Mutation.createPost — Create a new post
+  field

--- a/tests/integration/schema/snapshots/main__integration__schema__search__default_excludes_deprecated_members.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__default_excludes_deprecated_members.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 98
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "guest",
+    "results": [],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__default_excludes_deprecated_members_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__default_excludes_deprecated_members_text.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 207
+expression: text
+---
+No results for "guest"

--- a/tests/integration/schema/snapshots/main__integration__schema__search__description_only_match_surfaces_result.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__description_only_match_surfaces_result.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 90
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "membership",
+    "results": [
+      {
+        "coordinate": "Role",
+        "kind": "type",
+        "description": "Membership tier governing access",
+        "via": []
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__description_only_match_surfaces_result_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__description_only_match_surfaces_result_text.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 201
+expression: text
+---
+1 result for "membership"
+
+Role — Membership tier governing access
+  type

--- a/tests/integration/schema/snapshots/main__integration__schema__search__exact_name_match_returns_field.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__exact_name_match_returns_field.snap
@@ -1,0 +1,42 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 51
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "email",
+    "results": [
+      {
+        "coordinate": "User.email",
+        "kind": "field",
+        "description": "The user's email address",
+        "via": [
+          {
+            "segments": [
+              {
+                "type_name": "Query",
+                "field_name": "user"
+              }
+            ]
+          },
+          {
+            "segments": [
+              {
+                "type_name": "Mutation",
+                "field_name": "createPost"
+              },
+              {
+                "type_name": "Post",
+                "field_name": "author"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__exact_name_match_returns_field_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__exact_name_match_returns_field_text.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 171
+expression: text
+---
+1 result for "email"
+
+User.email — The user's email address
+  field  ·  via Query.user, Mutation.createPost -> Post.author

--- a/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_match_tolerates_single_edit.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_match_tolerates_single_edit.snap
@@ -1,0 +1,42 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 74
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "emaill",
+    "results": [
+      {
+        "coordinate": "User.email",
+        "kind": "field",
+        "description": "The user's email address",
+        "via": [
+          {
+            "segments": [
+              {
+                "type_name": "Query",
+                "field_name": "user"
+              }
+            ]
+          },
+          {
+            "segments": [
+              {
+                "type_name": "Mutation",
+                "field_name": "createPost"
+              },
+              {
+                "type_name": "Post",
+                "field_name": "author"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_match_tolerates_single_edit_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_match_tolerates_single_edit_text.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 189
+expression: text
+---
+1 result for "emaill"
+
+User.email — The user's email address
+  field  ·  via Query.user, Mutation.createPost -> Post.author

--- a/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_short_term_requires_exact_token.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_short_term_requires_exact_token.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 82
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "usr",
+    "results": [],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_short_term_requires_exact_token_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__fuzzy_short_term_requires_exact_token_text.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 195
+expression: text
+---
+No results for "usr"

--- a/tests/integration/schema/snapshots/main__integration__schema__search__include_deprecated_surfaces_deprecated_members.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__include_deprecated_surfaces_deprecated_members.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 105
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "guest",
+    "results": [
+      {
+        "coordinate": "Role.GUEST",
+        "kind": "enum_value",
+        "description": null,
+        "via": []
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__include_deprecated_surfaces_deprecated_members_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__include_deprecated_surfaces_deprecated_members_text.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 213
+expression: text
+---
+1 result for "guest"
+
+Role.GUEST
+  enum value

--- a/tests/integration/schema/snapshots/main__integration__schema__search__limit_caps_result_count.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__limit_caps_result_count.snap
@@ -1,0 +1,27 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 112
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "post",
+    "results": [
+      {
+        "coordinate": "CreatePostInput",
+        "kind": "type",
+        "description": null,
+        "via": []
+      },
+      {
+        "coordinate": "Mutation.createPost",
+        "kind": "field",
+        "description": "Create a new post",
+        "via": []
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__limit_caps_result_count_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__limit_caps_result_count_text.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 219
+expression: text
+---
+2 results for "post"
+
+CreatePostInput
+  type
+
+Mutation.createPost — Create a new post
+  field

--- a/tests/integration/schema/snapshots/main__integration__schema__search__multi_term_match_requires_all_terms.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__multi_term_match_requires_all_terms.snap
@@ -1,0 +1,27 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 59
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "create post",
+    "results": [
+      {
+        "coordinate": "CreatePostInput",
+        "kind": "type",
+        "description": null,
+        "via": []
+      },
+      {
+        "coordinate": "Mutation.createPost",
+        "kind": "field",
+        "description": "Create a new post",
+        "via": []
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__multi_term_match_requires_all_terms_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__multi_term_match_requires_all_terms_text.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 177
+expression: text
+---
+2 results for "create post"
+
+CreatePostInput
+  type
+
+Mutation.createPost — Create a new post
+  field

--- a/tests/integration/schema/snapshots/main__integration__schema__search__no_matches_returns_empty_results.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__no_matches_returns_empty_results.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 140
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "xyzzy",
+    "results": [],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__no_matches_returns_empty_results_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__no_matches_returns_empty_results_text.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 245
+expression: text
+---
+No results for "xyzzy"

--- a/tests/integration/schema/snapshots/main__integration__schema__search__stdin_input_via_dash.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__stdin_input_via_dash.snap
@@ -1,0 +1,42 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 133
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "email",
+    "results": [
+      {
+        "coordinate": "User.email",
+        "kind": "field",
+        "description": "The user's email address",
+        "via": [
+          {
+            "segments": [
+              {
+                "type_name": "Query",
+                "field_name": "user"
+              }
+            ]
+          },
+          {
+            "segments": [
+              {
+                "type_name": "Mutation",
+                "field_name": "createPost"
+              },
+              {
+                "type_name": "Post",
+                "field_name": "author"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__stdin_input_via_dash_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__stdin_input_via_dash_text.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 239
+expression: text
+---
+1 result for "email"
+
+User.email — The user's email address
+  field  ·  via Query.user, Mutation.createPost -> Post.author

--- a/tests/integration/schema/snapshots/main__integration__schema__search__stem_match_finds_via_english_stemming.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__stem_match_finds_via_english_stemming.snap
@@ -1,0 +1,27 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 67
+expression: json
+---
+{
+  "json_version": "1",
+  "data": {
+    "query": "creating",
+    "results": [
+      {
+        "coordinate": "CreatePostInput",
+        "kind": "type",
+        "description": null,
+        "via": []
+      },
+      {
+        "coordinate": "Mutation.createPost",
+        "kind": "field",
+        "description": "Create a new post",
+        "via": []
+      }
+    ],
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/schema/snapshots/main__integration__schema__search__stem_match_finds_via_english_stemming_text.snap
+++ b/tests/integration/schema/snapshots/main__integration__schema__search__stem_match_finds_via_english_stemming_text.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration/schema/search.rs
+assertion_line: 183
+expression: text
+---
+2 results for "creating"
+
+CreatePostInput
+  type
+
+Mutation.createPost — Create a new post
+  field


### PR DESCRIPTION
## Summary

Wires `ParsedSchema::search` (landed in #3262) into a new subcommand:
`rover schema search FILE TERMS...`. Reads SDL from a file path, or from
stdin when FILE is `-`. Renders results as `"Coordinate — description\n  kind · via Type.field -> Type.field"` or as JSON via the standard `CliOutput` plumbing. Supports `--limit/-n` and `--include-deprecated`.

## Integration tests

11 `insta` JSON snapshots under `tests/integration/schema/search.rs`, modeled
on the `client extract` tests. Fixture at `tests/fixtures/schema-search/schema.graphql`
covers each `MatchScore` tier (Exact, Stem, Fuzzy, Description), each
`ElementKind` (Type, Field, InputField, EnumValue), reachable vs.
unreachable types, and deprecated members.

Tests cover:
- per-tier name matching: exact, stem (`creating` → `createPost`), fuzzy (`emaill` → `email`)
- short fuzzy term must match a token exactly (`usr` → no match)
- multi-term AND semantics (`create post`)
- description-only matches (`membership` → `Role` via description)
- `--include-deprecated` toggle (default excludes; flag surfaces `Role.GUEST`)
- `-n` limit truncation
- stdin via `-`
- no-results case