### PR TITLE
Rewrite graph introspect to use apollo-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,26 +180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b877306ffde4d3cc428bbc8f506fdd67b99255298ae92b919954c0c52f530504"
 dependencies = [
  "ahash 0.8.12",
- "apollo-parser 0.8.6",
+ "apollo-parser",
  "ariadne",
  "futures",
  "indexmap 2.14.0",
- "rowan 0.16.1",
+ "rowan",
  "serde",
  "serde_json_bytes",
  "thiserror 2.0.18",
  "triomphe",
  "typed-arena",
-]
-
-[[package]]
-name = "apollo-encoder"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
-dependencies = [
- "apollo-parser 0.7.7",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -268,7 +258,7 @@ checksum = "2e35a18ec424a36424f493bb5c4df80e4f14ac39ee3c0ae78cafa4284dc02d85"
 dependencies = [
  "apollo-compiler",
  "apollo-federation-types",
- "apollo-parser 0.8.6",
+ "apollo-parser",
  "debounced",
  "futures",
  "itertools",
@@ -287,23 +277,12 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb7c8a9776825e5524b5ab3a7f478bf091a054180f244dff85814452cb87d90"
-dependencies = [
- "memchr",
- "rowan 0.15.18",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "apollo-parser"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f6e2be4b3474e5890d34d3e483d49ec9b5cbf9e358bc62c9cc5423376df54b"
 dependencies = [
  "memchr",
- "rowan 0.16.1",
+ "rowan",
  "thiserror 2.0.18",
 ]
 
@@ -3356,15 +3335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "memoize"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4666,7 +4636,7 @@ dependencies = [
  "apollo-compiler",
  "apollo-federation-types",
  "apollo-language-server",
- "apollo-parser 0.8.6",
+ "apollo-parser",
  "assert-json-diff",
  "assert_cmd",
  "assert_fs",
@@ -4768,9 +4738,9 @@ name = "rover-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "apollo-encoder",
+ "apollo-compiler",
  "apollo-federation-types",
- "apollo-parser 0.8.6",
+ "apollo-parser",
  "ariadne",
  "backon",
  "bon",
@@ -4940,19 +4910,6 @@ dependencies = [
  "mockall",
  "pastey",
  "tower 0.5.3",
-]
-
-[[package]]
-name = "rowan"
-version = "0.15.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
-dependencies = [
- "countme",
- "hashbrown 0.14.5",
- "memoffset",
- "rustc-hash 1.1.0",
- "text-size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ timber = { path = "./crates/timber" }
 # https://github.com/apollographql/apollo-rs
 apollo-compiler = "1.31.1"
 apollo-parser = "0.8"
-apollo-encoder = "0.8"
 
 # https://github.com/apollographql/federation-rs
 apollo-federation-types = { version = "0.17.0", features = ["json_schema"] }

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -12,9 +12,9 @@ testing = ["dep:mockall", "rover-tower/test"]
 
 [dependencies]
 ariadne = { workspace = true }
+apollo-compiler = { workspace = true }
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }
-apollo-encoder = { workspace = true }
 backon = { workspace = true }
 bon = { workspace = true }
 buildstructor = { workspace = true }

--- a/crates/rover-client/src/operations/graph/introspect/schema.rs
+++ b/crates/rover-client/src/operations/graph/introspect/schema.rs
@@ -5,10 +5,15 @@
 //!
 use std::convert::TryFrom;
 
-use apollo_encoder::{
-    Argument, Directive, DirectiveDefinition, Document as SDL, EnumDefinition, EnumValue,
-    FieldDefinition, InputField, InputObjectDefinition, InputValueDefinition, InterfaceDefinition,
-    ObjectDefinition, ScalarDefinition, SchemaDefinition, Type_, UnionDefinition, Value,
+use apollo_compiler::{
+    ast::{
+        Argument, Definition, Directive, DirectiveDefinition, DirectiveList, DirectiveLocation,
+        Document, EnumTypeDefinition, EnumValueDefinition, FieldDefinition,
+        InputObjectTypeDefinition, InputValueDefinition, InterfaceTypeDefinition,
+        ObjectTypeDefinition, OperationType, ScalarTypeDefinition, SchemaDefinition, Type,
+        UnionTypeDefinition, Value,
+    },
+    Name, Node,
 };
 use serde::Deserialize;
 
@@ -61,232 +66,265 @@ pub struct Schema {
 impl Schema {
     /// Encode Schema into an SDL.
     pub fn encode(self) -> String {
-        let mut sdl = SDL::new();
+        let mut document = Document::new();
 
         // When we have a defined mutation and subscription, we record
         // everything to Schema Definition.
         // https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema/
         if self.mutation_type.is_some() | self.subscription_type.is_some() {
-            let mut schema_def = SchemaDefinition::new();
-            if let Some(mutation_type) = self.mutation_type {
-                schema_def.mutation(mutation_type.name.unwrap());
+            let mut root_operations = Vec::new();
+            if let Some(name) = self.query_type.name.clone() {
+                root_operations.push(Node::new((
+                    OperationType::Query,
+                    Name::new_unchecked(&name),
+                )));
             }
-            if let Some(subscription_type) = self.subscription_type {
-                schema_def.subscription(subscription_type.name.unwrap());
+            if let Some(mutation_type) = &self.mutation_type {
+                let name = mutation_type.name.clone().unwrap_or_default();
+                root_operations.push(Node::new((
+                    OperationType::Mutation,
+                    Name::new_unchecked(&name),
+                )));
             }
-            if let Some(name) = self.query_type.name {
-                schema_def.query(name);
+            if let Some(subscription_type) = &self.subscription_type {
+                let name = subscription_type.name.clone().unwrap_or_default();
+                root_operations.push(Node::new((
+                    OperationType::Subscription,
+                    Name::new_unchecked(&name),
+                )));
             }
-            sdl.schema(schema_def);
-        } else if let Some(name) = self.query_type.name {
+            document
+                .definitions
+                .push(Definition::SchemaDefinition(Node::new(SchemaDefinition {
+                    description: None,
+                    directives: DirectiveList::default(),
+                    root_operations,
+                })));
+        } else if let Some(name) = &self.query_type.name {
             // If we don't have a mutation or a subscription, but do have a
             // query type, only create a Schema Definition when it's something
             // other than `Query`.
             if name != "Query" {
-                let mut schema_def = SchemaDefinition::new();
-                schema_def.query(name);
-                sdl.schema(schema_def);
+                document
+                    .definitions
+                    .push(Definition::SchemaDefinition(Node::new(SchemaDefinition {
+                        description: None,
+                        directives: DirectiveList::default(),
+                        root_operations: vec![Node::new((
+                            OperationType::Query,
+                            Name::new_unchecked(name),
+                        ))],
+                    })));
             }
+        }
+
+        // Exclude GraphQL named types like __Schema before encoding full type.
+        for type_ in self.types {
+            let skip = match type_.name.as_deref() {
+                Some(name) => GRAPHQL_NAMED_TYPES.contains(&name),
+                None => true,
+            };
+            if skip {
+                continue;
+            }
+            Self::encode_full_type(type_, &mut document);
         }
 
         // Exclude GraphQL directives like 'skip' and 'include' before encoding directives.
-        self.directives
-            .into_iter()
-            .filter(|directive| !SPECIFIED_DIRECTIVES.contains(&directive.name.as_str()))
-            .for_each(|directive| Self::encode_directives(directive, &mut sdl));
+        for directive in self.directives {
+            if SPECIFIED_DIRECTIVES.contains(&directive.name.as_str()) {
+                continue;
+            }
+            Self::encode_directive(directive, &mut document);
+        }
 
-        // Exclude GraphQL named types like __Schema before encoding full type.
-        self.types
-            .into_iter()
-            .filter(|type_| match type_.name.as_deref() {
-                Some(name) => !GRAPHQL_NAMED_TYPES.contains(&name),
-                None => false,
-            })
-            .for_each(|type_| Self::encode_full_type(type_, &mut sdl));
+        // Group definitions by kind so output is stable regardless of the
+        // order the introspection server reports types and directives in.
+        document.definitions.sort_by_key(definition_sort_key);
 
-        sdl.to_string()
+        document.to_string()
     }
 
-    fn encode_directives(directive: SchemaDirective, sdl: &mut SDL) {
-        let mut directive_ = DirectiveDefinition::new(directive.name);
-        if let Some(desc) = directive.description {
-            directive_.description(desc);
-        }
-        for arg in directive.args {
-            let input_value = Self::encode_arg(arg);
-            directive_.arg(input_value);
-        }
-
-        for location in directive.locations {
-            // Location is of a __DirectiveLocation enum that doesn't implement
-            // Display (meaning we can't just do .to_string). This next line
-            // just forces it into a String with format! debug.
-            directive_.location(format!("{location:?}"));
-        }
-
-        sdl.directive(directive_)
+    fn encode_directive(directive: SchemaDirective, document: &mut Document) {
+        let arguments = directive
+            .args
+            .into_iter()
+            .map(|arg| Node::new(Self::encode_arg(arg)))
+            .collect();
+        let locations = directive
+            .locations
+            .into_iter()
+            .filter_map(directive_location_from_query)
+            .collect();
+        document
+            .definitions
+            .push(Definition::DirectiveDefinition(Node::new(
+                DirectiveDefinition {
+                    description: description_node(directive.description),
+                    name: Name::new_unchecked(&directive.name),
+                    arguments,
+                    repeatable: false,
+                    locations,
+                },
+            )));
     }
 
-    fn encode_full_type(type_: SchemaType, sdl: &mut SDL) {
-        match type_.kind {
+    fn encode_full_type(type_: SchemaType, document: &mut Document) {
+        let definition = match type_.kind {
             __TypeKind::OBJECT => {
-                let mut object_def = ObjectDefinition::new(type_.name.unwrap_or_default());
-                if let Some(desc) = type_.description {
-                    object_def.description(desc);
-                }
-                if let Some(interfaces) = type_.interfaces {
-                    for interface in interfaces {
-                        object_def.interface(interface.name.unwrap_or_default());
-                    }
-                }
-                if let Some(field) = type_.fields {
-                    for f in field {
-                        let field_def = Self::encode_field(f);
-                        object_def.field(field_def);
-                    }
-                    sdl.object(object_def);
-                }
+                let Some(fields) = type_.fields else { return };
+                let implements_interfaces = type_
+                    .interfaces
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|i| Name::new_unchecked(&i.name.unwrap_or_default()))
+                    .collect();
+                let field_defs = fields
+                    .into_iter()
+                    .map(|f| Node::new(Self::encode_field(f)))
+                    .collect();
+                Definition::ObjectTypeDefinition(Node::new(ObjectTypeDefinition {
+                    description: description_node(type_.description),
+                    name: Name::new_unchecked(&type_.name.unwrap_or_default()),
+                    implements_interfaces,
+                    directives: DirectiveList::default(),
+                    fields: field_defs,
+                }))
             }
             __TypeKind::INPUT_OBJECT => {
-                let mut input_def = InputObjectDefinition::new(type_.name.unwrap_or_default());
-                if let Some(desc) = type_.description {
-                    input_def.description(desc);
-                }
-                if let Some(field) = type_.input_fields {
-                    for f in field {
-                        let input_field_def = Self::encode_input_field(f);
-                        input_def.field(input_field_def);
-                    }
-                    sdl.input_object(input_def);
-                }
+                let Some(input_fields) = type_.input_fields else {
+                    return;
+                };
+                let fields = input_fields
+                    .into_iter()
+                    .map(|f| Node::new(Self::encode_input_field(f)))
+                    .collect();
+                Definition::InputObjectTypeDefinition(Node::new(InputObjectTypeDefinition {
+                    description: description_node(type_.description),
+                    name: Name::new_unchecked(&type_.name.unwrap_or_default()),
+                    directives: DirectiveList::default(),
+                    fields,
+                }))
             }
             __TypeKind::INTERFACE => {
-                let mut interface_def = InterfaceDefinition::new(type_.name.unwrap_or_default());
-                if let Some(desc) = type_.description {
-                    interface_def.description(desc);
-                }
-                if let Some(interfaces) = type_.interfaces {
-                    for interface in interfaces {
-                        interface_def.interface(interface.name.unwrap_or_default());
-                    }
-                }
-                if let Some(field) = type_.fields {
-                    for f in field {
-                        let field_def = Self::encode_field(f);
-                        interface_def.field(field_def);
-                    }
-                    sdl.interface(interface_def);
-                }
+                let Some(fields) = type_.fields else { return };
+                let implements_interfaces = type_
+                    .interfaces
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|i| Name::new_unchecked(&i.name.unwrap_or_default()))
+                    .collect();
+                let field_defs = fields
+                    .into_iter()
+                    .map(|f| Node::new(Self::encode_field(f)))
+                    .collect();
+                Definition::InterfaceTypeDefinition(Node::new(InterfaceTypeDefinition {
+                    description: description_node(type_.description),
+                    name: Name::new_unchecked(&type_.name.unwrap_or_default()),
+                    implements_interfaces,
+                    directives: DirectiveList::default(),
+                    fields: field_defs,
+                }))
             }
             __TypeKind::SCALAR => {
-                let mut scalar_def = ScalarDefinition::new(type_.name.unwrap_or_default());
-                if let Some(desc) = type_.description {
-                    scalar_def.description(desc);
-                }
-                sdl.scalar(scalar_def);
+                Definition::ScalarTypeDefinition(Node::new(ScalarTypeDefinition {
+                    description: description_node(type_.description),
+                    name: Name::new_unchecked(&type_.name.unwrap_or_default()),
+                    directives: DirectiveList::default(),
+                }))
             }
             __TypeKind::UNION => {
-                let mut union_def = UnionDefinition::new(type_.name.unwrap_or_default());
-                if let Some(desc) = type_.description {
-                    union_def.description(desc);
-                }
-                if let Some(possible_types) = type_.possible_types {
-                    for possible_type in possible_types {
-                        union_def.member(possible_type.name.unwrap_or_default());
-                    }
-                }
-                sdl.union(union_def);
+                let members = type_
+                    .possible_types
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|p| Name::new_unchecked(&p.name.unwrap_or_default()))
+                    .collect();
+                Definition::UnionTypeDefinition(Node::new(UnionTypeDefinition {
+                    description: description_node(type_.description),
+                    name: Name::new_unchecked(&type_.name.unwrap_or_default()),
+                    directives: DirectiveList::default(),
+                    members,
+                }))
             }
             __TypeKind::ENUM => {
-                let mut enum_def = EnumDefinition::new(type_.name.unwrap_or_default());
-                if let Some(desc) = type_.description {
-                    enum_def.description(desc);
-                }
-                if let Some(enums) = type_.enum_values {
-                    for enum_ in enums {
-                        let mut enum_value = EnumValue::new(enum_.name);
-                        if let Some(desc) = enum_.description {
-                            enum_value.description(desc);
-                        }
-
-                        if enum_.is_deprecated {
-                            enum_value
-                                .directive(create_deprecated_directive(enum_.deprecation_reason));
-                        }
-
-                        enum_def.value(enum_value);
-                    }
-                }
-                sdl.enum_(enum_def);
+                let values = type_
+                    .enum_values
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|enum_| {
+                        Node::new(EnumValueDefinition {
+                            description: description_node(enum_.description),
+                            value: Name::new_unchecked(&enum_.name),
+                            directives: deprecation_directives(
+                                enum_.is_deprecated,
+                                enum_.deprecation_reason,
+                            ),
+                        })
+                    })
+                    .collect();
+                Definition::EnumTypeDefinition(Node::new(EnumTypeDefinition {
+                    description: description_node(type_.description),
+                    name: Name::new_unchecked(&type_.name.unwrap_or_default()),
+                    directives: DirectiveList::default(),
+                    values,
+                }))
             }
-            _ => (),
-        }
+            _ => return,
+        };
+        document.definitions.push(definition);
     }
 
     fn encode_field(field: FullTypeField) -> FieldDefinition {
         let ty = Self::encode_type(field.type_);
-        let mut field_def = FieldDefinition::new(field.name, ty);
-
-        for value in field.args {
-            let field_value = Self::encode_arg(value);
-            field_def.arg(field_value);
+        let arguments = field
+            .args
+            .into_iter()
+            .map(|arg| Node::new(Self::encode_arg(arg)))
+            .collect();
+        FieldDefinition {
+            description: description_node(field.description),
+            name: Name::new_unchecked(&field.name),
+            arguments,
+            ty,
+            directives: deprecation_directives(field.is_deprecated, field.deprecation_reason),
         }
-
-        if field.is_deprecated {
-            field_def.directive(create_deprecated_directive(field.deprecation_reason));
-        }
-        if let Some(desc) = field.description {
-            field_def.description(desc);
-        }
-        field_def
     }
 
-    fn encode_input_field(field: FullTypeInputField) -> InputField {
+    fn encode_input_field(field: FullTypeInputField) -> InputValueDefinition {
         let ty = Self::encode_type(field.type_);
-        let mut field_def = InputField::new(field.name, ty);
-        if let Some(default_value) = field.default_value {
-            field_def.default_value(default_value);
+        InputValueDefinition {
+            description: description_node(field.description),
+            name: Name::new_unchecked(&field.name),
+            ty: Node::new(ty),
+            default_value: default_value_node(field.default_value),
+            directives: deprecation_directives(field.is_deprecated, field.deprecation_reason),
         }
-        if let Some(desc) = field.description {
-            field_def.description(desc);
-        }
-
-        if field.is_deprecated {
-            field_def.directive(create_deprecated_directive(field.deprecation_reason));
-        }
-        field_def
     }
 
     fn encode_arg(value: FullTypeFieldArg) -> InputValueDefinition {
         let ty = Self::encode_type(value.type_);
-        let mut value_def = InputValueDefinition::new(value.name, ty);
-        if let Some(default_value) = value.default_value {
-            value_def.default_value(default_value);
+        InputValueDefinition {
+            description: description_node(value.description),
+            name: Name::new_unchecked(&value.name),
+            ty: Node::new(ty),
+            default_value: default_value_node(value.default_value),
+            directives: deprecation_directives(value.is_deprecated, value.deprecation_reason),
         }
-        if let Some(desc) = value.description {
-            value_def.description(desc);
-        }
-
-        if value.is_deprecated {
-            value_def.directive(create_deprecated_directive(value.deprecation_reason));
-        }
-        value_def
     }
 
-    fn encode_type(ty: impl OfType) -> Type_ {
+    fn encode_type(ty: impl OfType) -> Type {
         use graph_introspect_query::__TypeKind::*;
         match ty.kind() {
-            SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT => Type_::NamedType {
-                name: ty.name().unwrap().to_string(),
+            SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT => {
+                Type::Named(Name::new_unchecked(ty.name().unwrap()))
+            }
+            NON_NULL => match Self::encode_type(ty.of_type().unwrap()) {
+                Type::Named(name) => Type::NonNullNamed(name),
+                Type::List(inner) => Type::NonNullList(inner),
+                already_non_null => already_non_null,
             },
-            NON_NULL => {
-                let ty = Self::encode_type(ty.of_type().unwrap());
-                Type_::NonNull { ty: Box::new(ty) }
-            }
-            LIST => {
-                let ty = Self::encode_type(ty.of_type().unwrap());
-                Type_::List { ty: Box::new(ty) }
-            }
+            LIST => Type::List(Box::new(Self::encode_type(ty.of_type().unwrap()))),
             Other(ty) => unreachable!("Unknown type kind: {}", ty),
         }
     }
@@ -392,13 +430,75 @@ impl OfType for graph_introspect_query::TypeRefOfTypeOfTypeOfTypeOfTypeOfTypeOfT
     }
 }
 
-fn create_deprecated_directive(reason: Option<String>) -> Directive {
-    let mut deprecated_directive = Directive::new(String::from("deprecated"));
-    if let Some(reason) = reason {
-        deprecated_directive.arg(Argument::new(String::from("reason"), Value::String(reason)));
+/// Stable sort key matching apollo-encoder's by-category emission order
+const fn definition_sort_key(def: &Definition) -> u8 {
+    match def {
+        Definition::SchemaDefinition(_) => 0,
+        Definition::ScalarTypeDefinition(_) => 1,
+        Definition::ObjectTypeDefinition(_) => 2,
+        Definition::InterfaceTypeDefinition(_) => 3,
+        Definition::UnionTypeDefinition(_) => 4,
+        Definition::EnumTypeDefinition(_) => 5,
+        Definition::InputObjectTypeDefinition(_) => 6,
+        Definition::DirectiveDefinition(_) => 7,
+        _ => 8,
     }
+}
 
-    deprecated_directive
+fn description_node(desc: Option<String>) -> Option<Node<str>> {
+    desc.map(|d| Node::new_str(&d))
+}
+
+fn deprecation_directives(is_deprecated: bool, reason: Option<String>) -> DirectiveList {
+    if !is_deprecated {
+        return DirectiveList::default();
+    }
+    let mut directive = Directive {
+        name: Name::new_unchecked("deprecated"),
+        arguments: Vec::new(),
+    };
+    if let Some(reason) = reason {
+        directive.arguments.push(Node::new(Argument {
+            name: Name::new_unchecked("reason"),
+            value: Node::new(Value::String(reason)),
+        }));
+    }
+    DirectiveList(vec![Node::new(directive)])
+}
+
+fn default_value_node(literal: Option<String>) -> Option<Node<Value>> {
+    let raw = literal?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(Node::new(Value::Enum(Name::new_unchecked(&raw))))
+}
+
+fn directive_location_from_query(
+    location: graph_introspect_query::__DirectiveLocation,
+) -> Option<DirectiveLocation> {
+    use graph_introspect_query::__DirectiveLocation as Loc;
+    Some(match location {
+        Loc::QUERY => DirectiveLocation::Query,
+        Loc::MUTATION => DirectiveLocation::Mutation,
+        Loc::SUBSCRIPTION => DirectiveLocation::Subscription,
+        Loc::FIELD => DirectiveLocation::Field,
+        Loc::FRAGMENT_DEFINITION => DirectiveLocation::FragmentDefinition,
+        Loc::FRAGMENT_SPREAD => DirectiveLocation::FragmentSpread,
+        Loc::INLINE_FRAGMENT => DirectiveLocation::InlineFragment,
+        Loc::SCHEMA => DirectiveLocation::Schema,
+        Loc::SCALAR => DirectiveLocation::Scalar,
+        Loc::OBJECT => DirectiveLocation::Object,
+        Loc::FIELD_DEFINITION => DirectiveLocation::FieldDefinition,
+        Loc::ARGUMENT_DEFINITION => DirectiveLocation::ArgumentDefinition,
+        Loc::INTERFACE => DirectiveLocation::Interface,
+        Loc::UNION => DirectiveLocation::Union,
+        Loc::ENUM => DirectiveLocation::Enum,
+        Loc::ENUM_VALUE => DirectiveLocation::EnumValue,
+        Loc::INPUT_OBJECT => DirectiveLocation::InputObject,
+        Loc::INPUT_FIELD_DEFINITION => DirectiveLocation::InputFieldDefinition,
+        Loc::Other(_) => return None,
+    })
 }
 
 #[cfg(test)]
@@ -413,6 +513,14 @@ mod tests {
     use crate::operations::graph::introspect::types::QueryResponseData;
 
     #[test]
+    fn deprecated_reason_with_quotes_is_escaped() {
+        let rendered = deprecation_directives(true, Some(String::from(r#"use "valueV2.data""#)));
+        let directive = rendered.0[0].clone();
+        let printed = directive.to_string();
+        assert_eq!(printed, r#"@deprecated(reason: "use \"valueV2.data\"")"#);
+    }
+
+    #[test]
     fn it_builds_simple_schema() {
         let file = File::open("src/operations/graph/introspect/fixtures/simple.json").unwrap();
         let res: Response<QueryResponseData> = serde_json::from_reader(file).unwrap();
@@ -422,39 +530,47 @@ mod tests {
         assert_eq!(
             schema.encode(),
             indoc! { r#"
-        "The `Upload` scalar type represents a file upload."
-        scalar Upload
-        type Query {
-          "A simple type for getting started!"
-          hello: String
-          cats(cat: [String]! = ["Nori"]): [String]!
-          dogs(excludeChihuahuas: Boolean = false @deprecated(reason: "Chihuahuas are dogs too!")): [String]!
-        }
-        enum CacheControlScope {
-          PUBLIC
-          PRIVATE
-        }
-        input BooleanQueryOperatorInput {
-          eq: Boolean
-          ne: Boolean
-          in: [Boolean]
-          nin: [Boolean]
-        }
-        input StringQueryOperatorInput {
-          eq: String
-          ne: String
-          in: [String]
-          nin: [String]
-          regex: String
-          glob: String @deprecated(reason: "Glob is deprecated, use regex instead")
-        }
-        directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
-        "Exposes a URL that specifies the behaviour of this scalar."
-        directive @specifiedBy(
-            "The URL that specifies the behaviour of this scalar."
-            url: String!
-          ) on SCALAR
-    "#}
+                """The `Upload` scalar type represents a file upload."""
+                scalar Upload
+                
+                type Query {
+                  """A simple type for getting started!"""
+                  hello: String
+                  cats(cat: [String]! = ["Nori"]): [String]!
+                  dogs(
+                    excludeChihuahuas: Boolean = false @deprecated(reason: "Chihuahuas are dogs too!"),
+                  ): [String]!
+                }
+                
+                enum CacheControlScope {
+                  PUBLIC
+                  PRIVATE
+                }
+                
+                input BooleanQueryOperatorInput {
+                  eq: Boolean
+                  ne: Boolean
+                  in: [Boolean]
+                  nin: [Boolean]
+                }
+                
+                input StringQueryOperatorInput {
+                  eq: String
+                  ne: String
+                  in: [String]
+                  nin: [String]
+                  regex: String
+                  glob: String @deprecated(reason: "Glob is deprecated, use regex instead")
+                }
+                
+                directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
+                
+                """Exposes a URL that specifies the behaviour of this scalar."""
+                directive @specifiedBy(
+                  """The URL that specifies the behaviour of this scalar."""
+                  url: String!,
+                ) on SCALAR
+                "#}
         )
     }
 
@@ -468,965 +584,1010 @@ mod tests {
         assert_eq!(
             schema.encode(),
             indoc! { r#"
-        schema {
-          query: Root
-        }
-        type Root {
-          allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
-          film(id: ID, filmID: ID): Film
-          allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection
-          person(id: ID, personID: ID): Person
-          allPlanets(after: String, first: Int, before: String, last: Int): PlanetsConnection
-          planet(id: ID, planetID: ID): Planet
-          allSpecies(after: String, first: Int, before: String, last: Int): SpeciesConnection
-          species(id: ID, speciesID: ID): Species
-          allStarships(after: String, first: Int, before: String, last: Int): StarshipsConnection
-          starship(id: ID, starshipID: ID): Starship
-          allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
-          vehicle(id: ID, vehicleID: ID): Vehicle
-          "Fetches an object given its ID"
-          node(
-            "The ID of an object"
-            id: ID!
-          ): Node
-        }
-        "A connection to a list of items."
-        type FilmsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [FilmsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          films: [Film]
-        }
-        "Information about pagination in a connection."
-        type PageInfo {
-          "When paginating forwards, are there more items?"
-          hasNextPage: Boolean!
-          "When paginating backwards, are there more items?"
-          hasPreviousPage: Boolean!
-          "When paginating backwards, the cursor to continue."
-          startCursor: String
-          "When paginating forwards, the cursor to continue."
-          endCursor: String
-        }
-        "An edge in a connection."
-        type FilmsEdge {
-          "The item at the end of the edge"
-          node: Film
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A single film."
-        type Film implements Node {
-          "The title of this film."
-          title: String
-          "The episode number of this film."
-          episodeID: Int
-          "The opening paragraphs at the beginning of this film."
-          openingCrawl: String
-          "The name of the director of this film."
-          director: String
-          "The name(s) of the producer(s) of this film."
-          producers: [String]
-          "The ISO 8601 date format of film release at original creator country."
-          releaseDate: String
-          speciesConnection(after: String, first: Int, before: String, last: Int): FilmSpeciesConnection
-          starshipConnection(after: String, first: Int, before: String, last: Int): FilmStarshipsConnection
-          vehicleConnection(after: String, first: Int, before: String, last: Int): FilmVehiclesConnection
-          characterConnection(after: String, first: Int, before: String, last: Int): FilmCharactersConnection
-          planetConnection(after: String, first: Int, before: String, last: Int): FilmPlanetsConnection
-          "The ISO 8601 date format of the time that this resource was created."
-          created: String
-          "The ISO 8601 date format of the time that this resource was edited."
-          edited: String
-          "The ID of an object"
-          id: ID!
-        }
-        "A connection to a list of items."
-        type FilmSpeciesConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [FilmSpeciesEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          species: [Species]
-        }
-        "An edge in a connection."
-        type FilmSpeciesEdge {
-          "The item at the end of the edge"
-          node: Species
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A type of person or character within the Star Wars Universe."
-        type Species implements Node {
-          "The name of this species."
-          name: String
-          """
-          The classification of this species, such as "mammal" or "reptile".
-          """
-          classification: String
-          """
-          The designation of this species, such as "sentient".
-          """
-          designation: String
-          "The average height of this species in centimeters."
-          averageHeight: Float
-          "The average lifespan of this species in years, null if unknown."
-          averageLifespan: Int
-          """
-          Common eye colors for this species, null if this species does not typically
-          have eyes.
-          """
-          eyeColors: [String]
-          """
-          Common hair colors for this species, null if this species does not typically
-          have hair.
-          """
-          hairColors: [String]
-          """
-          Common skin colors for this species, null if this species does not typically
-          have skin.
-          """
-          skinColors: [String]
-          "The language commonly spoken by this species."
-          language: String
-          "A planet that this species originates from."
-          homeworld: Planet
-          personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
-          filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
-          "The ISO 8601 date format of the time that this resource was created."
-          created: String
-          "The ISO 8601 date format of the time that this resource was edited."
-          edited: String
-          "The ID of an object"
-          id: ID!
-        }
-        """
-        A large mass, planet or planetoid in the Star Wars Universe, at the time of
-        0 ABY.
-        """
-        type Planet implements Node {
-          "The name of this planet."
-          name: String
-          "The diameter of this planet in kilometers."
-          diameter: Int
-          """
-          The number of standard hours it takes for this planet to complete a single
-          rotation on its axis.
-          """
-          rotationPeriod: Int
-          """
-          The number of standard days it takes for this planet to complete a single orbit
-          of its local star.
-          """
-          orbitalPeriod: Int
-          """
-          A number denoting the gravity of this planet, where "1" is normal or 1 standard
-          G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
-          """
-          gravity: String
-          "The average population of sentient beings inhabiting this planet."
-          population: Float
-          "The climates of this planet."
-          climates: [String]
-          "The terrains of this planet."
-          terrains: [String]
-          """
-          The percentage of the planet surface that is naturally occuring water or bodies
-          of water.
-          """
-          surfaceWater: Float
-          residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
-          filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
-          "The ISO 8601 date format of the time that this resource was created."
-          created: String
-          "The ISO 8601 date format of the time that this resource was edited."
-          edited: String
-          "The ID of an object"
-          id: ID!
-        }
-        "A connection to a list of items."
-        type PlanetResidentsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PlanetResidentsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          residents: [Person]
-        }
-        "An edge in a connection."
-        type PlanetResidentsEdge {
-          "The item at the end of the edge"
-          node: Person
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "An individual person or character within the Star Wars universe."
-        type Person implements Node {
-          "The name of this person."
-          name: String
-          """
-          The birth year of the person, using the in-universe standard of BBY or ABY -
-          Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
-          a battle that occurs at the end of Star Wars episode IV: A New Hope.
-          """
-          birthYear: String
-          """
-          The eye color of this person. Will be "unknown" if not known or "n/a" if the
-          person does not have an eye.
-          """
-          eyeColor: String
-          """
-          The gender of this person. Either "Male", "Female" or "unknown",
-          "n/a" if the person does not have a gender.
-          """
-          gender: String
-          """
-          The hair color of this person. Will be "unknown" if not known or "n/a" if the
-          person does not have hair.
-          """
-          hairColor: String
-          "The height of the person in centimeters."
-          height: Int
-          "The mass of the person in kilograms."
-          mass: Float
-          "The skin color of this person."
-          skinColor: String
-          "A planet that this person was born on or inhabits."
-          homeworld: Planet
-          filmConnection(after: String, first: Int, before: String, last: Int): PersonFilmsConnection
-          "The species that this person belongs to, or null if unknown."
-          species: Species
-          starshipConnection(after: String, first: Int, before: String, last: Int): PersonStarshipsConnection
-          vehicleConnection(after: String, first: Int, before: String, last: Int): PersonVehiclesConnection
-          "The ISO 8601 date format of the time that this resource was created."
-          created: String
-          "The ISO 8601 date format of the time that this resource was edited."
-          edited: String
-          "The ID of an object"
-          id: ID!
-        }
-        "A connection to a list of items."
-        type PersonFilmsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PersonFilmsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          films: [Film]
-        }
-        "An edge in a connection."
-        type PersonFilmsEdge {
-          "The item at the end of the edge"
-          node: Film
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type PersonStarshipsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PersonStarshipsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          starships: [Starship]
-        }
-        "An edge in a connection."
-        type PersonStarshipsEdge {
-          "The item at the end of the edge"
-          node: Starship
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A single transport craft that has hyperdrive capability."
-        type Starship implements Node {
-          """
-          The name of this starship. The common name, such as "Death Star".
-          """
-          name: String
-          """
-          The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
-          Orbital Battle Station".
-          """
-          model: String
-          """
-          The class of this starship, such as "Starfighter" or "Deep Space Mobile
-          Battlestation"
-          """
-          starshipClass: String
-          "The manufacturers of this starship."
-          manufacturers: [String]
-          "The cost of this starship new, in galactic credits."
-          costInCredits: Float
-          "The length of this starship in meters."
-          length: Float
-          "The number of personnel needed to run or pilot this starship."
-          crew: String
-          "The number of non-essential people this starship can transport."
-          passengers: String
-          """
-          The maximum speed of this starship in atmosphere. null if this starship is
-          incapable of atmosphering flight.
-          """
-          maxAtmospheringSpeed: Int
-          "The class of this starships hyperdrive."
-          hyperdriveRating: Float
-          """
-          The Maximum number of Megalights this starship can travel in a standard hour.
-          A "Megalight" is a standard unit of distance and has never been defined before
-          within the Star Wars universe. This figure is only really useful for measuring
-          the difference in speed of starships. We can assume it is similar to AU, the
-          distance between our Sun (Sol) and Earth.
-          """
-          MGLT: Int
-          "The maximum number of kilograms that this starship can transport."
-          cargoCapacity: Float
-          """
-          The maximum length of time that this starship can provide consumables for its
-          entire crew without having to resupply.
-          """
-          consumables: String
-          pilotConnection(after: String, first: Int, before: String, last: Int): StarshipPilotsConnection
-          filmConnection(after: String, first: Int, before: String, last: Int): StarshipFilmsConnection
-          "The ISO 8601 date format of the time that this resource was created."
-          created: String
-          "The ISO 8601 date format of the time that this resource was edited."
-          edited: String
-          "The ID of an object"
-          id: ID!
-        }
-        "A connection to a list of items."
-        type StarshipPilotsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [StarshipPilotsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          pilots: [Person]
-        }
-        "An edge in a connection."
-        type StarshipPilotsEdge {
-          "The item at the end of the edge"
-          node: Person
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type StarshipFilmsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [StarshipFilmsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          films: [Film]
-        }
-        "An edge in a connection."
-        type StarshipFilmsEdge {
-          "The item at the end of the edge"
-          node: Film
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type PersonVehiclesConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PersonVehiclesEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          vehicles: [Vehicle]
-        }
-        "An edge in a connection."
-        type PersonVehiclesEdge {
-          "The item at the end of the edge"
-          node: Vehicle
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A single transport craft that does not have hyperdrive capability"
-        type Vehicle implements Node {
-          """
-          The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
-          bike".
-          """
-          name: String
-          """
-          The model or official name of this vehicle. Such as "All-Terrain Attack
-          Transport".
-          """
-          model: String
-          """
-          The class of this vehicle, such as "Wheeled" or "Repulsorcraft".
-          """
-          vehicleClass: String
-          "The manufacturers of this vehicle."
-          manufacturers: [String]
-          "The cost of this vehicle new, in Galactic Credits."
-          costInCredits: Float
-          "The length of this vehicle in meters."
-          length: Float
-          "The number of personnel needed to run or pilot this vehicle."
-          crew: String
-          "The number of non-essential people this vehicle can transport."
-          passengers: String
-          "The maximum speed of this vehicle in atmosphere."
-          maxAtmospheringSpeed: Int
-          "The maximum number of kilograms that this vehicle can transport."
-          cargoCapacity: Float
-          """
-          The maximum length of time that this vehicle can provide consumables for its
-          entire crew without having to resupply.
-          """
-          consumables: String
-          pilotConnection(after: String, first: Int, before: String, last: Int): VehiclePilotsConnection
-          filmConnection(after: String, first: Int, before: String, last: Int): VehicleFilmsConnection
-          "The ISO 8601 date format of the time that this resource was created."
-          created: String
-          "The ISO 8601 date format of the time that this resource was edited."
-          edited: String
-          "The ID of an object"
-          id: ID!
-        }
-        "A connection to a list of items."
-        type VehiclePilotsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [VehiclePilotsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          pilots: [Person]
-        }
-        "An edge in a connection."
-        type VehiclePilotsEdge {
-          "The item at the end of the edge"
-          node: Person
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type VehicleFilmsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [VehicleFilmsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          films: [Film]
-        }
-        "An edge in a connection."
-        type VehicleFilmsEdge {
-          "The item at the end of the edge"
-          node: Film
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type PlanetFilmsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PlanetFilmsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          films: [Film]
-        }
-        "An edge in a connection."
-        type PlanetFilmsEdge {
-          "The item at the end of the edge"
-          node: Film
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type SpeciesPeopleConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [SpeciesPeopleEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          people: [Person]
-        }
-        "An edge in a connection."
-        type SpeciesPeopleEdge {
-          "The item at the end of the edge"
-          node: Person
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type SpeciesFilmsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [SpeciesFilmsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          films: [Film]
-        }
-        "An edge in a connection."
-        type SpeciesFilmsEdge {
-          "The item at the end of the edge"
-          node: Film
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type FilmStarshipsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [FilmStarshipsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          starships: [Starship]
-        }
-        "An edge in a connection."
-        type FilmStarshipsEdge {
-          "The item at the end of the edge"
-          node: Starship
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type FilmVehiclesConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [FilmVehiclesEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          vehicles: [Vehicle]
-        }
-        "An edge in a connection."
-        type FilmVehiclesEdge {
-          "The item at the end of the edge"
-          node: Vehicle
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type FilmCharactersConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [FilmCharactersEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          characters: [Person]
-        }
-        "An edge in a connection."
-        type FilmCharactersEdge {
-          "The item at the end of the edge"
-          node: Person
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type FilmPlanetsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [FilmPlanetsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          planets: [Planet]
-        }
-        "An edge in a connection."
-        type FilmPlanetsEdge {
-          "The item at the end of the edge"
-          node: Planet
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type PeopleConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PeopleEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          people: [Person]
-        }
-        "An edge in a connection."
-        type PeopleEdge {
-          "The item at the end of the edge"
-          node: Person
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type PlanetsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [PlanetsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          planets: [Planet]
-        }
-        "An edge in a connection."
-        type PlanetsEdge {
-          "The item at the end of the edge"
-          node: Planet
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type SpeciesConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [SpeciesEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          species: [Species]
-        }
-        "An edge in a connection."
-        type SpeciesEdge {
-          "The item at the end of the edge"
-          node: Species
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type StarshipsConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [StarshipsEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          starships: [Starship]
-        }
-        "An edge in a connection."
-        type StarshipsEdge {
-          "The item at the end of the edge"
-          node: Starship
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "A connection to a list of items."
-        type VehiclesConnection {
-          "Information to aid in pagination."
-          pageInfo: PageInfo!
-          "A list of edges."
-          edges: [VehiclesEdge]
-          """
-          A count of the total number of objects in this connection, ignoring pagination.
-          This allows a client to fetch the first five objects by passing "5" as the
-          argument to "first", then fetch the total count so it could display "5 of 83",
-          for example.
-          """
-          totalCount: Int
-          """
-          A list of all of the objects returned in the connection. This is a convenience
-          field provided for quickly exploring the API; rather than querying for
-          "{ edges { node } }" when no edge data is needed, this field can be be used
-          instead. Note that when clients like Relay need to fetch the "cursor" field on
-          the edge to enable efficient pagination, this shortcut cannot be used, and the
-          full "{ edges { node } }" version should be used instead.
-          """
-          vehicles: [Vehicle]
-        }
-        "An edge in a connection."
-        type VehiclesEdge {
-          "The item at the end of the edge"
-          node: Vehicle
-          "A cursor for use in pagination"
-          cursor: String!
-        }
-        "An object with an ID"
-        interface Node {
-          "The id of the object."
-          id: ID!
-        }
-    "#}
+                schema {
+                  query: Root
+                }
+                
+                type Root {
+                  allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
+                  film(id: ID, filmID: ID): Film
+                  allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection
+                  person(id: ID, personID: ID): Person
+                  allPlanets(after: String, first: Int, before: String, last: Int): PlanetsConnection
+                  planet(id: ID, planetID: ID): Planet
+                  allSpecies(after: String, first: Int, before: String, last: Int): SpeciesConnection
+                  species(id: ID, speciesID: ID): Species
+                  allStarships(after: String, first: Int, before: String, last: Int): StarshipsConnection
+                  starship(id: ID, starshipID: ID): Starship
+                  allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
+                  vehicle(id: ID, vehicleID: ID): Vehicle
+                  """Fetches an object given its ID"""
+                  node(
+                    """The ID of an object"""
+                    id: ID!,
+                  ): Node
+                }
+                
+                """A connection to a list of items."""
+                type FilmsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [FilmsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  films: [Film]
+                }
+                
+                """Information about pagination in a connection."""
+                type PageInfo {
+                  """When paginating forwards, are there more items?"""
+                  hasNextPage: Boolean!
+                  """When paginating backwards, are there more items?"""
+                  hasPreviousPage: Boolean!
+                  """When paginating backwards, the cursor to continue."""
+                  startCursor: String
+                  """When paginating forwards, the cursor to continue."""
+                  endCursor: String
+                }
+                
+                """An edge in a connection."""
+                type FilmsEdge {
+                  """The item at the end of the edge"""
+                  node: Film
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A single film."""
+                type Film implements Node {
+                  """The title of this film."""
+                  title: String
+                  """The episode number of this film."""
+                  episodeID: Int
+                  """The opening paragraphs at the beginning of this film."""
+                  openingCrawl: String
+                  """The name of the director of this film."""
+                  director: String
+                  """The name(s) of the producer(s) of this film."""
+                  producers: [String]
+                  """The ISO 8601 date format of film release at original creator country."""
+                  releaseDate: String
+                  speciesConnection(after: String, first: Int, before: String, last: Int): FilmSpeciesConnection
+                  starshipConnection(after: String, first: Int, before: String, last: Int): FilmStarshipsConnection
+                  vehicleConnection(after: String, first: Int, before: String, last: Int): FilmVehiclesConnection
+                  characterConnection(after: String, first: Int, before: String, last: Int): FilmCharactersConnection
+                  planetConnection(after: String, first: Int, before: String, last: Int): FilmPlanetsConnection
+                  """The ISO 8601 date format of the time that this resource was created."""
+                  created: String
+                  """The ISO 8601 date format of the time that this resource was edited."""
+                  edited: String
+                  """The ID of an object"""
+                  id: ID!
+                }
+                
+                """A connection to a list of items."""
+                type FilmSpeciesConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [FilmSpeciesEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  species: [Species]
+                }
+                
+                """An edge in a connection."""
+                type FilmSpeciesEdge {
+                  """The item at the end of the edge"""
+                  node: Species
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A type of person or character within the Star Wars Universe."""
+                type Species implements Node {
+                  """The name of this species."""
+                  name: String
+                  """The classification of this species, such as "mammal" or "reptile"."""
+                  classification: String
+                  """The designation of this species, such as "sentient"."""
+                  designation: String
+                  """The average height of this species in centimeters."""
+                  averageHeight: Float
+                  """The average lifespan of this species in years, null if unknown."""
+                  averageLifespan: Int
+                  """
+                  Common eye colors for this species, null if this species does not typically
+                  have eyes.
+                  """
+                  eyeColors: [String]
+                  """
+                  Common hair colors for this species, null if this species does not typically
+                  have hair.
+                  """
+                  hairColors: [String]
+                  """
+                  Common skin colors for this species, null if this species does not typically
+                  have skin.
+                  """
+                  skinColors: [String]
+                  """The language commonly spoken by this species."""
+                  language: String
+                  """A planet that this species originates from."""
+                  homeworld: Planet
+                  personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
+                  filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
+                  """The ISO 8601 date format of the time that this resource was created."""
+                  created: String
+                  """The ISO 8601 date format of the time that this resource was edited."""
+                  edited: String
+                  """The ID of an object"""
+                  id: ID!
+                }
+                
+                """
+                A large mass, planet or planetoid in the Star Wars Universe, at the time of
+                0 ABY.
+                """
+                type Planet implements Node {
+                  """The name of this planet."""
+                  name: String
+                  """The diameter of this planet in kilometers."""
+                  diameter: Int
+                  """
+                  The number of standard hours it takes for this planet to complete a single
+                  rotation on its axis.
+                  """
+                  rotationPeriod: Int
+                  """
+                  The number of standard days it takes for this planet to complete a single orbit
+                  of its local star.
+                  """
+                  orbitalPeriod: Int
+                  """
+                  A number denoting the gravity of this planet, where "1" is normal or 1 standard
+                  G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
+                  """
+                  gravity: String
+                  """The average population of sentient beings inhabiting this planet."""
+                  population: Float
+                  """The climates of this planet."""
+                  climates: [String]
+                  """The terrains of this planet."""
+                  terrains: [String]
+                  """
+                  The percentage of the planet surface that is naturally occuring water or bodies
+                  of water.
+                  """
+                  surfaceWater: Float
+                  residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
+                  filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
+                  """The ISO 8601 date format of the time that this resource was created."""
+                  created: String
+                  """The ISO 8601 date format of the time that this resource was edited."""
+                  edited: String
+                  """The ID of an object"""
+                  id: ID!
+                }
+                
+                """A connection to a list of items."""
+                type PlanetResidentsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PlanetResidentsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  residents: [Person]
+                }
+                
+                """An edge in a connection."""
+                type PlanetResidentsEdge {
+                  """The item at the end of the edge"""
+                  node: Person
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """An individual person or character within the Star Wars universe."""
+                type Person implements Node {
+                  """The name of this person."""
+                  name: String
+                  """
+                  The birth year of the person, using the in-universe standard of BBY or ABY -
+                  Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
+                  a battle that occurs at the end of Star Wars episode IV: A New Hope.
+                  """
+                  birthYear: String
+                  """
+                  The eye color of this person. Will be "unknown" if not known or "n/a" if the
+                  person does not have an eye.
+                  """
+                  eyeColor: String
+                  """
+                  The gender of this person. Either "Male", "Female" or "unknown",
+                  "n/a" if the person does not have a gender.
+                  """
+                  gender: String
+                  """
+                  The hair color of this person. Will be "unknown" if not known or "n/a" if the
+                  person does not have hair.
+                  """
+                  hairColor: String
+                  """The height of the person in centimeters."""
+                  height: Int
+                  """The mass of the person in kilograms."""
+                  mass: Float
+                  """The skin color of this person."""
+                  skinColor: String
+                  """A planet that this person was born on or inhabits."""
+                  homeworld: Planet
+                  filmConnection(after: String, first: Int, before: String, last: Int): PersonFilmsConnection
+                  """The species that this person belongs to, or null if unknown."""
+                  species: Species
+                  starshipConnection(after: String, first: Int, before: String, last: Int): PersonStarshipsConnection
+                  vehicleConnection(after: String, first: Int, before: String, last: Int): PersonVehiclesConnection
+                  """The ISO 8601 date format of the time that this resource was created."""
+                  created: String
+                  """The ISO 8601 date format of the time that this resource was edited."""
+                  edited: String
+                  """The ID of an object"""
+                  id: ID!
+                }
+                
+                """A connection to a list of items."""
+                type PersonFilmsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PersonFilmsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  films: [Film]
+                }
+                
+                """An edge in a connection."""
+                type PersonFilmsEdge {
+                  """The item at the end of the edge"""
+                  node: Film
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type PersonStarshipsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PersonStarshipsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  starships: [Starship]
+                }
+                
+                """An edge in a connection."""
+                type PersonStarshipsEdge {
+                  """The item at the end of the edge"""
+                  node: Starship
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A single transport craft that has hyperdrive capability."""
+                type Starship implements Node {
+                  """The name of this starship. The common name, such as "Death Star"."""
+                  name: String
+                  """
+                  The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+                  Orbital Battle Station".
+                  """
+                  model: String
+                  """
+                  The class of this starship, such as "Starfighter" or "Deep Space Mobile
+                  Battlestation"
+                  """
+                  starshipClass: String
+                  """The manufacturers of this starship."""
+                  manufacturers: [String]
+                  """The cost of this starship new, in galactic credits."""
+                  costInCredits: Float
+                  """The length of this starship in meters."""
+                  length: Float
+                  """The number of personnel needed to run or pilot this starship."""
+                  crew: String
+                  """The number of non-essential people this starship can transport."""
+                  passengers: String
+                  """
+                  The maximum speed of this starship in atmosphere. null if this starship is
+                  incapable of atmosphering flight.
+                  """
+                  maxAtmospheringSpeed: Int
+                  """The class of this starships hyperdrive."""
+                  hyperdriveRating: Float
+                  """
+                  The Maximum number of Megalights this starship can travel in a standard hour.
+                  A "Megalight" is a standard unit of distance and has never been defined before
+                  within the Star Wars universe. This figure is only really useful for measuring
+                  the difference in speed of starships. We can assume it is similar to AU, the
+                  distance between our Sun (Sol) and Earth.
+                  """
+                  MGLT: Int
+                  """The maximum number of kilograms that this starship can transport."""
+                  cargoCapacity: Float
+                  """
+                  The maximum length of time that this starship can provide consumables for its
+                  entire crew without having to resupply.
+                  """
+                  consumables: String
+                  pilotConnection(after: String, first: Int, before: String, last: Int): StarshipPilotsConnection
+                  filmConnection(after: String, first: Int, before: String, last: Int): StarshipFilmsConnection
+                  """The ISO 8601 date format of the time that this resource was created."""
+                  created: String
+                  """The ISO 8601 date format of the time that this resource was edited."""
+                  edited: String
+                  """The ID of an object"""
+                  id: ID!
+                }
+                
+                """A connection to a list of items."""
+                type StarshipPilotsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [StarshipPilotsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  pilots: [Person]
+                }
+                
+                """An edge in a connection."""
+                type StarshipPilotsEdge {
+                  """The item at the end of the edge"""
+                  node: Person
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type StarshipFilmsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [StarshipFilmsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  films: [Film]
+                }
+                
+                """An edge in a connection."""
+                type StarshipFilmsEdge {
+                  """The item at the end of the edge"""
+                  node: Film
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type PersonVehiclesConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PersonVehiclesEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  vehicles: [Vehicle]
+                }
+                
+                """An edge in a connection."""
+                type PersonVehiclesEdge {
+                  """The item at the end of the edge"""
+                  node: Vehicle
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A single transport craft that does not have hyperdrive capability"""
+                type Vehicle implements Node {
+                  """
+                  The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+                  bike".
+                  """
+                  name: String
+                  """
+                  The model or official name of this vehicle. Such as "All-Terrain Attack
+                  Transport".
+                  """
+                  model: String
+                  """The class of this vehicle, such as "Wheeled" or "Repulsorcraft"."""
+                  vehicleClass: String
+                  """The manufacturers of this vehicle."""
+                  manufacturers: [String]
+                  """The cost of this vehicle new, in Galactic Credits."""
+                  costInCredits: Float
+                  """The length of this vehicle in meters."""
+                  length: Float
+                  """The number of personnel needed to run or pilot this vehicle."""
+                  crew: String
+                  """The number of non-essential people this vehicle can transport."""
+                  passengers: String
+                  """The maximum speed of this vehicle in atmosphere."""
+                  maxAtmospheringSpeed: Int
+                  """The maximum number of kilograms that this vehicle can transport."""
+                  cargoCapacity: Float
+                  """
+                  The maximum length of time that this vehicle can provide consumables for its
+                  entire crew without having to resupply.
+                  """
+                  consumables: String
+                  pilotConnection(after: String, first: Int, before: String, last: Int): VehiclePilotsConnection
+                  filmConnection(after: String, first: Int, before: String, last: Int): VehicleFilmsConnection
+                  """The ISO 8601 date format of the time that this resource was created."""
+                  created: String
+                  """The ISO 8601 date format of the time that this resource was edited."""
+                  edited: String
+                  """The ID of an object"""
+                  id: ID!
+                }
+                
+                """A connection to a list of items."""
+                type VehiclePilotsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [VehiclePilotsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  pilots: [Person]
+                }
+                
+                """An edge in a connection."""
+                type VehiclePilotsEdge {
+                  """The item at the end of the edge"""
+                  node: Person
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type VehicleFilmsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [VehicleFilmsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  films: [Film]
+                }
+                
+                """An edge in a connection."""
+                type VehicleFilmsEdge {
+                  """The item at the end of the edge"""
+                  node: Film
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type PlanetFilmsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PlanetFilmsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  films: [Film]
+                }
+                
+                """An edge in a connection."""
+                type PlanetFilmsEdge {
+                  """The item at the end of the edge"""
+                  node: Film
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type SpeciesPeopleConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [SpeciesPeopleEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  people: [Person]
+                }
+                
+                """An edge in a connection."""
+                type SpeciesPeopleEdge {
+                  """The item at the end of the edge"""
+                  node: Person
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type SpeciesFilmsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [SpeciesFilmsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  films: [Film]
+                }
+                
+                """An edge in a connection."""
+                type SpeciesFilmsEdge {
+                  """The item at the end of the edge"""
+                  node: Film
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type FilmStarshipsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [FilmStarshipsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  starships: [Starship]
+                }
+                
+                """An edge in a connection."""
+                type FilmStarshipsEdge {
+                  """The item at the end of the edge"""
+                  node: Starship
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type FilmVehiclesConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [FilmVehiclesEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  vehicles: [Vehicle]
+                }
+                
+                """An edge in a connection."""
+                type FilmVehiclesEdge {
+                  """The item at the end of the edge"""
+                  node: Vehicle
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type FilmCharactersConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [FilmCharactersEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  characters: [Person]
+                }
+                
+                """An edge in a connection."""
+                type FilmCharactersEdge {
+                  """The item at the end of the edge"""
+                  node: Person
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type FilmPlanetsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [FilmPlanetsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  planets: [Planet]
+                }
+                
+                """An edge in a connection."""
+                type FilmPlanetsEdge {
+                  """The item at the end of the edge"""
+                  node: Planet
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type PeopleConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PeopleEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  people: [Person]
+                }
+                
+                """An edge in a connection."""
+                type PeopleEdge {
+                  """The item at the end of the edge"""
+                  node: Person
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type PlanetsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [PlanetsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  planets: [Planet]
+                }
+                
+                """An edge in a connection."""
+                type PlanetsEdge {
+                  """The item at the end of the edge"""
+                  node: Planet
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type SpeciesConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [SpeciesEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  species: [Species]
+                }
+                
+                """An edge in a connection."""
+                type SpeciesEdge {
+                  """The item at the end of the edge"""
+                  node: Species
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type StarshipsConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [StarshipsEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  starships: [Starship]
+                }
+                
+                """An edge in a connection."""
+                type StarshipsEdge {
+                  """The item at the end of the edge"""
+                  node: Starship
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """A connection to a list of items."""
+                type VehiclesConnection {
+                  """Information to aid in pagination."""
+                  pageInfo: PageInfo!
+                  """A list of edges."""
+                  edges: [VehiclesEdge]
+                  """
+                  A count of the total number of objects in this connection, ignoring pagination.
+                  This allows a client to fetch the first five objects by passing "5" as the
+                  argument to "first", then fetch the total count so it could display "5 of 83",
+                  for example.
+                  """
+                  totalCount: Int
+                  """
+                  A list of all of the objects returned in the connection. This is a convenience
+                  field provided for quickly exploring the API; rather than querying for
+                  "{ edges { node } }" when no edge data is needed, this field can be be used
+                  instead. Note that when clients like Relay need to fetch the "cursor" field on
+                  the edge to enable efficient pagination, this shortcut cannot be used, and the
+                  full "{ edges { node } }" version should be used instead.
+                  """
+                  vehicles: [Vehicle]
+                }
+                
+                """An edge in a connection."""
+                type VehiclesEdge {
+                  """The item at the end of the edge"""
+                  node: Vehicle
+                  """A cursor for use in pagination"""
+                  cursor: String!
+                }
+                
+                """An object with an ID"""
+                interface Node {
+                  """The id of the object."""
+                  id: ID!
+                }
+                "#}
         );
     }
 
@@ -1440,157 +1601,171 @@ mod tests {
         assert_eq!(
             schema.encode(),
             indoc! { r#"
-             type Query {
-               "Fetch a simple list of products with an offset"
-               topProducts(first: Int = 5): [Product] @deprecated(reason: "Use `products` instead")
-               "Fetch a paginated list of products based on a filter type."
-               products(first: Int = 5, after: Int = 0, type: ProductType): ProductConnection
-               """
-               The currently authenticated user root. All nodes off of this
-               root will be authenticated as the current user
-               """
-               me: User
-             }
-             "A review is any feedback about products across the graph"
-             type Review {
-               id: ID!
-               "The plain text version of the review"
-               body: String
-               "The user who authored the review"
-               author: User
-               "The product which this review is about"
-               product: Product
-             }
-             "The base User in Acephei"
-             type User {
-               "A globally unique id for the user"
-               id: ID!
-               "The users full name as provided"
-               name: String
-               "The account username of the user"
-               username: String
-               "A list of all reviews by the user"
-               reviews: [Review]
-             }
-             "A connection wrapper for lists of reviews"
-             type ReviewConnection {
-               "Helpful metadata about the connection"
-               pageInfo: PageInfo
-               "List of reviews returned by the search"
-               edges: [ReviewEdge]
-             }
-             """
-             The PageInfo type provides pagination helpers for determining
-             if more data can be fetched from the list
-             """
-             type PageInfo {
-               "More items exist in the list"
-               hasNextPage: Boolean
-               "Items earlier in the list exist"
-               hasPreviousPage: Boolean
-             }
-             "A connection edge for the Review type"
-             type ReviewEdge {
-               review: Review
-             }
-             "A connection wrapper for lists of products"
-             type ProductConnection {
-               "Helpful metadata about the connection"
-               pageInfo: PageInfo
-               "List of products returned by the search"
-               edges: [ProductEdge]
-             }
-             "A connection edge for the Product type"
-             type ProductEdge {
-               product: Product
-             }
-             "The basic book in the graph"
-             type Book implements Product {
-               "All books can be found by an isbn"
-               isbn: String!
-               "The title of the book"
-               title: String
-               "The year the book was published"
-               year: Int
-               """
-               Улюблена книга, прочитана цього рока "" | 今年読んだお気に入りの本
-               """
-               favouriteBook: Book
-               "A simple list of similar books"
-               similarBooks: [Book]
-               reviews: [Review]
-               reviewList(first: Int = 5, after: Int = 0): ReviewConnection
-               """
-               relatedReviews for a book use the knowledge of `similarBooks` from the books
-               service to return related reviews that may be of interest to the user
-               """
-               relatedReviews(first: Int = 5, after: Int = 0): ReviewConnection
-               "Since books are now products, we can also use their upc as a primary id"
-               upc: String!
-               "The name of a book is the book's title + year published"
-               name(delimeter: String = " "): String
-               price: Int
-               weight: Int
-             }
-             "Information about the brand Amazon"
-             type Amazon {
-               "The url of a referrer for a product"
-               referrer: String
-             }
-             "Information about the brand Ikea"
-             type Ikea {
-               "Which asile to find an item"
-               asile: Int
-             }
-             """
-             The Furniture type represents all products which are items
-             of furniture.
-             """
-             type Furniture implements Product {
-               "The modern primary identifier for furniture"
-               upc: String!
-               "The SKU field is how furniture was previously stored, and still exists in some legacy systems"
-               sku: String!
-               name: String
-               price: Int
-               "The brand of furniture"
-               brand: Brand
-               weight: Int
-               reviews: [Review]
-               reviewList(first: Int = 5, after: Int = 0): ReviewConnection
-             }
-             "The Product type represents all products within the system"
-             interface Product {
-               "The primary identifier of products in the graph"
-               upc: String!
-               "The display name of the product"
-               name: String
-               "A simple integer price of the product in US dollars"
-               price: Int
-               "How much the product weighs in kg"
-               weight: Int @deprecated(reason: "Not all product's have a weight")
-               "A simple list of all reviews for a product"
-               reviews: [Review] @deprecated(reason: """The `reviews` field on product is deprecated to roll over the return
-             type from a simple list to a paginated list. The easiest way to fix your
-             operations is to alias the new field `reviewList` to `review`.
-             Once all clients have updated, we will roll over this field and deprecate
-             `reviewList` in favor of the field name `reviews` again""")
-               """
-               A paginated list of reviews. This field naming is temporary while all clients
-               migrate off of the un-paginated version of this field call reviews. To ease this migration,
-               alias your usage of `reviewList` to `reviews` so that after the roll over is finished, you
-               can remove the alias and use the final field name.
-               """
-               reviewList(first: Int = 5, after: Int = 0): ReviewConnection
-             }
-             "A union of all brands represented within the store"
-             union Brand = Ikea | Amazon
-             "An enum of product types"
-             enum ProductType {
-               LATEST
-               TRENDING
-             }
-         "#}
+                type Query {
+                  """Fetch a simple list of products with an offset"""
+                  topProducts(first: Int = 5): [Product] @deprecated(reason: "Use `products` instead")
+                  """Fetch a paginated list of products based on a filter type."""
+                  products(first: Int = 5, after: Int = 0, type: ProductType): ProductConnection
+                  """
+                  The currently authenticated user root. All nodes off of this
+                  root will be authenticated as the current user
+                  """
+                  me: User
+                }
+                
+                """A review is any feedback about products across the graph"""
+                type Review {
+                  id: ID!
+                  """The plain text version of the review"""
+                  body: String
+                  """The user who authored the review"""
+                  author: User
+                  """The product which this review is about"""
+                  product: Product
+                }
+                
+                """The base User in Acephei"""
+                type User {
+                  """A globally unique id for the user"""
+                  id: ID!
+                  """The users full name as provided"""
+                  name: String
+                  """The account username of the user"""
+                  username: String
+                  """A list of all reviews by the user"""
+                  reviews: [Review]
+                }
+                
+                """A connection wrapper for lists of reviews"""
+                type ReviewConnection {
+                  """Helpful metadata about the connection"""
+                  pageInfo: PageInfo
+                  """List of reviews returned by the search"""
+                  edges: [ReviewEdge]
+                }
+                
+                """
+                The PageInfo type provides pagination helpers for determining
+                if more data can be fetched from the list
+                """
+                type PageInfo {
+                  """More items exist in the list"""
+                  hasNextPage: Boolean
+                  """Items earlier in the list exist"""
+                  hasPreviousPage: Boolean
+                }
+                
+                """A connection edge for the Review type"""
+                type ReviewEdge {
+                  review: Review
+                }
+                
+                """A connection wrapper for lists of products"""
+                type ProductConnection {
+                  """Helpful metadata about the connection"""
+                  pageInfo: PageInfo
+                  """List of products returned by the search"""
+                  edges: [ProductEdge]
+                }
+                
+                """A connection edge for the Product type"""
+                type ProductEdge {
+                  product: Product
+                }
+                
+                """The basic book in the graph"""
+                type Book implements Product {
+                  """All books can be found by an isbn"""
+                  isbn: String!
+                  """The title of the book"""
+                  title: String
+                  """The year the book was published"""
+                  year: Int
+                  """
+                  Улюблена книга, прочитана цього рока "" | 今年読んだお気に入りの本
+                  """
+                  favouriteBook: Book
+                  """A simple list of similar books"""
+                  similarBooks: [Book]
+                  reviews: [Review]
+                  reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+                  """
+                  relatedReviews for a book use the knowledge of `similarBooks` from the books
+                  service to return related reviews that may be of interest to the user
+                  """
+                  relatedReviews(first: Int = 5, after: Int = 0): ReviewConnection
+                  """
+                  Since books are now products, we can also use their upc as a primary id
+                  """
+                  upc: String!
+                  """The name of a book is the book's title + year published"""
+                  name(delimeter: String = " "): String
+                  price: Int
+                  weight: Int
+                }
+                
+                """Information about the brand Amazon"""
+                type Amazon {
+                  """The url of a referrer for a product"""
+                  referrer: String
+                }
+                
+                """Information about the brand Ikea"""
+                type Ikea {
+                  """Which asile to find an item"""
+                  asile: Int
+                }
+                
+                """
+                The Furniture type represents all products which are items
+                of furniture.
+                """
+                type Furniture implements Product {
+                  """The modern primary identifier for furniture"""
+                  upc: String!
+                  """
+                  The SKU field is how furniture was previously stored, and still exists in some legacy systems
+                  """
+                  sku: String!
+                  name: String
+                  price: Int
+                  """The brand of furniture"""
+                  brand: Brand
+                  weight: Int
+                  reviews: [Review]
+                  reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+                }
+                
+                """The Product type represents all products within the system"""
+                interface Product {
+                  """The primary identifier of products in the graph"""
+                  upc: String!
+                  """The display name of the product"""
+                  name: String
+                  """A simple integer price of the product in US dollars"""
+                  price: Int
+                  """How much the product weighs in kg"""
+                  weight: Int @deprecated(reason: "Not all product's have a weight")
+                  """A simple list of all reviews for a product"""
+                  reviews: [Review] @deprecated(reason: "The `reviews` field on product is deprecated to roll over the return\ntype from a simple list to a paginated list. The easiest way to fix your\noperations is to alias the new field `reviewList` to `review`.\nOnce all clients have updated, we will roll over this field and deprecate\n`reviewList` in favor of the field name `reviews` again")
+                  """
+                  A paginated list of reviews. This field naming is temporary while all clients
+                  migrate off of the un-paginated version of this field call reviews. To ease this migration,
+                  alias your usage of `reviewList` to `reviews` so that after the roll over is finished, you
+                  can remove the alias and use the final field name.
+                  """
+                  reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+                }
+                
+                """A union of all brands represented within the store"""
+                union Brand = Ikea | Amazon
+                
+                """An enum of product types"""
+                enum ProductType {
+                  LATEST
+                  TRENDING
+                }
+                "#}
         )
     }
 }

--- a/regressions/e2e/introspection/is_deprecated.md
+++ b/regressions/e2e/introspection/is_deprecated.md
@@ -7,21 +7,32 @@ $ rover graph introspect http://localhost:8000
 schema {
   query: QueryRoot
 }
+
 type QueryRoot {
   recipe(id: String!): Recipe!
-  bogus(id: String!, title: String @deprecated(reason: "bar")): Int!
+  bogus(
+    id: String!,
+    title: String @deprecated(reason: "bar"),
+  ): Int!
 }
+
 type Recipe {
   creation: String!
   title: String! @deprecated(reason: "foo")
 }
-"Indicates that an Input Object is a OneOf Input Object (and thus requires exactly one of its field be provided)"
+
+"""
+Indicates that an Input Object is a OneOf Input Object (and thus requires exactly one of its field be provided)
+"""
 directive @oneOf on INPUT_OBJECT
-"Provides a scalar specification URL for specifying the behavior of custom scalar types."
+
+"""
+Provides a scalar specification URL for specifying the behavior of custom scalar types.
+"""
 directive @specifiedBy(
-    "URL that specifies the behavior of this scalar."
-    url: String!
-  ) on SCALAR
+  """URL that specifies the behavior of this scalar."""
+  url: String!,
+) on SCALAR
 
 
 ```

--- a/tests/e2e/artifacts/graph/inventory.graphql
+++ b/tests/e2e/artifacts/graph/inventory.graphql
@@ -1,51 +1,79 @@
 scalar _Any
+
 scalar FieldSet
+
 scalar link__Import
+
 scalar federation__ContextFieldValue
+
 scalar federation__Scope
+
 scalar federation__Policy
+
 type Variant {
   id: ID!
-  "Checks the warehouse API for inventory information."
+  """Checks the warehouse API for inventory information."""
   inventory: Inventory
 }
-"Inventory details about a specific Variant"
+
+"""Inventory details about a specific Variant"""
 type Inventory {
-  "Returns true if the inventory count is greater than 0"
+  """Returns true if the inventory count is greater than 0"""
   inStock: Boolean!
-  "The raw count of not purchased items in the warehouse"
+  """The raw count of not purchased items in the warehouse"""
   inventory: Int
 }
+
 type _Service {
   sdl: String!
 }
+
 type Query {
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!
 }
+
 union _Entity = Variant
+
 enum link__Purpose {
   SECURITY
   EXECUTION
 }
-"Exposes a URL that specifies the behavior of this scalar."
+
+"""Exposes a URL that specifies the behavior of this scalar."""
 directive @specifiedBy(
-    "The URL that specifies the behavior of this scalar."
-    url: String!
-  ) on SCALAR
+  """The URL that specifies the behavior of this scalar."""
+  url: String!,
+) on SCALAR
+
 directive @external on OBJECT | FIELD_DEFINITION
+
 directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
 directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+
 directive @key(fields: FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
+
 directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) on SCHEMA
+
 directive @shareable on OBJECT | FIELD_DEFINITION
+
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
 directive @tag(name: String!) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
 directive @override(from: String!) on FIELD_DEFINITION
+
 directive @composeDirective(name: String!) on SCHEMA
+
 directive @interfaceObject on OBJECT
+
 directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
 directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
 directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
 directive @context(name: String!) on INTERFACE | OBJECT | UNION
+
 directive @fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION

--- a/tests/e2e/artifacts/graph/pandas_changed_introspect.graphql
+++ b/tests/e2e/artifacts/graph/pandas_changed_introspect.graphql
@@ -1,18 +1,22 @@
-type Query {                                                                                               
+type Query {
   getMeAllThePandas: [Panda]
-  panda(name: ID!): Panda                                                                                  
+  panda(name: ID!): Panda
   _service: _Service!
-}                                                    
-type Panda {                                         
+}
+
+type Panda {
   name: ID!
   favoriteFood: String
 }
+
 type _Service {
   sdl: String!
 }
-"Exposes a URL that specifies the behavior of this scalar."
+
+"""Exposes a URL that specifies the behavior of this scalar."""
 directive @specifiedBy(
-    "The URL that specifies the behavior of this scalar."
-    url: String!
-  ) on SCALAR
+  """The URL that specifies the behavior of this scalar."""
+  url: String!,
+) on SCALAR
+
 directive @tag(name: String!) on FIELD_DEFINITION


### PR DESCRIPTION
Fixes #3312, as this bug was fixed upstream after the deprecation of apollo-encoder but Rover never moved off that crate.
