### PR TITLE
Remove unused querying for variant names

### DIFF
--- a/crates/rover-client/src/operations/persisted_queries/name/name_query.graphql
+++ b/crates/rover-client/src/operations/persisted_queries/name/name_query.graphql
@@ -4,8 +4,5 @@ query PersistedQueryListNameQuery($graphId: ID!, $listId: ID!) {
     persistedQueryList(id: $listId) {
       name
     }
-    variants {
-      name
-    }
   }
 }


### PR DESCRIPTION
The variant names are unused by rover and it is expensive to query for all graph variants. Removing that part of the query should improve performance of the query.