### PR TITLE
Update upload-artifacts to include retries

### DIFF
--- a/.github/actions/upload-artifact-with-retry/action.yml
+++ b/.github/actions/upload-artifact-with-retry/action.yml
@@ -1,0 +1,68 @@
+name: 'Upload artifact with retry'
+description: >-
+  Wraps actions/upload-artifact with up to 3 attempts so that transient
+  GitHub-side failures (e.g. CreateArtifact ENOTFOUND on the initial request)
+  do not fail the job. Inputs mirror actions/upload-artifact@v7.
+
+inputs:
+  name:
+    description: 'Artifact name'
+    required: true
+  path:
+    description: 'A file, directory or wildcard pattern that describes what to upload. Multi-line supported.'
+    required: true
+  if-no-files-found:
+    description: "Behavior when no files are found: warn (default), error, ignore"
+    required: false
+    default: 'warn'
+  retention-days:
+    description: 'Duration after which artifact will expire in days. 0 means use the repository default.'
+    required: false
+    default: '0'
+
+runs:
+  using: composite
+  steps:
+    - name: 'Upload artifact (attempt 1)'
+      id: upload1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      continue-on-error: true
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: 'Wait before retry 1'
+      if: steps.upload1.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "Upload attempt 1 failed (likely a transient GitHub Actions infra error). Sleeping 30s before retry."
+        sleep 30
+
+    - name: 'Upload artifact (attempt 2)'
+      id: upload2
+      if: steps.upload1.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      continue-on-error: true
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: 'Wait before retry 2'
+      if: steps.upload1.outcome == 'failure' && steps.upload2.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "Upload attempt 2 failed. Sleeping 60s before final retry."
+        sleep 60
+
+    - name: 'Upload artifact (attempt 3, final)'
+      if: steps.upload1.outcome == 'failure' && steps.upload2.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
         shell: bash
         run: cargo xtask package --rebuild
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: artifacts-${{ matrix.platform }}
           path: artifacts/*

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -52,7 +52,7 @@ jobs:
             export FEATURES=""
           fi
           cargo build --target ${{ matrix.compile_target.target }} --test e2e ${FEATURES}
-      - uses: actions/upload-artifact@v7
+      - uses: ./.github/actions/upload-artifact-with-retry
         name: "Store built binaries to use later on"
         with:
           name: ${{ matrix.compile_target.target }}


### PR DESCRIPTION
This should fix transient issues such as:

```
Run actions/upload-artifact@v7
  with:
    name: aarch64-apple-darwin
    path: target/aarch64-apple-darwin/debug/rover*
  !target/aarch64-apple-darwin/debug/rover.pdb
  target/aarch64-apple-darwin/debug/deps/e2e-*
  !target/aarch64-apple-darwin/debug/deps/e2e-*.o
  !target/aarch64-apple-darwin/debug/deps/e2e-*.d
  !target/aarch64-apple-darwin/debug/deps/e2e-*.exp
  !target/aarch64-apple-darwin/debug/deps/e2e-*.lib
  !target/aarch64-apple-darwin/debug/deps/e2e-*.pdb
  
    if-no-files-found: error
    retention-days: 5
    compression-level: 6
    overwrite: false
    include-hidden-files: false
    archive: true
  env:
    CARGO_INCREMENTAL: 0
    CARGO_PROFILE_DEV_DEBUG: 0
    CARGO_TERM_COLOR: always
    RUST_BACKTRACE: short
    RUSTFLAGS: -D warnings
    CARGO_UNSTABLE_SPARSE_REGISTRY: true
    CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
    CACHE_ON_FAILURE: true
With the provided path, there will be 2 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Unable to make request: ENOTFOUND
```
[reference](https://github.com/apollographql/rover/actions/runs/26230405592/job/77188913458)