### PR TITLE
Reconstruct reqwest's request within our tower layer

### DIFF
--- a/crates/rover-http/Cargo.toml
+++ b/crates/rover-http/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { workspace = true, features = [
 ] }
 rover-tower = { workspace = true, features = ["test"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 tower = { workspace = true }
 tap = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rover-http/src/error_on_status.rs
+++ b/crates/rover-http/src/error_on_status.rs
@@ -36,8 +36,16 @@ impl Default for ErrorOnStatusCriteria {
 }
 
 /// [`Layer`] that attaches the [`ErrorOnStatus`] middleware to the [`Service`] stack
+#[derive(Clone, Default)]
 pub struct ErrorOnStatusLayer {
     criteria: ErrorOnStatusCriteria,
+}
+
+impl ErrorOnStatusLayer {
+    /// Constructs an [`ErrorOnStatusLayer`] that errors on any status matching `criteria`.
+    pub const fn new(criteria: ErrorOnStatusCriteria) -> ErrorOnStatusLayer {
+        ErrorOnStatusLayer { criteria }
+    }
 }
 
 impl<S> Layer<S> for ErrorOnStatusLayer {

--- a/crates/rover-http/src/reqwest.rs
+++ b/crates/rover-http/src/reqwest.rs
@@ -1,15 +1,21 @@
-use std::{pin::Pin, time::Duration};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use buildstructor::buildstructor;
 use futures::Future;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use reqwest::ClientBuilder;
-use tower::{util::BoxCloneService, Service, ServiceBuilder, ServiceExt};
+use tower::{Service, ServiceExt};
 
 use crate::{
     body::body_to_bytes, HttpRequest, HttpResponse, HttpService, HttpServiceConfig,
     HttpServiceError, HttpServiceFactory,
 };
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Constructs [`HttpService`]s
 #[derive(Clone, Debug)]
@@ -33,7 +39,8 @@ impl HttpServiceFactory for ReqwestServiceFactory {
 /// A [`Service`] that wraps a [`reqwest`] client and uses [`http`] constructs for requests and responses
 #[derive(Clone, Debug)]
 pub struct ReqwestService {
-    client: BoxCloneService<reqwest::Request, reqwest::Response, HttpServiceError>,
+    client: reqwest::Client,
+    timeout: Duration,
 }
 
 #[buildstructor]
@@ -54,12 +61,8 @@ impl ReqwestService {
                 )
                 .build()?,
         };
-        let client = ServiceBuilder::new()
-            .map_err(HttpServiceError::from)
-            .timeout((*config.timeout()).unwrap_or_else(|| Duration::from_secs(90)))
-            .service(client)
-            .boxed_clone();
-        Ok(ReqwestService { client })
+        let timeout = config.timeout().unwrap_or(DEFAULT_TIMEOUT);
+        Ok(ReqwestService { client, timeout })
     }
 }
 
@@ -84,25 +87,41 @@ impl Service<HttpRequest> for ReqwestService {
     type Error = HttpServiceError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        self.client.poll_ready(cx).map_err(HttpServiceError::from)
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // `reqwest::Client` handles backpressure internally so there's nothing to gate on here.
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: HttpRequest) -> Self::Future {
-        // https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
-        let mut client = self.client.clone();
+        let client = self.client.clone();
+        let timeout = self.timeout;
         let fut = async move {
-            let mut req = req.clone();
-            let bytes = body_to_bytes(&mut req)
+            // `Request::try_from` doesn't do any processing that reqwest runs at builder-construction time.
+            // We instead go through its builder interface which retains all that internal logic.
+            let (parts, body) = req.into_parts();
+
+            let bytes = body
+                .collect()
                 .await
-                .map_err(|err| HttpServiceError::Body(Box::new(err)))?;
-            let body = reqwest::Body::from(bytes);
-            let req = req.map(move |_| body);
-            let req = reqwest::Request::try_from(req)?;
-            let mut resp = http::Response::from(client.call(req).await?);
+                .map_err(|err| HttpServiceError::Body(Box::new(err)))?
+                .to_bytes();
+
+            let mut builder = client
+                .request(parts.method, parts.uri.to_string())
+                .version(parts.version);
+
+            for (name, value) in parts.headers.iter() {
+                builder = builder.header(name, value);
+            }
+
+            let request = builder.body(reqwest::Body::from(bytes)).build()?;
+
+            let response = match tokio::time::timeout(timeout, client.execute(request)).await {
+                Ok(result) => result?,
+                Err(_) => return Err(HttpServiceError::TimedOut),
+            };
+
+            let mut resp = http::Response::from(response);
             let bytes = body_to_bytes(&mut resp)
                 .await
                 .map_err(|err| HttpServiceError::Body(Box::new(err)))?;
@@ -210,6 +229,33 @@ mod tests {
             assert_that!(body_bytes).is_equal_to(Bytes::from("def".as_bytes()));
         }
 
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    pub async fn url_userinfo_is_sent_as_basic_auth(
+        #[from(raw_service)] mut service: HttpService,
+    ) -> Result<()> {
+        let server = MockServer::start();
+        let expected_auth = "Basic dXNlcjpodW50ZXIy";
+
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/")
+                .header("authorization", expected_auth);
+            then.status(200).body("ok");
+        });
+
+        let uri = format!("http://user:hunter2@{}/", server.address());
+        let request = http::Request::builder()
+            .uri(uri)
+            .method(http::Method::GET)
+            .body(Full::default())?;
+
+        let resp = service.call(request).await?;
+        mock.assert_calls(1);
+        assert_that!(resp.status().as_u16()).is_equal_to(200);
         Ok(())
     }
 }

--- a/crates/rover-http/src/retry.rs
+++ b/crates/rover-http/src/retry.rs
@@ -51,6 +51,15 @@ impl RetryPolicy {
     }
 }
 
+/// Whether a response with the given status code is worth retrying.
+fn is_retryable_status(status: StatusCode) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_EARLY | StatusCode::TOO_MANY_REQUESTS
+        )
+}
+
 impl Policy<HttpRequest, HttpResponse, HttpServiceError> for RetryPolicy {
     type Future = tokio::time::Sleep;
     fn retry(
@@ -68,16 +77,8 @@ impl Policy<HttpRequest, HttpResponse, HttpServiceError> for RetryPolicy {
                 | Err(HttpServiceError::Closed(_)) => Some(self.backoff.next_backoff()),
                 Err(_) => None,
                 Ok(resp) => {
-                    let status = resp.status();
-                    if status.is_client_error()
-                        || status.is_server_error()
-                        || status.is_redirection()
-                    {
-                        if matches!(status, StatusCode::BAD_REQUEST) {
-                            None
-                        } else {
-                            Some(self.backoff.next_backoff())
-                        }
+                    if is_retryable_status(resp.status()) {
+                        Some(self.backoff.next_backoff())
                     } else {
                         None
                     }
@@ -157,6 +158,69 @@ mod tests {
         assert_that!(resp)
             .is_ok()
             .matches(|resp| resp.status() == StatusCode::INTERNAL_SERVER_ERROR);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::unauthorized(StatusCode::UNAUTHORIZED)]
+    #[case::forbidden(StatusCode::FORBIDDEN)]
+    #[case::not_found(StatusCode::NOT_FOUND)]
+    #[case::bad_request(StatusCode::BAD_REQUEST)]
+    #[tokio::test]
+    pub async fn non_retryable_4xx_is_not_retried(
+        #[case] status: StatusCode,
+        mut retry_service: HttpService,
+    ) -> Result<()> {
+        let server = MockServer::start();
+        let uri = format!("http://{}/", server.address());
+
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/");
+            then.status(status.as_u16()).body("");
+        });
+
+        let request = http::Request::builder()
+            .uri(uri)
+            .method(http::Method::GET)
+            .body(Full::default())?;
+
+        let resp = retry_service.call(request).await;
+
+        mock.assert_calls(1);
+        assert_that!(resp)
+            .is_ok()
+            .matches(|resp| resp.status() == status);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::request_timeout(StatusCode::REQUEST_TIMEOUT)]
+    #[case::too_many_requests(StatusCode::TOO_MANY_REQUESTS)]
+    #[tokio::test]
+    pub async fn retryable_4xx_is_retried(
+        #[case] status: StatusCode,
+        mut retry_service: HttpService,
+    ) -> Result<()> {
+        let server = MockServer::start();
+        let uri = format!("http://{}/", server.address());
+
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/");
+            then.status(status.as_u16()).body("");
+        });
+
+        let request = http::Request::builder()
+            .uri(uri)
+            .method(http::Method::GET)
+            .body(Full::default())?;
+
+        let resp = retry_service.call(request).await;
+
+        // 1.5s budget with 500ms initial backoff → at least a couple attempts.
+        assert_that!(mock.calls()).is_greater_than(1);
+        assert_that!(resp)
+            .is_ok()
+            .matches(|resp| resp.status() == status);
         Ok(())
     }
 }

--- a/installers/binstall/src/install/download/mod.rs
+++ b/installers/binstall/src/install/download/mod.rs
@@ -4,8 +4,8 @@ use bon::bon;
 use bytes::Bytes;
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use rover_http::{
-    extend_headers::ExtendHeadersLayer, retry::RetryPolicy, timeout::TimeoutLayer, Full,
-    HttpRequest, HttpResponse, HttpServiceError,
+    error_on_status::ErrorOnStatusLayer, extend_headers::ExtendHeadersLayer, retry::RetryPolicy,
+    timeout::TimeoutLayer, Full, HttpRequest, HttpResponse, HttpServiceError,
 };
 use tower::{retry::RetryLayer, util::BoxService, Service, ServiceBuilder};
 use tower_http::decompression::{DecompressionBody, DecompressionLayer};
@@ -37,6 +37,7 @@ impl FileDownloadService {
         let service = ServiceBuilder::new()
             .boxed()
             .layer(DecompressionLayer::default()) // explicit stand-in for reqwest's brotli/gzip decompression options
+            .layer(ErrorOnStatusLayer::default()) // short-circuit errors so that we don't attempt to decompress error bodies
             .layer(file_download_layer())
             .layer(RetryLayer::new(RetryPolicy::new(
                 max_elapsed_duration

--- a/installers/binstall/src/install/mod.rs
+++ b/installers/binstall/src/install/mod.rs
@@ -636,6 +636,52 @@ mod test {
     }
 
     #[rstest]
+    #[tokio::test]
+    async fn test_extract_plugin_tarball_errors_on_non_success_status(
+        binary_name: &str,
+        installer: Installer,
+        override_path: Utf8PathBuf,
+    ) {
+        let installer = Installer {
+            override_install_path: Some(override_path),
+            ..installer
+        };
+
+        let tarball_url = format!("http://example.com/{}", binary_name);
+        let mut mock_http_service = MockHttpService::new();
+        expect_poll_ready!(mock_http_service);
+        mock_http_service
+            .expect_call()
+            // 401 isn't retryable, so we expect exactly one call to the inner service.
+            .times(1)
+            .returning(move |_| {
+                future::ready(
+                    Response::builder()
+                        .status(401)
+                        .body(Full::new(Bytes::from_static(
+                            b"<html>401 Unauthorized</html>",
+                        )))
+                        .map_err(HttpServiceError::from),
+                )
+            });
+        let service = FileDownloadService::builder()
+            .http_service(MockCloneService::new(mock_http_service))
+            .max_elapsed_duration(Duration::from_secs(5))
+            .timeout_duration(Duration::from_secs(1))
+            .build();
+
+        let err = installer
+            .extract_plugin_tarball(binary_name, &tarball_url, service)
+            .await
+            .expect_err("a 401 response must produce an error");
+        let rendered = format!("{err:?}");
+
+        assert_that!(rendered.as_str()).contains("Bad Status code");
+        assert_that!(rendered.as_str()).contains("401");
+        assert_that!(rendered.as_str()).does_not_contain("invalid gzip header");
+    }
+
+    #[rstest]
     fn test_write_plugin_bin_to_fs(
         binary_name: &str,
         installer: Installer,


### PR DESCRIPTION
Fixes #3326

Reqwest's `try_from` doesn't get all of the helper logic that its builder does. This meant that things like auth got stripped incidentally when we built the request that way instead of getting extracted into headers as expected.

Includes minor fixes to make retries restricted to retriable HTTP status codes so that non-retriable responses don't manifest as hangs and not to try to un-GZIP error responses, both of which obfuscated the actual error in the issue report.
