### PR TITLE
Auto-fall back to legacy introspection query when modern query is rejected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,7 @@ dependencies = [
  "backon",
  "bon",
  "buildstructor",
+ "bytes",
  "camino",
  "chrono",
  "comfy-table",
@@ -7380,6 +7381,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "url",
  "which 8.0.2",
  "zip",
 ]

--- a/crates/rover-client/Cargo.toml
+++ b/crates/rover-client/Cargo.toml
@@ -65,6 +65,7 @@ reqwest = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
+bytes = { workspace = true }
 indoc = { workspace = true }
 mockall = { workspace = true }
 httpmock = { workspace = true }

--- a/crates/rover-client/src/operations/graph/introspect/introspect_query_legacy.graphql
+++ b/crates/rover-client/src/operations/graph/introspect/introspect_query_legacy.graphql
@@ -1,0 +1,99 @@
+query GraphIntrospectLegacyQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ...TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/operations/graph/introspect/mod.rs
+++ b/crates/rover-client/src/operations/graph/introspect/mod.rs
@@ -1,7 +1,9 @@
 mod runner;
 mod schema;
+mod service;
 mod types;
 
 pub use runner::run;
 pub use schema::Schema;
+pub use service::{GraphIntrospect, GraphIntrospectError, GraphIntrospectLegacy};
 pub use types::{GraphIntrospectInput, GraphIntrospectResponse};

--- a/crates/rover-client/src/operations/graph/introspect/runner.rs
+++ b/crates/rover-client/src/operations/graph/introspect/runner.rs
@@ -1,65 +1,348 @@
-use std::convert::{Into, TryFrom};
+use std::convert::TryFrom;
 
-use graphql_client::GraphQLQuery;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use reqwest::Client;
+use rover_graphql::{GraphQLLayer, GraphQLServiceError};
+use rover_http::{extend_headers::ExtendHeadersLayer, retry::RetryPolicy, ReqwestService};
+use tower::{retry::RetryLayer, ServiceBuilder, ServiceExt};
 
 use crate::{
-    blocking::GraphQLClient,
-    error::{EndpointKind, RoverClientError},
-    operations::graph::introspect::{types::*, Schema},
+    error::RoverClientError,
+    operations::graph::introspect::{
+        service::{
+            graph_introspect_query, GraphIntrospect, GraphIntrospectError, GraphIntrospectLegacy,
+        },
+        types::*,
+        Schema,
+    },
 };
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    query_path = "src/operations/graph/introspect/introspect_query.graphql",
-    schema_path = "src/operations/graph/introspect/introspect_schema.graphql",
-    response_derives = "PartialEq, Eq, Debug, Serialize, Deserialize",
-    deprecated = "warn"
-)]
-/// This struct is used to generate the module containing `Variables` and
-/// `ResponseData` structs.
-/// Snake case of this name is the mod name. i.e. graph_introspect_query
-pub(crate) struct GraphIntrospectQuery;
-
 /// The main function to be used from this module. This function fetches a
-/// schema from apollo studio and returns it in either sdl (default) or json format
+/// schema from a GraphQL endpoint and returns it as an SDL.
 pub async fn run(
     input: GraphIntrospectInput,
-    client: &GraphQLClient,
-    should_retry: bool,
+    client: &Client,
 ) -> Result<GraphIntrospectResponse, RoverClientError> {
-    let variables = input.clone().into();
+    let http_service = ReqwestService::builder()
+        .client(client.clone())
+        .build()
+        .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))?;
+
     let mut header_map = HeaderMap::new();
-    for (header_key, header_value) in input.headers {
+    for (header_key, header_value) in &input.headers {
         header_map.insert(
             HeaderName::from_bytes(header_key.as_bytes())?,
-            HeaderValue::from_str(&header_value)?,
+            HeaderValue::from_str(header_value)?,
         );
     }
-    let response_data = if should_retry {
-        client
-            .post::<GraphIntrospectQuery>(variables, &mut header_map, EndpointKind::Customer)
-            .await
+
+    let response_data = if input.use_legacy_introspection_query {
+        let legacy = ServiceBuilder::new()
+            .layer_fn(GraphIntrospectLegacy::new)
+            .layer(GraphQLLayer::new(input.endpoint.clone()))
+            .option_layer(retry_layer(&input))
+            .layer(ExtendHeadersLayer::new(header_map.clone()))
+            .service(http_service.clone());
+        legacy.oneshot(()).await?
     } else {
-        client
-            .post_no_retry::<GraphIntrospectQuery>(
-                variables,
-                &mut header_map,
-                EndpointKind::Customer,
-            )
-            .await
-    }?;
+        let modern = ServiceBuilder::new()
+            .layer_fn(GraphIntrospect::new)
+            .layer(GraphQLLayer::new(input.endpoint.clone()))
+            .option_layer(retry_layer(&input))
+            .layer(ExtendHeadersLayer::new(header_map.clone()))
+            .service(http_service.clone());
+        match modern.oneshot(()).await {
+            Ok(data) => data,
+            Err(GraphIntrospectError::ModernGraphQL(err)) if should_fall_back_to_legacy(&err) => {
+                tracing::debug!(
+                    "modern introspection query rejected ({err}); falling back to legacy query"
+                );
+                let legacy = ServiceBuilder::new()
+                    .layer_fn(GraphIntrospectLegacy::new)
+                    .layer(GraphQLLayer::new(input.endpoint.clone()))
+                    .option_layer(retry_layer(&input))
+                    .layer(ExtendHeadersLayer::new(header_map.clone()))
+                    .service(http_service.clone());
+                legacy.oneshot(()).await?
+            }
+            Err(other) => return Err(other.into()),
+        }
+    };
 
     build_response(response_data)
 }
 
+fn retry_layer(input: &GraphIntrospectInput) -> Option<RetryLayer<RetryPolicy>> {
+    if input.should_retry {
+        Some(RetryLayer::new(RetryPolicy::new(input.retry_period)))
+    } else {
+        None
+    }
+}
+
 fn build_response(
-    response: QueryResponseData,
+    response: graph_introspect_query::ResponseData,
 ) -> Result<GraphIntrospectResponse, RoverClientError> {
     match Schema::try_from(response) {
         Ok(schema) => Ok(GraphIntrospectResponse {
             schema_sdl: schema.encode(),
         }),
         Err(msg) => Err(RoverClientError::IntrospectionError { msg: msg.into() }),
+    }
+}
+
+/// Decide whether a failed modern-introspection attempt looks like the server
+/// doesn't implement the October-2021 spec additions.
+///
+/// Matches:
+/// - GraphQL body errors whose joined message mentions any of `__InputValue`,
+///   `includeDeprecated`, `isDeprecated`, or `deprecationReason` — what Apollo
+///   Server and graphql-js emit when meta-schema validation rejects the
+///   unknown fields.
+/// - HTTP 422 Unprocessable Entity — the server understood the request but
+///   rejected its contents. Surfaces as `Deserialization` because the response
+///   body is typically not a valid GraphQL response envelope.
+fn should_fall_back_to_legacy<T>(err: &GraphQLServiceError<T>) -> bool
+where
+    T: Send + Sync + std::fmt::Debug,
+{
+    const MARKERS: &[&str] = &[
+        "__InputValue",
+        "includeDeprecated",
+        "isDeprecated",
+        "deprecationReason",
+    ];
+    match err {
+        GraphQLServiceError::NoData(errors) | GraphQLServiceError::PartialError { errors, .. } => {
+            errors
+                .iter()
+                .any(|e| MARKERS.iter().any(|m| e.message.contains(m)))
+        }
+        GraphQLServiceError::Deserialization { status_code, .. } => {
+            *status_code == StatusCode::UNPROCESSABLE_ENTITY
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use graphql_client::Error as GraphQLError;
+    use httpmock::prelude::*;
+    use serde_json::json;
+
+    use super::*;
+
+    fn graphql_error(message: &str) -> GraphQLError {
+        GraphQLError {
+            message: message.to_string(),
+            locations: None,
+            path: None,
+            extensions: None,
+        }
+    }
+
+    fn deserialization_error(status: StatusCode) -> GraphQLServiceError<()> {
+        let json_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        GraphQLServiceError::Deserialization {
+            error: json_err,
+            data: Bytes::new(),
+            status_code: status,
+        }
+    }
+
+    #[test]
+    fn fallback_matches_input_value_meta_schema_error() {
+        let err: GraphQLServiceError<()> = GraphQLServiceError::NoData(vec![graphql_error(
+            "Cannot query field \"isDeprecated\" on type \"__InputValue\"",
+        )]);
+        assert!(should_fall_back_to_legacy(&err));
+    }
+
+    #[test]
+    fn fallback_matches_each_marker_individually() {
+        for marker in [
+            "__InputValue",
+            "includeDeprecated",
+            "isDeprecated",
+            "deprecationReason",
+        ] {
+            let err: GraphQLServiceError<()> = GraphQLServiceError::NoData(vec![graphql_error(
+                &format!("server complained about {marker}"),
+            )]);
+            assert!(
+                should_fall_back_to_legacy(&err),
+                "expected fallback for marker {marker}"
+            );
+        }
+    }
+
+    #[test]
+    fn fallback_ignores_unrelated_graphql_errors() {
+        let err: GraphQLServiceError<()> =
+            GraphQLServiceError::NoData(vec![graphql_error("permission denied")]);
+        assert!(!should_fall_back_to_legacy(&err));
+    }
+
+    #[test]
+    fn fallback_matches_partial_error_with_marker() {
+        let err: GraphQLServiceError<()> = GraphQLServiceError::PartialError {
+            data: (),
+            errors: vec![graphql_error(
+                "Cannot query field \"includeDeprecated\" on type \"__Field\"",
+            )],
+            friendly_errors_detail: Vec::new(),
+        };
+        assert!(should_fall_back_to_legacy(&err));
+    }
+
+    #[test]
+    fn fallback_matches_422_deserialization_error() {
+        let err = deserialization_error(StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(should_fall_back_to_legacy(&err));
+    }
+
+    #[test]
+    fn fallback_ignores_500_deserialization_error() {
+        let err = deserialization_error(StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!should_fall_back_to_legacy(&err));
+    }
+
+    fn introspect_input(endpoint: url::Url) -> GraphIntrospectInput {
+        GraphIntrospectInput {
+            headers: Default::default(),
+            endpoint,
+            should_retry: false,
+            retry_period: Duration::from_secs(1),
+            use_legacy_introspection_query: false,
+        }
+    }
+
+    fn empty_legacy_introspection_body() -> serde_json::Value {
+        json!({
+            "data": {
+                "__schema": {
+                    "queryType": { "name": "Query" },
+                    "mutationType": null,
+                    "subscriptionType": null,
+                    "types": [],
+                    "directives": []
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn run_falls_back_to_legacy_on_input_value_error() {
+        let server = MockServer::start_async().await;
+        let path = "/graphql";
+
+        let modern_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(path)
+                    .body_includes("GraphIntrospectQuery");
+                then.status(200).json_body(json!({
+                    "errors": [{
+                        "message": "Cannot query field \"isDeprecated\" on type \"__InputValue\""
+                    }]
+                }));
+            })
+            .await;
+
+        let legacy_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(path)
+                    .body_includes("GraphIntrospectLegacyQuery");
+                then.status(200)
+                    .json_body(empty_legacy_introspection_body());
+            })
+            .await;
+
+        let endpoint = url::Url::parse(&server.url(path)).unwrap();
+        let result = run(introspect_input(endpoint), &Client::new()).await;
+
+        assert_eq!(modern_mock.calls_async().await, 1);
+        assert_eq!(legacy_mock.calls_async().await, 1);
+        assert!(
+            result.is_ok(),
+            "expected fallback to succeed, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_falls_back_to_legacy_on_422() {
+        let server = MockServer::start_async().await;
+        let path = "/graphql";
+
+        let modern_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(path)
+                    .body_includes("GraphIntrospectQuery");
+                then.status(422).body("unprocessable");
+            })
+            .await;
+
+        let legacy_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(path)
+                    .body_includes("GraphIntrospectLegacyQuery");
+                then.status(200)
+                    .json_body(empty_legacy_introspection_body());
+            })
+            .await;
+
+        let endpoint = url::Url::parse(&server.url(path)).unwrap();
+        let result = run(introspect_input(endpoint), &Client::new()).await;
+
+        assert_eq!(modern_mock.calls_async().await, 1);
+        assert_eq!(legacy_mock.calls_async().await, 1);
+        assert!(
+            result.is_ok(),
+            "expected fallback to succeed, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_uses_legacy_directly_when_override_set() {
+        let server = MockServer::start_async().await;
+        let path = "/graphql";
+
+        let modern_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(path)
+                    .body_includes("GraphIntrospectQuery");
+                then.status(500).body("");
+            })
+            .await;
+
+        let legacy_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(path)
+                    .body_includes("GraphIntrospectLegacyQuery");
+                then.status(200)
+                    .json_body(empty_legacy_introspection_body());
+            })
+            .await;
+
+        let endpoint = url::Url::parse(&server.url(path)).unwrap();
+        let mut input = introspect_input(endpoint);
+        input.use_legacy_introspection_query = true;
+        let result = run(input, &Client::new()).await;
+
+        assert_eq!(modern_mock.calls_async().await, 0);
+        assert_eq!(legacy_mock.calls_async().await, 1);
+        assert!(
+            result.is_ok(),
+            "expected direct legacy call to succeed, got {result:?}"
+        );
     }
 }

--- a/crates/rover-client/src/operations/graph/introspect/schema.rs
+++ b/crates/rover-client/src/operations/graph/introspect/schema.rs
@@ -17,7 +17,7 @@ use apollo_compiler::{
 };
 use serde::Deserialize;
 
-use crate::operations::graph::introspect::runner::graph_introspect_query;
+use crate::operations::graph::introspect::service::graph_introspect_query;
 
 type FullTypeField = graph_introspect_query::FullTypeFields;
 type FullTypeInputField = graph_introspect_query::FullTypeInputFields;

--- a/crates/rover-client/src/operations/graph/introspect/service.rs
+++ b/crates/rover-client/src/operations/graph/introspect/service.rs
@@ -1,0 +1,256 @@
+use std::{future::Future, pin::Pin};
+
+use graphql_client::GraphQLQuery;
+use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+use serde_json::Value;
+use tower::Service;
+
+use crate::{EndpointKind, RoverClientError};
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/graph/introspect/introspect_query.graphql",
+    schema_path = "src/operations/graph/introspect/introspect_schema.graphql",
+    response_derives = "PartialEq, Eq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+pub struct GraphIntrospectQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/graph/introspect/introspect_query_legacy.graphql",
+    schema_path = "src/operations/graph/introspect/introspect_schema.graphql",
+    response_derives = "PartialEq, Eq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+pub struct GraphIntrospectLegacyQuery;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GraphIntrospectError {
+    #[error("Inner service failed to become ready.\n{}", .0)]
+    ServiceReady(Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    ModernGraphQL(GraphQLServiceError<graph_introspect_query::ResponseData>),
+    #[error(transparent)]
+    LegacyGraphQL(GraphQLServiceError<graph_introspect_legacy_query::ResponseData>),
+    #[error("Failed to convert legacy introspection response: {0}")]
+    LegacyConversion(serde_json::Error),
+}
+
+impl From<GraphIntrospectError> for RoverClientError {
+    fn from(value: GraphIntrospectError) -> Self {
+        match value {
+            GraphIntrospectError::ServiceReady(err) => RoverClientError::ServiceReady(err),
+            GraphIntrospectError::ModernGraphQL(err) => RoverClientError::Service {
+                source: Box::new(err),
+                endpoint_kind: EndpointKind::Customer,
+            },
+            GraphIntrospectError::LegacyGraphQL(err) => RoverClientError::Service {
+                source: Box::new(err),
+                endpoint_kind: EndpointKind::Customer,
+            },
+            GraphIntrospectError::LegacyConversion(err) => RoverClientError::IntrospectionError {
+                msg: format!("failed to convert legacy introspection response: {err}"),
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GraphIntrospect<S: Clone> {
+    inner: S,
+}
+
+impl<S: Clone> GraphIntrospect<S> {
+    pub const fn new(inner: S) -> GraphIntrospect<S> {
+        GraphIntrospect { inner }
+    }
+}
+
+impl<S, Fut> Service<()> for GraphIntrospect<S>
+where
+    S: Service<
+            GraphQLRequest<GraphIntrospectQuery>,
+            Response = graph_introspect_query::ResponseData,
+            Error = GraphQLServiceError<graph_introspect_query::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = graph_introspect_query::ResponseData;
+    type Error = GraphIntrospectError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        Service::<GraphQLRequest<GraphIntrospectQuery>>::poll_ready(&mut self.inner, cx)
+            .map_err(|err| GraphIntrospectError::ServiceReady(Box::new(err)))
+    }
+
+    fn call(&mut self, _req: ()) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let fut = async move {
+            inner
+                .call(GraphQLRequest::<GraphIntrospectQuery>::new(
+                    graph_introspect_query::Variables {},
+                ))
+                .await
+                .map_err(GraphIntrospectError::ModernGraphQL)
+        };
+        Box::pin(fut)
+    }
+}
+
+#[derive(Clone)]
+pub struct GraphIntrospectLegacy<S: Clone> {
+    inner: S,
+}
+
+impl<S: Clone> GraphIntrospectLegacy<S> {
+    pub const fn new(inner: S) -> GraphIntrospectLegacy<S> {
+        GraphIntrospectLegacy { inner }
+    }
+}
+
+impl<S, Fut> Service<()> for GraphIntrospectLegacy<S>
+where
+    S: Service<
+            GraphQLRequest<GraphIntrospectLegacyQuery>,
+            Response = graph_introspect_legacy_query::ResponseData,
+            Error = GraphQLServiceError<graph_introspect_legacy_query::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = graph_introspect_query::ResponseData;
+    type Error = GraphIntrospectError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        Service::<GraphQLRequest<GraphIntrospectLegacyQuery>>::poll_ready(&mut self.inner, cx)
+            .map_err(|err| GraphIntrospectError::ServiceReady(Box::new(err)))
+    }
+
+    fn call(&mut self, _req: ()) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let fut = async move {
+            let legacy_data = inner
+                .call(GraphQLRequest::<GraphIntrospectLegacyQuery>::new(
+                    graph_introspect_legacy_query::Variables {},
+                ))
+                .await
+                .map_err(GraphIntrospectError::LegacyGraphQL)?;
+            legacy_response_to_query_response(legacy_data)
+                .map_err(GraphIntrospectError::LegacyConversion)
+        };
+        Box::pin(fut)
+    }
+}
+
+/// Convert the legacy introspection response into the shape expected by
+/// `Schema`. The legacy query omits `isDeprecated`/`deprecationReason` on
+/// `__InputValue`, so we serialize through JSON and inject the defaults
+/// (`false` / `null`) at the three locations where `__InputValue` appears
+/// in the response: `types[].fields[].args[]`, `types[].inputFields[]`,
+/// and `directives[].args[]`.
+fn legacy_response_to_query_response(
+    legacy: graph_introspect_legacy_query::ResponseData,
+) -> Result<graph_introspect_query::ResponseData, serde_json::Error> {
+    let mut json = serde_json::to_value(&legacy)?;
+    patch_legacy_input_values(&mut json);
+    serde_json::from_value(json)
+}
+
+fn patch_legacy_input_values(value: &mut Value) {
+    let Some(schema) = value.get_mut("schema") else {
+        return;
+    };
+
+    for_each_in_array(schema, "types", |typ| {
+        for_each_in_array(typ, "fields", |field| {
+            for_each_in_array(field, "args", inject_input_value_defaults);
+        });
+        for_each_in_array(typ, "inputFields", inject_input_value_defaults);
+    });
+
+    for_each_in_array(schema, "directives", |dir| {
+        for_each_in_array(dir, "args", inject_input_value_defaults);
+    });
+}
+
+fn for_each_in_array(parent: &mut Value, key: &str, mut f: impl FnMut(&mut Value)) {
+    if let Some(arr) = parent.get_mut(key).and_then(Value::as_array_mut) {
+        arr.iter_mut().for_each(&mut f);
+    }
+}
+
+fn inject_input_value_defaults(value: &mut Value) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    obj.entry("isDeprecated").or_insert(Value::Bool(false));
+    obj.entry("deprecationReason").or_insert(Value::Null);
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn patcher_fills_input_value_defaults_under_all_paths() {
+        let mut value = json!({
+            "schema": {
+                "types": [{
+                    "fields": [{ "args": [{ "name": "a" }] }],
+                    "inputFields": [{ "name": "b" }],
+                }],
+                "directives": [{ "args": [{ "name": "c" }] }],
+            }
+        });
+        patch_legacy_input_values(&mut value);
+
+        let arg = &value["schema"]["types"][0]["fields"][0]["args"][0];
+        assert_eq!(arg["isDeprecated"], json!(false));
+        assert_eq!(arg["deprecationReason"], json!(null));
+
+        let input_field = &value["schema"]["types"][0]["inputFields"][0];
+        assert_eq!(input_field["isDeprecated"], json!(false));
+        assert_eq!(input_field["deprecationReason"], json!(null));
+
+        let directive_arg = &value["schema"]["directives"][0]["args"][0];
+        assert_eq!(directive_arg["isDeprecated"], json!(false));
+        assert_eq!(directive_arg["deprecationReason"], json!(null));
+    }
+
+    #[test]
+    fn patcher_preserves_existing_deprecation_values() {
+        let mut value = json!({
+            "schema": {
+                "types": [{
+                    "inputFields": [{
+                        "name": "b",
+                        "isDeprecated": true,
+                        "deprecationReason": "old",
+                    }],
+                }],
+            }
+        });
+        patch_legacy_input_values(&mut value);
+        let f = &value["schema"]["types"][0]["inputFields"][0];
+        assert_eq!(f["isDeprecated"], json!(true));
+        assert_eq!(f["deprecationReason"], json!("old"));
+    }
+}

--- a/crates/rover-client/src/operations/graph/introspect/types.rs
+++ b/crates/rover-client/src/operations/graph/introspect/types.rs
@@ -1,19 +1,20 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
-use crate::operations::graph::introspect::runner::graph_introspect_query;
-
-pub(crate) type QueryResponseData = graph_introspect_query::ResponseData;
-pub(crate) type QueryVariables = graph_introspect_query::Variables;
+#[cfg(test)]
+pub(crate) type QueryResponseData =
+    crate::operations::graph::introspect::service::graph_introspect_query::ResponseData;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraphIntrospectInput {
     pub headers: HashMap<String, String>,
-}
-
-impl From<GraphIntrospectInput> for QueryVariables {
-    fn from(_input: GraphIntrospectInput) -> Self {
-        Self {}
-    }
+    pub endpoint: url::Url,
+    pub should_retry: bool,
+    pub retry_period: Duration,
+    /// Use a pre-October-2021 introspection query that omits
+    /// `includeDeprecated` on `args`/`inputFields` and
+    /// `isDeprecated`/`deprecationReason` on `__InputValue`, for
+    /// servers that don't implement those introspection additions.
+    pub use_legacy_introspection_query: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/command/graph/introspect.rs
+++ b/src/command/graph/introspect.rs
@@ -2,10 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use clap::Parser;
 use reqwest::Client;
-use rover_client::{
-    blocking::GraphQLClient,
-    operations::graph::introspect::{self, GraphIntrospectInput},
-};
+use rover_client::operations::graph::introspect::{self, GraphIntrospectInput};
 use serde::Serialize;
 
 use crate::{
@@ -17,6 +14,18 @@ use crate::{
 pub struct Introspect {
     #[clap(flatten)]
     pub opts: IntrospectOpts,
+
+    /// Skip auto-detection and use the pre-October-2021 introspection query
+    /// directly, omitting `includeDeprecated` on `args`/`inputFields` and
+    /// `isDeprecated`/`deprecationReason` on `__InputValue`. By default
+    /// Rover runs the modern query first and automatically retries with the
+    /// legacy query when the server rejects it (HTTP 422, or GraphQL body
+    /// errors mentioning the unknown fields). Use this flag when you already
+    /// know the target server is pre-spec and want to avoid the extra
+    /// round-trip.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    pub legacy_introspection_query: bool,
 }
 
 impl Introspect {
@@ -41,8 +50,6 @@ impl Introspect {
         should_retry: bool,
         retry_period: Duration,
     ) -> RoverResult<String> {
-        let client = GraphQLClient::new(self.opts.endpoint.as_ref(), client.clone(), retry_period);
-
         // add the flag headers to a hashmap to pass along to rover-client
         let mut headers = HashMap::new();
         if let Some(arg_headers) = &self.opts.headers {
@@ -51,11 +58,18 @@ impl Introspect {
             }
         };
 
-        Ok(
-            introspect::run(GraphIntrospectInput { headers }, &client, should_retry)
-                .await?
-                .schema_sdl,
+        Ok(introspect::run(
+            GraphIntrospectInput {
+                headers,
+                endpoint: self.opts.endpoint.clone(),
+                should_retry,
+                retry_period,
+                use_legacy_introspection_query: self.legacy_introspection_query,
+            },
+            client,
         )
+        .await?
+        .schema_sdl)
     }
 
     pub async fn exec_and_watch(

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -29,6 +29,7 @@ shell-candy = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { workspace = true }
+url = { workspace = true }
 which = { workspace = true }
 zip = { workspace = true }
 

--- a/xtask/src/commands/prep/templates_schema.rs
+++ b/xtask/src/commands/prep/templates_schema.rs
@@ -3,11 +3,9 @@ use std::{collections::HashMap, process::Command, time::Duration};
 use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
 use reqwest::Client;
-use rover_client::{
-    blocking::GraphQLClient,
-    operations::graph::introspect::{self, GraphIntrospectInput},
-};
+use rover_client::operations::graph::introspect::{self, GraphIntrospectInput};
 use rover_std::Fs;
+use url::Url;
 
 const SCHEMA_PATH: &str = "./src/command/template/schema.graphql";
 const QUERIES_PATH: &str = "./src/command/template/queries.graphql";
@@ -32,14 +30,16 @@ async fn introspect() -> Result<String> {
         "fetching the latest templates schema by introspecting {}...",
         &graphql_endpoint
     );
-    let graphql_client =
-        GraphQLClient::new(graphql_endpoint, Client::new(), Duration::from_secs(10));
+    let endpoint = Url::parse(graphql_endpoint)?;
     introspect::run(
         GraphIntrospectInput {
             headers: HashMap::new(),
+            endpoint,
+            should_retry: false,
+            retry_period: Duration::from_secs(10),
+            use_legacy_introspection_query: false,
         },
-        &graphql_client,
-        false,
+        &Client::new(),
     )
     .await
     .map(|response| response.schema_sdl)


### PR DESCRIPTION
## Summary

Some GraphQL servers reject the modern (October-2021 spec) introspection query because they don't implement `includeDeprecated` on `args`/`inputFields` or `isDeprecated`/`deprecationReason` on `__InputValue`. Today users have to discover this by reading the error and re-run with `--legacy-introspection-query`. This PR makes `rover graph introspect` detect the two well-known failure shapes and transparently retry with the legacy query.

**Detection conditions (matched after the modern attempt fails):**

1. HTTP 200 with GraphQL errors whose messages mention any of `__InputValue`, `includeDeprecated`, `isDeprecated`, or `deprecationReason` — what Apollo Server and graphql-js emit when meta-schema validation rejects the unknown fields.
2. HTTP 422 Unprocessable Entity.

The `--legacy-introspection-query` flag remains as an explicit override that skips the modern attempt (still useful when users know the target is pre-spec and want to avoid the extra round-trip).

This is an attempt to fix https://github.com/apollographql/rover/issues/2908