### PR TITLE
ci: keep agentic workflow lock in sync with gh-aw bumps

### DIFF
--- a/.github/workflows/recompile-agentic.yml
+++ b/.github/workflows/recompile-agentic.yml
@@ -1,0 +1,75 @@
+name: Recompile Agentic Workflows
+
+# Generated *.lock.yml files must be recompiled with a gh-aw CLI that matches the
+# pinned github/gh-aw action, or the runtime drifts and the workflow fails at
+# activation.
+#
+# Renovate bumps the action pin but cannot run a postUpgradeTask,
+# so it can't recompile. This job runs on the Renovate branch, recompiles with a
+# version-matched CLI, and commits the result back into the same PR.
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+    paths:
+      - ".github/workflows/**.lock.yml"
+      - ".github/workflows/**.md"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: recompile-agentic-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  recompile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve gh-aw version from the action pin
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The version tag only lives in the Renovate-maintained comment on the
+          # gh-aw setup action; the uses: value is a SHA and --pin needs a tag.
+          mapfile -t versions < <(
+            grep -rhE 'uses:[[:space:]]*github/gh-aw/actions/setup@[0-9a-f]+[[:space:]]*#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+' \
+              .github/workflows/*.lock.yml \
+              | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -u
+          )
+          case "${#versions[@]}" in
+            0) echo "No github/gh-aw setup pin found; nothing to recompile."; echo "skip=true" >> "$GITHUB_OUTPUT" ;;
+            1) echo "Resolved gh-aw version: ${versions[0]}"; echo "version=${versions[0]}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Lock files pin conflicting gh-aw versions: ${versions[*]}"; exit 1 ;;
+          esac
+
+      - name: Install gh-aw CLI matching the action pin
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install github/gh-aw --pin "${{ steps.ver.outputs.version }}"
+
+      - name: Recompile lock files
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh aw compile
+
+      - name: Commit & push if the lock changed
+        if: steps.ver.outputs.skip != 'true'
+        run: |
+          if [ -z "$(git status --porcelain -- .github/workflows)" ]; then
+            echo "Lock files already match gh-aw ${{ steps.ver.outputs.version }} — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/workflows
+          git commit -m "chore: recompile agentic workflow locks for gh-aw ${{ steps.ver.outputs.version }}"
+          git push origin "HEAD:${{ github.ref_name }}"

--- a/.github/workflows/verify-agentic-lock.yml
+++ b/.github/workflows/verify-agentic-lock.yml
@@ -1,0 +1,54 @@
+name: Verify Agentic Workflow Lock
+
+# Fails any PR whose generated *.lock.yml is out  of sync with its .md source / the pinned gh-aw version
+# so a stale lock cannot be auto-merged before the recompile job pushes its fix.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**.lock.yml"
+      - ".github/workflows/**.md"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve gh-aw version from the action pin
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The version tag only lives in the Renovate-maintained comment on the
+          # gh-aw setup action; the uses: value is a SHA and --pin needs a tag.
+          mapfile -t versions < <(
+            grep -rhE 'uses:[[:space:]]*github/gh-aw/actions/setup@[0-9a-f]+[[:space:]]*#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+' \
+              .github/workflows/*.lock.yml \
+              | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -u
+          )
+          case "${#versions[@]}" in
+            0) echo "No github/gh-aw setup pin found; nothing to verify."; echo "skip=true" >> "$GITHUB_OUTPUT" ;;
+            1) echo "version=${versions[0]}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Lock files pin conflicting gh-aw versions: ${versions[*]}"; exit 1 ;;
+          esac
+
+      - name: Install gh-aw CLI matching the action pin
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install github/gh-aw --pin "${{ steps.ver.outputs.version }}"
+
+      - name: Recompile and check for drift
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh aw compile
+          if ! git diff --exit-code -- .github/workflows; then
+            echo "::error::Agentic workflow lock is out of date for gh-aw ${{ steps.ver.outputs.version }}. Run 'gh aw compile' locally and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

The `Issue Triage` agentic workflow has been failing since ~2026-05-12. Root cause is version drift:

- The compiled `issue-triage.lock.yml` was generated by **gh-aw CLI v0.53.4** (`# This file was automatically generated by gh-aw (v0.53.4)`).
- Renovate has since bumped the **`github/gh-aw` action** to **v0.76.1**, but its `github-actions` manager only rewrites the `uses:` pin — it does **not** recompile the lock.

So the stale v0.53.4 body runs `cat "/opt/gh-aw/prompts/xpia.md"`, which the v0.76.x runtime no longer provides, and the `activation` job dies with exit 1 before the agent runs. (This is also what files the `[agentics]`/`[aw]` tracking issues.)

`postUpgradeTasks` can't fix this — it requires self-hosted Renovate with `allowedPostUpgradeCommands`, which the hosted Mend app doesn't allow.

## Fix

Two workflows that keep the generated lock in sync with the pinned action:

- **`recompile-agentic.yml`** — on `renovate/**` branches touching a `*.lock.yml`/`*.md`, resolve the bumped gh-aw version from the action pin, install a **version-matched** `gh aw` CLI (`--pin`), `gh aw compile`, and commit the regenerated lock back into the same PR. Pushes with `GITHUB_TOKEN` (no workflow re-trigger, no loop).
- **`verify-agentic-lock.yml`** — PR backstop that recompiles and `git diff --exit-code`, failing if the lock is stale.

The version is read from the Renovate-maintained `github/gh-aw/actions/setup@<sha> # <tag>` comment (the `uses:` value is a SHA, and `gh extension install --pin` needs a tag). Extraction is anchored to that line, deduped, and **fails loudly** if lock files disagree.

## Required follow-ups (not in this PR)

1. **Mark `Verify Agentic Workflow Lock` as a required status check** in branch protection — otherwise `platformAutomerge` could merge a stale lock before the recompile job pushes its fix.
2. **One-time recompile of the current lock** (`gh aw compile`) — these workflows only act on *future* Renovate PRs; the currently-broken `issue-triage.lock.yml` still needs a manual recompile to restore triage.

> Note: once the recompile job commits to a Renovate branch, Mend may treat the branch as user-edited and stop auto-merging it, so a maintainer may need to merge manually. The PR will be green and valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)