### PR TITLE
fix: restore the unpinned-federation-version warning on `supergraph compose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Restore the "pin your federation version" warning on `supergraph compose` - @SharkBaitDLS PR #3347**
 
-  `rover supergraph compose` again warns when `federation_version` is not pinned to an exact version. This nudge was added in #1524 and inadvertently dropped in v0.27.2 (#2411) during the supergraph-config resolution rewrite; composing against a floating `1`/`2` (or omitting the key) now once again recommends pinning, to avoid pulling in breaking changes when a new federation release ships. `rover dev` and the language server remain silent. Fixes #1510.
+  `rover supergraph compose` again warns when `federation_version` is not pinned to an exact version, reinstating the documented notice that future versions will require one. This nudge was added in #1524 and inadvertently dropped in v0.27.2 (#2411) during the supergraph-config resolution rewrite; composing against a floating `1`/`2` (or omitting the key) now once again warns and recommends pinning, to avoid pulling in breaking changes when a new federation release ships. `rover dev` and the language server remain silent. Fixes #1510.
 
 # [0.40.0] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [Unreleased]
 
+## 🐛 Fixes
+
+- **Restore the "pin your federation version" warning on `supergraph compose` - @SharkBaitDLS PR #3347**
+
+  `rover supergraph compose` again warns when `federation_version` is not pinned to an exact version. This nudge was added in #1524 and inadvertently dropped in v0.27.2 (#2411) during the supergraph-config resolution rewrite; composing against a floating `1`/`2` (or omitting the key) now once again recommends pinning, to avoid pulling in breaking changes when a new federation release ships. `rover dev` and the language server remain silent. Fixes #1510.
+
 # [0.40.0] - 2026-05-28
 
 ## 🚀 Features

--- a/src/command/connector/mod.rs
+++ b/src/command/connector/mod.rs
@@ -99,6 +99,8 @@ impl Connector {
             self.plugin_opts.clone(),
             supergraph_yaml.clone(),
             self.graph_ref.clone(),
+            // `connector` only introspects connectors; no pin nag.
+            false,
         )
         .await?;
         let default_subgraph = default_subgraph(&supergraph_yaml, &composition_pipeline).await;

--- a/src/command/connector/mod.rs
+++ b/src/command/connector/mod.rs
@@ -99,7 +99,6 @@ impl Connector {
             self.plugin_opts.clone(),
             supergraph_yaml.clone(),
             self.graph_ref.clone(),
-            // `connector` only introspects connectors; no pin nag.
             false,
         )
         .await?;

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -148,6 +148,8 @@ impl Dev {
                 resolve_introspect_subgraph_factory.clone(),
                 fetch_remote_subgraph_factory.clone(),
                 federation_version,
+                // `rover dev` is local/ephemeral and hot-reloads; don't nag about pinning.
+                false,
             )
             .await
             .install_supergraph_binary(

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -148,7 +148,7 @@ impl Dev {
                 resolve_introspect_subgraph_factory.clone(),
                 fetch_remote_subgraph_factory.clone(),
                 federation_version,
-                // `rover dev` is local/ephemeral and hot-reloads; don't nag about pinning.
+                // don't nag about pinning the federation version for dev
                 false,
             )
             .await

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -148,7 +148,6 @@ impl Dev {
                 resolve_introspect_subgraph_factory.clone(),
                 fetch_remote_subgraph_factory.clone(),
                 federation_version,
-                // don't nag about pinning the federation version for dev
                 false,
             )
             .await

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -397,6 +397,8 @@ async fn create_composition_runner(
             resolve_introspect_subgraph_factory.clone(),
             fetch_remote_subgraph_factory.clone(),
             federation_version,
+            // LSP runs continuously; no floating-version warning.
+            false,
         )
         .await
         .install_supergraph_binary(

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -199,7 +199,6 @@ async fn load_spec_for_path(
         plugin_opts,
         Some(FileDescriptorType::File(supergraph_yaml_path)),
         None,
-        // LSP runs continuously; no floating-version warning.
         false,
     )
     .await
@@ -399,7 +398,6 @@ async fn create_composition_runner(
             resolve_introspect_subgraph_factory.clone(),
             fetch_remote_subgraph_factory.clone(),
             federation_version,
-            // don't nag about pinning the federation version when iterating with the LSP
             false,
         )
         .await

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -397,7 +397,7 @@ async fn create_composition_runner(
             resolve_introspect_subgraph_factory.clone(),
             fetch_remote_subgraph_factory.clone(),
             federation_version,
-            // LSP runs continuously; no floating-version warning.
+            // don't nag about pinning the federation version when iterating with the LSP
             false,
         )
         .await

--- a/src/command/lsp/mod.rs
+++ b/src/command/lsp/mod.rs
@@ -199,6 +199,8 @@ async fn load_spec_for_path(
         plugin_opts,
         Some(FileDescriptorType::File(supergraph_yaml_path)),
         None,
+        // LSP runs continuously; no floating-version warning.
+        false,
     )
     .await
     .ok()?

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -78,6 +78,8 @@ impl Compose {
             self.opts.plugin_opts.clone(),
             self.opts.supergraph_config_source.supergraph_yaml().clone(),
             self.opts.supergraph_config_source.graph_ref().clone(),
+            // warn when the federation version isn't pinned
+            true,
         )
         .await?;
         let composition_success = composition_pipeline

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -78,7 +78,6 @@ impl Compose {
             self.opts.plugin_opts.clone(),
             self.opts.supergraph_config_source.supergraph_yaml().clone(),
             self.opts.supergraph_config_source.graph_ref().clone(),
-            // warn when the federation version isn't pinned
             true,
         )
         .await?;

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -51,6 +51,9 @@ pub(crate) async fn get_supergraph_binary(
     plugin_opts: PluginOpts,
     supergraph_yaml: Option<FileDescriptorType>,
     graph_ref: Option<GraphRef>,
+    // Only `supergraph compose` nudges users to pin the federation version;
+    // `connector` and the LSP share this helper but shouldn't warn.
+    warn_on_floating_version: bool,
 ) -> Result<CompositionPipeline<Run>, RoverError> {
     let profile = plugin_opts.profile;
 
@@ -80,8 +83,7 @@ pub(crate) async fn get_supergraph_binary(
             resolve_introspect_subgraph_factory,
             fetch_remote_subgraph_factory,
             federation_version,
-            // `supergraph compose` warns when the federation version isn't pinned.
-            true,
+            warn_on_floating_version,
         )
         .await
         .install_supergraph_binary(

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -80,6 +80,8 @@ pub(crate) async fn get_supergraph_binary(
             resolve_introspect_subgraph_factory,
             fetch_remote_subgraph_factory,
             federation_version,
+            // `supergraph compose` warns when the federation version isn't pinned.
+            true,
         )
         .await
         .install_supergraph_binary(

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -188,10 +188,7 @@ impl CompositionPipeline<state::ResolveFederationVersion> {
         };
 
         // Nudge users to pin an exact federation version. Composing against a
-        // floating version (`federation_version: 1`/`2`, or omitted) can pull in
-        // breaking changes when a new federation release ships. This warning was
-        // originally added in #1524 and regressed in v0.27.2 (#2411); restoring it.
-        // The "will fail in future versions" framing matches the public docs.
+        // floating version can pull in breaking changes when a new federation release ships.
         if warn_on_floating_version && federation_version.get_exact().is_none() {
             warnln!(
                 "An exact {} was not specified in your supergraph configuration. Future versions of {} \

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -10,7 +10,7 @@ use apollo_federation_types::config::{
 };
 use camino::Utf8PathBuf;
 use rover_http::HttpService;
-use rover_std::warnln;
+use rover_std::{Style, warnln};
 use rover_studio::types::GraphRef;
 use tempfile::tempdir;
 use tower::MakeService;
@@ -191,15 +191,19 @@ impl CompositionPipeline<state::ResolveFederationVersion> {
         // floating version (`federation_version: 1`/`2`, or omitted) can pull in
         // breaking changes when a new federation release ships. This warning was
         // originally added in #1524 and regressed in v0.27.2 (#2411); restoring it.
+        // The "will fail in future versions" framing matches the public docs.
         if warn_on_floating_version && federation_version.get_exact().is_none() {
             warnln!(
-                "An exact federation version was not specified in your supergraph configuration, so \
-                 composition will track the latest available federation release. Pinning an exact version \
-                 (e.g. `federation_version: =2.x.y`) is strongly recommended: composing against a floating \
-                 version can introduce breaking changes when a new federation release ships, and you must \
-                 update your router before increasing your composition version. See \
-                 https://www.apollographql.com/docs/rover/commands/supergraphs#setting-a-composition-version \
-                 for details."
+                "An exact {} was not specified in your supergraph configuration. Future versions of {} \
+                 will fail without an exact federation version. Pin one (e.g. {}) to prevent breaking \
+                 changes, and make sure to update your router before increasing your composition version. \
+                 See {} for more information.",
+                Style::Command.paint("federation_version"),
+                Style::Command.paint("rover supergraph compose"),
+                Style::Command.paint("federation_version: =2.x.y"),
+                Style::Link.paint(
+                    "https://www.apollographql.com/docs/rover/commands/supergraphs#setting-a-composition-version"
+                ),
             );
         }
 

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -156,6 +156,7 @@ impl CompositionPipeline<state::ResolveFederationVersion> {
         resolve_introspect_subgraph_factory: ResolveIntrospectSubgraphFactory,
         fetch_remote_subgraph_factory: FetchRemoteSubgraphFactory,
         passed_in_fed_version: Option<FederationVersion>,
+        warn_on_floating_version: bool,
     ) -> CompositionPipeline<state::InstallSupergraph> {
         let resolved_federation_version = match self
             .state
@@ -185,6 +186,22 @@ impl CompositionPipeline<state::ResolveFederationVersion> {
         } else {
             resolved_federation_version
         };
+
+        // Nudge users to pin an exact federation version. Composing against a
+        // floating version (`federation_version: 1`/`2`, or omitted) can pull in
+        // breaking changes when a new federation release ships. This warning was
+        // originally added in #1524 and regressed in v0.27.2 (#2411); restoring it.
+        if warn_on_floating_version && federation_version.get_exact().is_none() {
+            warnln!(
+                "An exact federation version was not specified in your supergraph configuration, so \
+                 composition will track the latest available federation release. Pinning an exact version \
+                 (e.g. `federation_version: =2.x.y`) is strongly recommended: composing against a floating \
+                 version can introduce breaking changes when a new federation release ships, and you must \
+                 update your router before increasing your composition version. See \
+                 https://www.apollographql.com/docs/rover/commands/supergraphs#setting-a-composition-version \
+                 for details."
+            );
+        }
 
         debug!("Using Federation Version '{federation_version}'");
 


### PR DESCRIPTION
## Summary

`rover supergraph compose` used to print a warning when `federation_version` wasn't pinned to an exact version. That warning was added in #1524 (v0.12.2) and **silently regressed in v0.27.2** via #2411 ("ROVER-326 Ensure Rover expands references in the `supergraph.yaml`"), which rewrote supergraph-config resolution and deleted the `print_inexact_warning` `eprintln!` and its call sites as collateral.

Since then, composing against a floating `federation_version: 1`/`2` — or omitting the key entirely — produces **no user-visible nudge** to pin. That's the footgun behind #1510: an auto-bumped federation version generated a supergraph the user's router couldn't yet support, with no warning. (Tracked as #1518 phase-1, which was checked off but is no longer delivered.)

## What this does

Restores the warning in the shared composition pipeline (`resolve_federation_version`), gated to `supergraph compose` only via a new `warn_on_floating_version: bool`:

- **`supergraph compose`** → `true` (warns)
- **`rover dev`** / **LSP** → `false` (local/continuous; a per-hot-reload nag would be noise)

Keyed on `FederationVersion::get_exact().is_none()`, so it fires for `LatestFedOne`/`LatestFedTwo` (i.e. `1`/`2`/omitted) and stays silent for `=2.x.y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)