### PR TITLE
Improve the ergonomics around schema check for large schema

### DIFF
--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -139,10 +139,7 @@ impl GraphQLClient {
                                 || response_status.is_client_error()
                                 || response_status.is_redirection()
                             {
-                                if matches!(
-                                    response_status,
-                                    StatusCode::BAD_REQUEST | StatusCode::PAYLOAD_TOO_LARGE
-                                ) {
+                                if matches!(response_status, StatusCode::BAD_REQUEST) {
                                     if let Ok(text) = success.text().await {
                                         tracing::debug!("{}", text);
                                     }
@@ -183,13 +180,9 @@ impl GraphQLClient {
         }
         .map_err(|e| match e {
             BackoffError::Permanent(reqwest_error) | BackoffError::Transient(reqwest_error) => {
-                if reqwest_error.status() == Some(StatusCode::PAYLOAD_TOO_LARGE) {
-                    RoverClientError::RequestTooLarge { endpoint_kind }
-                } else {
-                    RoverClientError::SendRequest {
-                        source: reqwest_error,
-                        endpoint_kind,
-                    }
+                RoverClientError::SendRequest {
+                    source: reqwest_error,
+                    endpoint_kind,
                 }
             }
         })

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -139,7 +139,10 @@ impl GraphQLClient {
                                 || response_status.is_client_error()
                                 || response_status.is_redirection()
                             {
-                                if matches!(response_status, StatusCode::BAD_REQUEST) {
+                                if matches!(
+                                    response_status,
+                                    StatusCode::BAD_REQUEST | StatusCode::PAYLOAD_TOO_LARGE
+                                ) {
                                     if let Ok(text) = success.text().await {
                                         tracing::debug!("{}", text);
                                     }
@@ -180,9 +183,13 @@ impl GraphQLClient {
         }
         .map_err(|e| match e {
             BackoffError::Permanent(reqwest_error) | BackoffError::Transient(reqwest_error) => {
-                RoverClientError::SendRequest {
-                    source: reqwest_error,
-                    endpoint_kind,
+                if reqwest_error.status() == Some(StatusCode::PAYLOAD_TOO_LARGE) {
+                    RoverClientError::RequestTooLarge { endpoint_kind }
+                } else {
+                    RoverClientError::SendRequest {
+                        source: reqwest_error,
+                        endpoint_kind,
+                    }
                 }
             }
         })

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -101,6 +101,10 @@ pub enum RoverClientError {
         endpoint_kind: EndpointKind,
     },
 
+    /// The request body was larger than GraphOS accepts (HTTP 413).
+    #[error("The request was too large for GraphOS to process (HTTP 413 Payload Too Large).")]
+    RequestTooLarge { endpoint_kind: EndpointKind },
+
     /// when someone provides a bad graph/variant combination or isn't
     /// validated properly, we don't know which reason is at fault for data.service
     /// being empty, so this error tells them to check both.
@@ -262,6 +266,13 @@ pub enum RoverClientError {
     #[error("The check workflow took too long to run.")]
     ChecksTimeoutError { url: Option<String> },
 
+    #[error("The schema check finished, but Rover could not retrieve its full result.")]
+    CheckWorkflowResultUnavailable {
+        url: Option<String>,
+        #[source]
+        source: Box<RoverClientError>,
+    },
+
     #[error(
         "A check workflow status was reported but it was not specified as a pass or a failure."
     )]
@@ -318,6 +329,15 @@ pub enum RoverClientError {
         /// Graph creation error coming from schema encoder.
         msg: String,
     },
+}
+
+impl RoverClientError {
+    pub(crate) const fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            RoverClientError::SendRequest { .. } | RoverClientError::RateLimitExceeded
+        )
+    }
 }
 
 fn contract_publish_errors_msg(msgs: &[String], no_launch: &bool) -> String {

--- a/crates/rover-client/src/operations/graph/check/mod.rs
+++ b/crates/rover-client/src/operations/graph/check/mod.rs
@@ -1,4 +1,5 @@
 mod runner;
+mod service;
 mod types;
 
 pub use runner::run;

--- a/crates/rover-client/src/operations/graph/check/runner.rs
+++ b/crates/rover-client/src/operations/graph/check/runner.rs
@@ -1,32 +1,7 @@
-use graphql_client::*;
-use rover_studio::types::GraphRef;
+use tower::{Service, ServiceExt};
 
-use crate::{
-    blocking::StudioClient,
-    operations::graph::check::{
-        runner::graph_check_mutation::GraphCheckMutationGraphVariantSubmitCheckSchemaAsync::{
-            CheckRequestSuccess, InvalidInputError, PermissionError, PlanError,
-            RateLimitExceededError,
-        },
-        types::{CheckSchemaAsyncInput, MutationResponseData},
-    },
-    shared::CheckRequestSuccessResult,
-    RoverClientError,
-};
-
-#[derive(GraphQLQuery)]
-// The paths are relative to the directory where your `Cargo.toml` is located.
-// Both json and the GraphQL schema language are supported as sources for the schema
-#[graphql(
-    query_path = "src/operations/graph/check/graph_check_mutation.graphql",
-    schema_path = ".schema/schema.graphql",
-    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
-    deprecated = "warn"
-)]
-/// This struct is used to generate the module containing `Variables` and
-/// `ResponseData` structs.
-/// Snake case of this name is the mod name. i.e. graph_check_mutation
-pub(crate) struct GraphCheckMutation;
+use super::{service::GraphCheck, types::CheckSchemaAsyncInput};
+use crate::{blocking::StudioClient, shared::CheckRequestSuccessResult, RoverClientError};
 
 /// The main function to be used from this module.
 /// This function takes a proposed schema and validates it against a published
@@ -35,31 +10,65 @@ pub async fn run(
     input: CheckSchemaAsyncInput,
     client: &StudioClient,
 ) -> Result<CheckRequestSuccessResult, RoverClientError> {
-    let graph_ref = input.graph_ref.clone();
-    let data = client.post::<GraphCheckMutation>(input.into()).await?;
-    get_check_response_from_data(data, graph_ref)
+    let mut service = GraphCheck::new(
+        client
+            .studio_graphql_service()
+            .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))?,
+    );
+    let service = service.ready().await?;
+    service.call(input).await
 }
 
-fn get_check_response_from_data(
-    data: MutationResponseData,
-    graph_ref: GraphRef,
-) -> Result<CheckRequestSuccessResult, RoverClientError> {
-    let graph = data.graph.ok_or(RoverClientError::GraphNotFound {
-        graph_ref: graph_ref.clone(),
-    })?;
-    let variant = graph.variant.ok_or(RoverClientError::GraphNotFound {
-        graph_ref: graph_ref.clone(),
-    })?;
-    let typename = variant.submit_check_schema_async;
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
 
-    match typename {
-        CheckRequestSuccess(result) => Ok(CheckRequestSuccessResult {
-            target_url: result.target_url,
-            workflow_id: result.workflow_id,
-        }),
-        InvalidInputError(..) => Err(RoverClientError::InvalidInputError { graph_ref }),
-        PermissionError(error) => Err(RoverClientError::PermissionError { msg: error.message }),
-        PlanError(error) => Err(RoverClientError::PlanError { msg: error.message }),
-        RateLimitExceededError => Err(RoverClientError::RateLimitExceeded),
+    use houston::{Credential, CredentialOrigin};
+    use httpmock::prelude::*;
+    use reqwest::Client as ReqwestClient;
+
+    use super::*;
+    use crate::shared::{CheckConfig, GitContext};
+
+    /// A schema too large for Studio comes back as a 413. Through the tower stack
+    /// this surfaces as a GraphQL deserialization failure carrying the status,
+    /// which the check service translates into a clear `RequestTooLarge` error
+    /// rather than an opaque parse failure. See #1383.
+    #[tokio::test]
+    async fn run_maps_413_to_request_too_large() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(POST).body_includes("GraphCheckMutation");
+            then.status(413).body("payload too large");
+        });
+
+        let client = StudioClient::new(
+            Credential {
+                api_key: "test".to_string(),
+                origin: CredentialOrigin::EnvVar,
+            },
+            &server.url("/"),
+            "test-version",
+            false,
+            ReqwestClient::new(),
+            Duration::from_secs(1),
+        );
+        let input = CheckSchemaAsyncInput {
+            graph_ref: "test-graph@test-variant".parse().unwrap(),
+            proposed_schema: "type Query { hello: String }".to_string(),
+            git_context: GitContext::default(),
+            config: CheckConfig {
+                query_count_threshold: None,
+                query_count_threshold_percentage: None,
+                validation_period: None,
+            },
+        };
+
+        let result = run(input, &client).await;
+        mock.assert();
+        assert!(
+            matches!(result, Err(RoverClientError::RequestTooLarge { .. })),
+            "expected RequestTooLarge, got {result:?}"
+        );
     }
 }

--- a/crates/rover-client/src/operations/graph/check/service.rs
+++ b/crates/rover-client/src/operations/graph/check/service.rs
@@ -1,0 +1,103 @@
+use std::{future::Future, pin::Pin};
+
+use graphql_client::GraphQLQuery;
+use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+use rover_studio::types::GraphRef;
+use tower::Service;
+
+use crate::{
+    operations::graph::check::{
+        service::graph_check_mutation::GraphCheckMutationGraphVariantSubmitCheckSchemaAsync::{
+            CheckRequestSuccess, InvalidInputError, PermissionError, PlanError,
+            RateLimitExceededError,
+        },
+        types::{CheckSchemaAsyncInput, MutationResponseData},
+    },
+    shared::{map_check_submission_error, CheckRequestSuccessResult},
+    RoverClientError,
+};
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/graph/check/graph_check_mutation.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+pub(crate) struct GraphCheckMutation;
+
+/// A [`Service`] that submits an async graph check to Apollo Studio, layered over
+/// the studio GraphQL service.
+#[derive(Clone)]
+pub struct GraphCheck<S: Clone> {
+    inner: S,
+}
+
+impl<S: Clone> GraphCheck<S> {
+    pub const fn new(inner: S) -> GraphCheck<S> {
+        GraphCheck { inner }
+    }
+}
+
+impl<S, Fut> Service<CheckSchemaAsyncInput> for GraphCheck<S>
+where
+    S: Service<
+            GraphQLRequest<GraphCheckMutation>,
+            Response = graph_check_mutation::ResponseData,
+            Error = GraphQLServiceError<graph_check_mutation::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = CheckRequestSuccessResult;
+    type Error = RoverClientError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        tower::Service::<GraphQLRequest<GraphCheckMutation>>::poll_ready(&mut self.inner, cx)
+            .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))
+    }
+
+    fn call(&mut self, input: CheckSchemaAsyncInput) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let fut = async move {
+            let graph_ref = input.graph_ref.clone();
+            let response_data = inner
+                .call(GraphQLRequest::new(input.into()))
+                .await
+                .map_err(map_check_submission_error)?;
+            get_check_response_from_data(response_data, graph_ref)
+        };
+        Box::pin(fut)
+    }
+}
+
+fn get_check_response_from_data(
+    data: MutationResponseData,
+    graph_ref: GraphRef,
+) -> Result<CheckRequestSuccessResult, RoverClientError> {
+    let graph = data.graph.ok_or(RoverClientError::GraphNotFound {
+        graph_ref: graph_ref.clone(),
+    })?;
+    let variant = graph.variant.ok_or(RoverClientError::GraphNotFound {
+        graph_ref: graph_ref.clone(),
+    })?;
+    let typename = variant.submit_check_schema_async;
+
+    match typename {
+        CheckRequestSuccess(result) => Ok(CheckRequestSuccessResult {
+            target_url: result.target_url,
+            workflow_id: result.workflow_id,
+        }),
+        InvalidInputError(..) => Err(RoverClientError::InvalidInputError { graph_ref }),
+        PermissionError(error) => Err(RoverClientError::PermissionError { msg: error.message }),
+        PlanError(error) => Err(RoverClientError::PlanError { msg: error.message }),
+        RateLimitExceededError => Err(RoverClientError::RateLimitExceeded),
+    }
+}

--- a/crates/rover-client/src/operations/graph/check/types.rs
+++ b/crates/rover-client/src/operations/graph/check/types.rs
@@ -1,7 +1,7 @@
 use rover_studio::types::GraphRef;
 
 use crate::{
-    operations::graph::check::runner::graph_check_mutation,
+    operations::graph::check::service::graph_check_mutation,
     shared::{CheckConfig, GitContext},
 };
 

--- a/crates/rover-client/src/operations/graph/check_workflow/check_workflow_status_query.graphql
+++ b/crates/rover-client/src/operations/graph/check_workflow/check_workflow_status_query.graphql
@@ -1,0 +1,11 @@
+query GraphCheckWorkflowStatusQuery($workflowId: ID!, $graphId: ID!) {
+  graph(id: $graphId) {
+    checkWorkflow(id: $workflowId) {
+      status
+      tasks {
+        __typename
+        targetURL
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use graphql_client::*;
 use rover_studio::types::GraphRef;
 
@@ -16,6 +14,7 @@ use crate::{
     blocking::StudioClient,
     operations::graph::check_workflow::types::{CheckWorkflowInput, QueryResponseData},
     shared::{
+        check_workflow_poll::{poll_check_workflow, PollState},
         CheckWorkflowResponse, CustomCheckResponse, Diagnostic, LintCheckResponse,
         OperationCheckResponse, SchemaChange, Violation,
     },
@@ -36,6 +35,18 @@ use crate::{
 /// Snake case of this name is the mod name. i.e. graph_check_workflow_query
 pub(crate) struct GraphCheckWorkflowQuery;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/graph/check_workflow/check_workflow_status_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize, Clone",
+    deprecated = "warn"
+)]
+/// A lightweight, status-only poll query. Used to wait for the check workflow to
+/// finish without re-fetching the (potentially huge) per-task results on every
+/// poll — the full result is fetched once, after the workflow leaves PENDING.
+pub(crate) struct GraphCheckWorkflowStatusQuery;
+
 /// The main function to be used from this module.
 /// This function takes a proposed schema and validates it against a published
 /// schema.
@@ -44,35 +55,45 @@ pub async fn run(
     client: &StudioClient,
 ) -> Result<CheckWorkflowResponse, RoverClientError> {
     let graph_ref = input.graph_ref.clone();
-    let mut url: Option<String> = None;
-    let now = Instant::now();
-    loop {
-        let result = client
-            .post::<GraphCheckWorkflowQuery>(input.clone().into())
-            .await;
-        match result {
-            Ok(data) => {
-                let graph = data.clone().graph.ok_or(RoverClientError::GraphNotFound {
-                    graph_ref: graph_ref.clone(),
-                })?;
-                if let Some(check_workflow) = graph.check_workflow {
-                    if !matches!(check_workflow.status, CheckWorkflowStatus::PENDING) {
-                        return get_check_response_from_data(data, graph_ref);
-                    }
-                }
-                url = get_target_url_from_data(data);
-            }
-            Err(e) => {
-                eprintln!(
-                    "error while checking status of check: {e}\nthis error may be transient... retrying"
-                );
-            }
-        }
-        if now.elapsed() > Duration::from_secs(input.checks_timeout_seconds) {
-            return Err(RoverClientError::ChecksTimeoutError { url });
-        }
-        std::thread::sleep(Duration::from_secs(5));
-    }
+    let checks_timeout_seconds = input.checks_timeout_seconds;
+
+    let data = poll_check_workflow(
+        checks_timeout_seconds,
+        async || {
+            let data = client
+                .post::<GraphCheckWorkflowStatusQuery>(input.clone().into())
+                .await?;
+            // The graph (and its check workflow) may not be reportable on the very
+            // first polls; treat that as "not ready yet" and keep polling.
+            let Some(check_workflow) = data.graph.and_then(|graph| graph.check_workflow) else {
+                return Ok(None);
+            };
+            Ok(Some(PollState {
+                finished: !matches!(
+                    check_workflow.status,
+                    graph_check_workflow_status_query::CheckWorkflowStatus::PENDING
+                ),
+                target_url: get_target_url_from_status_data(&check_workflow),
+            }))
+        },
+        async || {
+            client
+                .post::<GraphCheckWorkflowQuery>(input.clone().into())
+                .await
+        },
+    )
+    .await?;
+    get_check_response_from_data(data, graph_ref)
+}
+
+fn get_target_url_from_status_data(
+    check_workflow: &graph_check_workflow_status_query::GraphCheckWorkflowStatusQueryGraphCheckWorkflow,
+) -> Option<String> {
+    check_workflow
+        .tasks
+        .iter()
+        .filter_map(|task| task.target_url.clone())
+        .next_back()
 }
 
 fn get_check_response_from_data(
@@ -174,23 +195,6 @@ fn get_check_response_from_data(
         }),
         _ => Err(RoverClientError::UnknownCheckWorkflowStatus),
     }
-}
-
-fn get_target_url_from_data(data: QueryResponseData) -> Option<String> {
-    let mut target_url = None;
-    if let Some(graph) = data.graph {
-        if let Some(check_workflow) = graph.check_workflow {
-            for task in check_workflow.tasks {
-                match task.on {
-                    OperationsCheckTask(_) => target_url = task.target_url,
-                    LintCheckTask(_) => target_url = task.target_url,
-                    CustomCheckTask(_) => target_url = task.target_url,
-                    _ => (),
-                }
-            }
-        }
-    }
-    target_url
 }
 
 fn get_operations_response_from_result(

--- a/crates/rover-client/src/operations/graph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/types.rs
@@ -7,7 +7,9 @@ use rover_studio::types::GraphRef;
 
 use self::graph_check_workflow_query::CheckWorkflowTaskStatus;
 use crate::{
-    operations::graph::check_workflow::runner::graph_check_workflow_query,
+    operations::graph::check_workflow::runner::{
+        graph_check_workflow_query, graph_check_workflow_status_query,
+    },
     shared::{ChangeSeverity, CheckTaskStatus},
 };
 
@@ -22,6 +24,16 @@ pub struct CheckWorkflowInput {
 }
 
 impl From<CheckWorkflowInput> for QueryVariables {
+    fn from(input: CheckWorkflowInput) -> Self {
+        let (graph_id, _variant) = input.graph_ref.into_parts();
+        Self {
+            graph_id,
+            workflow_id: input.workflow_id,
+        }
+    }
+}
+
+impl From<CheckWorkflowInput> for graph_check_workflow_status_query::Variables {
     fn from(input: CheckWorkflowInput) -> Self {
         let (graph_id, _variant) = input.graph_ref.into_parts();
         Self {

--- a/crates/rover-client/src/operations/subgraph/check/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/check/mod.rs
@@ -1,4 +1,5 @@
 mod runner;
+mod service;
 mod types;
 
 pub use runner::run;

--- a/crates/rover-client/src/operations/subgraph/check/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check/runner.rs
@@ -1,29 +1,14 @@
-use crate::blocking::StudioClient;
-use crate::operations::config::is_federated::{self, IsFederatedInput};
-use crate::operations::subgraph::check::types::{MutationResponseData, SubgraphCheckAsyncInput};
-use crate::shared::CheckRequestSuccessResult;
-use crate::RoverClientError;
+use tower::{Service, ServiceExt};
 
-use graphql_client::*;
-use rover_studio::types::GraphRef;
-
-use crate::operations::subgraph::check::runner::subgraph_check_mutation::SubgraphCheckMutationGraphVariantSubmitSubgraphCheckAsync::{CheckRequestSuccess, InvalidInputError, PermissionError, PlanError, RateLimitExceededError};
-
-type GraphQLDocument = String;
-
-#[derive(GraphQLQuery)]
-// The paths are relative to the directory where your `Cargo.toml` is located.
-// Both json and the GraphQL schema language are supported as sources for the schema
-#[graphql(
-    query_path = "src/operations/subgraph/check/subgraph_check_mutation.graphql",
-    schema_path = ".schema/schema.graphql",
-    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
-    deprecated = "warn"
-)]
-/// This struct is used to generate the module containing `Variables` and
-/// `ResponseData` structs.
-/// Snake case of this name is the mod name. i.e. subgraph_check_mutation
-pub(crate) struct SubgraphCheckMutation;
+use crate::{
+    blocking::StudioClient,
+    operations::{
+        config::is_federated::{self, IsFederatedInput},
+        subgraph::check::{service::SubgraphCheck, types::SubgraphCheckAsyncInput},
+    },
+    shared::CheckRequestSuccessResult,
+    RoverClientError,
+};
 
 /// The main function to be used from this module.
 /// This function takes a proposed schema and validates it against a published
@@ -47,30 +32,11 @@ pub async fn run(
             can_operation_convert: false,
         });
     }
-    let data = client.post::<SubgraphCheckMutation>(input.into()).await?;
-    get_check_response_from_data(data, graph_ref)
-}
-
-fn get_check_response_from_data(
-    data: MutationResponseData,
-    graph_ref: GraphRef,
-) -> Result<CheckRequestSuccessResult, RoverClientError> {
-    let graph = data.graph.ok_or(RoverClientError::GraphNotFound {
-        graph_ref: graph_ref.clone(),
-    })?;
-    let variant = graph.variant.ok_or(RoverClientError::GraphNotFound {
-        graph_ref: graph_ref.clone(),
-    })?;
-    let typename = variant.submit_subgraph_check_async;
-
-    match typename {
-        CheckRequestSuccess(result) => Ok(CheckRequestSuccessResult {
-            target_url: result.target_url,
-            workflow_id: result.workflow_id,
-        }),
-        InvalidInputError(..) => Err(RoverClientError::InvalidInputError { graph_ref }),
-        PermissionError(error) => Err(RoverClientError::PermissionError { msg: error.message }),
-        PlanError(error) => Err(RoverClientError::PlanError { msg: error.message }),
-        RateLimitExceededError => Err(RoverClientError::RateLimitExceeded),
-    }
+    let mut service = SubgraphCheck::new(
+        client
+            .studio_graphql_service()
+            .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))?,
+    );
+    let service = service.ready().await?;
+    service.call(input).await
 }

--- a/crates/rover-client/src/operations/subgraph/check/service.rs
+++ b/crates/rover-client/src/operations/subgraph/check/service.rs
@@ -1,0 +1,105 @@
+use std::{future::Future, pin::Pin};
+
+use graphql_client::GraphQLQuery;
+use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+use rover_studio::types::GraphRef;
+use tower::Service;
+
+use crate::{
+    operations::subgraph::check::{
+        service::subgraph_check_mutation::SubgraphCheckMutationGraphVariantSubmitSubgraphCheckAsync::{
+            CheckRequestSuccess, InvalidInputError, PermissionError, PlanError,
+            RateLimitExceededError,
+        },
+        types::{MutationResponseData, SubgraphCheckAsyncInput},
+    },
+    shared::{map_check_submission_error, CheckRequestSuccessResult},
+    RoverClientError,
+};
+
+type GraphQLDocument = String;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/subgraph/check/subgraph_check_mutation.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+pub(crate) struct SubgraphCheckMutation;
+
+/// A [`Service`] that submits an async subgraph check to Apollo Studio, layered
+/// over the studio GraphQL service.
+#[derive(Clone)]
+pub struct SubgraphCheck<S: Clone> {
+    inner: S,
+}
+
+impl<S: Clone> SubgraphCheck<S> {
+    pub const fn new(inner: S) -> SubgraphCheck<S> {
+        SubgraphCheck { inner }
+    }
+}
+
+impl<S, Fut> Service<SubgraphCheckAsyncInput> for SubgraphCheck<S>
+where
+    S: Service<
+            GraphQLRequest<SubgraphCheckMutation>,
+            Response = subgraph_check_mutation::ResponseData,
+            Error = GraphQLServiceError<subgraph_check_mutation::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = CheckRequestSuccessResult;
+    type Error = RoverClientError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        tower::Service::<GraphQLRequest<SubgraphCheckMutation>>::poll_ready(&mut self.inner, cx)
+            .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))
+    }
+
+    fn call(&mut self, input: SubgraphCheckAsyncInput) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let fut = async move {
+            let graph_ref = input.graph_ref.clone();
+            let response_data = inner
+                .call(GraphQLRequest::new(input.into()))
+                .await
+                .map_err(map_check_submission_error)?;
+            get_check_response_from_data(response_data, graph_ref)
+        };
+        Box::pin(fut)
+    }
+}
+
+fn get_check_response_from_data(
+    data: MutationResponseData,
+    graph_ref: GraphRef,
+) -> Result<CheckRequestSuccessResult, RoverClientError> {
+    let graph = data.graph.ok_or(RoverClientError::GraphNotFound {
+        graph_ref: graph_ref.clone(),
+    })?;
+    let variant = graph.variant.ok_or(RoverClientError::GraphNotFound {
+        graph_ref: graph_ref.clone(),
+    })?;
+    let typename = variant.submit_subgraph_check_async;
+
+    match typename {
+        CheckRequestSuccess(result) => Ok(CheckRequestSuccessResult {
+            target_url: result.target_url,
+            workflow_id: result.workflow_id,
+        }),
+        InvalidInputError(..) => Err(RoverClientError::InvalidInputError { graph_ref }),
+        PermissionError(error) => Err(RoverClientError::PermissionError { msg: error.message }),
+        PlanError(error) => Err(RoverClientError::PlanError { msg: error.message }),
+        RateLimitExceededError => Err(RoverClientError::RateLimitExceeded),
+    }
+}

--- a/crates/rover-client/src/operations/subgraph/check/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check/types.rs
@@ -1,7 +1,7 @@
 use rover_studio::types::GraphRef;
 
 use crate::{
-    operations::subgraph::check::runner::subgraph_check_mutation,
+    operations::subgraph::check::service::subgraph_check_mutation,
     shared::{CheckConfig, GitContext},
 };
 

--- a/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_status_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_status_query.graphql
@@ -1,0 +1,11 @@
+query SubgraphCheckWorkflowStatusQuery($workflowId: ID!, $graphId: ID!) {
+  graph(id: $graphId) {
+    checkWorkflow(id: $workflowId) {
+      status
+      tasks {
+        __typename
+        targetURL
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use apollo_federation_types::rover::BuildError;
 use graphql_client::*;
 use rover_studio::types::GraphRef;
@@ -20,6 +18,7 @@ use crate::{
     blocking::StudioClient,
     operations::subgraph::check_workflow::types::QueryResponseData,
     shared::{
+        check_workflow_poll::{poll_check_workflow, PollState},
         CheckWorkflowResponse, CustomCheckResponse, Diagnostic, DownstreamCheckResponse,
         LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
         ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange, Violation,
@@ -41,6 +40,18 @@ use crate::{
 /// Snake case of this name is the mod name. i.e. subgraph_check_workflow_query
 pub(crate) struct SubgraphCheckWorkflowQuery;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/subgraph/check_workflow/check_workflow_status_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "PartialEq, Eq, Debug, Serialize, Deserialize, Clone",
+    deprecated = "warn"
+)]
+/// A lightweight, status-only poll query. Used to wait for the check workflow to
+/// finish without re-fetching the (potentially huge) per-task results on every
+/// poll — the full result is fetched once, after the workflow leaves PENDING.
+pub(crate) struct SubgraphCheckWorkflowStatusQuery;
+
 /// The main function to be used from this module.
 /// This function takes a proposed schema and validates it against a published
 /// schema.
@@ -50,35 +61,45 @@ pub async fn run(
     client: &StudioClient,
 ) -> Result<CheckWorkflowResponse, RoverClientError> {
     let graph_ref = input.graph_ref.clone();
-    let mut url: Option<String> = None;
-    let now = Instant::now();
-    loop {
-        let result = client
-            .post::<SubgraphCheckWorkflowQuery>(input.clone().into())
-            .await;
-        match result {
-            Ok(data) => {
-                let graph = data.clone().graph.ok_or(RoverClientError::GraphNotFound {
-                    graph_ref: graph_ref.clone(),
-                })?;
-                if let Some(check_workflow) = graph.check_workflow {
-                    if !matches!(check_workflow.status, CheckWorkflowStatus::PENDING) {
-                        return get_check_response_from_data(data, graph_ref, subgraph);
-                    }
-                }
-                url = get_target_url_from_data(data);
-            }
-            Err(e) => {
-                eprintln!(
-                    "error while checking status of check: {e}\nthis error may be transient... retrying"
-                );
-            }
-        }
-        if now.elapsed() > Duration::from_secs(input.checks_timeout_seconds) {
-            return Err(RoverClientError::ChecksTimeoutError { url });
-        }
-        std::thread::sleep(Duration::from_secs(5));
-    }
+    let checks_timeout_seconds = input.checks_timeout_seconds;
+
+    let data = poll_check_workflow(
+        checks_timeout_seconds,
+        async || {
+            let data = client
+                .post::<SubgraphCheckWorkflowStatusQuery>(input.clone().into())
+                .await?;
+            // The graph (and its check workflow) may not be reportable on the very
+            // first polls; treat that as "not ready yet" and keep polling.
+            let Some(check_workflow) = data.graph.and_then(|graph| graph.check_workflow) else {
+                return Ok(None);
+            };
+            Ok(Some(PollState {
+                finished: !matches!(
+                    check_workflow.status,
+                    subgraph_check_workflow_status_query::CheckWorkflowStatus::PENDING
+                ),
+                target_url: get_target_url_from_status_data(&check_workflow),
+            }))
+        },
+        async || {
+            client
+                .post::<SubgraphCheckWorkflowQuery>(input.clone().into())
+                .await
+        },
+    )
+    .await?;
+    get_check_response_from_data(data, graph_ref, subgraph)
+}
+
+fn get_target_url_from_status_data(
+    check_workflow: &subgraph_check_workflow_status_query::SubgraphCheckWorkflowStatusQueryGraphCheckWorkflow,
+) -> Option<String> {
+    check_workflow
+        .tasks
+        .iter()
+        .filter_map(|task| task.target_url.clone())
+        .next_back()
 }
 
 fn get_check_response_from_data(
@@ -240,18 +261,6 @@ fn get_check_response_from_data(
         }),
         _ => Err(RoverClientError::UnknownCheckWorkflowStatus),
     }
-}
-
-fn get_target_url_from_data(data: QueryResponseData) -> Option<String> {
-    let mut target_url = None;
-    if let Some(graph) = data.graph {
-        if let Some(check_workflow) = graph.check_workflow {
-            for task in check_workflow.tasks {
-                target_url = task.target_url;
-            }
-        }
-    }
-    target_url
 }
 
 fn get_operations_response_from_result(
@@ -467,6 +476,64 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[tokio::test]
+    async fn run_points_to_studio_when_result_fetch_fails() {
+        use std::time::Duration;
+
+        use houston::{Credential, CredentialOrigin};
+        use httpmock::prelude::*;
+        use reqwest::Client as ReqwestClient;
+
+        let server = MockServer::start_async().await;
+        // Lightweight status poll: the workflow has finished (PASSED) and reports a
+        // Studio URL for the check.
+        let _status = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("SubgraphCheckWorkflowStatusQuery");
+            then.status(200).json_body(json!({
+                "data": { "graph": { "checkWorkflow": {
+                    "status": "PASSED",
+                    "tasks": [
+                        { "__typename": "OperationsCheckTask", "targetURL": "https://studio.example/checks/abc" }
+                    ]
+                } } }
+            }));
+        });
+        // The one-time full-result fetch fails (e.g. a result too large to
+        // download); we should surface CheckWorkflowResultUnavailable, not an
+        // opaque transport error, and keep the Studio URL from the status poll.
+        let _full = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("query SubgraphCheckWorkflowQuery");
+            then.status(400).body("too big");
+        });
+
+        let client = StudioClient::new(
+            Credential {
+                api_key: "test".to_string(),
+                origin: CredentialOrigin::EnvVar,
+            },
+            &server.url("/"),
+            "test-version",
+            false,
+            ReqwestClient::new(),
+            Duration::from_secs(1),
+        );
+        let input = CheckWorkflowInput {
+            graph_ref: "test-graph@test-variant".parse().unwrap(),
+            workflow_id: "test-workflow".to_string(),
+            checks_timeout_seconds: 30,
+        };
+
+        let result = run(input, "test-subgraph".to_string(), &client).await;
+        match result {
+            Err(RoverClientError::CheckWorkflowResultUnavailable { url, .. }) => {
+                assert_eq!(url, Some("https://studio.example/checks/abc".to_string()));
+            }
+            other => panic!("expected CheckWorkflowResultUnavailable, got {other:?}"),
+        }
+    }
 
     fn create_check_workflow_data(
         status: CheckWorkflowStatus,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
@@ -5,7 +5,9 @@ use rover_studio::types::GraphRef;
 
 use self::subgraph_check_workflow_query::CheckWorkflowTaskStatus;
 use crate::{
-    operations::subgraph::check_workflow::runner::subgraph_check_workflow_query,
+    operations::subgraph::check_workflow::runner::{
+        subgraph_check_workflow_query, subgraph_check_workflow_status_query,
+    },
     shared::{ChangeSeverity, CheckTaskStatus},
 };
 
@@ -22,6 +24,16 @@ pub struct CheckWorkflowInput {
 }
 
 impl From<CheckWorkflowInput> for QueryVariables {
+    fn from(input: CheckWorkflowInput) -> Self {
+        let (graph_id, _variant) = input.graph_ref.into_parts();
+        Self {
+            graph_id,
+            workflow_id: input.workflow_id,
+        }
+    }
+}
+
+impl From<CheckWorkflowInput> for subgraph_check_workflow_status_query::Variables {
     fn from(input: CheckWorkflowInput) -> Self {
         let (graph_id, _variant) = input.graph_ref.into_parts();
         Self {

--- a/crates/rover-client/src/shared/async_check_response.rs
+++ b/crates/rover-client/src/shared/async_check_response.rs
@@ -1,5 +1,11 @@
+use std::fmt::Debug;
+
+use http::StatusCode;
+use rover_graphql::GraphQLServiceError;
 use serde::Serialize;
 use serde_json::{json, Value};
+
+use crate::{error::EndpointKind, RoverClientError};
 
 /// CheckRequestSuccessResult is the return type of the
 /// `graph` and `subgraph` async check operations
@@ -8,6 +14,25 @@ use serde_json::{json, Value};
 pub struct CheckRequestSuccessResult {
     pub target_url: String,
     pub workflow_id: String,
+}
+
+/// Translates an error from submitting a check through the studio GraphQL service
+/// into a [`RoverClientError`], shared by the `graph` and `subgraph` async check
+/// submissions.
+pub(crate) fn map_check_submission_error<T>(err: GraphQLServiceError<T>) -> RoverClientError
+where
+    T: Debug + Send + Sync,
+{
+    match err {
+        GraphQLServiceError::Deserialization { status_code, .. }
+            if status_code == StatusCode::PAYLOAD_TOO_LARGE =>
+        {
+            RoverClientError::RequestTooLarge {
+                endpoint_kind: EndpointKind::ApolloStudio,
+            }
+        }
+        other => other.into(),
+    }
 }
 
 impl CheckRequestSuccessResult {

--- a/crates/rover-client/src/shared/check_workflow_poll.rs
+++ b/crates/rover-client/src/shared/check_workflow_poll.rs
@@ -1,0 +1,160 @@
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
+use crate::RoverClientError;
+
+/// The outcome of a single check-workflow status poll.
+pub(crate) struct PollState {
+    /// Whether the workflow has left the `PENDING` state.
+    pub finished: bool,
+    /// The Studio URL for the check, if known yet.
+    pub target_url: Option<String>,
+}
+
+/// Polls a lightweight, status-only query until the workflow finishes (or the
+/// timeout elapses), then fetches the full result exactly once to avoid polling the full
+/// result on every iteration makes the response balloon for large schemas, which
+/// can make the poll fail or time out.
+///
+/// `poll_status` returns `Ok(None)` when the workflow isn't reportable yet (so we
+/// keep polling). A transient `Err` (per [`RoverClientError::is_transient`]) is
+/// logged and retried until the timeout; any other `Err` surfaces immediately.
+pub(crate) async fn poll_check_workflow<T>(
+    checks_timeout_seconds: u64,
+    mut poll_status: impl AsyncFnMut() -> Result<Option<PollState>, RoverClientError>,
+    fetch_result: impl AsyncFnOnce() -> Result<T, RoverClientError>,
+) -> Result<T, RoverClientError> {
+    let now = Instant::now();
+    let mut url: Option<String> = None;
+    loop {
+        match poll_status().await {
+            Ok(None) => {}
+            Ok(Some(state)) => {
+                url = state.target_url.or(url);
+                if state.finished {
+                    break;
+                }
+            }
+            Err(e) if e.is_transient() => {
+                eprintln!("error while checking status of check: {e}\nretrying...");
+            }
+            Err(e) => return Err(e),
+        }
+        if now.elapsed() > Duration::from_secs(checks_timeout_seconds) {
+            return Err(RoverClientError::ChecksTimeoutError { url });
+        }
+        thread::sleep(Duration::from_secs(5));
+    }
+
+    fetch_result()
+        .await
+        .map_err(|source| RoverClientError::CheckWorkflowResultUnavailable {
+            url,
+            source: Box::new(source),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn some_error() -> RoverClientError {
+        RoverClientError::AdhocError {
+            msg: "boom".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetches_and_returns_result_once_finished() {
+        let out = poll_check_workflow(
+            30,
+            async || {
+                Ok(Some(PollState {
+                    finished: true,
+                    target_url: Some("https://studio.example/checks/abc".to_string()),
+                }))
+            },
+            async || Ok::<_, RoverClientError>(42),
+        )
+        .await;
+        assert!(matches!(out, Ok(42)));
+    }
+
+    #[tokio::test]
+    async fn wraps_failed_result_fetch_and_keeps_url() {
+        let out = poll_check_workflow(
+            30,
+            async || {
+                Ok(Some(PollState {
+                    finished: true,
+                    target_url: Some("https://studio.example/checks/abc".to_string()),
+                }))
+            },
+            async || Err::<i32, _>(some_error()),
+        )
+        .await;
+        match out {
+            Err(RoverClientError::CheckWorkflowResultUnavailable { url, .. }) => {
+                assert_eq!(url, Some("https://studio.example/checks/abc".to_string()));
+            }
+            other => panic!("expected CheckWorkflowResultUnavailable, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fails_fast_on_non_transient_poll_error() {
+        // A non-transient error must surface immediately (not retry, not time out),
+        // even with a generous timeout.
+        let out = poll_check_workflow::<i32>(
+            300,
+            async || Err(some_error()), // AdhocError is not transient
+            async || panic!("fetch must not run when polling fails fatally"),
+        )
+        .await;
+        assert!(
+            matches!(out, Err(RoverClientError::AdhocError { .. })),
+            "expected the non-transient error to surface immediately, got {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_transient_poll_error_until_timeout() {
+        // A transient error is retried; with a zero budget that means we log it and
+        // then time out, rather than surfacing the transient error itself.
+        let out = poll_check_workflow::<i32>(
+            0,
+            async || Err(RoverClientError::RateLimitExceeded), // transient
+            async || panic!("fetch must not run when the workflow never finishes"),
+        )
+        .await;
+        assert!(
+            matches!(out, Err(RoverClientError::ChecksTimeoutError { .. })),
+            "expected a transient error to be retried until timeout, got {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn times_out_carrying_last_known_url() {
+        // checks_timeout_seconds = 0 means the budget is already spent after the
+        // first (still-pending) poll, so we never sleep and never fetch.
+        let out = poll_check_workflow::<i32>(
+            0,
+            async || {
+                Ok(Some(PollState {
+                    finished: false,
+                    target_url: Some("https://studio.example/checks/abc".to_string()),
+                }))
+            },
+            async || panic!("fetch must not run when the workflow never finishes"),
+        )
+        .await;
+        match out {
+            Err(RoverClientError::ChecksTimeoutError { url }) => {
+                assert_eq!(url, Some("https://studio.example/checks/abc".to_string()));
+            }
+            other => panic!("expected ChecksTimeoutError, got {other:?}"),
+        }
+    }
+}

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -5,6 +5,7 @@ mod fetch_response;
 mod git_context;
 mod lint_response;
 
+pub(crate) use async_check_response::map_check_submission_error;
 pub use async_check_response::CheckRequestSuccessResult;
 pub use check_response::{
     ChangeSeverity, CheckConfig, CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse,

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -1,5 +1,6 @@
 mod async_check_response;
 mod check_response;
+pub(crate) mod check_workflow_poll;
 mod fetch_response;
 mod git_context;
 mod lint_response;

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -277,6 +277,16 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                     Some(RoverErrorSuggestion::IncreaseChecksTimeout { url: url.clone() }),
                     None,
                 ),
+                RoverClientError::CheckWorkflowResultUnavailable { url, .. } => (
+                    Some(RoverErrorSuggestion::ViewCheckResultInStudio { url: url.clone() }),
+                    None,
+                ),
+                RoverClientError::RequestTooLarge { .. } => (
+                    Some(RoverErrorSuggestion::Adhoc(
+                        "For schema checks and publishes, this usually means the schema exceeds the maximum size GraphOS accepts. Try reducing the schema's size, and if you believe this is in error, contact Apollo support.".to_string(),
+                    )),
+                    None,
+                ),
                 RoverClientError::UnknownCheckWorkflowStatus => {
                     (Some(RoverErrorSuggestion::SubmitIssue), None)
                 }

--- a/src/error/metadata/suggestion.rs
+++ b/src/error/metadata/suggestion.rs
@@ -64,6 +64,9 @@ pub enum RoverErrorSuggestion {
     IncreaseChecksTimeout {
         url: Option<String>,
     },
+    ViewCheckResultInStudio {
+        url: Option<String>,
+    },
     FixChecksInput {
         graph_ref: GraphRef,
     },
@@ -247,6 +250,7 @@ impl Display for RoverErrorSuggestion {
             FixLintFailure => "The schema you submitted contains lint violations. Please address the violations and resubmit the schema.".to_string(),
             IncreaseClientTimeout => "You can try increasing the timeout value by passing a higher value to the --client-timeout option.".to_string(),
             IncreaseChecksTimeout {url} => format!("You can try increasing the timeout value by setting APOLLO_CHECKS_TIMEOUT_SECONDS to a higher value in your env. The default value is 300 seconds. You can also view the live check progress by visiting {}.", Style::Link.paint(url.clone().unwrap_or_else(|| "https://studio.apollographql.com".to_string()))),
+            ViewCheckResultInStudio {url} => format!("If your schema is very large, the check result may be too large for Rover to download. You can view the full check result in Studio by visiting {}.", Style::Link.paint(url.clone().unwrap_or_else(|| "https://studio.apollographql.com".to_string()))),
             FixChecksInput { graph_ref } => format!("Graph {} has no published schema or is not a composition variant. Please publish a schema or use a different variant.", Style::Link.paint(graph_ref.to_string())),
             UpgradePlan => "Rover has likely reached rate limits while running graph or subgraph checks. Please try again later or contact your graph admin about upgrading your billing plan.".to_string(),
             ProvideRoutingUrl { subgraph_name, graph_ref } => {


### PR DESCRIPTION
If schema are too large, the download operation can time out. This change centralizes the poll loop between graph/subgraph checks, and makes the loop report a more helpful error if we suspect the loop failed due to the size of the schema, such as in #1383.
