### PR TITLE
Add rover-storage crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,7 +1063,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1240,6 +1246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
  "crossterm",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1447,6 +1463,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -1467,6 +1493,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -1475,7 +1515,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -1488,8 +1528,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1571,6 +1622,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-deftly"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c002a60a3baf5d3fa28db4e1c98733aa2bc784aa63b83c011a72ae9335fb2"
+dependencies = [
+ "derive-deftly-macros",
+ "heck",
+]
+
+[[package]]
+name = "derive-deftly-macros"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5850ec9ad2d9ba0aa33fb22c0b0ef4d91e524566be497ac2a6e40b847e67bb"
+dependencies = [
+ "heck",
+ "indexmap 2.14.0",
+ "itertools",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "strum 0.28.0",
+ "syn 2.0.117",
+ "unicode-ident",
+ "void",
+]
+
+[[package]]
 name = "derive-getters"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1683,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core_fork_arti"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c1b715c79be6328caa9a5e1a387a196ea503740f0722ec3dd8f67a9e72314d"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_fork_arti"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3eae24d595f4d0ecc90a9a5a6d11c2bd8dafe2375ec4a1ec63250e5ade7d228"
+dependencies = [
+ "derive_builder_macro_fork_arti",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1711,16 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro_fork_arti"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69887769a2489cd946bf782eb2b1bb2cb7bc88551440c94a765d4f040c08ebf3"
+dependencies = [
+ "derive_builder_core_fork_arti",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2002,6 +2113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "fs-mistrust"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cfebc7c6bb65d327ded064db65cd260b6c418c27ae790318650cfa2a81bf33f"
+dependencies = [
+ "derive_builder_fork_arti",
+ "dirs",
+ "libc",
+ "pwd-grp",
+ "thiserror 2.0.18",
+ "void",
+ "walkdir",
 ]
 
 [[package]]
@@ -3064,6 +3190,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,6 +3346,16 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3949,6 +4110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,6 +4407,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pwd-grp"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2023f41b5fcb7c30eb5300a5733edfaa9e0e0d502d51b586f65633fd39e40c"
+dependencies = [
+ "derive-deftly",
+ "libc",
+ "paste",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4702,7 +4881,7 @@ dependencies = [
  "shellexpand",
  "speculoos",
  "sputnik",
- "strsim",
+ "strsim 0.11.1",
  "strum 0.28.0",
  "strum_macros 0.28.0",
  "subgraph-mock",
@@ -4856,7 +5035,7 @@ dependencies = [
  "serde",
  "serde_json",
  "speculoos",
- "strsim",
+ "strsim 0.11.1",
  "strum 0.28.0",
  "strum_macros 0.28.0",
  "thiserror 2.0.18",
@@ -4883,6 +5062,21 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "rover-storage"
+version = "0.0.0"
+dependencies = [
+ "fs-mistrust",
+ "keyring",
+ "mockall",
+ "rstest",
+ "serde",
+ "serde_json",
+ "speculoos",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5047,7 +5241,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -5066,7 +5260,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5075,7 +5269,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -5197,12 +5391,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5468,6 +5675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "shape"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5699,6 +5917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "sputnik"
 version = "0.0.0"
 dependencies = [
@@ -5781,6 +6005,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5799,6 +6029,9 @@ name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
 
 [[package]]
 name = "strum_macros"
@@ -6705,6 +6938,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5068,6 +5068,7 @@ dependencies = [
 name = "rover-storage"
 version = "0.0.0"
 dependencies = [
+ "bon",
  "fs-mistrust",
  "keyring",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7129,7 +7129,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crates/rover-http",
     "crates/rover-graphql",
     "crates/rover-open",
+    "crates/rover-storage",
     "crates/rover-studio",
     "crates/sputnik",
     "crates/timber",
@@ -73,6 +74,7 @@ rover-http = { path = "./crates/rover-http" }
 rover-graphql = { path = "./crates/rover-graphql" }
 rover-open = { path = "./crates/rover-open" }
 rover-std = { path = "./crates/rover-std" }
+rover-storage = { path = "./crates/rover-storage" }
 rover-studio = { path = "./crates/rover-studio" }
 rover-schema = { path = "./crates/rover-schema" }
 rover-tower = { path = "./crates/rover-tower" }
@@ -125,6 +127,7 @@ directories-next = "2"
 dotenvy = "0.15"
 dunce = "1"
 flate2 = "1"
+fs-mistrust = "0.14.0"
 futures = "0.3"
 git-url-parse = "0.6"
 git2 = { version = "0.21", default-features = false }
@@ -139,6 +142,7 @@ hyper = "1"
 indoc = "2"
 insta = { version = "1", features = ["json"] }
 itertools = "0.14"
+keyring = "3.6.3"
 lazycell = "1"
 lazy_static = "1"
 mockall = "0.14.0"

--- a/crates/rover-storage/Cargo.toml
+++ b/crates/rover-storage/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 testing = ["mockall"]
 
 [dependencies]
+bon = { workspace = true }
 fs-mistrust = { workspace = true }
 keyring = { workspace = true, features = ["apple-native", "windows-native", "linux-native"] }
 mockall = { workspace = true, optional = true }

--- a/crates/rover-storage/Cargo.toml
+++ b/crates/rover-storage/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rover-storage"
+version = "0.0.0"
+edition = "2024"
+
+publish = false
+
+[features]
+testing = ["mockall"]
+
+[dependencies]
+fs-mistrust = { workspace = true }
+keyring = { workspace = true, features = ["apple-native", "windows-native", "linux-native"] }
+mockall = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
+rstest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+speculoos = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rover-storage/src/credentials_file.rs
+++ b/crates/rover-storage/src/credentials_file.rs
@@ -6,18 +6,17 @@ use serde_json::Value;
 
 use crate::{Store, StoreError};
 
-const CREDENTIALS_FILE: &str = "credentials.json";
+const DEFAULT_CREDENTIALS_FILE: &str = "credentials.json";
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, bon::Builder)]
 pub struct CredentialsFileStore {
+    #[builder(start_fn)]
     dir: PathBuf,
+    #[builder(default = DEFAULT_CREDENTIALS_FILE.to_string())]
+    credentials_file: String,
 }
 
 impl CredentialsFileStore {
-    pub const fn new(dir: PathBuf) -> CredentialsFileStore {
-        CredentialsFileStore { dir }
-    }
-
     fn checked_dir(&self) -> Result<fs_mistrust::CheckedDir, StoreError> {
         Mistrust::new()
             .verifier()
@@ -27,7 +26,7 @@ impl CredentialsFileStore {
 
     fn read_data(&self) -> Result<BTreeMap<String, Value>, StoreError> {
         let dir = self.checked_dir()?;
-        match dir.read(CREDENTIALS_FILE) {
+        match dir.read(&self.credentials_file) {
             Ok(data) => serde_json::from_slice(&data).map_err(StoreError::Deserialize),
             Err(fs_mistrust::Error::NotFound(_)) => Ok(BTreeMap::new()),
             Err(e) => Err(StoreError::Store(Box::new(e))),
@@ -37,7 +36,7 @@ impl CredentialsFileStore {
     fn write_data(&self, map: &BTreeMap<String, Value>) -> Result<(), StoreError> {
         let data = serde_json::to_vec_pretty(map).map_err(StoreError::Serialize)?;
         let dir = self.checked_dir()?;
-        dir.write_and_replace(CREDENTIALS_FILE, &data)
+        dir.write_and_replace(&self.credentials_file, &data)
             .map_err(|e| StoreError::Store(Box::new(e)))
     }
 }
@@ -128,7 +127,7 @@ mod tests {
         }
         let dir = temp.path().to_path_buf();
         TestStore {
-            store: CredentialsFileStore::new(dir.clone()),
+            store: CredentialsFileStore::builder(dir.clone()).build(),
             dir,
             _temp: temp,
         }

--- a/crates/rover-storage/src/credentials_file.rs
+++ b/crates/rover-storage/src/credentials_file.rs
@@ -1,0 +1,258 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use fs_mistrust::Mistrust;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{Store, StoreError};
+
+const CREDENTIALS_FILE: &str = "credentials.json";
+
+#[derive(Clone, Debug)]
+pub struct CredentialsFileStore {
+    dir: PathBuf,
+}
+
+impl CredentialsFileStore {
+    pub const fn new(dir: PathBuf) -> CredentialsFileStore {
+        CredentialsFileStore { dir }
+    }
+
+    fn checked_dir(&self) -> Result<fs_mistrust::CheckedDir, StoreError> {
+        Mistrust::new()
+            .verifier()
+            .make_secure_dir(&self.dir)
+            .map_err(|e| StoreError::Store(Box::new(e)))
+    }
+
+    fn read_data(&self) -> Result<BTreeMap<String, Value>, StoreError> {
+        let dir = self.checked_dir()?;
+        match dir.read(CREDENTIALS_FILE) {
+            Ok(data) => serde_json::from_slice(&data).map_err(StoreError::Deserialize),
+            Err(fs_mistrust::Error::NotFound(_)) => Ok(BTreeMap::new()),
+            Err(e) => Err(StoreError::Store(Box::new(e))),
+        }
+    }
+
+    fn write_data(&self, map: &BTreeMap<String, Value>) -> Result<(), StoreError> {
+        let data = serde_json::to_vec_pretty(map).map_err(StoreError::Serialize)?;
+        let dir = self.checked_dir()?;
+        dir.write_and_replace(CREDENTIALS_FILE, &data)
+            .map_err(|e| StoreError::Store(Box::new(e)))
+    }
+}
+
+impl Store for CredentialsFileStore {
+    fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
+    where
+        T: Serialize + 'static,
+    {
+        let mut map = self.read_data()?;
+        let serialized = serde_json::to_value(&value).map_err(StoreError::Serialize)?;
+        map.insert(key.to_string(), serialized);
+        self.write_data(&map)?;
+        Ok(value)
+    }
+
+    fn read<T>(&self, key: &str) -> Result<Option<T>, StoreError>
+    where
+        T: for<'de> Deserialize<'de> + 'static,
+    {
+        let map = self.read_data()?;
+        match map.get(key) {
+            Some(value) => {
+                let deserialized =
+                    serde_json::from_value(value.clone()).map_err(StoreError::Deserialize)?;
+                Ok(Some(deserialized))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn delete(&self, key: &str) -> Result<(), StoreError> {
+        let mut map = self.read_data()?;
+        map.remove(key);
+        self.write_data(&map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use rstest::{fixture, rstest};
+    use serde::{Deserialize, Serialize};
+    use speculoos::prelude::*;
+    use tempfile::TempDir;
+
+    use super::CredentialsFileStore;
+    use crate::Store;
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestValue {
+        data: String,
+    }
+
+    impl TestValue {
+        fn new(data: impl Into<String>) -> Self {
+            TestValue { data: data.into() }
+        }
+    }
+
+    /// Pairs the store with the [`TempDir`] backing it so the directory is
+    /// removed when the test ends. Derefs to the inner store and re-exposes
+    /// `dir`, so the test bodies need no changes.
+    struct TestStore {
+        store: CredentialsFileStore,
+        dir: PathBuf,
+        _temp: TempDir,
+    }
+
+    impl std::ops::Deref for TestStore {
+        type Target = CredentialsFileStore;
+
+        fn deref(&self) -> &Self::Target {
+            &self.store
+        }
+    }
+
+    #[fixture]
+    fn store() -> TestStore {
+        let temp = tempfile::tempdir().unwrap();
+        // `fs-mistrust` rejects group/world-accessible dirs, so tighten the
+        // umask-derived perms to 0700 (matching what `make_secure_dir` creates).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let dir = temp.path().to_path_buf();
+        TestStore {
+            store: CredentialsFileStore::new(dir.clone()),
+            dir,
+            _temp: temp,
+        }
+    }
+
+    #[rstest]
+    fn write_returns_the_written_value(store: TestStore) {
+        let value = TestValue::new("hello");
+
+        let result = store.write("key", value.clone());
+
+        assert_that!(result).is_ok().is_equal_to(value);
+    }
+
+    #[rstest]
+    fn read_returns_none_when_key_does_not_exist(store: TestStore) {
+        let value = TestValue::new("hello");
+        let result = store.write("key", value);
+        assert_that!(result).is_ok();
+        let result = store.read::<TestValue>("missing");
+
+        assert_that!(result).is_ok().is_none();
+    }
+
+    #[rstest]
+    fn read_returns_none_when_file_does_not_exist(store: TestStore) {
+        let result = store.read::<TestValue>("key");
+
+        assert_that!(result).is_ok().is_none();
+    }
+
+    #[rstest]
+    fn read_returns_written_value(store: TestStore) {
+        let value = TestValue::new("hello");
+        store.write("key", value.clone()).unwrap();
+
+        let result = store.read::<TestValue>("key");
+
+        assert_that!(result).is_ok().is_some().is_equal_to(value);
+    }
+
+    #[rstest]
+    fn write_overwrites_existing_value(store: TestStore) {
+        store.write("key", TestValue::new("first")).unwrap();
+
+        store.write("key", TestValue::new("second")).unwrap();
+
+        let result = store.read::<TestValue>("key");
+        assert_that!(result)
+            .is_ok()
+            .is_some()
+            .is_equal_to(TestValue::new("second"));
+    }
+
+    #[rstest]
+    fn write_preserves_other_keys(store: TestStore) {
+        store.write("a", TestValue::new("first")).unwrap();
+
+        store.write("b", TestValue::new("second")).unwrap();
+
+        assert_that!(store.read::<TestValue>("a"))
+            .is_ok()
+            .is_some()
+            .is_equal_to(TestValue::new("first"));
+
+        assert_that!(store.read::<TestValue>("b"))
+            .is_ok()
+            .is_some()
+            .is_equal_to(TestValue::new("second"));
+    }
+
+    #[rstest]
+    fn delete_removes_key(store: TestStore) {
+        store.write("key", TestValue::new("hello")).unwrap();
+
+        store.delete("key").unwrap();
+
+        assert_that!(store.read::<TestValue>("key"))
+            .is_ok()
+            .is_none();
+    }
+
+    #[rstest]
+    fn delete_is_ok_when_key_does_not_exist(store: TestStore) {
+        let result = store.delete("missing");
+
+        assert_that!(result).is_ok();
+    }
+
+    #[rstest]
+    fn delete_preserves_other_keys(store: TestStore) {
+        store.write("a", TestValue::new("keep")).unwrap();
+        store.write("b", TestValue::new("remove")).unwrap();
+
+        store.delete("b").unwrap();
+
+        assert_that!(store.read::<TestValue>("a"))
+            .is_ok()
+            .is_some()
+            .is_equal_to(TestValue::new("keep"));
+    }
+
+    #[cfg(unix)]
+    #[rstest]
+    fn dir_is_created_with_0700_permissions(store: TestStore) {
+        use std::os::unix::fs::PermissionsExt;
+
+        store.write("key", TestValue::new("hello")).unwrap();
+
+        let mode = std::fs::metadata(&store.dir).unwrap().permissions().mode();
+        assert_that!(mode & 0o777).is_equal_to(0o700);
+    }
+
+    #[cfg(unix)]
+    #[rstest]
+    fn file_is_created_with_0600_permissions(store: TestStore) {
+        use std::os::unix::fs::PermissionsExt;
+
+        store.write("key", TestValue::new("hello")).unwrap();
+
+        let mode = std::fs::metadata(store.dir.join("credentials.json"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_that!(mode & 0o777).is_equal_to(0o600);
+    }
+}

--- a/crates/rover-storage/src/credentials_file.rs
+++ b/crates/rover-storage/src/credentials_file.rs
@@ -103,6 +103,8 @@ mod tests {
     /// `dir`, so the test bodies need no changes.
     struct TestStore {
         store: CredentialsFileStore,
+        // Only read by the `#[cfg(unix)]` permission tests below.
+        #[cfg_attr(not(unix), allow(dead_code))]
         dir: PathBuf,
         _temp: TempDir,
     }

--- a/crates/rover-storage/src/lib.rs
+++ b/crates/rover-storage/src/lib.rs
@@ -1,0 +1,27 @@
+pub mod credentials_file;
+pub mod secret;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(thiserror::Error, Debug)]
+pub enum StoreError {
+    #[error("No keystore backend available")]
+    NoBackend,
+    #[error("Failed to serialize: {0}")]
+    Serialize(#[source] serde_json::Error),
+    #[error("Failed to deserialize: {0}")]
+    Deserialize(#[source] serde_json::Error),
+    #[error("{0}")]
+    Store(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[cfg_attr(any(test, feature = "testing"), mockall::automock)]
+pub trait Store {
+    fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
+    where
+        T: Serialize + 'static;
+    fn read<T>(&self, key: &str) -> Result<Option<T>, StoreError>
+    where
+        T: for<'de> Deserialize<'de> + 'static;
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}

--- a/crates/rover-storage/src/lib.rs
+++ b/crates/rover-storage/src/lib.rs
@@ -15,6 +15,15 @@ pub enum StoreError {
     Store(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
+impl From<keyring::Error> for StoreError {
+    fn from(err: keyring::Error) -> Self {
+        match err {
+            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            err => StoreError::Store(Box::new(err)),
+        }
+    }
+}
+
 #[cfg_attr(any(test, feature = "testing"), mockall::automock)]
 pub trait Store {
     fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>

--- a/crates/rover-storage/src/secret.rs
+++ b/crates/rover-storage/src/secret.rs
@@ -42,7 +42,9 @@ impl Store for KeyringSecretStore {
 
     fn delete(&self, key: &str) -> Result<(), StoreError> {
         let entry = Entry::new(&self.service, key)?;
-        entry.delete_credential()?;
-        Ok(())
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
     }
 }

--- a/crates/rover-storage/src/secret.rs
+++ b/crates/rover-storage/src/secret.rs
@@ -20,14 +20,8 @@ impl Store for KeyringSecretStore {
         T: Serialize + 'static,
     {
         let data = serde_json::to_vec(&value).map_err(StoreError::Serialize)?;
-        let entry = Entry::new(&self.service, key).map_err(|err| match err {
-            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
-            err => StoreError::Store(Box::new(err)),
-        })?;
-        entry.set_secret(&data).map_err(|err| match err {
-            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
-            err => StoreError::Store(Box::new(err)),
-        })?;
+        let entry = Entry::new(&self.service, key)?;
+        entry.set_secret(&data)?;
         Ok(value)
     }
 
@@ -35,30 +29,20 @@ impl Store for KeyringSecretStore {
     where
         T: for<'de> Deserialize<'de> + 'static,
     {
-        let entry = Entry::new(&self.service, key).map_err(|err| match err {
-            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
-            err => StoreError::Store(Box::new(err)),
-        })?;
+        let entry = Entry::new(&self.service, key)?;
         match entry.get_secret() {
             Ok(data) => {
                 let value = serde_json::from_slice(&data).map_err(StoreError::Deserialize)?;
                 Ok(Some(value))
             }
             Err(keyring::Error::NoEntry) => Ok(None),
-            Err(keyring::Error::NoStorageAccess(_)) => Err(StoreError::NoBackend),
-            Err(err) => Err(StoreError::Store(Box::new(err))),
+            Err(err) => Err(err.into()),
         }
     }
 
     fn delete(&self, key: &str) -> Result<(), StoreError> {
-        let entry = Entry::new(&self.service, key).map_err(|err| match err {
-            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
-            err => StoreError::Store(Box::new(err)),
-        })?;
-        entry.delete_credential().map_err(|err| match err {
-            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
-            err => StoreError::Store(Box::new(err)),
-        })?;
+        let entry = Entry::new(&self.service, key)?;
+        entry.delete_credential()?;
         Ok(())
     }
 }

--- a/crates/rover-storage/src/secret.rs
+++ b/crates/rover-storage/src/secret.rs
@@ -1,0 +1,64 @@
+use keyring::Entry;
+use serde::{Deserialize, Serialize};
+
+use crate::{Store, StoreError};
+
+#[derive(Clone, Debug)]
+pub struct KeyringSecretStore {
+    service: String,
+}
+
+impl KeyringSecretStore {
+    pub const fn new(service: String) -> KeyringSecretStore {
+        KeyringSecretStore { service }
+    }
+}
+
+impl Store for KeyringSecretStore {
+    fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
+    where
+        T: Serialize + 'static,
+    {
+        let data = serde_json::to_vec(&value).map_err(StoreError::Serialize)?;
+        let entry = Entry::new(&self.service, key).map_err(|err| match err {
+            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            err => StoreError::Store(Box::new(err)),
+        })?;
+        entry.set_secret(&data).map_err(|err| match err {
+            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            err => StoreError::Store(Box::new(err)),
+        })?;
+        Ok(value)
+    }
+
+    fn read<T>(&self, key: &str) -> Result<Option<T>, StoreError>
+    where
+        T: for<'de> Deserialize<'de> + 'static,
+    {
+        let entry = Entry::new(&self.service, key).map_err(|err| match err {
+            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            err => StoreError::Store(Box::new(err)),
+        })?;
+        match entry.get_secret() {
+            Ok(data) => {
+                let value = serde_json::from_slice(&data).map_err(StoreError::Deserialize)?;
+                Ok(Some(value))
+            }
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(keyring::Error::NoStorageAccess(_)) => Err(StoreError::NoBackend),
+            Err(err) => Err(StoreError::Store(Box::new(err))),
+        }
+    }
+
+    fn delete(&self, key: &str) -> Result<(), StoreError> {
+        let entry = Entry::new(&self.service, key).map_err(|err| match err {
+            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            err => StoreError::Store(Box::new(err)),
+        })?;
+        entry.delete_credential().map_err(|err| match err {
+            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            err => StoreError::Store(Box::new(err)),
+        })?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds `rover-storage`, which will be used to store sensitive values in the OS keychain and/or fallback to a more restrictive file format if a keychain is not found.