### PR TITLE
Migrate to keyring-core (aka keyring-4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -284,6 +284,17 @@ dependencies = [
  "memchr",
  "rowan",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
 ]
 
 [[package]]
@@ -779,7 +790,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1250,16 +1261,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1644,7 +1645,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "strum 0.27.2",
+ "strum 0.28.0",
  "syn 2.0.117",
  "unicode-ident",
  "void",
@@ -1833,7 +1834,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1966,7 +1967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3031,7 +3032,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3200,18 +3201,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "linux-keyutils",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -3355,6 +3350,16 @@ checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
+]
+
+[[package]]
+name = "linux-keyutils-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39fbed79f71dc21eb21d3d07c0e908a3c58ff9a1fdbf5cf44230fb3deb6d994b"
+dependencies = [
+ "keyring-core",
+ "linux-keyutils",
 ]
 
 [[package]]
@@ -3713,7 +3718,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4062,7 +4067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5081,16 +5086,18 @@ dependencies = [
 name = "rover-storage"
 version = "0.0.0"
 dependencies = [
+ "apple-native-keyring-store",
  "bon",
  "fs-mistrust",
- "keyring",
- "mockall",
+ "keyring-core",
+ "linux-keyutils-keyring-store",
  "rstest",
  "serde",
  "serde_json",
  "speculoos",
  "tempfile",
  "thiserror 2.0.18",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -5229,7 +5236,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5255,7 +5262,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5274,7 +5281,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5283,10 +5290,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5405,25 +5412,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5911,7 +5905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6043,6 +6037,9 @@ name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
 
 [[package]]
 name = "strum_macros"
@@ -6187,7 +6184,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7139,7 +7136,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "jni",
  "log",
  "ndk-context",
@@ -7201,7 +7198,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7250,6 +7247,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,6 @@ hyper = "1"
 indoc = "2"
 insta = { version = "1", features = ["json"] }
 itertools = "0.14"
-keyring = "3.6.3"
 lazycell = "1"
 lazy_static = "1"
 mockall = "0.14.0"
@@ -202,6 +201,12 @@ uuid = "1"
 url = "2"
 webbrowser = "1"
 zip = "8"
+
+### keyring ecosystem
+keyring-core = "1.0"
+apple-native-keyring-store = { version = "1.0", features = ["protected"] }
+linux-keyutils-keyring-store = "1.0"
+windows-native-keyring-store = "1.0"
 
 ### rover specific dependencies
 [dependencies]

--- a/crates/rover-storage/Cargo.toml
+++ b/crates/rover-storage/Cargo.toml
@@ -5,20 +5,24 @@ edition = "2024"
 
 publish = false
 
-[features]
-testing = ["mockall"]
-
 [dependencies]
 bon = { workspace = true }
 fs-mistrust = { workspace = true }
-keyring = { workspace = true, features = ["apple-native", "windows-native", "linux-native"] }
-mockall = { workspace = true, optional = true }
+keyring-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-keyutils-keyring-store = { workspace = true }
+
 [dev-dependencies]
-mockall = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 speculoos = { workspace = true }

--- a/crates/rover-storage/src/credentials_file.rs
+++ b/crates/rover-storage/src/credentials_file.rs
@@ -1,10 +1,21 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+    any::Any,
+    collections::{BTreeMap, HashMap},
+    fmt,
+    fmt::{Debug, Formatter},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use fs_mistrust::Mistrust;
+use keyring_core::{
+    Credential, Entry as KeyringEntry,
+    api::{CredentialApi, CredentialPersistence, CredentialStoreApi},
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{Store, StoreError};
+use crate::StoreError;
 
 const DEFAULT_CREDENTIALS_FILE: &str = "credentials.json";
 
@@ -41,7 +52,7 @@ impl CredentialsFileStore {
     }
 }
 
-impl Store for CredentialsFileStore {
+impl CredentialsFileStore {
     fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
     where
         T: Serialize + 'static,
@@ -75,6 +86,104 @@ impl Store for CredentialsFileStore {
     }
 }
 
+#[derive(Clone, Debug)]
+struct CredentialsFileCredential {
+    store: CredentialsFileStore,
+    service: String,
+    user: String,
+}
+
+impl CredentialApi for CredentialsFileCredential {
+    fn set_secret(&self, secret: &[u8]) -> keyring_core::Result<()> {
+        let value: Value = serde_json::from_slice(secret).map_err(|e| {
+            keyring_core::Error::Invalid("secret".to_string(), format!("not valid JSON: {e}"))
+        })?;
+        self.store
+            .write(&self.user, value)
+            .map(|_| ())
+            .map_err(|e| keyring_core::Error::PlatformFailure(Box::new(e)))
+    }
+
+    fn get_secret(&self) -> keyring_core::Result<Vec<u8>> {
+        match self.store.read::<Value>(&self.user) {
+            Ok(Some(value)) => serde_json::to_vec(&value).map_err(|e| {
+                keyring_core::Error::BadStoreFormat(format!(
+                    "credential value cannot be re-serialized: {e}"
+                ))
+            }),
+            Ok(None) => Err(keyring_core::Error::NoEntry),
+            Err(e) => Err(keyring_core::Error::PlatformFailure(Box::new(e))),
+        }
+    }
+
+    fn delete_credential(&self) -> keyring_core::Result<()> {
+        self.store
+            .delete(&self.user)
+            .map_err(|e| keyring_core::Error::PlatformFailure(Box::new(e)))
+    }
+
+    fn get_credential(&self) -> keyring_core::Result<Option<Arc<Credential>>> {
+        match self.store.read::<Value>(&self.user) {
+            Ok(Some(_)) => Ok(None),
+            Ok(None) => Err(keyring_core::Error::NoEntry),
+            Err(e) => Err(keyring_core::Error::PlatformFailure(Box::new(e))),
+        }
+    }
+
+    fn get_specifiers(&self) -> Option<(String, String)> {
+        Some((self.service.clone(), self.user.clone()))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn debug_fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl CredentialStoreApi for CredentialsFileStore {
+    fn vendor(&self) -> String {
+        String::from("rover, https://github.com/apollographql/rover")
+    }
+
+    fn id(&self) -> String {
+        format!("CredentialsFileStore({})", self.dir.display())
+    }
+
+    fn build(
+        &self,
+        service: &str,
+        user: &str,
+        modifiers: Option<&HashMap<&str, &str>>,
+    ) -> keyring_core::Result<KeyringEntry> {
+        if modifiers.is_some_and(|m| !m.is_empty()) {
+            return Err(keyring_core::Error::NotSupportedByStore(
+                "CredentialsFileStore does not support entry modifiers".to_string(),
+            ));
+        }
+        let cred: Arc<Credential> = Arc::new(CredentialsFileCredential {
+            store: self.clone(),
+            service: service.to_string(),
+            user: user.to_string(),
+        });
+        Ok(KeyringEntry::new_with_credential(cred))
+    }
+
+    fn persistence(&self) -> CredentialPersistence {
+        CredentialPersistence::UntilDelete
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn debug_fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -85,7 +194,6 @@ mod tests {
     use tempfile::TempDir;
 
     use super::CredentialsFileStore;
-    use crate::Store;
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     struct TestValue {

--- a/crates/rover-storage/src/lib.rs
+++ b/crates/rover-storage/src/lib.rs
@@ -1,7 +1,5 @@
-pub mod credentials_file;
+mod credentials_file;
 pub mod secret;
-
-use serde::{Deserialize, Serialize};
 
 #[derive(thiserror::Error, Debug)]
 pub enum StoreError {
@@ -15,22 +13,11 @@ pub enum StoreError {
     Store(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
-impl From<keyring::Error> for StoreError {
-    fn from(err: keyring::Error) -> Self {
+impl From<keyring_core::Error> for StoreError {
+    fn from(err: keyring_core::Error) -> Self {
         match err {
-            keyring::Error::NoStorageAccess(_) => StoreError::NoBackend,
+            keyring_core::Error::NoStorageAccess(_) => StoreError::NoBackend,
             err => StoreError::Store(Box::new(err)),
         }
     }
-}
-
-#[cfg_attr(any(test, feature = "testing"), mockall::automock)]
-pub trait Store {
-    fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
-    where
-        T: Serialize + 'static;
-    fn read<T>(&self, key: &str) -> Result<Option<T>, StoreError>
-    where
-        T: for<'de> Deserialize<'de> + 'static;
-    fn delete(&self, key: &str) -> Result<(), StoreError>;
 }

--- a/crates/rover-storage/src/secret.rs
+++ b/crates/rover-storage/src/secret.rs
@@ -1,50 +1,108 @@
-use keyring::Entry;
+use std::{path::PathBuf, sync::Arc};
+
+use keyring_core::CredentialStore;
 use serde::{Deserialize, Serialize};
 
-use crate::{Store, StoreError};
+use crate::{StoreError, credentials_file::CredentialsFileStore};
 
 #[derive(Clone, Debug)]
-pub struct KeyringSecretStore {
+pub struct RoverSecretStore {
     service: String,
+    backend: Arc<CredentialStore>,
 }
 
-impl KeyringSecretStore {
-    pub const fn new(service: String) -> KeyringSecretStore {
-        KeyringSecretStore { service }
+impl RoverSecretStore {
+    /// Create a store using the platform's default credential backend, falling
+    /// back to [`CredentialsFileStore`] in `credentials_dir` when the platform
+    /// keyring is unavailable or the target has no native keyring.
+    pub fn new(service: String, credentials_dir: PathBuf) -> Result<Self, StoreError> {
+        let backend = default_backend(credentials_dir)?;
+        Ok(RoverSecretStore { service, backend })
     }
-}
 
-impl Store for KeyringSecretStore {
-    fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
+    /// Create a store with a given `backend` for test scaffolding.
+    #[cfg(test)]
+    pub fn new_with_backend(service: String, backend: Arc<CredentialStore>) -> Self {
+        RoverSecretStore { service, backend }
+    }
+
+    pub fn write<T>(&self, key: &str, value: T) -> Result<T, StoreError>
     where
         T: Serialize + 'static,
     {
         let data = serde_json::to_vec(&value).map_err(StoreError::Serialize)?;
-        let entry = Entry::new(&self.service, key)?;
+        let entry = self.backend.build(&self.service, key, None)?;
         entry.set_secret(&data)?;
         Ok(value)
     }
 
-    fn read<T>(&self, key: &str) -> Result<Option<T>, StoreError>
+    pub fn read<T>(&self, key: &str) -> Result<Option<T>, StoreError>
     where
         T: for<'de> Deserialize<'de> + 'static,
     {
-        let entry = Entry::new(&self.service, key)?;
+        let entry = self.backend.build(&self.service, key, None)?;
         match entry.get_secret() {
             Ok(data) => {
                 let value = serde_json::from_slice(&data).map_err(StoreError::Deserialize)?;
                 Ok(Some(value))
             }
-            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(keyring_core::Error::NoEntry) => Ok(None),
             Err(err) => Err(err.into()),
         }
     }
 
-    fn delete(&self, key: &str) -> Result<(), StoreError> {
-        let entry = Entry::new(&self.service, key)?;
+    pub fn delete(&self, key: &str) -> Result<(), StoreError> {
+        let entry = self.backend.build(&self.service, key, None)?;
         match entry.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Ok(()) | Err(keyring_core::Error::NoEntry) => Ok(()),
             Err(err) => Err(err.into()),
         }
     }
+}
+
+fn file_store_backend(credentials_dir: PathBuf) -> Result<Arc<CredentialStore>, StoreError> {
+    let store: Arc<CredentialStore> =
+        Arc::new(CredentialsFileStore::builder(credentials_dir).build());
+    Ok(store)
+}
+
+#[cfg(target_os = "macos")]
+fn default_backend(credentials_dir: PathBuf) -> Result<Arc<CredentialStore>, StoreError> {
+    use std::collections::HashMap;
+
+    use apple_native_keyring_store::protected::Store;
+    match Store::new_with_configuration(&HashMap::new()) {
+        Ok(store) => Ok(store),
+        Err(keyring_core::Error::NoStorageAccess(_)) => file_store_backend(credentials_dir),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn default_backend(credentials_dir: PathBuf) -> Result<Arc<CredentialStore>, StoreError> {
+    use std::collections::HashMap;
+
+    use windows_native_keyring_store::Store;
+    match Store::new_with_configuration(&HashMap::new()) {
+        Ok(store) => Ok(store),
+        Err(keyring_core::Error::NoStorageAccess(_)) => file_store_backend(credentials_dir),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn default_backend(credentials_dir: PathBuf) -> Result<Arc<CredentialStore>, StoreError> {
+    use std::collections::HashMap;
+
+    use linux_keyutils_keyring_store::Store;
+    match Store::new_with_configuration(&HashMap::new()) {
+        Ok(store) => Ok(store),
+        Err(keyring_core::Error::NoStorageAccess(_)) => file_store_backend(credentials_dir),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux",)))]
+fn default_backend(credentials_dir: PathBuf) -> Result<Arc<CredentialStore>, StoreError> {
+    file_store_backend(credentials_dir)
 }


### PR DESCRIPTION
This leaves the public API largely the same, but centralizes the logic into RoverSecretStore over the new traits that keyring-core provides, making CredentialsFileStore an internal implementation detail rather than a public API.
