### PR TITLE
Report downstream contract failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+- **Report downstream contract check and launch failures from `subgraph check` and `subgraph publish`**
+
+  `rover subgraph check` now treats failed blocking downstream contract workflows as check failures even when the source workflow response does not mark `failsUpstreamWorkflow`. `rover subgraph publish` now initiates downstream contract launches synchronously and waits for the source and downstream launches to finish before reporting success.
+
 - **Fall back to an installed plugin when the registry is unreachable - @SharkBaitDLS PR #3362 fixes #1791 #1808**
 
   When Rover needs the latest `supergraph` or `router` plugin but can't reach the plugin registry (an outage, a network blip, or simply being offline), it now falls back to the newest compatible plugin already installed in `~/.rover/bin` with a warning instead of failing outright. Exact version pins still return an error.

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -8,6 +8,13 @@ use thiserror::Error;
 
 use crate::shared::{CheckTaskStatus, CheckWorkflowResponse, LintResponse};
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FailedLaunch {
+    pub graph_id: String,
+    pub graph_variant: String,
+    pub launch_id: String,
+}
+
 /// RoverClientError represents all possible failures that can occur during a client request.
 #[derive(Error, Debug)]
 pub enum RoverClientError {
@@ -172,6 +179,13 @@ pub enum RoverClientError {
         source: BuildErrors,
     },
 
+    #[error("{}", subgraph_publish_launch_failure_msg(.graph_ref, .launch_id, .failed_downstream_launches))]
+    SubgraphPublishLaunchFailure {
+        graph_ref: GraphRef,
+        launch_id: String,
+        failed_downstream_launches: Vec<FailedLaunch>,
+    },
+
     #[error("{}", contract_publish_errors_msg(.msgs, .no_launch))]
     ContractPublishErrors { msgs: Vec<String>, no_launch: bool },
 
@@ -274,6 +288,9 @@ pub enum RoverClientError {
     #[error("The check workflow took too long to run.")]
     ChecksTimeoutError { url: Option<String> },
 
+    #[error("The launch took too long to complete.")]
+    LaunchTimeoutError { url: Option<String> },
+
     #[error("The schema check finished, but Rover could not retrieve its full result.")]
     CheckWorkflowResultUnavailable {
         url: Option<String>,
@@ -344,6 +361,32 @@ impl RoverClientError {
         matches!(
             self,
             RoverClientError::SendRequest { .. } | RoverClientError::RateLimitExceeded
+        )
+    }
+}
+
+fn subgraph_publish_launch_failure_msg(
+    graph_ref: &GraphRef,
+    launch_id: &str,
+    failed_downstream_launches: &[FailedLaunch],
+) -> String {
+    if failed_downstream_launches.is_empty() {
+        format!(
+            "The subgraph publish was accepted for '{graph_ref}', but launch '{launch_id}' failed."
+        )
+    } else {
+        let downstream_launches = failed_downstream_launches
+            .iter()
+            .map(|launch| {
+                format!(
+                    "{}@{} (launch {})",
+                    launch.graph_id, launch.graph_variant, launch.launch_id
+                )
+            })
+            .join(", ");
+
+        format!(
+            "The subgraph publish was accepted for '{graph_ref}', but downstream contract launch(es) failed: {downstream_launches}."
         )
     }
 }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
@@ -96,7 +96,11 @@ query SubgraphCheckWorkflowQuery($workflowId: ID!, $graphId: ID!) {
         ... on DownstreamCheckTask {
           results {
             __typename
+            blocking
             downstreamVariantName
+            downstreamWorkflow {
+              status
+            }
             failsUpstreamWorkflow
           }
         }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -222,6 +222,16 @@ fn get_check_response_from_data(
         graph_ref.variant()
     );
 
+    let maybe_downstream_response = get_downstream_response_from_result(
+        downstream_status,
+        downstream_target_url,
+        downstream_result,
+    );
+    let downstream_failed = maybe_downstream_response
+        .as_ref()
+        .map(|response| response.task_status == crate::shared::CheckTaskStatus::FAILED)
+        .unwrap_or(false);
+
     let check_response = CheckWorkflowResponse {
         default_target_url,
         maybe_core_schema_modified: Some(core_schema_modified),
@@ -246,16 +256,16 @@ fn get_check_response_from_data(
             custom_target_url,
             custom_result,
         ),
-        maybe_downstream_response: get_downstream_response_from_result(
-            downstream_status,
-            downstream_target_url,
-            downstream_result,
-        ),
+        maybe_downstream_response,
     };
 
     match check_workflow.status {
-        CheckWorkflowStatus::PASSED => Ok(check_response),
+        CheckWorkflowStatus::PASSED if !downstream_failed => Ok(check_response),
         CheckWorkflowStatus::FAILED => Err(RoverClientError::CheckWorkflowFailure {
+            graph_ref,
+            check_response: Box::new(check_response),
+        }),
+        CheckWorkflowStatus::PASSED => Err(RoverClientError::CheckWorkflowFailure {
             graph_ref,
             check_response: Box::new(check_response),
         }),
@@ -457,11 +467,24 @@ fn get_downstream_response_from_result(
         Some(results) => {
             let blocking_variants = results
                 .iter()
-                .filter(|result| result.fails_upstream_workflow.unwrap_or(false))
+                .filter(|result| {
+                    result.fails_upstream_workflow.unwrap_or(false)
+                        || (result.blocking
+                            && result
+                                .downstream_workflow
+                                .as_ref()
+                                .map(|workflow| workflow.status == CheckWorkflowStatus::FAILED)
+                                .unwrap_or(false))
+                })
                 .map(|result| result.downstream_variant_name.clone())
-                .collect();
+                .collect::<Vec<_>>();
+            let task_status = if blocking_variants.is_empty() {
+                task_status.into()
+            } else {
+                crate::shared::CheckTaskStatus::FAILED
+            };
             Some(DownstreamCheckResponse {
-                task_status: task_status.into(),
+                task_status,
                 target_url,
                 blocking_variants,
             })
@@ -591,6 +614,58 @@ mod tests {
                 assert_eq!(
                     check_response.default_target_url,
                     "https://studio.apollographql.com/graph/test-graph/variant/test-variant/checks/variant"
+                );
+            }
+            _ => panic!("Expected CheckWorkflowFailure error"),
+        }
+    }
+
+    #[test]
+    fn test_get_check_response_from_data_with_failed_blocking_downstream_workflow() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetUrl": "https://studio.apollographql.com/graph/test/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": true,
+                            "downstreamVariantName": "contract",
+                            "downstreamWorkflow": {
+                                "status": "FAILED"
+                            },
+                            "failsUpstreamWorkflow": null
+                        }
+                    ]
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+        let subgraph = "test-subgraph".to_string();
+
+        let result = get_check_response_from_data(data, graph_ref.clone(), subgraph);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            RoverClientError::CheckWorkflowFailure {
+                graph_ref: returned_graph_ref,
+                check_response,
+            } => {
+                assert_eq!(returned_graph_ref, graph_ref);
+                let downstream_response = check_response
+                    .maybe_downstream_response
+                    .expect("expected downstream response");
+                assert_eq!(
+                    downstream_response.task_status,
+                    crate::shared::CheckTaskStatus::FAILED
+                );
+                assert_eq!(
+                    downstream_response.blocking_variants,
+                    vec!["contract".to_string()]
                 );
             }
             _ => panic!("Expected CheckWorkflowFailure error"),

--- a/crates/rover-client/src/operations/subgraph/publish/launch_status_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/publish/launch_status_query.graphql
@@ -1,0 +1,22 @@
+query SubgraphPublishLaunchStatusQuery(
+  $graph_id: ID!
+  $variant: String!
+  $launch_id: ID!
+) {
+  graph(id: $graph_id) {
+    variant(name: $variant) {
+      launch(id: $launch_id) {
+        id
+        graphId
+        graphVariant
+        status
+        downstreamLaunches {
+          id
+          graphId
+          graphVariant
+          status
+        }
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/operations/subgraph/publish/publish_mutation.graphql
+++ b/crates/rover-client/src/operations/subgraph/publish/publish_mutation.graphql
@@ -15,6 +15,7 @@ mutation SubgraphPublishMutation(
       activePartialSchema: $schema
       graphVariant: $variant
       gitContext: $git_context
+      downstreamLaunchInitiation: SYNC
     ) {
       compositionConfig {
         schemaHash
@@ -26,6 +27,9 @@ mutation SubgraphPublishMutation(
       didUpdateGateway: updatedGateway
       serviceWasCreated: wasCreated
       serviceWasUpdated: wasUpdated
+      launch {
+        id
+      }
       launchCliCopy
       launchUrl
     }

--- a/crates/rover-client/src/operations/subgraph/publish/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/runner.rs
@@ -1,10 +1,19 @@
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
 use apollo_federation_types::rover::{BuildError, BuildErrors};
 use graphql_client::*;
 use rover_studio::types::GraphRef;
 
+use self::subgraph_publish_launch_status_query::{
+    LaunchStatus, SubgraphPublishLaunchStatusQueryGraphVariantLaunch,
+};
 use super::types::*;
 use crate::{
     blocking::StudioClient,
+    error::FailedLaunch,
     operations::{
         config::is_federated::{self, IsFederatedInput},
         graph::{variant, variant::VariantListInput},
@@ -25,6 +34,15 @@ use crate::{
 /// `ResponseData` structs.
 /// Snake case of this name is the mod name. i.e. subgraph_publish_mutation
 pub(crate) struct SubgraphPublishMutation;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/operations/subgraph/publish/launch_status_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize, Clone",
+    deprecated = "warn"
+)]
+pub(crate) struct SubgraphPublishLaunchStatusQuery;
 
 pub async fn run(
     input: SubgraphPublishInput,
@@ -73,7 +91,21 @@ pub async fn run(
         }
     }
     let data = client.post::<SubgraphPublishMutation>(variables).await?;
-    let publish_response = get_publish_response_from_data(data, graph_ref)?;
+    let publish_response = get_publish_response_from_data(data, graph_ref.clone())?;
+    if let Some(launch_id) = publish_response
+        .launch
+        .as_ref()
+        .map(|launch| launch.id.clone())
+    {
+        let launch = poll_launch(
+            &graph_ref,
+            &launch_id,
+            input.launch_poll_timeout_seconds,
+            client,
+        )
+        .await?;
+        ensure_launch_succeeded(&graph_ref, &launch)?;
+    }
     Ok(build_response(publish_response))
 }
 
@@ -90,6 +122,118 @@ fn get_publish_response_from_data(
         .ok_or(RoverClientError::MalformedResponse {
             null_field: "service.upsertImplementingServiceAndTriggerComposition".to_string(),
         })
+}
+
+async fn poll_launch(
+    graph_ref: &GraphRef,
+    launch_id: &str,
+    timeout_seconds: u64,
+    client: &StudioClient,
+) -> Result<SubgraphPublishLaunchStatusQueryGraphVariantLaunch, RoverClientError> {
+    let now = Instant::now();
+    let launch_url = Some(launch_url(graph_ref.graph_id(), launch_id));
+
+    loop {
+        match fetch_launch(graph_ref, launch_id, client).await {
+            Ok(launch) => {
+                if launch_is_finished(&launch) {
+                    return Ok(launch);
+                }
+            }
+            Err(e) if e.is_transient() => {
+                eprintln!("error while checking status of launch: {e}\nretrying...");
+            }
+            Err(e) => return Err(e),
+        }
+
+        if now.elapsed() > Duration::from_secs(timeout_seconds) {
+            return Err(RoverClientError::LaunchTimeoutError { url: launch_url });
+        }
+        thread::sleep(Duration::from_secs(5));
+    }
+}
+
+async fn fetch_launch(
+    graph_ref: &GraphRef,
+    launch_id: &str,
+    client: &StudioClient,
+) -> Result<SubgraphPublishLaunchStatusQueryGraphVariantLaunch, RoverClientError> {
+    let (graph_id, variant) = graph_ref.clone().into_parts();
+    let data = client
+        .post::<SubgraphPublishLaunchStatusQuery>(LaunchStatusVariables {
+            graph_id,
+            variant,
+            launch_id: launch_id.to_string(),
+        })
+        .await?;
+
+    get_launch_from_data(data, graph_ref.clone())
+}
+
+fn get_launch_from_data(
+    data: LaunchStatusResponseData,
+    graph_ref: GraphRef,
+) -> Result<SubgraphPublishLaunchStatusQueryGraphVariantLaunch, RoverClientError> {
+    let graph = data
+        .graph
+        .ok_or(RoverClientError::GraphNotFound { graph_ref })?;
+
+    let variant = graph.variant.ok_or(RoverClientError::MalformedResponse {
+        null_field: "graph.variant".to_string(),
+    })?;
+
+    variant.launch.ok_or(RoverClientError::MalformedResponse {
+        null_field: "graph.variant.launch".to_string(),
+    })
+}
+
+fn launch_is_finished(launch: &SubgraphPublishLaunchStatusQueryGraphVariantLaunch) -> bool {
+    !launch_status_is_pending(&launch.status)
+        && launch
+            .downstream_launches
+            .iter()
+            .all(|launch| !launch_status_is_pending(&launch.status))
+}
+
+fn ensure_launch_succeeded(
+    graph_ref: &GraphRef,
+    launch: &SubgraphPublishLaunchStatusQueryGraphVariantLaunch,
+) -> Result<(), RoverClientError> {
+    let failed_downstream_launches = launch
+        .downstream_launches
+        .iter()
+        .filter(|launch| launch_status_is_failed(&launch.status))
+        .map(|launch| FailedLaunch {
+            graph_id: launch.graph_id.clone(),
+            graph_variant: launch.graph_variant.clone(),
+            launch_id: launch.id.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    if launch_status_is_failed(&launch.status) || !failed_downstream_launches.is_empty() {
+        Err(RoverClientError::SubgraphPublishLaunchFailure {
+            graph_ref: graph_ref.clone(),
+            launch_id: launch.id.clone(),
+            failed_downstream_launches,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn launch_status_is_pending(status: &LaunchStatus) -> bool {
+    matches!(status, LaunchStatus::LAUNCH_INITIATED)
+}
+
+fn launch_status_is_failed(status: &LaunchStatus) -> bool {
+    !matches!(
+        status,
+        LaunchStatus::LAUNCH_COMPLETED | LaunchStatus::LAUNCH_INITIATED
+    )
+}
+
+fn launch_url(graph_id: &str, launch_id: &str) -> String {
+    format!("https://studio.apollographql.com/graph/{graph_id}/launches/{launch_id}")
 }
 
 fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {
@@ -119,9 +263,119 @@ fn build_response(publish_response: UpdateResponse) -> SubgraphPublishResponse {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use houston::{Credential, CredentialOrigin};
+    use httpmock::prelude::*;
+    use reqwest::Client as ReqwestClient;
     use serde_json::json;
 
     use super::*;
+
+    #[tokio::test]
+    async fn run_fails_when_downstream_launch_fails() {
+        let server = MockServer::start_async().await;
+        let _publish = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("mutation SubgraphPublishMutation")
+                .body_includes("downstreamLaunchInitiation: SYNC");
+            then.status(200).json_body(json!({
+                "data": {
+                    "graph": {
+                        "publishSubgraph": {
+                            "compositionConfig": { "schemaHash": "5gf564" },
+                            "errors": [],
+                            "didUpdateGateway": true,
+                            "serviceWasCreated": false,
+                            "serviceWasUpdated": true,
+                            "launch": {
+                                "id": "source-launch"
+                            },
+                            "launchUrl": "https://studio.example/launches/source-launch",
+                            "launchCliCopy": "You can monitor this launch in Apollo Studio."
+                        }
+                    }
+                }
+            }));
+        });
+        let _launch = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("query SubgraphPublishLaunchStatusQuery");
+            then.status(200).json_body(json!({
+                "data": {
+                    "graph": {
+                        "variant": {
+                            "launch": {
+                                "id": "source-launch",
+                                "graphId": "test-graph",
+                                "graphVariant": "current",
+                                "status": "LAUNCH_COMPLETED",
+                                "downstreamLaunches": [
+                                    {
+                                        "id": "contract-launch",
+                                        "graphId": "test-graph",
+                                        "graphVariant": "contract",
+                                        "status": "LAUNCH_FAILED"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }));
+        });
+        let client = StudioClient::new(
+            Credential {
+                api_key: "test".to_string(),
+                origin: CredentialOrigin::EnvVar,
+            },
+            &server.url("/"),
+            "test-version",
+            false,
+            ReqwestClient::new(),
+            Duration::from_secs(1),
+        );
+
+        let result = run(
+            SubgraphPublishInput {
+                graph_ref: "test-graph@current".parse().unwrap(),
+                subgraph: "products".to_string(),
+                url: Some("https://example.com/graphql".to_string()),
+                schema: "type Query { product: String }".to_string(),
+                git_context: crate::shared::GitContext {
+                    branch: None,
+                    commit: None,
+                    author: None,
+                    remote_url: None,
+                },
+                convert_to_federated_graph: true,
+                launch_poll_timeout_seconds: 0,
+            },
+            &client,
+        )
+        .await;
+
+        match result {
+            Err(RoverClientError::SubgraphPublishLaunchFailure {
+                graph_ref,
+                launch_id,
+                failed_downstream_launches,
+            }) => {
+                assert_eq!(graph_ref.to_string(), "test-graph@current");
+                assert_eq!(launch_id, "source-launch");
+                assert_eq!(
+                    failed_downstream_launches,
+                    vec![FailedLaunch {
+                        graph_id: "test-graph".to_string(),
+                        graph_variant: "contract".to_string(),
+                        launch_id: "contract-launch".to_string(),
+                    }]
+                );
+            }
+            other => panic!("expected downstream launch failure, got {other:?}"),
+        }
+    }
+
     #[test]
     fn build_response_works_with_composition_errors() {
         let json_response = json!({

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -1,10 +1,12 @@
-use super::runner::subgraph_publish_mutation;
+use super::runner::{subgraph_publish_launch_status_query, subgraph_publish_mutation};
 use crate::shared::GitContext;
 
 pub(crate) type ResponseData = subgraph_publish_mutation::ResponseData;
 pub(crate) type MutationVariables = subgraph_publish_mutation::Variables;
 pub(crate) type UpdateResponse =
     subgraph_publish_mutation::SubgraphPublishMutationGraphPublishSubgraph;
+pub(crate) type LaunchStatusResponseData = subgraph_publish_launch_status_query::ResponseData;
+pub(crate) type LaunchStatusVariables = subgraph_publish_launch_status_query::Variables;
 
 use apollo_federation_types::rover::BuildErrors;
 
@@ -22,6 +24,7 @@ pub struct SubgraphPublishInput {
     pub schema: String,
     pub git_context: GitContext,
     pub convert_to_federated_graph: bool,
+    pub launch_poll_timeout_seconds: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Eq, PartialEq)]

--- a/src/command/init/operations.rs
+++ b/src/command/init/operations.rs
@@ -125,6 +125,7 @@ pub(crate) async fn publish_subgraphs(
                     remote_url: None,
                 },
                 convert_to_federated_graph: false,
+                launch_poll_timeout_seconds: 300,
             },
             client,
         )

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -192,6 +192,7 @@ impl Publish {
                 schema,
                 git_context,
                 convert_to_federated_graph: self.convert,
+                launch_poll_timeout_seconds: checks_timeout_seconds,
             },
             &client,
         )

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -155,6 +155,17 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                         )
                     }
                 }
+                RoverClientError::SubgraphPublishLaunchFailure {
+                    graph_ref,
+                    launch_id,
+                    failed_downstream_launches: _,
+                } => (
+                    Some(RoverErrorSuggestion::RetryLaunch {
+                        graph_id: graph_ref.graph_id().to_string(),
+                        launch_id: launch_id.clone(),
+                    }),
+                    None,
+                ),
                 RoverClientError::ContractPublishErrors {
                     msgs: _,
                     no_launch: _,
@@ -339,6 +350,9 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                 RoverClientError::InvalidTimestamp(_) => (None, None),
                 RoverClientError::ApiKeyNotFound { .. } => (None, None),
                 RoverClientError::GraphCreationError { .. } => (None, None),
+                RoverClientError::LaunchTimeoutError { .. } => {
+                    (Some(RoverErrorSuggestion::TryAgainLater), None)
+                }
                 RoverClientError::GraphArtifactOperationInProgress { .. } => {
                     (Some(RoverErrorSuggestion::TryAgainLater), None)
                 }


### PR DESCRIPTION
## Summary

This fixes Rover's local handling for downstream contract failures triggered by `rover subgraph check` and `rover subgraph publish`.

- Treat blocking downstream contract check workflows as failures when the downstream workflow reports `FAILED`, even if `failsUpstreamWorkflow` is absent or the source workflow status is optimistic.
- Initiate downstream launches synchronously for subgraph publish, then poll the source and downstream launches before returning success.
- Surface a nonzero Rover error when the source launch or any downstream contract launch fails, and include retry metadata for the launch.
- Add regression coverage and an Unreleased changelog entry.

## Root Cause

`subgraph check` only trusted the source workflow status plus `failsUpstreamWorkflow`, so failed blocking downstream contract workflows could be missed. `subgraph publish` used the `publishSubgraph` default async downstream launch initiation and returned after composition/publish response handling, before downstream contract launch results were known.

## Validation

- `cargo check --locked -p rover`
- `PATH="$HOME/.cargo/bin:$PATH" cargo +nightly fmt --all -- --check`
- `cargo test --locked -p rover-client operations::subgraph`

Note: Homebrew Rust was upgraded to 1.96.0 so plain `cargo check --locked -p rover` now works in this checkout. The `cargo +nightly` command still requires the rustup cargo shim first on PATH because Homebrew cargo does not parse rustup's `+toolchain` syntax.
