### PR TITLE
Add --supergraph-output flag to control the output of rover dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🚀 Features
 
+- **Add `rover dev --supergraph-output` to control the output of the composed supergraph - @SharkBaitDLS PR #3383 fixes #1864**
+
+  `rover dev` can now write the supergraph schema it composes to a path of your choosing and keep it updated on every recomposition, e.g. `rover dev --supergraph-output build/supergraph.graphql`. Previously the composed supergraph only lived in a temp file, and the global `--output`/`-o` flag (which controls a command's own CLI output, not its artifacts) appeared to be silently ignored by `dev`. The global `--output` help text now clarifies that distinction.
+
 - **Add `APOLLO_ROVER_SKIP_UPDATE` to disable all auto-updating at once - @SharkBaitDLS PR #3378 fixes #1892**
 
   Setting the `APOLLO_ROVER_SKIP_UPDATE` environment variable (to `1` or `true`) opts out of all of Rover's auto-updating in a single switch: it skips both the rover self-update check (the `--skip-update-check` flag) and the `supergraph`/`router` plugin auto-updates (the `--skip-update` flag), so on-the-fly plugin resolution uses an already-installed plugin instead of contacting the registry. This is aimed at tightly-controlled monorepo/CI setups that want plugin versions lockstep with CI and prod. The explicit `rover install` command still installs as requested.

--- a/crates/rover-std/src/fs/mod.rs
+++ b/crates/rover-std/src/fs/mod.rs
@@ -75,10 +75,15 @@ impl Fs {
 
         // Grab the parent path then attempt to canonicalize it, we can't just canonicalize the
         // entire path because that would entail the file existing, which of course it doesn't yet.
-        let mut canonical_final_path = path
-            .parent()
-            .map(Self::upsert_path_exists)
-            .ok_or_else(|| anyhow!("cannot write file to root or prefix {path}"))??;
+        let parent = match path.parent() {
+            // A bare file name (e.g. `schema.graphql`) has an empty parent, which refers to the
+            // current directory. That always exists, so we mustn't try to create/canonicalize an
+            // empty path — doing so fails with "No such file or directory".
+            Some(parent) if parent.as_str().is_empty() => Utf8Path::new("."),
+            Some(parent) => parent,
+            None => return Err(anyhow!("cannot write file to root or prefix {path}").into()),
+        };
+        let mut canonical_final_path = Self::upsert_path_exists(parent)?;
 
         // Create the final version of the path we want to create
         canonical_final_path.push(file_name);

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -272,6 +272,13 @@ impl Dev {
             router_address.pretty_string()
         );
 
+        let supergraph_output = self.opts.supergraph_opts.supergraph_output.clone();
+        if let Some(ref path) = supergraph_output {
+            infoln!(
+                "writing the composed supergraph schema to {path} (updated on every recomposition)"
+            );
+        }
+
         let mut run_router = run_router
             .run(
                 FsWriteFile::default(),
@@ -283,6 +290,7 @@ impl Dev {
                 home_override,
                 api_key_override,
                 log_level,
+                supergraph_output,
             )
             .await?
             .watch_for_changes(write_file_impl, composition_messages)

--- a/src/command/dev/mod.rs
+++ b/src/command/dev/mod.rs
@@ -103,6 +103,10 @@ pub struct SupergraphOpts {
     /// For more information, please see https://www.apollographql.com/docs/router/enterprise-features/#offline-enterprise-license
     #[arg(long)]
     license: Option<Utf8PathBuf>,
+
+    /// Path to write the composed supergraph schema to, (re)writing it on every successful composition.
+    #[arg(long = "supergraph-output")]
+    supergraph_output: Option<Utf8PathBuf>,
 }
 
 lazy_static::lazy_static! {
@@ -113,4 +117,29 @@ lazy_static::lazy_static! {
     // https://www.apollographql.com/docs/router/federation-version-support/#support-table
     pub(crate) static ref OVERRIDE_DEV_COMPOSITION_VERSION: Option<String> =
         std::env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION").ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+    use clap::Parser;
+
+    use super::DevOpts;
+
+    #[test]
+    fn supergraph_output_flag_parses_into_supergraph_opts() {
+        let opts =
+            DevOpts::try_parse_from(["dev", "--supergraph-output", "build/supergraph.graphql"])
+                .unwrap();
+        assert_eq!(
+            opts.supergraph_opts.supergraph_output,
+            Some(Utf8PathBuf::from("build/supergraph.graphql"))
+        );
+    }
+
+    #[test]
+    fn supergraph_output_defaults_to_none() {
+        let opts = DevOpts::try_parse_from(["dev"]).unwrap();
+        assert_eq!(opts.supergraph_opts.supergraph_output, None);
+    }
 }

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -157,6 +157,7 @@ impl RunRouter<state::Run> {
         home_override: Option<String>,
         api_key_override: Option<String>,
         log_level: Option<Level>,
+        supergraph_output: Option<Utf8PathBuf>,
     ) -> Result<RunRouter<state::Watch>, RunRouterBinaryError>
     where
         Spawn: Service<ExecCommandConfig, Response = Child> + Send + Clone + 'static,
@@ -191,9 +192,10 @@ impl RunRouter<state::Run> {
                 err: Box::new(err),
             })?;
 
-        let hot_reload_schema_path = temp_router_dir.join("supergraph.graphql");
+        let hot_reload_schema_path =
+            supergraph_output.unwrap_or_else(|| temp_router_dir.join("supergraph.graphql"));
         tracing::debug!(
-            "Creating temporary supergraph schema path at {}",
+            "Writing supergraph schema (watched for hot reload) to {}",
             hot_reload_schema_path
         );
         write_file

--- a/src/options/output.rs
+++ b/src/options/output.rs
@@ -89,7 +89,7 @@ pub struct OutputOpts {
     #[arg(long = "format", global = true, default_value_t)]
     pub format_kind: RoverOutputFormatKind,
 
-    /// Specify a file to write Rover's output to
+    /// Specify a file to write Rover's console output to instead of stdout
     #[arg(long = "output", short = 'o', global = true, value_parser = Self::parse_absolute_path)]
     pub output_file: Option<Utf8PathBuf>,
 

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -26,6 +26,7 @@ use super::{
 };
 
 const ROVER_DEV_TIMEOUT: Duration = Duration::from_secs(45);
+const ROVER_DEV_SUPERGRAPH_OUTPUT_FILE: &str = "composed-supergraph.graphql";
 
 #[fixture]
 #[once]
@@ -44,6 +45,8 @@ fn run_rover_dev(run_subgraphs_retail_supergraph: &RunningRetailSupergraph) -> S
         "router-config-dev.yaml",
         "--supergraph-port",
         &format!("{port}"),
+        "--supergraph-output",
+        ROVER_DEV_SUPERGRAPH_OUTPUT_FILE,
         "--elv2-license",
         "accept",
     ]);
@@ -215,6 +218,27 @@ async fn e2e_test_rover_dev(
     })
     .await
     .expect("Failed to run query before timeout hit");
+}
+
+#[ignore]
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+#[serial]
+async fn e2e_test_rover_dev_writes_supergraph_output(
+    #[from(run_rover_dev)] _router_url: &str,
+    run_subgraphs_retail_supergraph: &RunningRetailSupergraph,
+) {
+    let output_path = run_subgraphs_retail_supergraph
+        .retail_supergraph
+        .working_dir
+        .path()
+        .join(ROVER_DEV_SUPERGRAPH_OUTPUT_FILE);
+    let contents = std::fs::read_to_string(&output_path).unwrap_or_else(|err| {
+        panic!("expected a composed supergraph at {output_path:?}, but couldn't read it: {err}")
+    });
+    // A composed Federation 2 supergraph always links the join/link specs.
+    assert_that(&contents).contains("@link");
 }
 
 /// Test for issue #2751: Router config env var double expansion bug


### PR DESCRIPTION
Previously the composed supergraph only lived in a temp file, and the global output flag appeared to be silently ignored as the help text didn't fully clarify its scope.
