### PR TITLE
Re-add incidentally regressed behavior around download timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   When Rover needs the latest `supergraph` or `router` plugin but can't reach the plugin registry (an outage, a network blip, or simply being offline), it now falls back to the newest compatible plugin already installed in `~/.rover/bin` with a warning instead of failing outright. Exact version pins still return an error.
 
-- **Extend the timeout for plugin downloads - @SharkBaitDLS PR #3358 fixes #1583 #1867**
+- **Extend the timeout for plugin downloads - @SharkBaitDLS PR #3358 #3386 fixes #1583 #1867**
 
-  Downloading plugins no longer uses the API `--client-timeout` (30s by default) as a whole-request deadline. The plugin download path now has a 300s timeout and a 30s connection timeout so that it still fails-fast if the network is genuinely offline.
+  Plugin downloads no longer inherit the 30s default that bounds API requests. With `--client-timeout` unset, downloads get a 300s default timeout (plus a 30s connection timeout so a genuinely-offline run still fails fast). When `--client-timeout` *is* provided, it still applies to downloads as before.
 
 - **Read UTF-16 (and BOM-prefixed) schema files - @SharkBaitDLS PR #3351 fixes #653**
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,12 +97,10 @@ pub struct Rover {
     accept_invalid_hostnames: bool,
 
     /// Configure the timeout length (in seconds) when performing HTTP(S) requests.
-    #[arg(
-        long = "client-timeout",
-        global = true,
-        default_value_t = ClientTimeout::default()
-    )]
-    client_timeout: ClientTimeout,
+    ///
+    /// Defaults to 30s for standard operations and 300s for plugin downloads.
+    #[arg(long = "client-timeout", global = true)]
+    client_timeout: Option<ClientTimeout>,
 
     /// Skip checking for newer versions of rover.
     ///
@@ -291,13 +289,18 @@ impl Rover {
             false
         };
         let config = self.get_rover_config()?;
-        Ok(StudioClientConfig::new(
+        let client_config = StudioClientConfig::new(
             override_endpoint,
             config,
             is_sudo,
             self.get_reqwest_client_builder(),
-            self.client_timeout,
-        ))
+            self.client_timeout.unwrap_or_default(),
+        );
+        // Downloads should honor the client timeout if set despite having a different default
+        Ok(match self.client_timeout {
+            Some(timeout) => client_config.with_download_timeout(timeout.get_duration()),
+            None => client_config,
+        })
     }
 
     pub(crate) fn get_install_override_path(&self) -> RoverResult<Option<Utf8PathBuf>> {
@@ -343,7 +346,7 @@ impl Rover {
                     ClientBuilder::new()
                         .accept_invalid_certs(self.accept_invalid_certs)
                         .accept_invalid_hostnames(self.accept_invalid_hostnames)
-                        .with_timeout(self.client_timeout.get_duration()),
+                        .with_timeout(self.client_timeout.unwrap_or_default().get_duration()),
                 )
                 .ok();
             self.get_reqwest_client_builder()

--- a/src/command/install/plugin.rs
+++ b/src/command/install/plugin.rs
@@ -443,6 +443,9 @@ impl PluginInstaller {
         }
         let file_download_service = FileDownloadService::builder()
             .http_service(self.client_config.download_service()?)
+            // Match the per-attempt timeout to the configured download timeout so it
+            // isn't capped by FileDownloadService's shorter default.
+            .timeout_duration(*self.client_config.download_timeout())
             .build();
         Ok(self
             .installer

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -159,6 +159,7 @@ pub struct StudioClientConfig {
     is_sudo: bool,
     client: Option<Client>,
     client_timeout: ClientTimeout,
+    download_timeout: Duration,
 }
 
 impl StudioClientConfig {
@@ -183,7 +184,13 @@ impl StudioClientConfig {
             is_sudo,
             client: None,
             client_timeout,
+            download_timeout: DOWNLOAD_REQUEST_TIMEOUT,
         }
+    }
+
+    pub const fn with_download_timeout(mut self, download_timeout: Duration) -> Self {
+        self.download_timeout = download_timeout;
+        self
     }
 
     pub(crate) fn get_reqwest_client(&self) -> Result<Client> {
@@ -210,7 +217,7 @@ impl StudioClientConfig {
         let client = self
             .client_builder
             .clear_timeout()
-            .with_timeout(DOWNLOAD_REQUEST_TIMEOUT)
+            .with_timeout(self.download_timeout)
             .with_connect_timeout(DOWNLOAD_CONNECT_TIMEOUT)
             .build()?;
         Ok(ReqwestService::builder()
@@ -275,5 +282,37 @@ mod tests {
             .with_connect_timeout(Duration::from_secs(5));
         assert_eq!(builder.timeout, Some(Duration::from_secs(30)));
         assert_eq!(builder.connect_timeout, Some(Duration::from_secs(5)));
+    }
+
+    fn test_client_config() -> super::StudioClientConfig {
+        super::StudioClientConfig::new(
+            None,
+            houston::Config {
+                home: camino::Utf8PathBuf::from("/tmp/rover-client-test"),
+                override_api_key: None,
+            },
+            false,
+            ClientBuilder::default(),
+            super::ClientTimeout::default(),
+        )
+    }
+
+    /// Plugin downloads default to the generous timeout, and an explicit
+    /// `--client-timeout` (applied via `with_download_timeout`) overrides it —
+    /// up or down. Regression guard: #3358 made this unconfigurable.
+    #[test]
+    fn download_timeout_defaults_to_the_generous_default() {
+        assert_eq!(
+            *test_client_config().download_timeout(),
+            super::DOWNLOAD_REQUEST_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn with_download_timeout_overrides_the_default_up_or_down() {
+        for secs in [5, 99_999] {
+            let config = test_client_config().with_download_timeout(Duration::from_secs(secs));
+            assert_eq!(*config.download_timeout(), Duration::from_secs(secs));
+        }
     }
 }


### PR DESCRIPTION
Before adding a separate default for download timeouts, it respected the `--client-timeout` flag. This change re-introduces that behavior.
