### PR TITLE
Add --changelog-message to graph/subgraph publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🚀 Features
 
+- **Add `--changelog-message` to `graph publish` and `subgraph publish` - @SharkBaitDLS PR #3398 fixes #1884 #292**
+
+  `rover graph publish` and `rover subgraph publish` now accept `--changelog-message <MESSAGE>` to attach a note to the publish in the Studio schema changelog. The publish output has also been enriched: `graph publish` now reports the schema hash and total named type count and `subgraph publish` now includes the resulting supergraph composition hash when one is available.
+
 - **Add `rover dev --supergraph-output` to control the output of the composed supergraph - @SharkBaitDLS PR #3383 fixes #1864**
 
   `rover dev` can now write the supergraph schema it composes to a path of your choosing and keep it updated on every recomposition, e.g. `rover dev --supergraph-output build/supergraph.graphql`. Previously the composed supergraph only lived in a temp file, and the global `--output`/`-o` flag (which controls a command's own CLI output, not its artifacts) appeared to be silently ignored by `dev`. The global `--output` help text now clarifies that distinction.

--- a/crates/rover-client/src/operations/graph/publish/runner.rs
+++ b/crates/rover-client/src/operations/graph/publish/runner.rs
@@ -1,3 +1,4 @@
+use apollo_parser::Parser;
 use graphql_client::*;
 use rover_studio::types::GraphRef;
 
@@ -31,9 +32,29 @@ pub async fn run(
     client: &StudioClient,
 ) -> Result<GraphPublishResponse, RoverClientError> {
     let graph_ref = input.graph_ref.clone();
+    let total_type_count = count_schema_types(&input.proposed_schema);
     let data = client.post::<GraphPublishMutation>(input.into()).await?;
     let publish_response = get_publish_response_from_data(data, graph_ref)?;
-    build_response(publish_response)
+    build_response(publish_response, total_type_count)
+}
+
+fn count_schema_types(schema: &str) -> u64 {
+    use apollo_parser::cst::Definition;
+    let cst = Parser::new(schema).parse();
+    cst.document()
+        .definitions()
+        .filter(|def| {
+            matches!(
+                def,
+                Definition::ObjectTypeDefinition(_)
+                    | Definition::InputObjectTypeDefinition(_)
+                    | Definition::InterfaceTypeDefinition(_)
+                    | Definition::EnumTypeDefinition(_)
+                    | Definition::UnionTypeDefinition(_)
+                    | Definition::ScalarTypeDefinition(_)
+            )
+        })
+        .count() as u64
 }
 
 fn get_publish_response_from_data(
@@ -54,6 +75,7 @@ fn get_publish_response_from_data(
 
 fn build_response(
     publish_response: graph_publish_mutation::GraphPublishMutationGraphUploadSchema,
+    total_type_count: u64,
 ) -> Result<GraphPublishResponse, RoverClientError> {
     if !publish_response.success {
         let msg = format!(
@@ -100,6 +122,7 @@ fn build_response(
     Ok(GraphPublishResponse {
         api_schema_hash: hash,
         change_summary,
+        total_type_count,
     })
 }
 
@@ -146,6 +169,26 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn count_schema_types_counts_named_type_definitions() {
+        let schema = r#"
+            type Query { hello: String }
+            type Foo { id: ID! }
+            input CreateFooInput { name: String! }
+            interface Node { id: ID! }
+            enum Status { ACTIVE INACTIVE }
+            union SearchResult = Foo
+            scalar DateTime
+            extend type Foo { extra: String }
+        "#;
+        assert_eq!(count_schema_types(schema), 7);
+    }
+
+    #[test]
+    fn count_schema_types_returns_zero_for_empty_schema() {
+        assert_eq!(count_schema_types(""), 0);
+    }
 
     #[test]
     fn get_publish_response_from_data_gets_data() {
@@ -223,7 +266,7 @@ mod tests {
         });
         let update_response: graph_publish_mutation::GraphPublishMutationGraphUploadSchema =
             serde_json::from_value(json_response).unwrap();
-        let output = build_response(update_response);
+        let output = build_response(update_response, 5);
 
         assert!(output.is_ok());
         assert_eq!(
@@ -231,6 +274,7 @@ mod tests {
             GraphPublishResponse {
                 api_schema_hash: "123456".to_string(),
                 change_summary: ChangeSummary::none(),
+                total_type_count: 5,
             }
         );
     }
@@ -245,7 +289,7 @@ mod tests {
         });
         let update_response: graph_publish_mutation::GraphPublishMutationGraphUploadSchema =
             serde_json::from_value(json_response).unwrap();
-        let output = build_response(update_response);
+        let output = build_response(update_response, 0);
 
         assert!(output.is_err());
     }
@@ -260,7 +304,7 @@ mod tests {
         });
         let update_response: graph_publish_mutation::GraphPublishMutationGraphUploadSchema =
             serde_json::from_value(json_response).unwrap();
-        let output = build_response(update_response);
+        let output = build_response(update_response, 0);
 
         assert!(output.is_err());
     }

--- a/crates/rover-client/src/operations/graph/publish/types.rs
+++ b/crates/rover-client/src/operations/graph/publish/types.rs
@@ -10,6 +10,7 @@ pub struct GraphPublishInput {
     pub graph_ref: GraphRef,
     pub proposed_schema: String,
     pub git_context: GitContext,
+    pub changelog_message: Option<String>,
 }
 
 type MutationVariables = graph_publish_mutation::Variables;
@@ -20,20 +21,13 @@ impl From<GraphPublishInput> for MutationVariables {
             graph_id,
             variant,
             proposed_schema: input.proposed_schema,
-            git_context: input.git_context.into(),
-        }
-    }
-}
-
-type GraphPublishContextInput = graph_publish_mutation::GitContextInput;
-impl From<GitContext> for GraphPublishContextInput {
-    fn from(git_context: GitContext) -> GraphPublishContextInput {
-        GraphPublishContextInput {
-            branch: git_context.branch,
-            commit: git_context.commit,
-            committer: git_context.author,
-            remote_url: git_context.remote_url,
-            message: None,
+            git_context: graph_publish_mutation::GitContextInput {
+                branch: input.git_context.branch,
+                commit: input.git_context.commit,
+                committer: input.git_context.author,
+                remote_url: input.git_context.remote_url,
+                message: input.changelog_message,
+            },
         }
     }
 }
@@ -43,6 +37,7 @@ pub struct GraphPublishResponse {
     pub api_schema_hash: String,
     #[serde(flatten)]
     pub change_summary: ChangeSummary,
+    pub total_type_count: u64,
 }
 
 #[derive(Clone, Serialize, Debug, Eq, PartialEq)]

--- a/crates/rover-client/src/operations/subgraph/publish/types.rs
+++ b/crates/rover-client/src/operations/subgraph/publish/types.rs
@@ -22,6 +22,7 @@ pub struct SubgraphPublishInput {
     pub schema: String,
     pub git_context: GitContext,
     pub convert_to_federated_graph: bool,
+    pub changelog_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Eq, PartialEq)]
@@ -54,20 +55,14 @@ impl From<SubgraphPublishInput> for MutationVariables {
                 sdl: Some(publish_input.schema),
                 hash: None,
             },
-            git_context: publish_input.git_context.into(),
+            git_context: GitContextInput {
+                branch: publish_input.git_context.branch,
+                commit: publish_input.git_context.commit,
+                committer: publish_input.git_context.author,
+                remote_url: publish_input.git_context.remote_url,
+                message: publish_input.changelog_message,
+            },
             revision: "".to_string(),
-        }
-    }
-}
-
-impl From<GitContext> for GitContextInput {
-    fn from(git_context: GitContext) -> GitContextInput {
-        GitContextInput {
-            branch: git_context.branch,
-            commit: git_context.commit,
-            committer: git_context.author,
-            remote_url: git_context.remote_url,
-            message: None,
         }
     }
 }

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -36,6 +36,10 @@ pub struct Publish {
 
     #[clap(flatten)]
     check_config: CheckConfigOpts,
+
+    /// A message to associate with this publish in the Studio changelog
+    #[arg(long, value_name = "MESSAGE")]
+    changelog_message: Option<String>,
 }
 
 impl Publish {
@@ -124,6 +128,7 @@ impl Publish {
                 graph_ref: self.graph.graph_ref.clone(),
                 proposed_schema,
                 git_context,
+                changelog_message: self.changelog_message.clone(),
             },
             &client,
         )

--- a/src/command/init/operations.rs
+++ b/src/command/init/operations.rs
@@ -125,6 +125,7 @@ pub(crate) async fn publish_subgraphs(
                     remote_url: None,
                 },
                 convert_to_federated_graph: false,
+                changelog_message: None,
             },
             client,
         )

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -262,10 +262,11 @@ impl RoverOutput {
                 publish_response,
             } => {
                 stderrln!(
-                    "{}#{} published successfully {}",
+                    "{}#{} published successfully {} ({} total types)",
                     graph_ref,
                     publish_response.api_schema_hash,
-                    publish_response.change_summary
+                    publish_response.change_summary,
+                    publish_response.total_type_count
                 )?;
                 Some((publish_response.api_schema_hash).to_string())
             }
@@ -274,14 +275,26 @@ impl RoverOutput {
                 subgraph,
                 publish_response,
             } => {
+                let hash_suffix = publish_response
+                    .api_schema_hash
+                    .as_deref()
+                    .map(|h| format!(" (#{h})"))
+                    .unwrap_or_default();
+
                 if publish_response.subgraph_was_created {
                     stderrln!(
-                        "A new subgraph called '{}' was created in '{}'",
+                        "A new subgraph called '{}' was created in '{}'{}",
                         subgraph,
-                        graph_ref
+                        graph_ref,
+                        hash_suffix
                     )?;
                 } else if publish_response.subgraph_was_updated {
-                    stderrln!("The '{}' subgraph in '{}' was updated", subgraph, graph_ref)?;
+                    stderrln!(
+                        "The '{}' subgraph in '{}' was updated{}",
+                        subgraph,
+                        graph_ref,
+                        hash_suffix
+                    )?;
                 } else {
                     stderrln!(
                         "The '{}' subgraph was NOT updated because no changes were detected",
@@ -1587,6 +1600,7 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
                     edits: 7,
                 },
             },
+            total_type_count: 50,
         };
         let actual_json = JsonOutput::from(&RoverOutput::GraphPublishResponse {
             graph_ref: GraphRef::new("graph", Some("variant")).unwrap(),
@@ -1607,6 +1621,7 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
                     "removals": 0,
                     "edits": 7
                 },
+                "total_type_count": 50,
                 "success": true
             },
             "error": null

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -67,6 +67,10 @@ pub struct Publish {
 
     #[clap(flatten)]
     check_config: CheckConfigOpts,
+
+    /// A message to associate with this publish in the Studio changelog
+    #[arg(long, value_name = "MESSAGE")]
+    changelog_message: Option<String>,
 }
 
 impl Publish {
@@ -192,6 +196,7 @@ impl Publish {
                 schema,
                 git_context,
                 convert_to_federated_graph: self.convert,
+                changelog_message: self.changelog_message.clone(),
             },
             &client,
         )


### PR DESCRIPTION
Implements three backlog items together:
- graph publish and subgraph publish now accept --changelog-message to populate
  the Studio changelog entry via GitContextInput.message
- graph publish output now includes the schema hash and total named type count
- subgraph publish output now includes the supergraph composition hash when
  available

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
