### PR TITLE
Remove composition-js requirement from utils/expansion

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,7 +10,6 @@ pub mod telemetry;
 pub mod template;
 pub mod version;
 
-#[cfg(feature = "composition-js")]
 pub(crate) mod expansion;
 
 /// The environment variable that opts out of *all* of Rover's auto-updating at


### PR DESCRIPTION
This module is just yaml processing and does not need to be gated