### PR TITLE
release: v0.41.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4704,9 +4704,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.41.0-rc.1"
+version = "0.41.0-rc.2"
 dependencies = [
  "anyhow",
  "apollo-compiler",
@@ -7644,18 +7644,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7751,9 +7751,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.41.0-rc.1"
+version = "0.41.0-rc.2"
 default-run = "rover"
 
 publish = false

--- a/actions/persisted-queries-publish/action.yml
+++ b/actions/persisted-queries-publish/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.1"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/actions/subgraph-check/action.yml
+++ b/actions/subgraph-check/action.yml
@@ -42,7 +42,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.1"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/actions/subgraph-lint/action.yml
+++ b/actions/subgraph-lint/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.1"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/actions/subgraph-publish/action.yml
+++ b/actions/subgraph-publish/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.1"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX:="https://github.c
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.41.0-rc.1"
+PACKAGE_VERSION="v0.41.0-rc.2"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.41.0-rc.1'
+$package_version = 'v0.41.0-rc.2'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference


### PR DESCRIPTION
Previously broken due to `cargo npm generate` omission