### PR TITLE
release: v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
-## 🛠 Maintenance
-
-## 📚 Documentation -->
+## 🛠 Maintenance  -->
 
 # [Unreleased]
+
+> Important: 0 potentially breaking changes below, indicated by **❗ BREAKING ❗**
+
+## ❗ BREAKING ❗
+
+## 🚀 Features
+
+## 🐛 Fixes
+
+## 🛠 Maintenance
+
+# [0.41.0] - 2026-07-09
 
 > Important: 1 potentially breaking change below, indicated by **❗ BREAKING ❗**
 
 ## ❗ BREAKING ❗
 
-- **`graph introspect --format json` now returns GraphQL introspection JSON - @smyrick**
+- **`graph introspect --format json` now returns GraphQL introspection JSON - @smyrick PR #3440**
 
   `rover graph introspect` with `--format json` now puts the schema as a GraphQL introspection object (`{ "__schema": ... }`) under `data.introspection_response` instead of an SDL string. Default plain output remains SDL. This is a behavior change for existing `--format json` consumers: traverse `data.introspection_response` to get the introspection object (for example, `jq '.data.introspection_response'`). No field or value transformation is needed beyond envelope traversal.
 
@@ -41,6 +51,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Add `rover dev --supergraph-output` to control the output of the composed supergraph - @SharkBaitDLS PR #3383 fixes #1864**
 
   `rover dev` can now write the supergraph schema it composes to a path of your choosing and keep it updated on every recomposition, e.g. `rover dev --supergraph-output build/supergraph.graphql`. Previously the composed supergraph only lived in a temp file, and the global `--output`/`-o` flag (which controls a command's own CLI output, not its artifacts) appeared to be silently ignored by `dev`. The global `--output` help text now clarifies that distinction.
+
+- **Add `rover graph-artifact tag` command - @zw428 PR #3282**
+
+  Adds the `rover graph-artifact tag` command for [Graph Artifact](https://www.apollographql.com/docs/graphos/platform/schema-management/delivery/graph-artifacts) tagging.
+
+- **Add `rover persisted-queries generate` command - @dotdat PR #3481**
+
+  Scans GraphQL operation files and generates a persisted query manifest, written to a file (`--manifest-path`) or stdout. Supports `--include`/`--exclude` glob filtering and a configurable `--root-dir`.
+
+- **Add `--check` flag to the `subgraph-publish` GitHub Action - @SharkBaitDLS PR #3375**
 
 - **Add `APOLLO_ROVER_SKIP_UPDATE` to disable all auto-updating at once - @SharkBaitDLS PR #3378 fixes #1892**
 
@@ -73,6 +93,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Restore the "pin your federation version" warning on `supergraph compose` - @SharkBaitDLS PR #3347**
 
   `rover supergraph compose` again warns when `federation_version` is not pinned to an exact version, reinstating the documented notice that future versions will require one. This nudge was added in #1524 and inadvertently dropped in v0.27.2 (#2411) during the supergraph-config resolution rewrite; composing against a floating `1`/`2` (or omitting the key) now once again warns and recommends pinning, to avoid pulling in breaking changes when a new federation release ships. `rover dev` and the language server remain silent. Fixes #1510.
+
+- **Report a clearer error when schema-check polling fails on large schemas - @SharkBaitDLS PR #3349**
+
+  Centralizes the poll loop between `graph`/`subgraph check`, and surfaces a more helpful error when a check likely failed because the schema was too large to download in time. Relates to #1383.
+
+## 🛠 Maintenance
+
+- **Migrate npm packaging to `cargo-npm`, removing the `postinstall` script - @dotdat PR #3430**
+- **Fix `cargo npm generate` invocation in the release workflow - @dotdat PR #3492**
+- **Migrate to `keyring-core` (keyring 4.0) - @SharkBaitDLS PR #3370**
+- **Remove unused Pandas npm package from test tooling - @SharkBaitDLS PR #3335**
+- **Upgrade default Federation version to 2.15 - @SharkBaitDLS PR #3472**
 
 # [0.40.0] - 2026-05-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "rover"
-version = "0.41.0-rc.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "apollo-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "./LICENSE"
 name = "rover"
 readme = "README.md"
 repository = "https://github.com/apollographql/rover/"
-version = "0.41.0-rc.2"
+version = "0.41.0"
 default-run = "rover"
 
 publish = false

--- a/actions/persisted-queries-publish/action.yml
+++ b/actions/persisted-queries-publish/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/actions/subgraph-check/action.yml
+++ b/actions/subgraph-check/action.yml
@@ -42,7 +42,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/actions/subgraph-lint/action.yml
+++ b/actions/subgraph-lint/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/actions/subgraph-publish/action.yml
+++ b/actions/subgraph-publish/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "docker"
   # The image tag is rewritten by `cargo xtask prep` so each release tag pins
   # the action to the matching Rover version. Do not edit by hand.
-  image: "docker://ghcr.io/apollographql/rover:0.41.0-rc.2"
+  image: "docker://ghcr.io/apollographql/rover:0.41.0"
   entrypoint: "/bin/bash"
   args:
     - "-c"

--- a/docs/source/ci-cd.mdx
+++ b/docs/source/ci-cd.mdx
@@ -47,10 +47,10 @@ Starting with Rover 0.39.1, Apollo publishes immutable Linux container images fo
 
 ```bash
 # GitHub Container Registry
-docker pull ghcr.io/apollographql/rover:0.40.0
+docker pull ghcr.io/apollographql/rover:0.41.0
 
 # Docker Hub
-docker pull apollograph/rover:0.40.0
+docker pull apollograph/rover:0.41.0
 ```
 
 <Note>
@@ -67,7 +67,7 @@ The default `ENTRYPOINT` is `rover`, so you can pass arguments to `docker run` d
 docker run --rm \
   -e APOLLO_KEY \
   -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/apollographql/rover:0.40.0 \
+  ghcr.io/apollographql/rover:0.41.0 \
   subgraph check my-graph@prod --name products --schema ./schema.graphql
 ```
 
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Run a schema check against your graph
-      - uses: apollographql-gh-actions/rover-subgraph-check@rover-v0.40.0
+      - uses: apollographql-gh-actions/rover-subgraph-check@rover-v0.41.0
         with:
           apollo-key: ${{ secrets.APOLLO_KEY }}
           # This could also be provided via an environment variable or GitHub Action variable
@@ -143,7 +143,7 @@ jobs:
           background: true
 
       # Lint the subgraph schema.
-      - uses: apollographql-gh-actions/rover-subgraph-lint@rover-v0.40.0
+      - uses: apollographql-gh-actions/rover-subgraph-lint@rover-v0.41.0
         with:
           apollo-key: ${{ secrets.APOLLO_KEY }}
           # This could also be provided via an environment variable or GitHub Action variable
@@ -153,7 +153,7 @@ jobs:
           schema: ./path/to/schema.graphql
 
       # Publish the subgraph to GraphOS
-      - uses: apollographql-gh-actions/rover-subgraph-publish@rover-v0.40.0
+      - uses: apollographql-gh-actions/rover-subgraph-publish@rover-v0.41.0
         with:
           apollo-key: ${{ secrets.APOLLO_KEY }}
           # This could also be provided via an environment variable or GitHub Action variable
@@ -172,7 +172,7 @@ jobs:
           no-url: true
 
       # Publish persisted queries to GraphOS.
-      - uses: apollographql-gh-actions/rover-persisted-queries-publish@rover-v0.40.0
+      - uses: apollographql-gh-actions/rover-persisted-queries-publish@rover-v0.41.0
         with:
           apollo-key: ${{ secrets.APOLLO_KEY }}
           graph-ref: ${{ secrets.APOLLO_GRAPH_REF }}
@@ -180,7 +180,7 @@ jobs:
           manifest: ./path/to/persisted-queries-manifest.json
 
       # Target a list by graph-id + list-id instead of graph-ref:
-      - uses: apollographql-gh-actions/rover-persisted-queries-publish@rover-v0.40.0
+      - uses: apollographql-gh-actions/rover-persisted-queries-publish@rover-v0.41.0
         with:
           apollo-key: ${{ secrets.APOLLO_KEY }}
           graph-id: ${{ vars.APOLLO_GRAPH_ID }}
@@ -206,7 +206,7 @@ jobs:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
     steps:
       - uses: actions/checkout@v4
-      - uses: apollographql-gh-actions/install-rover@rover-v0.40.0
+      - uses: apollographql-gh-actions/install-rover@rover-v0.41.0
       - run: rover graph check my-graph@prod --schema ./schema.graphql --background
 ```
 
@@ -252,7 +252,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.40.0 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.41.0 | sh
 
           # Add Rover to the $GITHUB_PATH so it can be used in another step
           # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
@@ -284,7 +284,7 @@ version: 2.1
 jobs:
   schema-check:
     docker:
-      - image: ghcr.io/apollographql/rover:0.40.0
+      - image: ghcr.io/apollographql/rover:0.41.0
         # The image's default entrypoint is `rover`. Override it so CircleCI's
         # `run:` steps can execute shell commands.
         entrypoint: ""
@@ -325,7 +325,7 @@ jobs:
       - run:
           name: Install
           command: |
-            curl -sSL https://rover.apollo.dev/nix/v0.40.0 | sh
+            curl -sSL https://rover.apollo.dev/nix/v0.41.0 | sh
             # Persist the PATH change for subsequent steps.
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
       - checkout
@@ -357,7 +357,7 @@ definitions:
   steps:
     - step: &rover-subgraph-check
         name: "[Rover] Subgraph Check"
-        image: ghcr.io/apollographql/rover:0.40.0
+        image: ghcr.io/apollographql/rover:0.41.0
         script:
           - rover subgraph check my-graph@prod
               --name "$APOLLO_SUBGRAPH_NAME"
@@ -365,7 +365,7 @@ definitions:
 
     - step: &local-publish
         name: "[Rover] @local publish (sync with main/master)"
-        image: ghcr.io/apollographql/rover:0.40.0
+        image: ghcr.io/apollographql/rover:0.41.0
         script:
           - rover subgraph publish my-graph@local
               --name "$APOLLO_SUBGRAPH_NAME"
@@ -395,7 +395,7 @@ definitions:
         name: "[Rover] Subgraph Check"
         script:
           - apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-          - curl -sSL https://rover.apollo.dev/nix/v0.40.0 | sh
+          - curl -sSL https://rover.apollo.dev/nix/v0.41.0 | sh
           - export PATH="$HOME/.rover/bin:$PATH"
           - rover subgraph check my-graph@prod
               --name "$APOLLO_SUBGRAPH_NAME"
@@ -415,7 +415,7 @@ pipeline {
     stage('Rover Check') {
       agent {
         docker {
-          image 'ghcr.io/apollographql/rover:0.40.0'
+          image 'ghcr.io/apollographql/rover:0.41.0'
           // The image's default entrypoint is `rover`. Override it so Jenkins
           // can run shell steps inside the container.
           args  '--entrypoint='
@@ -434,7 +434,7 @@ pipeline {
       when { expression { env.BRANCH_NAME == 'main' } }
       agent {
         docker {
-          image 'ghcr.io/apollographql/rover:0.40.0'
+          image 'ghcr.io/apollographql/rover:0.41.0'
           args  '--entrypoint='
         }
       }
@@ -466,7 +466,7 @@ If you'd rather bake Rover into your existing build image, use the shell install
 FROM golang:1.18
 RUN useradd -m rover && echo "rover:rover" | chpasswd
 USER rover
-RUN curl -sSL https://rover.apollo.dev/nix/v0.40.0 | sh
+RUN curl -sSL https://rover.apollo.dev/nix/v0.41.0 | sh
 ```
 
 Reference Rover by its full path in pipeline steps (Jenkins doesn't persist `$PATH` across `sh` blocks):
@@ -487,7 +487,7 @@ stages:
 
 publish_subgraphs:
   stage: publish_subgraphs
-  image: ghcr.io/apollographql/rover:0.40.0
+  image: ghcr.io/apollographql/rover:0.41.0
   retry: 1
   script:
     - rover subgraph publish "$APOLLO_GRAPH_REF"
@@ -512,7 +512,7 @@ publish_subgraphs:
   before_script:
     - apt-get update && apt-get install curl -y
   script:
-    - curl -sSL https://rover.apollo.dev/nix/v0.40.0 | sh
+    - curl -sSL https://rover.apollo.dev/nix/v0.41.0 | sh
     - export PATH="$HOME/.rover/bin:$PATH"
     - export APOLLO_KEY=$APOLLO_FEDERATION_KEY
     - rover subgraph publish "$APOLLO_GRAPH_REF" --name "$APOLLO_SUBGRAPH_NAME" --schema "$SCHEMA_PATH"

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -20,7 +20,7 @@ To install or upgrade to a **specific version** of Rover (recommended for CI env
 
 ```bash
 # Note the `v` prefixing the version number
-curl -sSL https://rover.apollo.dev/nix/v0.40.0 | sh
+curl -sSL https://rover.apollo.dev/nix/v0.41.0 | sh
 ```
 
 If your machine doesn't have the `curl` command, you can get the latest version from the [`curl` downloads page](https://curl.se/download.html).
@@ -43,7 +43,7 @@ To install or upgrade to a **specific version** of Rover (recommended for CI env
 
 ```bash
 # Note the `v` prefixing the version number
-iwr 'https://rover.apollo.dev/win/v0.40.0' | iex
+iwr 'https://rover.apollo.dev/win/v0.41.0' | iex
 ```
 
 #### Installing from a binary mirror using the bash and PowerShell scripts
@@ -79,9 +79,9 @@ Starting with Rover v0.39.1, Apollo publishes a Linux container image with each 
 Pull from either GitHub Container Registry or Docker Hub:
 
 ```bash
-docker pull ghcr.io/apollographql/rover:0.40.0
+docker pull ghcr.io/apollographql/rover:0.41.0
 # or
-docker pull apollograph/rover:0.40.0
+docker pull apollograph/rover:0.41.0
 ```
 
 Then run any Rover command:
@@ -90,7 +90,7 @@ Then run any Rover command:
 docker run --rm \
   -e APOLLO_KEY \
   -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/apollographql/rover:0.40.0 \
+  ghcr.io/apollographql/rover:0.41.0 \
   subgraph check my-graph@prod --name products --schema ./schema.graphql
 ```
 

--- a/installers/binstall/scripts/nix/install.sh
+++ b/installers/binstall/scripts/nix/install.sh
@@ -20,7 +20,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_ROVER_BINARY_DOWNLOAD_PREFIX:="https://github.c
 # Rover version defined in root cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-PACKAGE_VERSION="v0.41.0-rc.2"
+PACKAGE_VERSION="v0.41.0"
 
 download_binary_and_run_installer() {
     downloader --check

--- a/installers/binstall/scripts/windows/install.ps1
+++ b/installers/binstall/scripts/windows/install.ps1
@@ -14,7 +14,7 @@
 # version found in Rover's Cargo.toml
 # Note: this line is built automatically
 # in build.rs. Don't touch it!
-$package_version = 'v0.41.0-rc.2'
+$package_version = 'v0.41.0'
 
 function Install-Binary($rover_install_args) {
   $old_erroractionpreference = $ErrorActionPreference


### PR DESCRIPTION
> Important: 1 potentially breaking change below, indicated by **❗ BREAKING ❗**

## ❗ BREAKING ❗

- **`graph introspect --format json` now returns GraphQL introspection JSON - @smyrick PR #3440**

  `rover graph introspect` with `--format json` now puts the schema as a GraphQL introspection object (`{ "__schema": ... }`) under `data.introspection_response` instead of an SDL string. Default plain output remains SDL. This is a behavior change for existing `--format json` consumers: traverse `data.introspection_response` to get the introspection object (for example, `jq '.data.introspection_response'`). No field or value transformation is needed beyond envelope traversal.

## 🚀 Features

- **Add `rover supergraph config expand` to preview an expanded supergraph config - @SharkBaitDLS PR #3447 fixes #1579**

  `rover supergraph config expand --config ./supergraph.yaml` prints your supergraph configuration file with all variable references (e.g. `${env.PRODUCTS_URL}` and `${file.path}`) expanded. This makes it easy to confirm what Rover actually resolves your config to before a composition run. Use `--format json` to get the expanded config under an `expanded_config` field.

- **Add `--changelog-message` to `graph publish` and `subgraph publish` - @SharkBaitDLS PR #3398 fixes #1884 #292**

  `rover graph publish` and `rover subgraph publish` now accept `--changelog-message <MESSAGE>` to attach a note to the publish in the Studio schema changelog. The publish output has also been enriched: `graph publish` now reports the schema hash and total named type count and `subgraph publish` now includes the resulting supergraph composition hash when one is available.

- **Add `rover dev --supergraph-output` to control the output of the composed supergraph - @SharkBaitDLS PR #3383 fixes #1864**

  `rover dev` can now write the supergraph schema it composes to a path of your choosing and keep it updated on every recomposition, e.g. `rover dev --supergraph-output build/supergraph.graphql`. Previously the composed supergraph only lived in a temp file, and the global `--output`/`-o` flag (which controls a command's own CLI output, not its artifacts) appeared to be silently ignored by `dev`. The global `--output` help text now clarifies that distinction.

- **Add `rover graph-artifact tag` command - @zw428 PR #3282**

  Adds the `rover graph-artifact tag` command for [Graph Artifact](https://www.apollographql.com/docs/graphos/platform/schema-management/delivery/graph-artifacts) tagging.

- **Add `rover persisted-queries generate` command - @dotdat PR #3481**

  Scans GraphQL operation files and generates a persisted query manifest, written to a file (`--manifest-path`) or stdout. Supports `--include`/`--exclude` glob filtering and a configurable `--root-dir`.

- **Add `--check` flag to the `subgraph-publish` GitHub Action - @SharkBaitDLS PR #3375**

- **Add `APOLLO_ROVER_SKIP_UPDATE` to disable all auto-updating at once - @SharkBaitDLS PR #3378 fixes #1892**

  Setting the `APOLLO_ROVER_SKIP_UPDATE` environment variable (to `1` or `true`) opts out of all of Rover's auto-updating in a single switch: it skips both the rover self-update check (the `--skip-update-check` flag) and the `supergraph`/`router` plugin auto-updates (the `--skip-update` flag), so on-the-fly plugin resolution uses an already-installed plugin instead of contacting the registry. This is aimed at tightly-controlled monorepo/CI setups that want plugin versions lockstep with CI and prod. The explicit `rover install` command still installs as requested.

## 🐛 Fixes

- **Include error cause detail in `--format json` output - @SharkBaitDLS PR#3408 fixes #1320**

  When a command fails, its JSON output now includes a `causes` array carrying the same `Caused by:` detail that plain-text output already shows, outermost cause first.

- **Install plugins without relying on a writable system temp directory - @SharkBaitDLS PR #3385 fixes #1422**

  Rover now extracts downloaded `supergraph`/`router` plugin tarballs inside its own install directory rather than the system temp dir (`TMPDIR`/`/tmp`), so installations can succeed on read-only filesystems.

- **Return a clear error when composition produces no output - @SharkBaitDLS PR #3384 fixes #1904**

- **Fall back to an installed plugin when the registry is unreachable - @SharkBaitDLS PR #3362 fixes #1791 #1808**

  When Rover needs the latest `supergraph` or `router` plugin but can't reach the plugin registry (an outage, a network blip, or simply being offline), it now falls back to the newest compatible plugin already installed in `~/.rover/bin` with a warning instead of failing outright. Exact version pins still return an error.

- **Extend the timeout for plugin downloads - @SharkBaitDLS PR #3358 #3386 fixes #1583 #1867**

  Plugin downloads no longer inherit the 30s default that bounds API requests. With `--client-timeout` unset, downloads get a 300s default timeout (plus a 30s connection timeout so a genuinely-offline run still fails fast). When `--client-timeout` *is* provided, it still applies to downloads as before.

- **Read UTF-16 (and BOM-prefixed) schema files - @SharkBaitDLS PR #3351 fixes #653**

  `Fs::read_file` now detects a leading byte-order mark and transcodes the file to UTF-8, so schemas saved as UTF-16 — most commonly produced by Windows PowerShell `>` redirects, e.g. `rover graph introspect ... > schema.gql` — are read instead of failing with "stream did not contain valid UTF-8". A UTF-8 BOM is stripped; files with no recognized BOM are still read as UTF-8 (preserving prior behavior), and malformed input surfaces an error rather than being silently replaced. Decoding is handled by `encoding_rs`.

- **Restore the "pin your federation version" warning on `supergraph compose` - @SharkBaitDLS PR #3347**

  `rover supergraph compose` again warns when `federation_version` is not pinned to an exact version, reinstating the documented notice that future versions will require one. This nudge was added in #1524 and inadvertently dropped in v0.27.2 (#2411) during the supergraph-config resolution rewrite; composing against a floating `1`/`2` (or omitting the key) now once again warns and recommends pinning, to avoid pulling in breaking changes when a new federation release ships. `rover dev` and the language server remain silent. Fixes #1510.

- **Report a clearer error when schema-check polling fails on large schemas - @SharkBaitDLS PR #3349**

  Centralizes the poll loop between `graph`/`subgraph check`, and surfaces a more helpful error when a check likely failed because the schema was too large to download in time. Relates to #1383.

## 🛠 Maintenance

- **Migrate npm packaging to `cargo-npm`, removing the `postinstall` script - @dotdat PR #3430**
- **Fix `cargo npm generate` invocation in the release workflow - @dotdat PR #3492**
- **Migrate to `keyring-core` (keyring 4.0) - @SharkBaitDLS PR #3370**
- **Remove unused Pandas npm package from test tooling - @SharkBaitDLS PR #3335**
- **Upgrade default Federation version to 2.15 - @SharkBaitDLS PR #3472**