### PR TITLE
Docs-only update: `--check` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🚀 Features
 
-- Add `--check` flag to `rover graph publish` or `rover subgraph publish` to run all configured schema checks before publishing. If any check fails, the publish is aborted and no schema changes are pushed to the registry.
-
 ## 🐛 Fixes
 
 ## 🛠 Maintenance
+
+## 📚 Documentation
+
+- Add `--check` flag to `rover graph publish` or `rover subgraph publish` to run all configured schema checks before publishing. If any check fails, the publish is aborted and no schema changes are pushed to the registry.
 
 # [0.41.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🚀 Features
 
+- Add `--check` flag to `rover graph publish` or `rover subgraph publish` to run all configured schema checks before publishing. If any check fails, the publish is aborted and no schema changes are pushed to the registry.
+
 ## 🐛 Fixes
 
 ## 🛠 Maintenance

--- a/docs/source/commands/graphs.mdx
+++ b/docs/source/commands/graphs.mdx
@@ -121,27 +121,38 @@ Whenever possible, we recommend publishing a `.graphql` file directly instead of
 
 For more on accepting input via `stdin`, see [Conventions](/rover/conventions#using-stdin).
 
-Run all configured checks before publishing via the `--check` option. This flag takes no value, and it runs all the standard checks configured for your graph.
+#### Running checks before publishing
 
-If any checks fail, an error message appears and the publish action stops. If all checks pass, the schema publishing proceeds.
+Use the `--check` flag to run all configured schema checks and then publish in a single command. If any checks fail, the publish is aborted and no schema changes are pushed to the registry.
 
-For example, to check a schema change for `test-graph` and then publish it, run these two commands:
+Running check and publish as two separate commands introduces two risks:
+
+- **Human error** — You must type or paste both commands with identical arguments. A mismatched `--schema` path or graph ref means you could publish a schema that was never actually checked.
+- **Race conditions** — Another team member could publish a change between your check and your publish, so the check result no longer reflects the state of the graph at publish time.
+
+`--check` eliminates both risks by treating the check and publish as one atomic operation.
+
+The `--check` flag honors all schema check settings configured for your graph variant in GraphOS Studio—including linting rules, operation checks, and any other check configurations—exactly as a standalone `rover graph check` would.
+
+To exemplify the difference, here is the previous two-step approach:
 
 ```shell
-# Check that schema.graphql works
-rover graph check --schema schemas/schema.graphql test-graph@current
+# Step 1: check
+rover graph check my-graph@current --schema ./schema.graphql
 
-# Publish what we just checked
-rover graph publish --schema schemas/schema.graphql test-graph@current
+# Step 2: publish (only safe if nothing changed between the two commands)
+rover graph publish my-graph@current --schema ./schema.graphql
 ```
 
-Or you could use the `--check` flag and do both in one command
+With `--check`, both steps happen in one command:
 
 ```shell
-graph publish --check --schema schemas/schema.graphql test-graph@current
+rover graph publish my-graph@current --schema ./schema.graphql --check
 ```
 
-For more information on checks, see the following section on `graph check`. Passing the `--check` option runs the same checks `rover graph check` would with the same arguments.
+If all checks pass, Rover publishes the schema. If any check fails, Rover prints the check output and exits without publishing.
+
+For details on configuring checks (time range, operation thresholds, linting rules), see the [`graph check`](#graph-check) section.
 
 ## Validating schema changes
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -287,8 +287,56 @@ This is shorthand for `--routing-url "" --allow-invalid-routing-url`. **It will 
 
 </td>
 </tr>
+<tr>
+<td>
+
+###### `--check`
+
+</td>
+
+<td>
+
+Run all configured checks before publishing. If any checks fail, the publish is aborted and no schema changes are pushed. Equivalent to running `rover subgraph check` with the same arguments before publishing.
+
+</td>
+</tr>
 </tbody>
 </table>
+
+#### Running checks before publishing
+
+Use the `--check` flag to run all configured schema checks and then publish in a single command. If any checks fail, the publish is aborted and no schema changes are pushed to the registry.
+
+Running check and publish as two separate commands introduces two risks:
+
+- **Human error** — You must type or paste both commands with identical arguments. A mismatched `--schema` path, `--name`, or graph ref means you could publish a schema that was never actually checked.
+- **Race conditions** — Another team member could publish a change between your check and your publish, so the check result no longer reflects the state of the subgraph at publish time.
+
+`--check` eliminates both risks by treating the check and publish as one atomic operation.
+
+The `--check` flag honors all schema check settings configured for your graph variant in GraphOS Studio—including linting rules, operation checks, and any other check configurations—exactly as a standalone `rover subgraph check` would.
+
+To illustrate the difference, here is the previous two-step approach:
+
+```shell
+# Step 1: check
+rover subgraph check my-graph@current --schema ./schema.graphql --name accounts
+
+# Step 2: publish (only safe if nothing changed between the two commands)
+rover subgraph publish my-graph@current --schema ./schema.graphql --name accounts \
+  --routing-url "https://my-running-subgraph.com/api"
+```
+
+With `--check`, both steps happen in one command:
+
+```shell
+rover subgraph publish my-graph@current --schema ./schema.graphql --name accounts \
+  --routing-url "https://my-running-subgraph.com/api" --check
+```
+
+If all checks pass, Rover publishes the subgraph schema. If any check fails, Rover prints the check output and exits without publishing.
+
+For details on configuring checks (time range, operation thresholds, linting rules), see the [`subgraph check`](#subgraph-check) section.
 
 #### Creating variants
 


### PR DESCRIPTION
Docs only.

Add `--check` flag to `rover graph publish` and `rover subgraph publish` commands

The update introduces documentation for the new `--check` flag that allows users to run all configured schema checks before publishing. Content notes that, if any checks fail, the publish action is aborted, ensuring that no schema changes are pushed to the registry without validation. All relevant documentation has been edited to reflect this new feature and its usage.
