### PR TITLE
Add retries to check-links check

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,4 +16,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
-      - run: mise run check-links
+      - name: Check links
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: mise run check-links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🛠 Maintenance
 
+- **Retry the Check Markdown Links CI job on transient network failures - @dotdat**
+
+  The `Check Markdown Links` job now retries up to 3 times if it fails, since transient connection resets to external hosts were occasionally failing the job on a link that was never actually broken. `lychee` (the link checker) doesn't retry connection-establishment errors regardless of its own retry config, so this is handled at the CI level instead, matching how other flaky steps are already retried in this repo. No user-facing change.
+
 - **Store profile credentials in the OS keychain instead of a plaintext file - @dotdat**
 
   `rover config auth` now stores each profile's API key in the OS-native credential store (Keychain on macOS, Credential Manager on Windows, the kernel keyring on Linux), falling back to a permission-hardened (`0600`/`0700`) JSON file when no native keychain is available — for example, headless Linux/CI, or an unsigned local build on macOS. Existing plaintext `$APOLLO_CONFIG_HOME/profiles/<profile>/.sensitive` files are transparently migrated the first time they're read, then removed. `rover config auth`, `whoami`, `list`, `delete`, and `clear` all behave the same as before, and the `APOLLO_KEY` environment variable override is unaffected. On some platforms the OS may now prompt for keychain access the first time a credential is read or written in a session. If Rover ever fails to read, write, or delete a credential, it now surfaces a dedicated error, E046, instead of a generic failure.


### PR DESCRIPTION
lychee doesn't retry on network hangups, so we need to wrap this job to retry if it fails (in case it's a network blip)