### PR TITLE
fix(check): show successful check sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+- **Show successful build and operation check sections in plain-text check output - fixes #1816**
+
+  `rover subgraph check` and `rover graph check` now show explicit `Build Check [PASSED]` and `Operation Check [PASSED]` sections even when no schema changes or operation warnings were found. This makes successful check results visible alongside linter and other check sections.
+
 - **Fix a flaky lint-report test - @dotdat**
 
   `rover-client`'s `utf8_points_to_correct_place` test could fail depending on whether the `NO_COLOR`/`APOLLO_NO_COLOR` environment variables happened to be set in the environment running the test suite, since that changes not just color but the literal report-kind text ("Warning" vs the raw "WARNING" level string). The test now pins both env vars unset for its duration, so it's deterministic regardless of the ambient environment. No user-facing behavior change.

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -167,6 +167,7 @@ fn get_check_response_from_data(
     let check_response = CheckWorkflowResponse {
         default_target_url,
         maybe_core_schema_modified: None,
+        maybe_core_schema_status: None,
         maybe_operations_response: get_operations_response_from_result(
             operations_target_url,
             number_of_checked_operations,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -21,7 +21,8 @@ use crate::{
         check_workflow_poll::{poll_check_workflow, PollState},
         CheckWorkflowResponse, CustomCheckResponse, Diagnostic, DownstreamCheckResponse,
         LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
-        ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange, Violation,
+        CheckTaskStatus, ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal,
+        SchemaChange, Violation,
     },
     RoverClientError,
 };
@@ -117,6 +118,7 @@ fn get_check_response_from_data(
         })?;
 
     let mut core_schema_modified = false;
+    let mut core_schema_status: Option<CheckTaskStatus> = None;
     let mut composition_errors = Vec::new();
 
     let mut operations_status = None;
@@ -151,6 +153,7 @@ fn get_check_response_from_data(
     for task in check_workflow.tasks {
         match task.on {
             CompositionCheckTask(typed_task) => {
+                core_schema_status = Some(task.status.into());
                 core_schema_modified = typed_task.core_schema_modified;
                 if let Some(result) = typed_task.result {
                     composition_errors = result.errors;
@@ -225,6 +228,7 @@ fn get_check_response_from_data(
     let check_response = CheckWorkflowResponse {
         default_target_url,
         maybe_core_schema_modified: Some(core_schema_modified),
+        maybe_core_schema_status: core_schema_status,
         maybe_operations_response: get_operations_response_from_result(
             operations_target_url,
             number_of_checked_operations,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -153,7 +153,7 @@ fn get_check_response_from_data(
     for task in check_workflow.tasks {
         match task.on {
             CompositionCheckTask(typed_task) => {
-                core_schema_status = Some(task.status.into());
+                core_schema_status = Some(Some(task.status).into());
                 core_schema_modified = typed_task.core_schema_modified;
                 if let Some(result) = typed_task.result {
                     composition_errors = result.errors;
@@ -600,6 +600,36 @@ mod tests {
             }
             _ => panic!("Expected CheckWorkflowFailure error"),
         }
+    }
+
+    #[test]
+    fn test_get_check_response_preserves_composition_task_status() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "CompositionCheckTask",
+                    "id": "composition-task",
+                    "status": "PASSED",
+                    "targetUrl": null,
+                    "coreSchemaModified": false,
+                    "result": null
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+
+        let response = get_check_response_from_data(
+            data,
+            graph_ref,
+            "test-subgraph".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            response.maybe_core_schema_status,
+            Some(CheckTaskStatus::PASSED)
+        );
     }
 
     #[test]

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -19,10 +19,9 @@ use crate::{
     operations::subgraph::check_workflow::types::QueryResponseData,
     shared::{
         check_workflow_poll::{poll_check_workflow, PollState},
-        CheckWorkflowResponse, CustomCheckResponse, Diagnostic, DownstreamCheckResponse,
-        LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
-        CheckTaskStatus, ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal,
-        SchemaChange, Violation,
+        CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, Diagnostic,
+        DownstreamCheckResponse, LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
+        ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange, Violation,
     },
     RoverClientError,
 };
@@ -619,12 +618,8 @@ mod tests {
         );
         let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
-        let response = get_check_response_from_data(
-            data,
-            graph_ref,
-            "test-subgraph".to_string(),
-        )
-        .unwrap();
+        let response =
+            get_check_response_from_data(data, graph_ref, "test-subgraph".to_string()).unwrap();
 
         assert_eq!(
             response.maybe_core_schema_status,

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -55,11 +55,7 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(lint_response) = &self.maybe_lint_response {
-            Self::append_task_title(
-                &mut msg,
-                "Linter Check",
-                lint_response.task_status.clone(),
-            );
+            Self::append_task_title(&mut msg, "Linter Check", lint_response.task_status.clone());
             msg.push_str(lint_response.get_output().as_str());
         }
 
@@ -92,7 +88,7 @@ impl CheckWorkflowResponse {
             }
         }
 
-        msg
+        msg.trim_end().to_string()
     }
 
     pub fn get_json(&self) -> Value {
@@ -130,6 +126,9 @@ impl CheckWorkflowResponse {
 
     fn append_task_title(msg: &mut String, title: &str, status: CheckTaskStatus) {
         if !msg.is_empty() {
+            if !msg.ends_with('\n') {
+                msg.push('\n');
+            }
             msg.push('\n');
         }
         msg.push_str(&Self::task_title(title, status));

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -16,6 +16,9 @@ pub struct CheckWorkflowResponse {
     // None here means there was no core schema (or build step) for this
     // check which is the case for `graph check`.
     pub maybe_core_schema_modified: Option<bool>,
+    // The status of the build check, when the workflow includes one.
+    #[serde(skip)]
+    pub maybe_core_schema_status: Option<CheckTaskStatus>,
     // TODO: I didn't have time to refactor this into a list with
     // a common task abstraction.
     pub maybe_operations_response: Option<OperationCheckResponse>,
@@ -30,9 +33,11 @@ impl CheckWorkflowResponse {
     pub fn get_output(&self) -> String {
         let mut msg = String::new();
 
-        if let Some(core_schema_modified) = self.maybe_core_schema_modified {
-            msg.push('\n');
-            msg.push_str(&Self::task_title("Build Check", CheckTaskStatus::PASSED));
+        if let (Some(core_schema_modified), Some(core_schema_status)) = (
+            self.maybe_core_schema_modified,
+            self.maybe_core_schema_status.clone(),
+        ) {
+            msg.push_str(&Self::task_title("Build Check", core_schema_status));
             if core_schema_modified {
                 msg.push_str("There were no changes detected in the composed API schema, but the core schema was modified.")
             } else {
@@ -41,7 +46,6 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(operations_response) = &self.maybe_operations_response {
-            msg.push('\n');
             msg.push_str(&Self::task_title(
                 "Operation Check",
                 operations_response.task_status.clone(),
@@ -50,7 +54,6 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(lint_response) = &self.maybe_lint_response {
-            msg.push('\n');
             msg.push_str(&Self::task_title(
                 "Linter Check",
                 lint_response.task_status.clone(),
@@ -59,7 +62,6 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(proposals_response) = &self.maybe_proposals_response {
-            msg.push('\n');
             msg.push_str(&Self::task_title(
                 "Proposals Check",
                 proposals_response.task_status.clone(),
@@ -68,7 +70,6 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(custom_response) = &self.maybe_custom_response {
-            msg.push('\n');
             msg.push_str(&Self::task_title(
                 "Custom Check",
                 custom_response.task_status.clone(),
@@ -78,7 +79,6 @@ impl CheckWorkflowResponse {
 
         if let Some(downstream_response) = &self.maybe_downstream_response {
             if !downstream_response.blocking_variants.is_empty() {
-                msg.push('\n');
                 msg.push_str(&Self::task_title(
                     "Downstream Check",
                     downstream_response.task_status.clone(),

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -37,7 +37,7 @@ impl CheckWorkflowResponse {
             self.maybe_core_schema_modified,
             self.maybe_core_schema_status.clone(),
         ) {
-            msg.push_str(&Self::task_title("Build Check", core_schema_status));
+            Self::append_task_title(&mut msg, "Build Check", core_schema_status);
             if core_schema_modified {
                 msg.push_str("There were no changes detected in the composed API schema, but the core schema was modified.")
             } else {
@@ -46,43 +46,48 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(operations_response) = &self.maybe_operations_response {
-            msg.push_str(&Self::task_title(
+            Self::append_task_title(
+                &mut msg,
                 "Operation Check",
                 operations_response.task_status.clone(),
-            ));
+            );
             msg.push_str(operations_response.get_output().as_str());
         }
 
         if let Some(lint_response) = &self.maybe_lint_response {
-            msg.push_str(&Self::task_title(
+            Self::append_task_title(
+                &mut msg,
                 "Linter Check",
                 lint_response.task_status.clone(),
-            ));
+            );
             msg.push_str(lint_response.get_output().as_str());
         }
 
         if let Some(proposals_response) = &self.maybe_proposals_response {
-            msg.push_str(&Self::task_title(
+            Self::append_task_title(
+                &mut msg,
                 "Proposals Check",
                 proposals_response.task_status.clone(),
-            ));
+            );
             msg.push_str(proposals_response.get_output().as_str());
         }
 
         if let Some(custom_response) = &self.maybe_custom_response {
-            msg.push_str(&Self::task_title(
+            Self::append_task_title(
+                &mut msg,
                 "Custom Check",
                 custom_response.task_status.clone(),
-            ));
+            );
             msg.push_str(custom_response.get_output().as_str());
         }
 
         if let Some(downstream_response) = &self.maybe_downstream_response {
             if !downstream_response.blocking_variants.is_empty() {
-                msg.push_str(&Self::task_title(
+                Self::append_task_title(
+                    &mut msg,
                     "Downstream Check",
                     downstream_response.task_status.clone(),
-                ));
+                );
                 msg.push_str(downstream_response.get_output().as_str());
             }
         }
@@ -123,9 +128,16 @@ impl CheckWorkflowResponse {
         json_result
     }
 
+    fn append_task_title(msg: &mut String, title: &str, status: CheckTaskStatus) {
+        if !msg.is_empty() {
+            msg.push('\n');
+        }
+        msg.push_str(&Self::task_title(title, status));
+    }
+
     fn task_title(title: &str, status: CheckTaskStatus) -> String {
         format!(
-            "\n{} [{}]:\n",
+            "{} [{}]:\n",
             Style::Heading.paint(title),
             match status {
                 CheckTaskStatus::BLOCKED => status.as_ref().to_string(),

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -32,6 +32,7 @@ impl CheckWorkflowResponse {
 
         if let Some(core_schema_modified) = self.maybe_core_schema_modified {
             msg.push('\n');
+            msg.push_str(&Self::task_title("Build Check", CheckTaskStatus::PASSED));
             if core_schema_modified {
                 msg.push_str("There were no changes detected in the composed API schema, but the core schema was modified.")
             } else {
@@ -40,14 +41,12 @@ impl CheckWorkflowResponse {
         }
 
         if let Some(operations_response) = &self.maybe_operations_response {
-            if !operations_response.changes.is_empty() {
-                msg.push('\n');
-                msg.push_str(&Self::task_title(
-                    "Operation Check",
-                    operations_response.task_status.clone(),
-                ));
-                msg.push_str(operations_response.get_output().as_str());
-            }
+            msg.push('\n');
+            msg.push_str(&Self::task_title(
+                "Operation Check",
+                operations_response.task_status.clone(),
+            ));
+            msg.push_str(operations_response.get_output().as_str());
         }
 
         if let Some(lint_response) = &self.maybe_lint_response {
@@ -202,7 +201,11 @@ impl OperationCheckResponse {
 
         msg.push('\n');
 
-        msg.push_str(&self.get_table());
+        if self.changes.is_empty() {
+            msg.push_str("No schema changes detected.\n");
+        } else {
+            msg.push_str(&self.get_table());
+        }
 
         if let Some(url) = &self.target_url {
             msg.push_str("View operation check details at: ");

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1375,7 +1375,15 @@ mod tests {
                 "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1"
                     .to_string(),
             maybe_core_schema_modified: Some(true),
-            maybe_operations_response: None,
+            maybe_operations_response: Some(OperationCheckResponse::try_new(
+                CheckTaskStatus::PASSED,
+                Some(
+                    "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1"
+                        .to_string(),
+                ),
+                0,
+                vec![],
+            )),
             maybe_lint_response: Some(LintCheckResponse {
                 task_status: CheckTaskStatus::PASSED,
                 target_url: Some(
@@ -1405,7 +1413,13 @@ mod tests {
         let actual_text = strip_ansi_codes(&actual_text);
 
         let expected_text = "
+Build Check [PASSED]:
 There were no changes detected in the composed API schema, but the core schema was modified.
+
+Operation Check [PASSED]:
+Compared 0 schema changes against 0 operations.
+No schema changes detected.
+View operation check details at: https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1
 
 Linter Check [PASSED]:
 No linting errors or warnings found.

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1414,8 +1414,7 @@ mod tests {
             .expect("Expected response to exist");
         let actual_text = strip_ansi_codes(&actual_text);
 
-        let expected_text = "
-Build Check [PASSED]:
+        let expected_text = "Build Check [PASSED]:
 There were no changes detected in the composed API schema, but the core schema was modified.
 
 Operation Check [PASSED]:
@@ -1461,7 +1460,44 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
 
         assert_eq!(
             actual_text,
-            "\nOperation Check [PASSED]:\nCompared 0 schema changes against 0 operations.\nNo schema changes detected."
+            "Operation Check [PASSED]:\nCompared 0 schema changes against 0 operations.\nNo schema changes detected."
+        );
+    }
+
+    #[test]
+    fn check_graph_response_text_includes_each_present_task() {
+        let check_response = CheckWorkflowResponse {
+            default_target_url: "https://studio.apollographql.com/graph/my-graph/checks"
+                .to_string(),
+            maybe_core_schema_modified: None,
+            maybe_core_schema_status: None,
+            maybe_operations_response: Some(OperationCheckResponse::try_new(
+                CheckTaskStatus::PASSED,
+                None,
+                0,
+                vec![],
+            )),
+            maybe_lint_response: Some(LintCheckResponse {
+                task_status: CheckTaskStatus::FAILED,
+                target_url: None,
+                diagnostics: vec![],
+                errors_count: 0,
+                warnings_count: 0,
+            }),
+            maybe_proposals_response: None,
+            maybe_custom_response: None,
+            maybe_downstream_response: None,
+        };
+
+        let actual_text = RoverOutput::CheckWorkflowResponse(check_response)
+            .get_stdout()
+            .expect("Expected response to be Ok")
+            .expect("Expected response to exist");
+        let actual_text = strip_ansi_codes(&actual_text);
+
+        assert_eq!(
+            actual_text,
+            "Operation Check [PASSED]:\nCompared 0 schema changes against 0 operations.\nNo schema changes detected.\n\nLinter Check [FAILED]:\nNo linting errors or warnings found."
         );
     }
 
@@ -1486,7 +1522,7 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
 
         assert_eq!(
             actual_text,
-            "\nBuild Check [BLOCKED]:\nThere were no changes detected in the composed schema."
+            "Build Check [BLOCKED]:\nThere were no changes detected in the composed schema."
         );
     }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -1234,6 +1234,7 @@ mod tests {
         let mock_check_response = CheckWorkflowResponse {
             default_target_url: "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1".to_string(),
             maybe_core_schema_modified: Some(true),
+            maybe_core_schema_status: Some(CheckTaskStatus::PASSED),
             maybe_operations_response: Some(OperationCheckResponse::try_new(
                 CheckTaskStatus::PASSED,
                 Some("https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1".to_string()),
@@ -1375,6 +1376,7 @@ mod tests {
                 "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1"
                     .to_string(),
             maybe_core_schema_modified: Some(true),
+            maybe_core_schema_status: Some(CheckTaskStatus::PASSED),
             maybe_operations_response: Some(OperationCheckResponse::try_new(
                 CheckTaskStatus::PASSED,
                 Some(
@@ -1433,12 +1435,69 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
     }
 
     #[test]
+    fn check_graph_response_text_has_no_build_section() {
+        let check_response = CheckWorkflowResponse {
+            default_target_url: "https://studio.apollographql.com/graph/my-graph/checks"
+                .to_string(),
+            maybe_core_schema_modified: None,
+            maybe_core_schema_status: None,
+            maybe_operations_response: Some(OperationCheckResponse::try_new(
+                CheckTaskStatus::PASSED,
+                None,
+                0,
+                vec![],
+            )),
+            maybe_lint_response: None,
+            maybe_proposals_response: None,
+            maybe_custom_response: None,
+            maybe_downstream_response: None,
+        };
+
+        let actual_text = RoverOutput::CheckWorkflowResponse(check_response)
+            .get_stdout()
+            .expect("Expected response to be Ok")
+            .expect("Expected response to exist");
+        let actual_text = strip_ansi_codes(&actual_text);
+
+        assert_eq!(
+            actual_text,
+            "\nOperation Check [PASSED]:\nCompared 0 schema changes against 0 operations.\nNo schema changes detected."
+        );
+    }
+
+    #[test]
+    fn check_build_status_uses_response_status() {
+        let check_response = CheckWorkflowResponse {
+            default_target_url: String::new(),
+            maybe_core_schema_modified: Some(false),
+            maybe_core_schema_status: Some(CheckTaskStatus::BLOCKED),
+            maybe_operations_response: None,
+            maybe_lint_response: None,
+            maybe_proposals_response: None,
+            maybe_custom_response: None,
+            maybe_downstream_response: None,
+        };
+
+        let actual_text = RoverOutput::CheckWorkflowResponse(check_response)
+            .get_stdout()
+            .expect("Expected response to be Ok")
+            .expect("Expected response to exist");
+        let actual_text = strip_ansi_codes(&actual_text);
+
+        assert_eq!(
+            actual_text,
+            "\nBuild Check [BLOCKED]:\nThere were no changes detected in the composed schema."
+        );
+    }
+
+    #[test]
     fn check_failure_response_json() {
         let graph_ref = GraphRef::new("name", Some("current")).unwrap();
         let check_response = CheckWorkflowResponse {
             default_target_url:
                 "https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1".to_string(),
             maybe_core_schema_modified: Some(false),
+            maybe_core_schema_status: Some(CheckTaskStatus::PASSED),
             maybe_operations_response: Some(OperationCheckResponse::try_new(
                 CheckTaskStatus::FAILED,
                 Some("https://studio.apollographql.com/graph/my-graph/variant/current/operationsCheck/1".to_string()),


### PR DESCRIPTION
Fixes #1816\n\nPlain-text over graph check and over subgraph check output now shows explicit Build Check [PASSED] and Operation Check [PASSED] sections when those checks succeed without warnings or schema changes. Empty operation results now explain that no schema changes were detected instead of omitting the section. JSON output is unchanged.\n\nValidation: focused output regression coverage was updated, and git diff --check passes. Cargo/Rust tests were not available because Rust tooling is not installed in this Windows environment.