### PR TITLE
Integrate native Rust composition preview

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,17 @@
       matchPackageNames: ["apollographql/federation-rs"],
       extractVersion: "^supergraph@(?<version>v\\d+\\.\\d+\\.\\d+)$",
       automerge: false,
+      prBodyNotes: [
+        "**If `native_composition_keeps_up_with_the_plugin_version_ci_tests` fails,** native composition cannot compose at the version this bumps to. Fix by bumping `apollo-composition` in `Cargo.toml` and updating `MAX_SUPPORTED_FEDERATION_SPEC` in `src/composition/supergraph/native.rs`. Merging without that leaves `--native-composition` unable to compose at the version everything else defaults to.",
+      ],
+    },
+    {
+      matchManagers: ["cargo"],
+      matchPackageNames: ["apollo-composition"],
+      automerge: false,
+      prBodyNotes: [
+        "**Check the federation spec ceiling.** `MAX_SUPPORTED_FEDERATION_SPEC` in `src/composition/supergraph/native.rs` mirrors a private table in `apollo-federation` and is not updated automatically. If `max_supported_federation_spec_is_accurate` fails, set it to the new ceiling; that test composes at the ceiling and at the next minor up, so it pins the value from both sides.",
+      ],
     },
     {
       matchPackageNames: ["apollographql/router"],

--- a/.github/workflows/run-smokes-on-pr.yml
+++ b/.github/workflows/run-smokes-on-pr.yml
@@ -40,4 +40,7 @@ jobs:
     with:
       composition-versions: '${{ needs.calculate_correct_version_ranges.outputs.supergraph_versions }}'
       router-versions: '${{ needs.calculate_correct_version_ranges.outputs.router_versions }}'
+      # Builds the e2e binary with native composition so the composition-parity tests are
+      # compiled in. Release artifacts do not enable this feature; only these tests do.
+      features: 'composition-rust'
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🚀 Features
 
+- **Add support for native composition, gated behind the experimental `composition-rust` feature flag - @imgood**
+
+  Native composition is currently in opt-in preview. For details, see https://www.apollographql.com/blog/apollo-federation-goes-full-rust.
+
 - **Add `rover auth logout`, gated behind the experimental `oauth` feature flag - @dotdat**
 
   `rover auth logout` revokes the OAuth session stored by `rover auth login` for the given `--profile` (or "default") — the access token and, if one was issued, the refresh token (RFC 7009) — then removes the local credential. Revocation is best-effort: if the OAuth server can't be reached, Rover still clears the local credential and warns instead of leaving you stuck "logged in" locally. Only meaningful for profiles logged in via `rover auth login`; running it against a profile holding a Personal API Key (from `rover config auth`) errors and points you at `rover config delete` instead. Only compiled in when built with `--features oauth`, matching `rover auth login`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -190,6 +190,17 @@ dependencies = [
  "thiserror 2.0.19",
  "triomphe",
  "typed-arena",
+]
+
+[[package]]
+name = "apollo-composition"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff78154bea8fa4056d11654b02f797d54984a880346766e2770817916e7ff39c"
+dependencies = [
+ "apollo-compiler",
+ "apollo-federation",
+ "apollo-federation-types",
 ]
 
 [[package]]
@@ -1827,7 +1838,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1960,7 +1971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3026,7 +3037,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3739,7 +3750,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4117,7 +4128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4450,7 +4461,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4513,7 +4524,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4853,6 +4864,7 @@ version = "0.41.0"
 dependencies = [
  "anyhow",
  "apollo-compiler",
+ "apollo-composition",
  "apollo-federation-types",
  "apollo-language-server",
  "apollo-parser",
@@ -5310,7 +5322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5367,7 +5379,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5979,7 +5991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6269,7 +6281,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7273,7 +7285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ default = ["composition-js"]
 # because of this GitHub issue: https://github.com/denoland/deno/issues/3711
 composition-js = []
 
+# Native composition via the `apollo-composition` crate, instead of shelling out to the
+# JS `supergraph` plugin binary. Still in preview, not GA.
+composition-rust = ["dep:apollo-composition"]
+
 # gates `rover auth login` and its supporting OAuth machinery, which is still
 # under active development (ROVER-391) and not yet ready for general release.
 oauth = ["dep:rover-auth", "dep:rover-open"]
@@ -121,7 +125,11 @@ apollo-compiler = "1.31.1"
 apollo-parser = "0.8"
 
 # https://github.com/apollographql/federation-rs
-apollo-federation-types = { version = "=0.17.7", features = ["json_schema"] }
+apollo-composition = "=0.5.6"
+apollo-federation-types = { version = "=0.17.7", features = [
+  "json_schema",
+  "composition",
+] }
 apollo-language-server = { version = "=0.9.0", default-features = false, features = ["tokio"] }
 
 # tree-sitter grammars for client extraction
@@ -250,6 +258,7 @@ anyhow = { workspace = true }
 assert_fs = { workspace = true }
 async-trait = { workspace = true }
 apollo-compiler = { workspace = true }
+apollo-composition = { workspace = true, optional = true }
 apollo-language-server = { workspace = true }
 apollo-federation-types = { workspace = true }
 apollo-parser = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,12 @@ allow = ["Elastic-2.0"]
 name = "apollo-federation"
 allow = ["Elastic-2.0"]
 
+# Native composition. Rover gates this behind ELv2 acceptance at runtime, the same as the
+# ELv2-licensed `supergraph` plugin it replaces.
+[[licenses.exceptions]]
+name = "apollo-composition"
+allow = ["Elastic-2.0"]
+
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html

--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ run = "cargo +nightly fmt --all -- --check"
 run = "cargo clippy --locked --workspace --all-features --all-targets"
 
 [tasks.test]
-run = "cargo test --locked --workspace --exclude regressions --features oauth"
+run = "cargo test --locked --workspace --exclude regressions --features oauth,composition-rust"
 
 [tasks.generate-npm]
 description = "Generate npm packages via cargo-npm and patch the shim"

--- a/src/command/supergraph/compose/do_compose.rs
+++ b/src/command/supergraph/compose/do_compose.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::{
     RoverOutput, RoverResult,
-    composition::get_supergraph_binary,
+    composition::{CompositionSuccess, get_supergraph_binary},
     options::PluginOpts,
     utils::{
         client::StudioClientConfig,
@@ -59,6 +59,16 @@ pub struct SupergraphComposeOpts {
     /// will automatically determine the version from the supergraph config
     #[arg(long = "federation-version")]
     pub federation_version: Option<FederationVersion>,
+
+    /// Compose natively, in-process, instead of downloading and running the `supergraph` plugin.
+    ///
+    /// Native composition does not require a plugin download and does not embed a JS runtime. It
+    /// implements federation specs up to the version this Rover build was compiled against, but
+    /// is not a guaranteed byte-for-byte reproduction of JS composition during the preview phase.
+    /// Expect minor differences in errors and hints in particular.
+    #[cfg(feature = "composition-rust")]
+    #[arg(long = "native-composition")]
+    pub native_composition: bool,
 }
 
 impl Compose {
@@ -71,18 +81,13 @@ impl Compose {
         let write_file_impl = FsWriteFile::default();
         let exec_command_impl = TokioCommand::default();
 
-        let composition_pipeline = get_supergraph_binary(
-            self.opts.federation_version.clone(),
-            client_config,
-            override_install_path,
-            self.opts.plugin_opts.clone(),
-            self.opts.supergraph_config_source.supergraph_yaml().clone(),
-            self.opts.supergraph_config_source.graph_ref().clone(),
-            true,
-        )
-        .await?;
-        let composition_success = composition_pipeline
-            .compose(&exec_command_impl, &write_file_impl)
+        let composition_success = self
+            .compose_supergraph(
+                client_config,
+                override_install_path,
+                &exec_command_impl,
+                &write_file_impl,
+            )
             .await?;
 
         if let Some(output_file) = output_file {
@@ -98,5 +103,54 @@ impl Compose {
         }
 
         Ok(RoverOutput::CompositionResult(composition_success.into()))
+    }
+
+    /// Runs composition, either natively or via the `supergraph` plugin binary.
+    async fn compose_supergraph(
+        &self,
+        client_config: StudioClientConfig,
+        override_install_path: Option<Utf8PathBuf>,
+        exec_command_impl: &TokioCommand,
+        write_file_impl: &FsWriteFile,
+    ) -> RoverResult<CompositionSuccess> {
+        #[cfg(feature = "composition-rust")]
+        if self.opts.native_composition {
+            // Stop the pipeline before the install step; native composition needs no binary.
+            let pipeline = crate::composition::resolve_composition_pipeline(
+                self.opts.federation_version.clone(),
+                &client_config,
+                &self.opts.plugin_opts,
+                self.opts.supergraph_config_source.supergraph_yaml().clone(),
+                self.opts.supergraph_config_source.graph_ref().clone(),
+                true,
+            )
+            .await?;
+
+            return match pipeline
+                .compose_native(&client_config, self.opts.plugin_opts.elv2_license_accepter)
+                .await
+            {
+                Ok(success) => Ok(success),
+                // Return the inner error as-is; it carries the suggestion explaining how to
+                // accept the ELv2 license, which wrapping would discard.
+                Err(crate::composition::CompositionError::Elv2LicenseNotAccepted(err)) => Err(*err),
+                Err(err) => Err(err.into()),
+            };
+        }
+
+        let composition_pipeline = get_supergraph_binary(
+            self.opts.federation_version.clone(),
+            client_config,
+            override_install_path,
+            self.opts.plugin_opts.clone(),
+            self.opts.supergraph_config_source.supergraph_yaml().clone(),
+            self.opts.supergraph_config_source.graph_ref().clone(),
+            true,
+        )
+        .await?;
+
+        Ok(composition_pipeline
+            .compose(exec_command_impl, write_file_impl)
+            .await?)
     }
 }

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -13,7 +13,10 @@ use tower::ServiceExt;
 use crate::{
     RoverError,
     composition::{
-        pipeline::{CompositionPipeline, state::Run},
+        pipeline::{
+            CompositionPipeline,
+            state::{InstallSupergraph, Run},
+        },
         supergraph::{
             config::{
                 error::ResolveSubgraphError,
@@ -42,20 +45,21 @@ pub mod types;
 #[cfg(feature = "composition-js")]
 mod watchers;
 
-/// A reusable, shareable, canonical way to get a supergraph binary from the common options
-/// used around Rover.
-pub(crate) async fn get_supergraph_binary(
+/// Builds a composition pipeline up to the resolved federation version.
+///
+/// Split out from [`get_supergraph_binary`] so native composition can stop short of the plugin
+/// download.
+pub(crate) async fn resolve_composition_pipeline(
     federation_version: Option<FederationVersion>,
-    client_config: StudioClientConfig,
-    override_install_path: Option<Utf8PathBuf>,
-    plugin_opts: PluginOpts,
+    client_config: &StudioClientConfig,
+    plugin_opts: &PluginOpts,
     supergraph_yaml: Option<FileDescriptorType>,
     graph_ref: Option<GraphRef>,
     // Only `supergraph compose` nudges users to pin the federation version;
     // `connector` and the LSP share this helper but shouldn't warn.
     warn_on_floating_version: bool,
-) -> Result<CompositionPipeline<Run>, RoverError> {
-    let profile = plugin_opts.profile;
+) -> Result<CompositionPipeline<InstallSupergraph>, RoverError> {
+    let profile = plugin_opts.profile.clone();
 
     let fetch_remote_subgraphs_factory = MakeFetchRemoteSubgraphs::builder()
         .studio_client_config(client_config.clone())
@@ -70,7 +74,7 @@ pub(crate) async fn get_supergraph_binary(
     let resolve_introspect_subgraph_factory =
         MakeResolveIntrospectSubgraph::new(client_config.service()?).boxed_clone();
 
-    CompositionPipeline::default()
+    Ok(CompositionPipeline::default()
         .init(
             &mut stdin(),
             fetch_remote_subgraphs_factory,
@@ -85,15 +89,37 @@ pub(crate) async fn get_supergraph_binary(
             federation_version,
             warn_on_floating_version,
         )
-        .await
-        .install_supergraph_binary(
-            client_config,
-            override_install_path,
-            plugin_opts.elv2_license_accepter,
-            plugin_opts.skip_update,
-        )
-        .await
-        .map_err(RoverError::from)
+        .await)
+}
+
+/// A reusable, shareable, canonical way to get a supergraph binary from the common options
+/// used around Rover.
+pub(crate) async fn get_supergraph_binary(
+    federation_version: Option<FederationVersion>,
+    client_config: StudioClientConfig,
+    override_install_path: Option<Utf8PathBuf>,
+    plugin_opts: PluginOpts,
+    supergraph_yaml: Option<FileDescriptorType>,
+    graph_ref: Option<GraphRef>,
+    warn_on_floating_version: bool,
+) -> Result<CompositionPipeline<Run>, RoverError> {
+    resolve_composition_pipeline(
+        federation_version,
+        &client_config,
+        &plugin_opts,
+        supergraph_yaml,
+        graph_ref,
+        warn_on_floating_version,
+    )
+    .await?
+    .install_supergraph_binary(
+        client_config,
+        override_install_path,
+        plugin_opts.elv2_license_accepter,
+        plugin_opts.skip_update,
+    )
+    .await
+    .map_err(RoverError::from)
 }
 
 #[derive(Debug, Clone)]
@@ -159,6 +185,25 @@ pub enum CompositionError {
     ResolvingSubgraphsError(#[from] ResolveSupergraphConfigError),
     #[error("Could not install supergraph binary:\n{}", .source)]
     InstallSupergraphBinaryError { source: InstallSupergraphError },
+    #[error(
+        "`federation_version: {requested}` is newer than the federation spec this build of Rover \
+         composes natively, which supports up to {max_supported}. Either lower the version, or \
+         drop `--native-composition` to compose with the supergraph plugin."
+    )]
+    NativeCompositionSpecTooNew {
+        requested: FederationVersion,
+        max_supported: String,
+    },
+    #[error(
+        "Native composition only supports federation 2, but `{requested}` was requested. Drop \
+         `--native-composition` to compose with the supergraph plugin."
+    )]
+    NativeCompositionRequiresFedTwo { requested: FederationVersion },
+    /// Carries the original [`RoverError`] for its suggestion (how to accept the license), which
+    /// only survives if callers return the inner error rather than wrapping it.
+    // Not `#[error(transparent)]`: `RoverError` implements `Display` but not `std::error::Error`.
+    #[error("{}", .0)]
+    Elv2LicenseNotAccepted(Box<RoverError>),
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/composition/pipeline.rs
+++ b/src/composition/pipeline.rs
@@ -218,6 +218,48 @@ impl CompositionPipeline<state::ResolveFederationVersion> {
     }
 }
 impl CompositionPipeline<state::InstallSupergraph> {
+    /// Composes in-process via `apollo-composition`, with no supergraph plugin binary.
+    ///
+    /// Lives on the `InstallSupergraph` state rather than `Run` because stopping before that
+    /// transition is what skips the plugin download. ELv2 is still required — see the
+    /// [`native`](super::supergraph::native) module docs for why.
+    #[cfg(feature = "composition-rust")]
+    pub async fn compose_native(
+        &self,
+        studio_client_config: &StudioClientConfig,
+        elv2_license_accepter: LicenseAccepter,
+    ) -> Result<CompositionSuccess, CompositionError> {
+        use super::supergraph::native::NativeComposer;
+        use crate::options::Elv2Subject;
+
+        // Unconditional, unlike the plugin install path, which only requires ELv2 for fed 2.
+        // Native composition is always fed 2.
+        elv2_license_accepter
+            .require_elv2_license_for(studio_client_config, Elv2Subject::NativeComposition)
+            .map_err(|err| CompositionError::Elv2LicenseNotAccepted(Box::new(err)))?;
+
+        // Before resolving subgraphs, which can hit the network for introspection and Studio.
+        let composer = NativeComposer::new(&self.state.federation_version)?;
+
+        let (fully_resolved_supergraph_config, errors) = self
+            .state
+            .resolver
+            .fully_resolve_subgraphs(
+                self.state.resolve_introspect_subgraph_factory.clone(),
+                self.state.fetch_remote_subgraph_factory.clone(),
+                &self.state.supergraph_root,
+            )
+            .await?;
+
+        if !errors.is_empty() {
+            return Err(CompositionError::ResolvingSubgraphsError(
+                ResolveSupergraphConfigError::ResolveSubgraphs(errors),
+            ));
+        }
+
+        composer.compose(&fully_resolved_supergraph_config).await
+    }
+
     pub async fn install_supergraph_binary(
         self,
         studio_client_config: StudioClientConfig,

--- a/src/composition/supergraph/mod.rs
+++ b/src/composition/supergraph/mod.rs
@@ -1,4 +1,6 @@
 pub mod binary;
 pub mod config;
 pub mod install;
+#[cfg(feature = "composition-rust")]
+pub mod native;
 pub mod version;

--- a/src/composition/supergraph/native.rs
+++ b/src/composition/supergraph/native.rs
@@ -1,0 +1,743 @@
+//! Native, in-process composition via the [`apollo_composition`] crate.
+//!
+//! ## Licensing
+//!
+//! Skipping the download does *not* skip the ELv2 license requirement. `apollo-composition` and
+//! `apollo-federation` are ELv2-licensed and compiled into Rover, so the licensed code runs
+//! either way — it just ships with the binary instead of being fetched.
+//! [`CompositionPipeline::compose_native`](crate::composition::pipeline::CompositionPipeline)
+//! requires acceptance before doing any work, matching the plugin install path.
+//!
+//! ## Federation version
+//!
+//! Three unrelated things are all called a "federation version", and conflating them is easy:
+//!
+//! 1. The **spec** version a subgraph `@link`s, e.g. `.../federation/v2.3`. Major/minor only.
+//! 2. The `apollo-federation` **crate** version, e.g. `2.16.1`. crates.io numbering, and *not*
+//!    a value users can put in `federation_version`.
+//! 3. Rover's [`FederationVersion`] — what `federation_version:` in `supergraph.yaml` means: a
+//!    published composition release, matching the plugin and `@apollo/composition` npm.
+//!
+//! Spec features are backported, so `apollo-federation` supports every spec version from
+//! `v2.0` up to [`MAX_SUPPORTED_FEDERATION_SPEC`] — not only the newest. And because
+//! composition release `2.N` is the release that first introduced spec `v2.N`, a
+//! `federation_version: =2.N` pin in `supergraph.yaml` can be range-checked directly against
+//! the spec ceiling — which is what [`NativeComposer::new`] does. Subgraphs that declare a
+//! spec version beyond that ceiling are rejected by `apollo-federation` itself during
+//! composition, so there is no separate pre-check here.
+
+use apollo_composition::HybridComposition;
+use apollo_federation_types::{
+    build_plugin::{BuildMessage, BuildMessageLevel, PluginFailureReason, PluginResult},
+    composition::Issue,
+    config::FederationVersion,
+    javascript::SubgraphDefinition,
+    rover::{BuildError, BuildErrors, BuildHint},
+};
+
+use crate::composition::{
+    CompositionError, CompositionSuccess, supergraph::config::full::FullyResolvedSupergraphConfig,
+};
+
+/// The newest federation spec version (major, minor) the pinned `apollo-federation` implements.
+///
+/// `apollo-federation` registers its supported specs in a private `FEDERATION_VERSIONS` table
+/// with no public accessor, so this has to be mirrored here and updated when the crate is
+/// bumped. [`tests::max_supported_federation_spec_is_accurate`] pins it from both sides by
+/// composing subgraphs at this spec and at the next one up, so a stale value fails a test
+/// rather than silently misreporting what we support.
+const MAX_SUPPORTED_FEDERATION_SPEC: (u64, u64) = (2, 15);
+
+/// Composes a supergraph in-process, without the `supergraph` plugin binary.
+#[derive(Debug)]
+pub struct NativeComposer;
+
+impl NativeComposer {
+    /// Creates a composer for the given federation version, or errors if native composition
+    /// cannot honor it.
+    ///
+    /// [`FederationVersion::LatestFedTwo`] is always accepted — that is what an unpinned
+    /// `supergraph.yaml` resolves to. Exact fed-2 pins are accepted up to this build's
+    /// [`MAX_SUPPORTED_FEDERATION_SPEC`], a pin above that ceiling returns
+    /// [`CompositionError::NativeCompositionSpecTooNew`]. Fed-1 versions always return
+    /// [`CompositionError::NativeCompositionRequiresFedTwo`].
+    ///
+    /// See the module docs on the three meanings of "federation version".
+    pub fn new(federation_version: &FederationVersion) -> Result<Self, CompositionError> {
+        match federation_version {
+            FederationVersion::LatestFedTwo => {}
+            // Fed-1 *subgraphs* are upgraded and compose fine; it's fed-1 composition, which
+            // always produced a fed-1 supergraph, that has no native equivalent.
+            FederationVersion::LatestFedOne | FederationVersion::ExactFedOne(_) => {
+                return Err(CompositionError::NativeCompositionRequiresFedTwo {
+                    requested: federation_version.clone(),
+                });
+            }
+            FederationVersion::ExactFedTwo(requested) => {
+                // Comparing a release version against a spec range is only valid because
+                // release `2.N` is the one that introduced spec `v2.N`.
+                if (requested.major, requested.minor) > MAX_SUPPORTED_FEDERATION_SPEC {
+                    return Err(CompositionError::NativeCompositionSpecTooNew {
+                        requested: federation_version.clone(),
+                        max_supported: format!(
+                            "{}.{}",
+                            MAX_SUPPORTED_FEDERATION_SPEC.0, MAX_SUPPORTED_FEDERATION_SPEC.1
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(Self)
+    }
+
+    /// Composes the given subgraphs into a supergraph SDL.
+    ///
+    /// # Warning: blocks the async runtime
+    ///
+    /// This is CPU-bound work. Calling it from an async context will block the Tokio
+    /// worker thread for the duration of composition stalling other tasks on that
+    /// thread. Wrap in [`tokio::task::spawn_blocking`] if called from a long-running
+    /// async context such as watch mode.
+    pub async fn compose(
+        self,
+        supergraph_config: &FullyResolvedSupergraphConfig,
+    ) -> Result<CompositionSuccess, CompositionError> {
+        let federation_version = supergraph_config.federation_version().clone();
+        let subgraph_definitions = subgraph_definitions(supergraph_config);
+
+        // Must stay `experimental_compose`: the plain `compose` is the hybrid flow that calls
+        // out to `@apollo/composition`, which is exactly what this path replaces.
+        let result = self.experimental_compose(subgraph_definitions).await;
+
+        into_composition_result(result, federation_version)
+    }
+}
+
+/// Flattens a fully-resolved supergraph config into what `apollo-composition` wants.
+fn subgraph_definitions(
+    supergraph_config: &FullyResolvedSupergraphConfig,
+) -> Vec<SubgraphDefinition> {
+    supergraph_config
+        .subgraphs()
+        .iter()
+        .map(|(name, subgraph)| SubgraphDefinition {
+            name: name.clone(),
+            // A missing routing URL is legal (e.g. connector-only subgraphs), and empty is how
+            // the plugin sees it too when the YAML key is absent.
+            url: subgraph.routing_url.clone().unwrap_or_default(),
+            sdl: subgraph.schema().clone(),
+        })
+        .collect()
+}
+
+/// Translates `apollo-composition`'s result into Rover's composition types.
+///
+/// `apollo-federation-types` supplies every hop (`Issue` -> `BuildMessage` ->
+/// `BuildHint`/`BuildError`), so all this decides is which bucket each message lands in.
+fn into_composition_result(
+    result: Result<PluginResult, Vec<Issue>>,
+    federation_version: FederationVersion,
+) -> Result<CompositionSuccess, CompositionError> {
+    let plugin_result = match result {
+        Ok(plugin_result) => plugin_result,
+        // These issues are a mix of severities, not just errors; `build_failure` filters.
+        Err(issues) => {
+            return Err(build_failure(
+                issues.into_iter().map(BuildMessage::from).collect(),
+                federation_version,
+            ));
+        }
+    };
+
+    let PluginResult {
+        result,
+        build_messages,
+        ..
+    } = plugin_result;
+
+    let supergraph_sdl = match result {
+        Ok(supergraph_sdl) => supergraph_sdl,
+        // Unreachable today — `experimental_compose` signals failure via `Err(Vec<Issue>)` — but
+        // `PluginResult` can also encode it inline, and honouring that beats returning a
+        // success with no SDL.
+        Err(reason) => {
+            let mut messages = build_messages;
+            if !messages
+                .iter()
+                .any(|message| message.level == BuildMessageLevel::Error)
+            {
+                // `build_failure` would substitute a generic message here; naming the actual
+                // `PluginFailureReason` is more useful.
+                messages.push(BuildMessage::new_error(
+                    format!(
+                        "Composition failed: {}",
+                        failure_reason_description(&reason)
+                    ),
+                    Some("NATIVE_COMPOSITION".to_string()),
+                    Some("COMPOSITION_FAILURE".to_string()),
+                ));
+            }
+            return Err(build_failure(messages, federation_version));
+        }
+    };
+
+    // If composition claimed success but still reported errors, trust the messages.
+    let (errors, hints): (Vec<_>, Vec<_>) = build_messages
+        .into_iter()
+        .partition(|message| message.level == BuildMessageLevel::Error);
+
+    if !errors.is_empty() {
+        return Err(build_failure(errors, federation_version));
+    }
+
+    Ok(CompositionSuccess {
+        supergraph_sdl,
+        // Every non-error message becomes a hint, including `Debug`-level ones. `Debug` here is
+        // `apollo-federation`'s `HintLevel::Debug` — a low-importance composition hint, not
+        // internal tracing — and the plugin reports those too, so filtering them would silently
+        // lose hints relative to the plugin path.
+        hints: hints.into_iter().map(BuildHint::from).collect(),
+        federation_version,
+    })
+}
+
+/// Builds a [`CompositionError::Build`], keeping only error-level messages.
+///
+/// The filter is load-bearing. `experimental_compose` appends WARN-level merge hints to the
+/// error list it returns, and `BuildError::from` hardcodes `BuildErrorType::Composition` without
+/// looking at the level — so unfiltered, hints would be reported to the user as composition
+/// errors. `BuildErrors` has nowhere to put non-errors, and the plugin's `BuildResult` drops
+/// hints on failure too, so discarding them keeps the two paths in agreement.
+fn build_failure(
+    messages: Vec<BuildMessage>,
+    federation_version: FederationVersion,
+) -> CompositionError {
+    let mut errors: Vec<BuildError> = messages
+        .into_iter()
+        .filter(|message| message.level == BuildMessageLevel::Error)
+        .map(BuildError::from)
+        .collect();
+
+    if errors.is_empty() {
+        errors.push(BuildError::from(BuildMessage::new_error(
+            "Composition failed, but reported no errors. This is a bug in Rover; please report \
+             it at https://github.com/apollographql/rover/issues."
+                .to_string(),
+            Some("NATIVE_COMPOSITION".to_string()),
+            Some("COMPOSITION_FAILURE".to_string()),
+        )));
+    }
+
+    CompositionError::Build {
+        source: errors.into_iter().collect::<BuildErrors>(),
+        federation_version,
+    }
+}
+
+const fn failure_reason_description(reason: &PluginFailureReason) -> &'static str {
+    match reason {
+        PluginFailureReason::Build => "the subgraphs could not be composed",
+        PluginFailureReason::Config => "the composition configuration was invalid",
+        PluginFailureReason::InternalFailure => "composition failed for an internal reason",
+        // `PluginFailureReason` is `#[non_exhaustive]`.
+        _ => "composition failed for an unknown reason",
+    }
+}
+
+/// These four are required trait methods, but they exist for consumers that splice JavaScript
+/// into individual phases. [`HybridComposition::experimental_compose`] is a provided method that
+/// is all-Rust and calls none of them, so implementing the trait is pure obligation.
+///
+/// `unreachable!()` is safe here rather than a fallback path because `apollo-composition` is
+/// pinned to an exact version, so this can only change on a deliberate bump — and
+/// [`tests::composes_two_subgraphs_natively`] drives the real code, so a bump that starts
+/// routing through a hook fails CI instead of panicking for a user.
+impl HybridComposition for NativeComposer {
+    async fn compose_services_without_satisfiability(
+        &mut self,
+        _subgraph_definitions: Vec<SubgraphDefinition>,
+    ) -> Option<apollo_composition::SupergraphSdl<'_>> {
+        unreachable!("{JS_HOOK_CALLED}")
+    }
+
+    async fn validate_satisfiability(&mut self) -> Result<Vec<Issue>, Vec<Issue>> {
+        unreachable!("{JS_HOOK_CALLED}")
+    }
+
+    fn update_supergraph_sdl(&mut self, _supergraph_sdl: String) {
+        unreachable!("{JS_HOOK_CALLED}")
+    }
+
+    fn add_issues<Source: Iterator<Item = Issue>>(&mut self, _issues: Source) {
+        unreachable!("{JS_HOOK_CALLED}")
+    }
+}
+
+const JS_HOOK_CALLED: &str = "apollo-composition called a JavaScript hook from experimental_compose, which it did not do \
+     at the pinned version; revisit the native composition path before bumping the crate";
+
+#[cfg(test)]
+mod tests {
+    use apollo_federation_types::{
+        build_plugin::BuildMessageLevel, composition::Severity, config::SchemaSource,
+        rover::BuildErrorType,
+    };
+    use rstest::rstest;
+    use semver::Version;
+    use speculoos::prelude::*;
+
+    use super::*;
+    use crate::composition::supergraph::config::full::FullyResolvedSubgraph;
+
+    fn subgraph(name: &str, sdl: &str) -> FullyResolvedSubgraph {
+        FullyResolvedSubgraph::builder()
+            .name(name.to_string())
+            .schema(sdl.to_string())
+            .routing_url(format!("http://{name}.example.com"))
+            .schema_source(SchemaSource::Sdl {
+                sdl: sdl.to_string(),
+            })
+            .build()
+    }
+
+    fn supergraph_config(
+        subgraphs: Vec<(&str, &str)>,
+        federation_version: FederationVersion,
+    ) -> FullyResolvedSupergraphConfig {
+        FullyResolvedSupergraphConfig::builder()
+            .subgraphs(
+                subgraphs
+                    .into_iter()
+                    .map(|(name, sdl)| (name.to_string(), subgraph(name, sdl)))
+                    .collect::<std::collections::BTreeMap<_, _>>(),
+            )
+            .federation_version(federation_version)
+            .build()
+    }
+
+    const FED_TWO_LINK: &str =
+        r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])"#;
+
+    /// Connectors needs its own `@link` and an `@source` to point connectors at.
+    const CONNECT_PREAMBLE: &str = r#"extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.10", import: ["@key"])
+      @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source", "@connect"])
+      @source(name: "api", http: { baseURL: "http://127.0.0.1" })"#;
+
+    fn connectors_subgraph(source: &str, selection: &str) -> String {
+        format!(
+            "{CONNECT_PREAMBLE}\n\
+             type Query {{ thing: Thing @connect(source: \"{source}\", \
+             http: {{ GET: \"/thing\" }}, selection: \"{selection}\") }}\n\
+             type Thing {{ id: ID! name: String }}"
+        )
+    }
+
+    /// `@cacheTag` comes from the federation spec at v2.12+, not from a separate `cacheTag` link
+    /// — linking one directly is an `INVALID_LINK_DIRECTIVE_USAGE` error instead. Both formats
+    /// here are invalid: `{ namedField }` is malformed, and `$args` is not allowed on an entity.
+    const CACHE_TAG_INVALID: &str = r#"extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@cacheTag"])
+    type Product @key(fields: "upc") @cacheTag(format: "{ namedField }") {
+      upc: String!
+      name: String
+    }
+    type Query {
+      topProducts(first: Int = 5): [Product] @cacheTag(format: "{$args}")
+    }"#;
+
+    /// Collects the codes of a `CompositionError::Build`, failing on any other variant.
+    fn build_error_codes(error: CompositionError) -> Vec<String> {
+        let CompositionError::Build { source, .. } = error else {
+            panic!("expected CompositionError::Build, got {error:?}");
+        };
+        source.iter().filter_map(|e| e.code.clone()).collect()
+    }
+
+    async fn compose_all(
+        subgraphs: Vec<(&str, &str)>,
+    ) -> Result<CompositionSuccess, CompositionError> {
+        let config = supergraph_config(subgraphs, FederationVersion::LatestFedTwo);
+        NativeComposer::new(config.federation_version())
+            .expect("LatestFedTwo is supported")
+            .compose(&config)
+            .await
+    }
+
+    /// The common case: an unpinned `supergraph.yaml` resolves to this.
+    #[test]
+    fn accepts_latest_fed_two() {
+        assert_that!(NativeComposer::new(&FederationVersion::LatestFedTwo).map(|_| ())).is_ok();
+    }
+
+    /// Spec features are backported, so pinning an older composition release is supported.
+    #[rstest]
+    #[case::oldest(Version::new(2, 0, 0))]
+    #[case::mid_range(Version::new(2, 9, 0))]
+    #[case::max_supported(Version::new(
+        MAX_SUPPORTED_FEDERATION_SPEC.0,
+        MAX_SUPPORTED_FEDERATION_SPEC.1,
+        0
+    ))]
+    fn accepts_exact_pins_within_spec_support(#[case] version: Version) {
+        assert_that!(NativeComposer::new(&FederationVersion::ExactFedTwo(version)).map(|_| ()))
+            .is_ok();
+    }
+
+    /// A pin above our spec range asks for features this build doesn't have, so it must fail
+    /// rather than compose at something older and call it that version.
+    #[test]
+    fn rejects_exact_pins_newer_than_spec_support() {
+        let too_new = Version::new(
+            MAX_SUPPORTED_FEDERATION_SPEC.0,
+            MAX_SUPPORTED_FEDERATION_SPEC.1 + 1,
+            0,
+        );
+        let error = NativeComposer::new(&FederationVersion::ExactFedTwo(too_new))
+            .expect_err("a pin newer than our spec support cannot be honoured");
+
+        assert_that!(matches!(
+            error,
+            CompositionError::NativeCompositionSpecTooNew { .. }
+        ))
+        .is_true();
+    }
+
+    #[rstest]
+    #[case::latest(FederationVersion::LatestFedOne)]
+    #[case::exact(FederationVersion::ExactFedOne(Version::new(0, 36, 0)))]
+    fn rejects_federation_one(#[case] version: FederationVersion) {
+        let error =
+            NativeComposer::new(&version).expect_err("native composition is federation 2 only");
+
+        assert_that!(matches!(
+            error,
+            CompositionError::NativeCompositionRequiresFedTwo { .. }
+        ))
+        .is_true();
+    }
+
+    /// Fails when the `supergraph` plugin version CI tests against has outrun what native
+    /// composition implements.
+    ///
+    /// This is the one signal that native composition is falling behind, and it deliberately
+    /// fails rather than warns: the bump that triggers it arrives as an automated Renovate PR, so
+    /// anything quieter would merge unnoticed.
+    ///
+    /// It lives here, in the fast unit-test leg, rather than in the e2e parity suite. The parity
+    /// tests pin their own version so that they keep working when the plugin moves ahead —
+    /// otherwise the coverage would go dark exactly when it matters, and every matrix leg would
+    /// red with a misleading message instead of this one.
+    #[test]
+    fn native_composition_keeps_up_with_the_plugin_version_ci_tests() {
+        const MANIFEST: &str = include_str!("../../../latest_plugin_versions.json");
+
+        let manifest: serde_json::Value =
+            serde_json::from_str(MANIFEST).expect("latest_plugin_versions.json is not valid JSON");
+        let latest = manifest["supergraph"]["versions"]["latest-2"]
+            .as_str()
+            .expect("`supergraph.versions.latest-2` is missing or not a string");
+        let latest = Version::parse(latest.trim_start_matches('v'))
+            .expect("`supergraph.versions.latest-2` is not a semver version");
+
+        let (major, minor) = MAX_SUPPORTED_FEDERATION_SPEC;
+        assert!(
+            (latest.major, latest.minor) <= (major, minor),
+            "CI tests against supergraph plugin {latest}, but native composition only implements \
+             federation specs up to {major}.{minor}, so it can no longer compose what the plugin \
+             can.\n\n\
+             To fix: bump `apollo-composition` in Cargo.toml and update \
+             MAX_SUPPORTED_FEDERATION_SPEC to the spec ceiling of the `apollo-federation` it \
+             pins.\n\n\
+             If native composition cannot catch up yet, this is the decision to make \
+             deliberately: users passing `--native-composition` will be unable to compose at the \
+             version everything else defaults to."
+        );
+    }
+
+    /// Pins [`MAX_SUPPORTED_FEDERATION_SPEC`] against what `apollo-federation` actually accepts,
+    /// from both directions: a subgraph at that spec must compose, and one at the next minor up
+    /// must be rejected. If the crate gains a spec version, the second half fails and the
+    /// constant needs bumping; if it drops one, the first half fails.
+    #[tokio::test]
+    async fn max_supported_federation_spec_is_accurate() {
+        async fn composes_at_spec(major: u64, minor: u64) -> bool {
+            let sdl = format!(
+                r#"extend schema @link(url: "https://specs.apollo.dev/federation/v{major}.{minor}", import: ["@key"])
+                type Query {{ thing: Thing }}
+                type Thing @key(fields: "id") {{ id: ID! }}"#
+            );
+            let config = supergraph_config(vec![("one", &sdl)], FederationVersion::LatestFedTwo);
+            NativeComposer::new(&FederationVersion::LatestFedTwo)
+                .expect("LatestFedTwo is accepted")
+                .compose(&config)
+                .await
+                .is_ok()
+        }
+
+        let (major, minor) = MAX_SUPPORTED_FEDERATION_SPEC;
+        assert!(
+            composes_at_spec(major, minor).await,
+            "expected federation spec v{major}.{minor} to be supported"
+        );
+        assert!(
+            !composes_at_spec(major, minor + 1).await,
+            "federation spec v{major}.{} now composes; bump MAX_SUPPORTED_FEDERATION_SPEC",
+            minor + 1
+        );
+    }
+
+    /// Real subgraphs through the real crate — no plugin binary, no JavaScript, no mocks.
+    #[tokio::test]
+    async fn composes_two_subgraphs_natively() {
+        let config = supergraph_config(
+            vec![
+                (
+                    "products",
+                    &format!(
+                        "{FED_TWO_LINK}
+                        type Query {{ products: [Product!]! }}
+                        type Product @key(fields: \"id\") {{ id: ID! name: String! }}"
+                    ),
+                ),
+                (
+                    "reviews",
+                    &format!(
+                        "{FED_TWO_LINK}
+                        type Query {{ reviews: [Review!]! }}
+                        type Review {{ id: ID! body: String! product: Product! }}
+                        type Product @key(fields: \"id\") {{ id: ID! }}"
+                    ),
+                ),
+            ],
+            FederationVersion::LatestFedTwo,
+        );
+
+        let composer = NativeComposer::new(config.federation_version())
+            .expect("LatestFedTwo is supported natively");
+
+        let success = composer
+            .compose(&config)
+            .await
+            .expect("two valid subgraphs should compose");
+
+        assert_that!(&success.supergraph_sdl).contains("PRODUCTS");
+        assert_that!(&success.supergraph_sdl).contains("REVIEWS");
+        assert_that!(&success.supergraph_sdl).contains("join__Graph");
+        // Contributed only by `reviews`, so this proves the merge happened.
+        assert_that!(&success.supergraph_sdl).contains("body");
+
+        assert_that!(&success.federation_version).is_equal_to(FederationVersion::LatestFedTwo);
+    }
+
+    /// Connectors validation and expansion live in `apollo-composition`, above plain merge, so
+    /// this is the one part of the pipeline that merge-only fixtures never reach.
+    #[tokio::test]
+    async fn expands_connectors_into_the_supergraph() {
+        let subgraph = connectors_subgraph("api", "id name");
+        let success = compose_all(vec![("api", &subgraph)])
+            .await
+            .expect("a valid connectors subgraph should compose");
+
+        // Both prove expansion actually ran, rather than the connector passing through untouched.
+        assert_that!(&success.supergraph_sdl).contains("specs.apollo.dev/connect");
+        assert_that!(&success.supergraph_sdl).contains(r#"@join__directive(name: "source""#);
+    }
+
+    /// Validation that only `apollo-composition` performs — connectors and `@cacheTag` — has to
+    /// reach the user through the same `CompositionError::Build` as a merge failure.
+    ///
+    /// The expected codes were observed from the pinned crate, so if it changes what it reports
+    /// these fail rather than silently altering Rover's output.
+    #[rstest]
+    #[case::connector_invalid_selection(connectors_subgraph("api", "id {"), "INVALID_SELECTION")]
+    #[case::connector_unknown_source(connectors_subgraph("nope", "id"), "SOURCE_NAME_MISMATCH")]
+    #[case::cache_tag_invalid_format(CACHE_TAG_INVALID.to_string(), "CACHE_TAG_INVALID_FORMAT")]
+    #[tokio::test]
+    async fn surfaces_validation_errors_as_build_errors(
+        #[case] sdl: String,
+        #[case] expected_code: &str,
+    ) {
+        let error = compose_all(vec![("api", &sdl)])
+            .await
+            .expect_err("this subgraph should fail validation");
+
+        let codes = build_error_codes(error);
+        assert_that!(&codes).contains(expected_code.to_string());
+    }
+
+    /// `Severity::Info` is the level most composition hints actually use, so it must survive as a
+    /// hint — neither dropped nor promoted into the error list.
+    #[rstest]
+    #[case::overridden_field_can_be_removed(
+        &format!("{FED_TWO_LINK}\ntype Query {{ t: T }}\ntype T @key(fields: \"id\") {{ id: ID! f: String }}"),
+        r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@override"])
+           type T @key(fields: "id") { id: ID! f: String @override(from: "a") }"#,
+        "OVERRIDDEN_FIELD_CAN_BE_REMOVED"
+    )]
+    #[case::inconsistent_but_compatible_field_type(
+        r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable"])
+           type Query { v: V }
+           type V { x: String @shareable }"#,
+        r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable"])
+           type V { x: String! @shareable }"#,
+        "INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE"
+    )]
+    #[tokio::test]
+    async fn reports_info_level_hints(
+        #[case] a: &str,
+        #[case] b: &str,
+        #[case] expected_code: &str,
+    ) {
+        let success = compose_all(vec![("a", a), ("b", b)])
+            .await
+            .expect("hints alone should not fail composition");
+
+        let codes: Vec<_> = success
+            .hints
+            .iter()
+            .filter_map(|h| h.code.clone())
+            .collect();
+        assert_that!(&codes).contains(expected_code.to_string());
+    }
+
+    /// Must surface as `CompositionError::Build` — the same variant the plugin produces — so
+    /// Rover's existing output and exit-code handling works unchanged.
+    #[tokio::test]
+    async fn reports_composition_errors_as_build_errors() {
+        let config = supergraph_config(
+            vec![
+                (
+                    "one",
+                    &format!(
+                        "{FED_TWO_LINK}
+                        type Query {{ thing: Thing }}
+                        type Thing @key(fields: \"id\") {{ id: ID! shared: Int! }}"
+                    ),
+                ),
+                (
+                    "two",
+                    &format!(
+                        "{FED_TWO_LINK}
+                        type Query {{ other: Thing }}
+                        type Thing @key(fields: \"id\") {{ id: ID! shared: String! }}"
+                    ),
+                ),
+            ],
+            FederationVersion::LatestFedTwo,
+        );
+
+        let error = NativeComposer::new(config.federation_version())
+            .expect("LatestFedTwo is supported natively")
+            .compose(&config)
+            .await
+            .expect_err("mismatched field types should fail composition");
+
+        let CompositionError::Build { source, .. } = error else {
+            panic!("expected CompositionError::Build, got {error:?}");
+        };
+
+        assert_that!(&source.iter().count()).is_greater_than(0);
+        // Errors must be typed as composition errors so Rover's error codes stay correct.
+        assert_that!(
+            &source
+                .iter()
+                .all(|e| e.get_type() == BuildErrorType::Composition)
+        )
+        .is_true();
+    }
+
+    /// `experimental_compose` appends WARN-level merge hints to the error list it returns, and
+    /// `BuildError::from` ignores level — so without filtering these would reach the user as
+    /// composition errors.
+    #[test]
+    fn keeps_only_errors_from_a_mixed_severity_failure() {
+        let issue = |code: &str, severity| Issue {
+            code: code.to_string(),
+            message: format!("{code} message"),
+            locations: vec![],
+            severity,
+        };
+
+        let error = into_composition_result(
+            Err(vec![
+                issue("REAL_ERROR", Severity::Error),
+                issue("JUST_A_HINT", Severity::Warning),
+            ]),
+            FederationVersion::LatestFedTwo,
+        )
+        .expect_err("an Err from composition is a failure");
+
+        let CompositionError::Build { source, .. } = error else {
+            panic!("expected CompositionError::Build, got {error:?}");
+        };
+
+        let codes: Vec<_> = source.iter().filter_map(|e| e.code.clone()).collect();
+        assert_that!(&codes).is_equal_to(vec!["REAL_ERROR".to_string()]);
+    }
+
+    #[test]
+    fn treats_error_level_messages_as_failure_even_when_composition_claims_success() {
+        let result = into_composition_result(
+            Ok(PluginResult::new(
+                Ok("type Query { hello: String }".to_string()),
+                vec![BuildMessage::new_error(
+                    "something went wrong".to_string(),
+                    None,
+                    Some("SOME_ERROR".to_string()),
+                )],
+            )),
+            FederationVersion::LatestFedTwo,
+        );
+
+        assert_that!(matches!(result, Err(CompositionError::Build { .. }))).is_true();
+    }
+
+    #[test]
+    fn keeps_every_non_error_message_as_a_hint() {
+        let message = |text: &str, level| {
+            let mut message = BuildMessage::new_error(text.to_string(), None, None);
+            message.level = level;
+            message
+        };
+
+        let success = into_composition_result(
+            Ok(PluginResult::new(
+                Ok("type Query { hello: String }".to_string()),
+                vec![
+                    message("a warning", BuildMessageLevel::Warn),
+                    message("some info", BuildMessageLevel::Info),
+                    // `HintLevel::Debug` is a low-importance composition hint, and the plugin
+                    // reports it, so dropping it here would lose parity.
+                    message("a debug hint", BuildMessageLevel::Debug),
+                ],
+            )),
+            FederationVersion::LatestFedTwo,
+        )
+        .expect("non-error messages should not fail composition");
+
+        let messages: Vec<_> = success.hints.iter().map(|h| h.message.clone()).collect();
+        assert_that!(&messages).is_equal_to(vec![
+            "a warning".to_string(),
+            "some info".to_string(),
+            "a debug hint".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn inline_plugin_failure_always_produces_at_least_one_error() {
+        let result = into_composition_result(
+            Ok(PluginResult::new_failure(
+                vec![],
+                PluginFailureReason::InternalFailure,
+            )),
+            FederationVersion::LatestFedTwo,
+        );
+
+        let Err(CompositionError::Build { source, .. }) = result else {
+            panic!("expected a build failure");
+        };
+        assert_that!(&source.iter().count()).is_equal_to(1);
+    }
+}

--- a/src/options/license.rs
+++ b/src/options/license.rs
@@ -16,10 +16,44 @@ pub struct LicenseAccepter {
     pub(crate) elv2_license_accepted: Option<bool>,
 }
 
+/// What the user is being asked to accept the ELv2 license for.
+///
+/// Acceptance is recorded once per machine and covers every ELv2-licensed thing
+/// Rover can run, so the two are interchangeable once accepted.
+#[derive(Debug, Clone, Copy)]
+pub enum Elv2Subject {
+    /// Downloading and running an ELv2-licensed plugin binary, such as `supergraph`.
+    Plugin,
+    /// Composing with the ELv2-licensed composition code compiled into Rover itself. No
+    /// download happens, but the licensed code still runs, so acceptance is still required.
+    NativeComposition,
+}
+
+impl Elv2Subject {
+    const fn prompt_preamble(self) -> &'static str {
+        match self {
+            Self::Plugin => {
+                "By installing this plugin, you accept the terms and conditions outlined by this license."
+            }
+            Self::NativeComposition => {
+                "By invoking composition, you accept the terms and conditions outlined by this license."
+            }
+        }
+    }
+}
+
 impl LicenseAccepter {
     pub fn require_elv2_license(&self, client_config: &StudioClientConfig) -> RoverResult<()> {
+        self.require_elv2_license_for(client_config, Elv2Subject::Plugin)
+    }
+
+    pub fn require_elv2_license_for(
+        &self,
+        client_config: &StudioClientConfig,
+        subject: Elv2Subject,
+    ) -> RoverResult<()> {
         let did_accept = self.previously_accepted(client_config)?;
-        if did_accept || self.prompt_accept(client_config)? {
+        if did_accept || self.prompt_accept(client_config, subject)? {
             Ok(())
         } else {
             Err(RoverError::new(anyhow!(
@@ -43,7 +77,11 @@ impl LicenseAccepter {
         )
     }
 
-    fn prompt_accept(&self, client_config: &StudioClientConfig) -> RoverResult<bool> {
+    fn prompt_accept(
+        &self,
+        client_config: &StudioClientConfig,
+        subject: Elv2Subject,
+    ) -> RoverResult<bool> {
         // If we're not attached to a TTY then we can't get user input, so there's
         // nothing to do except inform the user about the `--elv2-license` flag.
         if !std::io::stdin().is_terminal() {
@@ -57,9 +95,7 @@ impl LicenseAccepter {
             err.set_suggestion(RoverErrorSuggestion::Adhoc(suggestion));
             Err(err)
         } else {
-            eprintln!(
-                "By installing this plugin, you accept the terms and conditions outlined by this license."
-            );
+            eprintln!("{}", subject.prompt_preamble());
             eprintln!(
                 "More information on the ELv2 license can be found here: https://go.apollo.dev/elv2."
             );
@@ -82,5 +118,24 @@ fn license_accept(elv2_license: &str) -> std::result::Result<bool, anyhow::Error
         Ok(true)
     } else {
         Err(anyhow!("Allowed values: 'accept'"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Native composition installs nothing, so the plugin wording would be misleading. The exact
+    /// phrasing is free to change; not claiming an install is the part that has to hold.
+    #[test]
+    fn native_composition_preamble_does_not_mention_installing() {
+        let preamble = Elv2Subject::NativeComposition.prompt_preamble();
+        assert!(!preamble.contains("install"), "got: {preamble}");
+        assert!(preamble.contains("accept"), "got: {preamble}");
+    }
+
+    #[test]
+    fn plugin_preamble_still_mentions_installing() {
+        assert!(Elv2Subject::Plugin.prompt_preamble().contains("installing"));
     }
 }

--- a/tests/e2e/supergraph/composition_parity.rs
+++ b/tests/e2e/supergraph/composition_parity.rs
@@ -1,0 +1,366 @@
+//! Parity between native composition and the `supergraph` plugin binary.
+//!
+//! Each scenario is composed twice through the real CLI — once with `--native-composition`, once
+//! with the plugin and the outputs (including warnings and hints) are compared.
+
+use std::{collections::BTreeSet, path::Path, process::Command};
+
+use assert_cmd::cargo;
+use rstest::rstest;
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// The federation version both paths are pinned to.
+///
+/// Deliberately a constant rather than the smoke matrix's
+/// `APOLLO_ROVER_DEV_COMPOSITION_VERSION`. Inheriting that coupled this suite to Renovate's
+/// plugin bumps: the moment the plugin moved past what native composition implements, every case
+/// here failed, so parity went unverified exactly when a version had changed. Pinning
+/// independently keeps the comparison working;
+/// `native_composition_keeps_up_with_the_plugin_version_ci_tests` is the single check that
+/// notices native falling behind.
+///
+/// When changing this: it must be a published `supergraph` release at or below
+/// `MAX_SUPPORTED_FEDERATION_SPEC`. Both paths must use the *same* version, or any difference is
+/// meaningless — plugin generations differ in SDL formatting and hint wording.
+const PARITY_FEDERATION_VERSION: &str = "2.15.1";
+
+/// Writes subgraph SDL plus a pinned `supergraph.yaml` into a fresh directory.
+fn write_fixture(subgraphs: &[(&str, String)]) -> TempDir {
+    let dir = TempDir::new().expect("could not create temp dir");
+
+    let mut config = format!("federation_version: ={PARITY_FEDERATION_VERSION}\n");
+    config.push_str("subgraphs:\n");
+
+    for (name, sdl) in subgraphs {
+        let file = format!("{name}.graphql");
+        std::fs::write(dir.path().join(&file), sdl).expect("could not write subgraph sdl");
+        config.push_str(&format!(
+            "  {name}:\n    routing_url: http://{name}.invalid\n    schema:\n      file: ./{file}\n"
+        ));
+    }
+
+    std::fs::write(dir.path().join("supergraph.yaml"), config)
+        .expect("could not write supergraph.yaml");
+    dir
+}
+
+/// Runs `rover supergraph compose` in `dir` and returns its parsed JSON.
+fn compose(dir: &Path, native: bool) -> Value {
+    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+    cmd.args([
+        "supergraph",
+        "compose",
+        "--config",
+        "supergraph.yaml",
+        "--format",
+        "json",
+        "--elv2-license",
+        "accept",
+    ]);
+    if native {
+        cmd.arg("--native-composition");
+    }
+    cmd.current_dir(dir);
+
+    let output = cmd
+        .output()
+        .expect("could not run `rover supergraph compose`");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    serde_json::from_str(&stdout).unwrap_or_else(|err| {
+        panic!(
+            "`rover supergraph compose` did not emit JSON ({err})\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// `(code, message)` for every entry of `data.hints`.
+fn hints(output: &Value) -> BTreeSet<(String, String)> {
+    message_pairs(output.pointer("/data/hints"))
+}
+
+/// `(code, message)` for every entry of `error.details.build_errors`.
+///
+/// Node locations are deliberately excluded: they are derived from the input SDL, which is
+/// identical for both paths, so they add no signal while making the assertion brittle against
+/// either path changing its location reporting.
+fn build_errors(output: &Value) -> BTreeSet<(String, String)> {
+    message_pairs(output.pointer("/error/details/build_errors"))
+}
+
+fn message_pairs(value: Option<&Value>) -> BTreeSet<(String, String)> {
+    value
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .map(|entry| {
+                    let field = |key: &str| {
+                        entry
+                            .get(key)
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string()
+                    };
+                    (field("code"), field("message"))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Splits SDL into top-level definitions with internal whitespace collapsed.
+///
+/// Compared as a set rather than as text because plugin generations differ in how they format
+/// and order definitions and those are purely cosmetic differences.
+fn definitions(sdl: &str) -> BTreeSet<String> {
+    let mut definitions = BTreeSet::new();
+    let mut current = String::new();
+    let mut depth = 0usize;
+
+    for line in sdl.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() && depth == 0 {
+            continue;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(trimmed);
+        depth += trimmed.matches('{').count();
+        depth = depth.saturating_sub(trimmed.matches('}').count());
+
+        // A definition ends at depth zero: either it closed its braces, or it never had any
+        // (a `directive`, `scalar`, or `extend` line).
+        if depth == 0 {
+            definitions.insert(current.split_whitespace().collect::<Vec<_>>().join(" "));
+            current.clear();
+        }
+    }
+    if !current.trim().is_empty() {
+        definitions.insert(current.split_whitespace().collect::<Vec<_>>().join(" "));
+    }
+    definitions
+}
+
+const FED_TWO: &str =
+    r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])"#;
+const FED_TWO_SHAREABLE: &str = r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable"])"#;
+
+fn two_subgraph_baseline() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "products",
+            format!(
+                "{FED_TWO}\ntype Query {{ products: [Product!]! }}\n\
+                 type Product @key(fields: \"id\") {{ id: ID! name: String! }}"
+            ),
+        ),
+        (
+            "reviews",
+            format!(
+                "{FED_TWO}\ntype Query {{ reviews: [Review!]! }}\n\
+                 type Review {{ id: ID! body: String! product: Product! }}\n\
+                 type Product @key(fields: \"id\") {{ id: ID! }}"
+            ),
+        ),
+    ]
+}
+
+/// Produces a `Debug`-level `INCONSISTENT_OBJECT_VALUE_TYPE_FIELD` hint on an otherwise clean
+/// composition. This is the shape that caught hints being dropped from successful output.
+fn debug_hint() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "a",
+            format!(
+                "{FED_TWO_SHAREABLE}\ntype Query {{ v: V }}\n\
+                 type V {{ shared: String @shareable onlyInA: String }}"
+            ),
+        ),
+        (
+            "b",
+            format!("{FED_TWO_SHAREABLE}\ntype V {{ shared: String @shareable }}"),
+        ),
+    ]
+}
+
+/// Produces an `Info`-level `OVERRIDDEN_FIELD_CAN_BE_REMOVED` hint.
+fn info_hint() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "a",
+            format!("{FED_TWO}\ntype Query {{ t: T }}\ntype T @key(fields: \"id\") {{ id: ID! f: String }}"),
+        ),
+        (
+            "b",
+            r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@override"])
+               type T @key(fields: "id") { id: ID! f: String @override(from: "a") }"#
+                .to_string(),
+        ),
+    ]
+}
+
+/// A connectors subgraph, so the parity check covers `apollo-composition`'s connector
+/// validation and expansion rather than plain merge alone.
+fn connectors() -> Vec<(&'static str, String)> {
+    vec![(
+        "api",
+        r#"extend schema
+             @link(url: "https://specs.apollo.dev/federation/v2.10", import: ["@key"])
+             @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source", "@connect"])
+             @source(name: "api", http: { baseURL: "http://127.0.0.1" })
+           type Query {
+             thing: Thing @connect(source: "api", http: { GET: "/thing" }, selection: "id name")
+           }
+           type Thing { id: ID! name: String }"#
+            .to_string(),
+    )]
+}
+
+/// Two subgraphs disagreeing on a field type: a plain composition failure.
+fn field_type_mismatch() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "one",
+            format!(
+                "{FED_TWO}\ntype Query {{ thing: Thing }}\ntype Thing @key(fields: \"id\") {{ id: ID! shared: Int! }}"
+            ),
+        ),
+        (
+            "two",
+            format!(
+                "{FED_TWO}\ntype Query {{ other: Thing }}\ntype Thing @key(fields: \"id\") {{ id: ID! shared: String! }}"
+            ),
+        ),
+    ]
+}
+
+/// A failure that *also* produces a hint. This is the shape that caught hints being promoted
+/// into the error list, which inflated the reported error count.
+fn mixed_severity_failure() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "a",
+            format!(
+                "{FED_TWO_SHAREABLE}\ntype Query {{ v: V }}\ntype V {{ shared: String onlyInA: String }}"
+            ),
+        ),
+        (
+            "b",
+            format!("{FED_TWO_SHAREABLE}\ntype V {{ shared: String }}"),
+        ),
+    ]
+}
+
+/// `@cacheTag` validation, which `apollo-composition` runs before anything else.
+fn cache_tag_failure() -> Vec<(&'static str, String)> {
+    vec![(
+        "api",
+        r#"extend schema
+             @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@cacheTag"])
+           type Product @key(fields: "upc") @cacheTag(format: "{ namedField }") {
+             upc: String!
+             name: String
+           }
+           type Query {
+             topProducts(first: Int = 5): [Product] @cacheTag(format: "{$args}")
+           }"#
+        .to_string(),
+    )]
+}
+
+#[rstest]
+#[case::two_subgraph_baseline(two_subgraph_baseline())]
+#[case::debug_level_hint(debug_hint())]
+#[case::info_level_hint(info_hint())]
+#[case::connectors(connectors())]
+#[case::field_type_mismatch(field_type_mismatch())]
+#[case::mixed_severity_failure(mixed_severity_failure())]
+#[case::cache_tag_failure(cache_tag_failure())]
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn native_composition_matches_the_plugin(#[case] subgraphs: Vec<(&'static str, String)>) {
+    let native_dir = write_fixture(&subgraphs);
+    let plugin_dir = write_fixture(&subgraphs);
+
+    let native = compose(native_dir.path(), true);
+    let plugin = compose(plugin_dir.path(), false);
+
+    // Guards the invariant documented on `PARITY_FEDERATION_VERSION`: it must stay within what
+    // native composition implements, or there is nothing to compare.
+    let native_error = native
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        !native_error.contains("newer than the federation spec"),
+        "PARITY_FEDERATION_VERSION ({PARITY_FEDERATION_VERSION}) is beyond what native \
+         composition implements, so these tests cannot compare the two paths. Lower it to a \
+         published `supergraph` release within MAX_SUPPORTED_FEDERATION_SPEC.\n\n\
+         Native reported: {native_error}",
+    );
+
+    let native_success = native.pointer("/data/success").and_then(Value::as_bool);
+    let plugin_success = plugin.pointer("/data/success").and_then(Value::as_bool);
+    assert_eq!(
+        native_success, plugin_success,
+        "native and plugin disagree on success\nnative: {native:#}\nplugin: {plugin:#}"
+    );
+
+    // Both are pinned, so both should echo the pin. (Left unpinned they legitimately differ:
+    // native echoes the resolved config, `2`, while the plugin names the binary it installed.)
+    assert_eq!(
+        native.pointer("/data/federation_version"),
+        plugin.pointer("/data/federation_version"),
+        "native and plugin report different federation versions"
+    );
+
+    assert_eq!(
+        hints(&native),
+        hints(&plugin),
+        "native and plugin produced different hints"
+    );
+
+    assert_eq!(
+        build_errors(&native),
+        build_errors(&plugin),
+        "native and plugin produced different build errors"
+    );
+
+    if native_success == Some(true) {
+        let sdl = |output: &Value| {
+            output
+                .pointer("/data/core_schema")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        let (native_sdl, plugin_sdl) = (sdl(&native), sdl(&plugin));
+        assert!(
+            !native_sdl.is_empty(),
+            "native composition succeeded but produced no supergraph"
+        );
+
+        let (native_definitions, plugin_definitions) =
+            (definitions(&native_sdl), definitions(&plugin_sdl));
+        assert_eq!(
+            native_definitions.difference(&plugin_definitions).count(),
+            0,
+            "native produced definitions the plugin did not:\n{:#?}",
+            native_definitions
+                .difference(&plugin_definitions)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            plugin_definitions.difference(&native_definitions).count(),
+            0,
+            "the plugin produced definitions native did not:\n{:#?}",
+            plugin_definitions
+                .difference(&native_definitions)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/tests/e2e/supergraph/mod.rs
+++ b/tests/e2e/supergraph/mod.rs
@@ -1,3 +1,6 @@
 mod compose;
+/// Only builds when native composition is compiled in; release artifacts do not enable it.
+#[cfg(feature = "composition-rust")]
+mod composition_parity;
 mod config;
 mod fetch;


### PR DESCRIPTION
Adds a native, in-process composition path via the `apollo-composition` crate, alongside the existing `supergraph` plugin binary path.
