### PR TITLE
Switch all multi-job workflows to use aggregation and change gates

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,82 @@
+on:
+  pull_request:
+    # `edited` is here so that ticking the opt-out checkbox in the description
+    # re-evaluates the check. It lives in this workflow alone: any workflow that
+    # fires on `edited` reports a fresh verdict for every description tweak, and
+    # a workflow that also runs real jobs cannot do that without either
+    # re-running them or reporting a verdict derived from nothing.
+    types: [opened, synchronize, reopened, edited]
+  merge_group:
+
+# A burst of description edits produces a run per edit, each reading a different
+# snapshot of the body, and the last one to finish wins the check regardless of
+# which snapshot it saw. Superseding the in-flight run keeps the newest body
+# authoritative. Safe to cancel here because this job is cheap and side-effect
+# free, which is not true of the suites in checks.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# `gh pr diff` reads GET /pulls/{n}/files, so `pull-requests: read` is the actual
+# dependency. The repository default is currently `write` on everything, so
+# stating it here both documents the need and drops the rest.
+permissions:
+  contents: read
+  pull-requests: read
+
+name: Changelog
+jobs:
+  changelog:
+    name: Changelog Entry
+    # Admits `merge_group` while the only step below excludes it, so a merge
+    # group deliberately runs this as a no-op: a required context has to report
+    # on the merge-group ref, and there is nothing left to check by then because
+    # the pull request already passed.
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+       !contains(fromJSON('["renovate[bot]", "dependabot[bot]"]'), github.event.pull_request.user.login))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a CHANGELOG.md entry or opt-out checkbox
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # `set -eu` deliberately without `pipefail`: every pipeline below is a
+          # `printf | grep -q` guard, and `grep -q` exits on its first match,
+          # which can SIGPIPE the `printf`. Under `pipefail` that non-zero status
+          # would mask a successful match and invert the check on a diff large
+          # enough to fill the pipe buffer.
+          set -eu
+
+          # Guarded so an API failure reports itself as one. The default `run:`
+          # shell is `bash -e`, so a bare assignment would already abort here,
+          # but it would surface as a raw git/gh error rather than something an
+          # author can act on. Failing closed is right for this check: unlike the
+          # change classifier there is no conservative fallback to take.
+          if ! CHANGED_FILES="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"; then
+            echo '::error::Could not read the pull request diff to check for a changelog entry. This is an API failure, not a missing entry; re-run the job.'
+            exit 1
+          fi
+
+          if printf '%s\n' "$CHANGED_FILES" | grep -qx "CHANGELOG.md"; then
+            echo "CHANGELOG.md was updated in this PR."
+            exit 0
+          fi
+
+          if ! printf '%s\n' "$CHANGED_FILES" | grep -qvE '^docs/'; then
+            echo "This PR only touches docs/, no changelog entry required."
+            exit 0
+          fi
+
+          if printf '%s\n' "$PR_BODY" | grep -qiE '^\s*-?\s*\[[xX]\]\s*a changelog\.md entry is not needed'; then
+            echo "PR description confirms a changelog entry is not needed."
+            exit 0
+          fi
+
+          echo "::error::This PR doesn't modify CHANGELOG.md. Add an entry under 'Unreleased' (see CONTRIBUTING.md), or check the 'A CHANGELOG.md entry is not needed for this PR' box in the PR description."
+          exit 1

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,16 +1,32 @@
 on:
+  # No `paths:` filter. This check is required, and a workflow-level path filter
+  # never creates a check run at all, so a required context would wait forever.
+  # The gating lives on the job instead, via Detect Changes.
   pull_request:
-    paths:
-      - "**/*.md"
+  merge_group:
   schedule:
     - cron: '0 0 * * *'
 
-permissions: {}
+# Raised from `permissions: {}` because Detect Changes needs `pull-requests: read`
+# to read the diff, and a called workflow can never hold more than its caller.
+permissions:
+  contents: read
+  pull-requests: read
 
 name: Check Markdown Links
 jobs:
+  changes:
+    name: Detect Changes
+    uses: ./.github/workflows/detect-changes.yml
+
   check-links:
+    needs: changes
+    if: needs.changes.outputs.markdown == 'true'
     runs-on: ubuntu-latest
+    # This file deliberately ran on `permissions: {}` before. Only `changes`
+    # needs to read the diff, so keep that grant off this job.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -22,3 +38,47 @@ jobs:
           max_attempts: 3
           timeout_minutes: 5
           command: mise run check-links
+
+  # The single context branch protection requires from this workflow. See the
+  # equivalent job in checks.yml for why this shape is necessary.
+  link_check_complete:
+    name: Link Check Complete
+    if: always()
+    needs: [changes, check-links]
+    runs-on: ubuntu-latest
+    steps:
+      # See the equivalent step in checks.yml: without this, a broken
+      # classification output skips the check and still reports a green
+      # aggregate.
+      - name: Fail if Detect Changes produced no classification
+        if: >-
+          ${{
+               needs.changes.result != 'success'
+            || (needs.changes.outputs.markdown != 'true' && needs.changes.outputs.markdown != 'false')
+          }}
+        env:
+          RESULT: ${{ needs.changes.result }}
+          MARKDOWN: ${{ needs.changes.outputs.markdown }}
+        run: |
+          echo "::error::Detect Changes did not classify this change (result='$RESULT', markdown='$MARKDOWN')."
+          exit 1
+
+      - name: Fail if a check failed or was cancelled
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}
+        run: |
+          echo '::error::The markdown link check failed or was cancelled.'
+          exit 1
+
+      - name: Fail if the link check was skipped despite markdown changes
+        if: >-
+          ${{
+            needs.changes.outputs.markdown == 'true'
+              && needs['check-links'].result == 'skipped'
+          }}
+        run: |
+          echo '::error::The link check was skipped even though this change touches markdown it reads. Check the job if: conditions in check-links.yml.'
+          exit 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,52 +2,20 @@ on:
   push:
     branches:
       - main
+  # Deliberately the default types (opened, synchronize, reopened) — no `edited`.
+  # Editing a description cannot change what any job here would conclude, and a
+  # run triggered by an edit would have to either repeat the whole suite or skip
+  # it and report a verdict derived from nothing, overwriting the real run's
+  # result for the same commit. The changelog check is the one thing that does
+  # care about the description, and it lives in changelog.yml for that reason.
   pull_request:
-    types: [opened, synchronize, reopened, edited]
   merge_group:
 
 name: Commit Checks
 jobs:
   changes:
     name: Detect Changes
-    if: github.event.action != 'edited'
     uses: ./.github/workflows/detect-changes.yml
-
-  changelog:
-    name: Changelog Entry
-    if: >-
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
-       !contains(fromJSON('["renovate[bot]", "dependabot[bot]"]'), github.event.pull_request.user.login))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for a CHANGELOG.md entry or opt-out checkbox
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          CHANGED_FILES="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"
-
-          if printf '%s\n' "$CHANGED_FILES" | grep -qx "CHANGELOG.md"; then
-            echo "CHANGELOG.md was updated in this PR."
-            exit 0
-          fi
-
-          if ! printf '%s\n' "$CHANGED_FILES" | grep -qvE '^docs/'; then
-            echo "This PR only touches docs/, no changelog entry required."
-            exit 0
-          fi
-
-          if printf '%s\n' "$PR_BODY" | grep -qiE '^\s*-?\s*\[[xX]\]\s*a changelog\.md entry is not needed'; then
-            echo "PR description confirms a changelog entry is not needed."
-            exit 0
-          fi
-
-          echo "::error::This PR doesn't modify CHANGELOG.md. Add an entry under 'Unreleased' (see CONTRIBUTING.md), or check the 'A CHANGELOG.md entry is not needed for this PR' box in the PR description."
-          exit 1
 
   cargo-deny:
     name: Cargo Deny
@@ -228,7 +196,6 @@ jobs:
     if: always()
     needs:
       - changes
-      - changelog
       - cargo-deny
       - fmt
       - clippy
@@ -268,7 +235,6 @@ jobs:
       # a docs-only pull request merge. The flip side is that a mistake in a
       # job's `if:` would skip the Rust suite and still go green, so assert that
       # nothing was skipped once Detect Changes says the change touches code.
-      # `changelog` is exempt: it skips on purpose for Renovate and Dependabot.
       - name: Fail if a check was skipped despite code changes
         if: >-
           ${{

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -158,18 +158,23 @@ jobs:
     container: ghcr.io/apollographql/ci-utility-docker-images/apollo-rust-builder:0.30.10
 
     steps:
+    # No `ref:` override. It used to be `github.head_ref || github.ref_name`,
+    # which is a bare branch name resolved against the base repository, so it
+    # matched nothing on a pull request from a fork and checkout failed there —
+    # see run 30554828564 on #3558. That was survivable only while this job sat
+    # outside the required set; it is inside the aggregator now, so with
+    # `enforce_admins: true` it would have made every fork pull request
+    # unmergeable by anyone. Defaulting also means this job tests the same
+    # `refs/pull/N/merge` commit as every other job in this workflow, rather
+    # than the branch tip. Nothing downstream needs a named branch:
+    # check-glibc.sh only objdumps target/debug/rover.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ github.head_ref || github.ref_name }}
+    # Still required: the container runs as a different user than the one that
+    # owns the checkout.
     - name: Fix git ownership
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - name: Debug git state
-      run: |
-        git status
-        git branch -a
-        git log --oneline -1
-        git symbolic-ref HEAD || echo "Detached HEAD detected"
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
     - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       with:
@@ -189,8 +194,9 @@ jobs:
   # adding, renaming or gating a job above no longer means hand-editing the list
   # of required status checks in the repository settings.
   #
-  # `test_minimal_glibc` is deliberately absent from `needs`: it is advisory
-  # today and stays advisory.
+  # Every job in this workflow is listed in `needs`, deliberately. There is no
+  # advisory tier: a check worth running on every pull request is worth blocking
+  # on, and a job that is only sometimes trusted is a job nobody reads.
   commit_checks_complete:
     name: Commit Checks Complete
     if: always()
@@ -201,6 +207,7 @@ jobs:
       - clippy
       - test
       - test_installers
+      - test_minimal_glibc
     runs-on: ubuntu-latest
     steps:
       # Every gate in this workflow keys on `code`, so if that output breaks —
@@ -244,6 +251,7 @@ jobs:
               || needs.clippy.result == 'skipped'
               || needs.test.result == 'skipped'
               || needs.test_installers.result == 'skipped'
+              || needs.test_minimal_glibc.result == 'skipped'
             )
           }}
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,11 @@ on:
 
 name: Commit Checks
 jobs:
+  changes:
+    name: Detect Changes
+    if: github.event.action != 'edited'
+    uses: ./.github/workflows/detect-changes.yml
+
   changelog:
     name: Changelog Entry
     if: >-
@@ -46,7 +51,8 @@ jobs:
 
   cargo-deny:
     name: Cargo Deny
-    if: github.event.action != 'edited'
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -67,7 +73,8 @@ jobs:
 
   fmt:
     name: Format
-    if: github.event.action != 'edited'
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -82,7 +89,8 @@ jobs:
 
   clippy:
     name: Clippy
-    if: github.event.action != 'edited'
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -95,7 +103,12 @@ jobs:
       run: cargo clippy --locked --workspace --all-features --all-targets
 
   test_installers:
-    needs: test
+    # Gated explicitly as well as transitively. `needs: test` alone would skip
+    # this correctly today, but relying on that propagation makes it the one job
+    # whose gating is invisible at the job level. `changes` has to be in `needs`
+    # for `needs.changes` to resolve at all.
+    needs: [changes, test]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       matrix:
         runner: [ubuntu-latest, macos-latest, windows-latest]
@@ -132,7 +145,8 @@ jobs:
           ROVER_PACKAGES_BASE: ${{ github.workspace }}
 
   test:
-    if: github.event.action != 'edited'
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       matrix:
         runner: [ubuntu-latest, macos-latest, windows-latest]
@@ -170,7 +184,8 @@ jobs:
 
   test_minimal_glibc:
     name: Test with minimal glibc versions
-    if: github.event.action != 'edited'
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     container: ghcr.io/apollographql/ci-utility-docker-images/apollo-rust-builder:0.30.10
 
@@ -201,3 +216,70 @@ jobs:
         command: mise install
     - run: mise run test
     - run: mise run check-glibc
+
+  # Branch protection requires this job and nothing else from this workflow, so
+  # adding, renaming or gating a job above no longer means hand-editing the list
+  # of required status checks in the repository settings.
+  #
+  # `test_minimal_glibc` is deliberately absent from `needs`: it is advisory
+  # today and stays advisory.
+  commit_checks_complete:
+    name: Commit Checks Complete
+    if: always()
+    needs:
+      - changes
+      - changelog
+      - cargo-deny
+      - fmt
+      - clippy
+      - test
+      - test_installers
+    runs-on: ubuntu-latest
+    steps:
+      # Every gate in this workflow keys on `code`, so if that output breaks —
+      # renamed, or a mistyped step id making it resolve to '' — every job skips
+      # and the checks below have nothing left to object to. Assert the
+      # classifier ran and returned one of its two values, so a broken gate
+      # fails loudly instead of reporting a green aggregate over no work.
+      - name: Fail if Detect Changes produced no classification
+        if: >-
+          ${{
+               needs.changes.result != 'success'
+            || (needs.changes.outputs.code != 'true' && needs.changes.outputs.code != 'false')
+          }}
+        env:
+          RESULT: ${{ needs.changes.result }}
+          CODE: ${{ needs.changes.outputs.code }}
+        run: |
+          echo "::error::Detect Changes did not classify this change (result='$RESULT', code='$CODE')."
+          exit 1
+
+      - name: Fail if a check failed or was cancelled
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}
+        run: |
+          echo '::error::A commit check failed or was cancelled.'
+          exit 1
+
+      # Branch protection counts a skipped job as satisfied, which is what lets
+      # a docs-only pull request merge. The flip side is that a mistake in a
+      # job's `if:` would skip the Rust suite and still go green, so assert that
+      # nothing was skipped once Detect Changes says the change touches code.
+      # `changelog` is exempt: it skips on purpose for Renovate and Dependabot.
+      - name: Fail if a check was skipped despite code changes
+        if: >-
+          ${{
+            needs.changes.outputs.code == 'true' && (
+                 needs['cargo-deny'].result == 'skipped'
+              || needs.fmt.result == 'skipped'
+              || needs.clippy.result == 'skipped'
+              || needs.test.result == 'skipped'
+              || needs.test_installers.result == 'skipped'
+            )
+          }}
+        run: |
+          echo '::error::A Rust check was skipped even though this change touches code. Check the job if: conditions in checks.yml.'
+          exit 1

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -6,11 +6,16 @@ on:
           'true' when this change can affect the outcome of a cargo build, test,
           clippy, fmt or deny run.
         value: ${{ jobs.detect.outputs.code }}
+      markdown:
+        description: >-
+          'true' when this change touches a markdown file that the link checker
+          actually reads.
+        value: ${{ jobs.detect.outputs.markdown }}
 
 # `gh pr diff` reads GET /pulls/{n}/files, so `pull-requests: read` is the actual
 # dependency and is worth stating rather than inheriting. The repository default
 # is currently `write` on everything, so this is a reduction; a called workflow
-# can never hold more than its caller, and every caller here takes the default.
+# can never hold more than its caller, so every caller must grant at least this.
 permissions:
   contents: read
   pull-requests: read
@@ -21,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      markdown: ${{ steps.filter.outputs.markdown }}
     steps:
       - name: Classify the changed files
         id: filter
@@ -32,28 +38,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Only pull requests get filtered. Pushes to main and merge queue runs
-          # always exercise the full suite, so the last gate before main never
-          # depends on the classification below being right.
-          if [ "$EVENT_NAME" != 'pull_request' ]; then
-            echo "Event is '$EVENT_NAME' rather than a pull request; running everything."
+          # Every fallback runs the full suite: a classifier that cannot see the
+          # diff must not be the reason something goes unchecked.
+          run_everything() {
+            echo "$1"
             echo 'code=true' >> "$GITHUB_OUTPUT"
+            echo 'markdown=true' >> "$GITHUB_OUTPUT"
+          }
+
+          # Only pull requests get filtered. Pushes to main, merge queue runs and
+          # the nightly schedule always exercise everything, so the last gate
+          # before main never depends on the classification below being right.
+          if [ "$EVENT_NAME" != 'pull_request' ]; then
+            run_everything "Event is '$EVENT_NAME' rather than a pull request; running everything."
             exit 0
           fi
 
           # Guarded rather than a bare assignment: under `set -e` a failing `gh`
-          # would abort the step, so the fallback below would be dead code and a
+          # would abort the step, so the fallback would be dead code and a
           # transient API error would wedge the pull request instead of just
           # costing a full run.
           if ! CHANGED_FILES="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"; then
-            echo '::warning::Could not read the pull request diff; running everything.'
-            echo 'code=true' >> "$GITHUB_OUTPUT"
+            run_everything '::warning::Could not read the pull request diff; running everything.'
             exit 0
           fi
 
           if [ -z "$CHANGED_FILES" ]; then
-            echo '::warning::The pull request reports no changed files; running everything.'
-            echo 'code=true' >> "$GITHUB_OUTPUT"
+            run_everything '::warning::The pull request reports no changed files; running everything.'
             exit 0
           fi
 
@@ -78,7 +89,33 @@ jobs:
           )
           INERT="$(IFS='|'; echo "${INERT_PATTERNS[*]}")"
 
+          # The link checker walks the tree itself and skips docs/ (which has its
+          # own checker), CHANGELOG.md, hidden directories, node_modules and
+          # target. Gating on the same set keeps a docs-only or changelog-only
+          # change from paying for a network check that reads none of its files.
+          # Mirrors .mise/tasks/check-links.sh — the two must stay in sync.
+          LINK_SKIP_PATTERNS=(
+            '^docs/'
+            '(^|/)CHANGELOG\.md$'
+            '(^|/)\.'
+            '(^|/)node_modules/'
+            '(^|/)target/'
+          )
+          LINK_SKIP="$(IFS='|'; echo "${LINK_SKIP_PATTERNS[*]}")"
+
+          # The checker's own inputs count as markdown it reads: without these,
+          # a pull request that only edits lychee's config would run nothing at
+          # all — the config is inert for cargo, and is not a .md file — so a
+          # broken `accept` value or a desynced skip list would first surface on
+          # some later unrelated pull request that happened to touch a README.
+          # Matched separately because LINK_SKIP's `(^|/)\.` would otherwise
+          # exclude the .mise and .github paths below.
+          LINK_CONFIG='^(lychee\.toml|\.lychee\.yaml|\.mise/tasks/check-links\.sh|\.github/workflows/check-links\.yml)$'
+
           CODE_FILES="$(printf '%s\n' "$CHANGED_FILES" | grep -vE "$INERT" || true)"
+          LINK_MD="$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.md$' | grep -vE "$LINK_SKIP" || true)"
+          LINK_CFG="$(printf '%s\n' "$CHANGED_FILES" | grep -E "$LINK_CONFIG" || true)"
+          LINK_FILES="$(printf '%s\n%s\n' "$LINK_MD" "$LINK_CFG" | grep -v '^$' || true)"
 
           if [ -n "$CODE_FILES" ]; then
             echo 'These changed files can affect a cargo run:'
@@ -87,4 +124,13 @@ jobs:
           else
             echo 'Only docs, companion actions and editor config changed; skipping the Rust suite.'
             echo 'code=false' >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$LINK_FILES" ]; then
+            echo 'These changed files are inputs to the link checker:'
+            printf '%s\n' "$LINK_FILES" | sed 's/^/  /'
+            echo 'markdown=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'No link checker inputs changed; skipping the link check.'
+            echo 'markdown=false' >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,90 @@
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: >-
+          'true' when this change can affect the outcome of a cargo build, test,
+          clippy, fmt or deny run.
+        value: ${{ jobs.detect.outputs.code }}
+
+# `gh pr diff` reads GET /pulls/{n}/files, so `pull-requests: read` is the actual
+# dependency and is worth stating rather than inheriting. The repository default
+# is currently `write` on everything, so this is a reduction; a called workflow
+# can never hold more than its caller, and every caller here takes the default.
+permissions:
+  contents: read
+  pull-requests: read
+
+name: Detect Changes
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Classify the changed files
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Only pull requests get filtered. Pushes to main and merge queue runs
+          # always exercise the full suite, so the last gate before main never
+          # depends on the classification below being right.
+          if [ "$EVENT_NAME" != 'pull_request' ]; then
+            echo "Event is '$EVENT_NAME' rather than a pull request; running everything."
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Guarded rather than a bare assignment: under `set -e` a failing `gh`
+          # would abort the step, so the fallback below would be dead code and a
+          # transient API error would wedge the pull request instead of just
+          # costing a full run.
+          if ! CHANGED_FILES="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"; then
+            echo '::warning::Could not read the pull request diff; running everything.'
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo '::warning::The pull request reports no changed files; running everything.'
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Paths that cannot change the outcome of a cargo run. This is an
+          # allowlist on purpose: anything not named here counts as code, so a
+          # new directory runs the full suite until somebody deliberately adds
+          # it below. Getting this list wrong should cost CI minutes, never
+          # coverage.
+          #
+          # One case escapes that guarantee: `gh pr diff --name-only` reports
+          # only the new path of a rename, so moving a Rust file into an inert
+          # directory reads as an inert-only change even though the deletion
+          # breaks the build. `merge_group` forces the full suite regardless, so
+          # such a change still cannot reach main unchecked.
+          INERT_PATTERNS=(
+            '^(actions|docs|examples)/'
+            '^\.(claude|vscode)/'
+            '^\.github/(ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)/'
+            '^\.github/(CODEOWNERS|PULL_REQUEST_TEMPLATE\.md)$'
+            '^(AGENTS|ARCHITECTURE|CHANGELOG|CLAUDE|CONTRIBUTING|README|RELEASE_CHECKLIST)\.md$'
+            '^(\.gitleaks\.toml|\.lychee\.yaml|lychee\.toml)$'
+          )
+          INERT="$(IFS='|'; echo "${INERT_PATTERNS[*]}")"
+
+          CODE_FILES="$(printf '%s\n' "$CHANGED_FILES" | grep -vE "$INERT" || true)"
+
+          if [ -n "$CODE_FILES" ]; then
+            echo 'These changed files can affect a cargo run:'
+            printf '%s\n' "$CODE_FILES" | sed 's/^/  /'
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'Only docs, companion actions and editor config changed; skipping the Rust suite.'
+            echo 'code=false' >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/run-commands-e2e.yml
+++ b/.github/workflows/run-commands-e2e.yml
@@ -7,8 +7,14 @@ on:
 
 name: Run Command E2E Tests
 jobs:
+  changes:
+    name: Detect Changes
+    uses: ./.github/workflows/detect-changes.yml
+
   introspection_e2e:
     name: introspection E2E
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -32,6 +38,8 @@ jobs:
 
   connectors_e2e:
     name: connectors E2E
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,5 +55,48 @@ jobs:
         run: |
             cargo build
             cargo test --locked --package regressions --test cli_tests -- connectors_cli_tests
-            
 
+  # The single context branch protection requires from this workflow. See the
+  # equivalent job in checks.yml for why this shape is necessary.
+  command_e2e_complete:
+    name: Command E2E Complete
+    if: always()
+    needs: [changes, introspection_e2e, connectors_e2e]
+    runs-on: ubuntu-latest
+    steps:
+      # See the equivalent step in checks.yml: without this, a broken `code`
+      # output skips every job and still reports a green aggregate.
+      - name: Fail if Detect Changes produced no classification
+        if: >-
+          ${{
+               needs.changes.result != 'success'
+            || (needs.changes.outputs.code != 'true' && needs.changes.outputs.code != 'false')
+          }}
+        env:
+          RESULT: ${{ needs.changes.result }}
+          CODE: ${{ needs.changes.outputs.code }}
+        run: |
+          echo "::error::Detect Changes did not classify this change (result='$RESULT', code='$CODE')."
+          exit 1
+
+      - name: Fail if a check failed or was cancelled
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}
+        run: |
+          echo '::error::A command E2E test failed or was cancelled.'
+          exit 1
+
+      - name: Fail if a check was skipped despite code changes
+        if: >-
+          ${{
+            needs.changes.outputs.code == 'true' && (
+                 needs.introspection_e2e.result == 'skipped'
+              || needs.connectors_e2e.result == 'skipped'
+            )
+          }}
+        run: |
+          echo '::error::A command E2E test was skipped even though this change touches code. Check the job if: conditions in run-commands-e2e.yml.'
+          exit 1

--- a/.github/workflows/run-smokes-on-pr.yml
+++ b/.github/workflows/run-smokes-on-pr.yml
@@ -11,8 +11,14 @@ concurrency:
 
 name: "Run End-To-End Tests"
 jobs:
+  changes:
+    name: Detect Changes
+    uses: ./.github/workflows/detect-changes.yml
+
   calculate_correct_version_ranges:
     name: "Calculate Correct Version Ranges"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     outputs:
       router_versions: ${{ steps.router-versions.outputs.router_versions }}
@@ -35,9 +41,58 @@ jobs:
   run-smokes:
     name: "Run Tests"
     needs:
+      - changes
       - calculate_correct_version_ranges
+    if: needs.changes.outputs.code == 'true'
     uses: ./.github/workflows/smoke-test.yml
     with:
       composition-versions: '${{ needs.calculate_correct_version_ranges.outputs.supergraph_versions }}'
       router-versions: '${{ needs.calculate_correct_version_ranges.outputs.router_versions }}'
     secrets: inherit
+
+  # The single context branch protection requires from this workflow, replacing
+  # `Run Tests / Final Results`. That inner job still guards the smoke matrix
+  # itself; this one exists so the whole workflow can be skipped for a
+  # docs-only change without leaving a required check waiting forever.
+  smoke_tests_complete:
+    name: Smoke Tests Complete
+    if: always()
+    needs: [changes, calculate_correct_version_ranges, run-smokes]
+    runs-on: ubuntu-latest
+    steps:
+      # See the equivalent step in checks.yml: without this, a broken `code`
+      # output skips every job and still reports a green aggregate.
+      - name: Fail if Detect Changes produced no classification
+        if: >-
+          ${{
+               needs.changes.result != 'success'
+            || (needs.changes.outputs.code != 'true' && needs.changes.outputs.code != 'false')
+          }}
+        env:
+          RESULT: ${{ needs.changes.result }}
+          CODE: ${{ needs.changes.outputs.code }}
+        run: |
+          echo "::error::Detect Changes did not classify this change (result='$RESULT', code='$CODE')."
+          exit 1
+
+      - name: Fail if a check failed or was cancelled
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}
+        run: |
+          echo '::error::A smoke test failed or was cancelled.'
+          exit 1
+
+      - name: Fail if a check was skipped despite code changes
+        if: >-
+          ${{
+            needs.changes.outputs.code == 'true' && (
+                 needs.calculate_correct_version_ranges.result == 'skipped'
+              || needs['run-smokes'].result == 'skipped'
+            )
+          }}
+        run: |
+          echo '::error::A smoke test was skipped even though this change touches code. Check the job if: conditions in run-smokes-on-pr.yml.'
+          exit 1


### PR DESCRIPTION
This allows us to simplify our branch protection rules and to better
control what does or doesn't run on a given set of changes long term.

https://apollographql.atlassian.net/browse/ROVER-452

## What changes

- **`detect-changes.yml`** (new) — a `workflow_call` reusable workflow that classifies the PR diff via `gh pr diff --name-only` (the approach the changelog check already used, so no new action dependency) and emits two outputs: `code` for anything that can affect a cargo run, and `markdown` for the files the link checker actually reads. `code` uses an inert-path *allowlist*, so anything unlisted counts as code and a new top-level directory runs the full suite until somebody adds it. Every non-PR event and every fallback returns `true`, so the last gate before `main` never trusts the classifier.
- **`changelog.yml`** (new) — the `Changelog Entry` check, moved out of `checks.yml` so `edited` lives in exactly one workflow. `checks.yml` fired on `edited` only for this check's benefit, which meant a description edit produced a run where every real job skipped, overwriting the genuine run's conclusions for the same commit.
- **`checks.yml`, `run-commands-e2e.yml`, `run-smokes-on-pr.yml`, `check-links.yml`** — expensive jobs gated on the relevant classification, each workflow gaining one always-running aggregator job that derives its verdict from `needs.*.result`.
- **No more advisory tier.** `Test with minimal glibc versions` and `Check Markdown Links` were outside the required set because of past flakiness that has since been addressed and never reconciled. Both are now inside an aggregator. See the note below for what `check-links` needed to get there.

Net effect: docs-only and `actions/`-only PRs skip the Rust suite, the link check runs only when it would read a changed file, and branch protection drops from 19 hand-maintained contexts to 5.

## ⚠️ Merge checklist

Branch protection must be updated in the same window as the merge. **The intermediate state is not safe to sit in.**

1. [ ] Merge this PR. It touches `.github/workflows/**`, so it classifies as code, runs everything, and reports all 19 currently-required contexts — it merges cleanly under today's rules.
2. [ ] **Immediately** replace the required status checks with exactly these five, dropping `Run Tests / Final Results` and the 12 matrix-expanded `test (…)` / `test_installers (…)` contexts:
   - `Changelog Entry`
   - `Commit Checks Complete`
   - `Command E2E Complete`
   - `Smoke Tests Complete`
   - `Link Check Complete`
3. [ ] Update the branch of any other open PR before merging it. PRs based on the old `main` run their own copies of these workflows, so they report the old contexts and not the new ones. `strict: true` requires the update anyway.

<details>
<summary>Why step 2 cannot wait</summary>

A job skipped via `if:` still emits a check run with a `skipped` conclusion, which branch protection accepts as satisfied — so leaving the old leaf contexts required is merely stale, not fatal. Two things are fatal:

- **`run-smokes` is a reusable workflow call.** When it is skipped, the called workflow's jobs are never instantiated, so no `Run Tests / Final Results` check run is created *at all*. With that context still required, the first docs-only PR after this merges sits at "Expected — waiting for status to be reported" forever.
- **A skipped matrix job emits one check run under the bare job name.** Confirmed on this PR: gating `test` off produces a single `test` check run, not `test (ubuntu-latest)` and friends, so the 12 matrix-expanded required contexts receive no report either.

`main` has `enforce_admins: true`, so neither case can be overridden by a human — unwedging means editing the protection rule.

</details>

```bash
gh api -X PATCH repos/apollographql/rover/branches/main/protection/required_status_checks --input - <<'JSON'
{
  "strict": true,
  "checks": [
    { "context": "Changelog Entry",        "app_id": 15368 },
    { "context": "Commit Checks Complete", "app_id": 15368 },
    { "context": "Command E2E Complete",   "app_id": 15368 },
    { "context": "Smoke Tests Complete",   "app_id": 15368 },
    { "context": "Link Check Complete",    "app_id": 15368 }
  ]
}
JSON
```

## Notes for reviewers

- **Each aggregator asserts that `Detect Changes` actually returned `true` or `false`.** Without that, a broken classification output would skip every job and still report a green aggregate, which is fail-open on the one thing branch protection now depends on.
- **`check-links` needed a second classification, not a reuse of `code`.** The link checker walks the tree itself and skips `docs/`, `CHANGELOG.md` and hidden directories, so the old `paths: ["**/*.md"]` trigger was broader than what actually gets scanned. Since nearly every PR touches `CHANGELOG.md`, gating on markdown-in-general would have put a network-dependent check in front of almost every PR while reading none of its changed files. The `markdown` output mirrors `.mise/tasks/check-links.sh`; the two must stay in sync, which is called out in a comment at both ends.
- **`check-links` permissions went from `{}` to `contents: read` + `pull-requests: read`,** because `Detect Changes` reads the diff and a called workflow can never hold more than its caller.
- **Tunable:** in `merge_group` the link check runs, since non-PR events always classify as `true`. That is consistent with the rest of the design, but it does put a network check in front of every merge. If queue flake shows up, having `markdown` return `false` for `merge_group` is a safe trim — the PR run already validated the links and the aggregator stays green on a skip.
- **Known limitation,** documented in `detect-changes.yml`: `gh pr diff --name-only` reports only the *new* path of a rename, so moving a Rust file into an inert directory reads as inert-only. `merge_group` forces the full suite, so it cannot reach `main` unchecked.

- [x] A CHANGELOG.md entry is not needed for this PR
