### PR TITLE
REG-1909 Contract Preview 3b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover dev` has always been able to compose and run a local router session with no API key, graph ref, or offline license — but running it that way gave no confirmation that this was expected, intentional behavior rather than a misconfiguration. It now prints `Running without GraphOS credentials. GraphOS Router Enterprise features and @connect are disabled. Pass --graph-ref, set APOLLO_KEY/APOLLO_GRAPH_REF, or pass --license to enable them.` once at startup, but only when nothing else already explained the gap (e.g. a `--graph-ref` or non-default `--profile` that couldn't resolve credentials still gets its existing, more specific warning instead).
 
+- **Add `rover contract preview` - @sirdodger**
+
+  `rover contract preview` previews a contract by applying include/exclude/hide-unreachable-types filters to a graph variant's current composed schema, without publishing a contract variant. It runs asynchronously on the server; by default Rover polls until the build completes (or `APOLLO_CHECKS_TIMEOUT_SECONDS` elapses), or pass `--async` to just start the build and check on it later with `--build-id`. Exits non-zero if composition or filtering fails.
+
 ## 🐛 Fixes
 
 - **Surface the underlying GraphQL errors when a response has no `data` field - @sirdodger**

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -217,7 +217,14 @@ impl Rover {
                     )
                     .await
             }
-            Command::Contract(command) => command.run(self.get_client_config().await?).await,
+            Command::Contract(command) => {
+                command
+                    .run(
+                        self.get_client_config().await?,
+                        self.get_checks_timeout_seconds()?,
+                    )
+                    .await
+            }
             Command::Schema(command) => command.run(self.get_client_config().await?).await,
             Command::Dev(command) => {
                 command

--- a/src/command/contract/mod.rs
+++ b/src/command/contract/mod.rs
@@ -1,4 +1,5 @@
 mod describe;
+mod preview;
 mod publish;
 
 use clap::Parser;
@@ -17,14 +18,30 @@ pub enum Command {
     /// Describe the configuration of a contract variant from the Apollo graph registry
     Describe(describe::Describe),
 
+    /// Preview the contract schema produced by a filter without publishing a contract variant
+    Preview(preview::Preview),
+
     /// Publish an updated contract configuration to the Apollo graph registry and trigger launch in the graph router
     Publish(publish::Publish),
 }
 
 impl Contract {
-    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+    pub async fn run(
+        &self,
+        client_config: StudioClientConfig,
+        checks_timeout_seconds: u64,
+    ) -> RoverResult<RoverOutput> {
         match &self.command {
             Command::Describe(command) => command.run(client_config).await,
+            Command::Preview(command) => {
+                command
+                    .run(
+                        client_config,
+                        checks_timeout_seconds,
+                        &rover_print::print::stderr::default(),
+                    )
+                    .await
+            }
             Command::Publish(command) => command.run(client_config).await,
         }
     }

--- a/src/command/contract/preview/mod.rs
+++ b/src/command/contract/preview/mod.rs
@@ -118,7 +118,7 @@ impl Preview {
                     graph_ref,
                     build_id: build_id.clone(),
                 },
-                &client,
+                preview::contract_preview_result_service(&client)?,
             )
             .await?;
             return Ok(RoverOutput::CliOutput(Box::new(ContractPreviewOutput(
@@ -138,7 +138,8 @@ impl Preview {
             graph_ref: graph_ref.clone(),
             filter_config: self.required_filter_config()?,
         };
-        let started = preview::start(input, &client).await?;
+        let started =
+            preview::start(input, preview::contract_preview_start_service(&client)?).await?;
 
         if self.asynchronous {
             return Ok(RoverOutput::CliOutput(Box::new(ContractPreviewOutput(

--- a/src/command/contract/preview/mod.rs
+++ b/src/command/contract/preview/mod.rs
@@ -92,6 +92,7 @@ pub struct Preview {
             "no_hide_unreachable_types",
         ]
     )]
+    #[serde(skip_serializing)]
     build_id: Option<String>,
 }
 
@@ -203,6 +204,8 @@ impl Preview {
 
 #[cfg(test)]
 mod tests {
+    use speculoos::prelude::*;
+
     use super::*;
 
     /// A `Preview` with every include/exclude/hide flag explicitly decided,
@@ -252,7 +255,9 @@ mod tests {
             ..valid_preview()
         };
         let err = preview.required_filter_config().unwrap_err();
-        assert!(err.to_string().contains("--include-tag"));
+        assert_that!(err.message()).is_equal_to(
+            "You must specify either --include-tag <TAG> or --no-include-tags.".to_string(),
+        );
     }
 
     #[test]
@@ -263,7 +268,9 @@ mod tests {
             ..valid_preview()
         };
         let err = preview.required_filter_config().unwrap_err();
-        assert!(err.to_string().contains("--exclude-tag"));
+        assert_that!(err.message()).is_equal_to(
+            "You must specify either --exclude-tag <TAG> or --no-exclude-tags.".to_string(),
+        );
     }
 
     #[test]
@@ -274,6 +281,9 @@ mod tests {
             ..valid_preview()
         };
         let err = preview.required_filter_config().unwrap_err();
-        assert!(err.to_string().contains("--hide-unreachable-types"));
+        assert_that!(err.message()).is_equal_to(
+            "You must specify either --hide-unreachable-types or --no-hide-unreachable-types."
+                .to_string(),
+        );
     }
 }

--- a/src/command/contract/preview/mod.rs
+++ b/src/command/contract/preview/mod.rs
@@ -1,0 +1,279 @@
+mod output;
+
+use anyhow::anyhow;
+use clap::{ArgGroup, Parser};
+use output::ContractPreviewOutput;
+use rover_client::operations::contract::preview::{
+    self, ContractFilterConfig, ContractPreviewInput, ContractPreviewStatusInput,
+};
+use rover_print::{
+    print::{Print, PrintExt},
+    style::{Style, StyledText},
+};
+use serde::Serialize;
+
+use crate::{
+    RoverError, RoverOutput, RoverResult,
+    options::{GraphRefOpt, ProfileOpt},
+    utils::client::StudioClientConfig,
+};
+
+#[derive(Debug, Serialize, Parser)]
+#[clap(
+    group = ArgGroup::new("include_tags_group")
+        .args(&["include_tag", "no_include_tags"]),
+    group = ArgGroup::new("exclude_tags_group")
+        .args(&["exclude_tag", "no_exclude_tags"]),
+    group = ArgGroup::new("hide_unreachable_types_group")
+        .args(&["hide_unreachable_types", "no_hide_unreachable_types"])
+)]
+pub struct Preview {
+    /// Required to identify graph and check permissions even though buildId is unique.
+    #[clap(flatten)]
+    graph: GraphRefOpt,
+
+    #[clap(flatten)]
+    profile: ProfileOpt,
+
+    /// List of tag names to include in the contract preview schema (e.g. '--include-tag foo --include-tag bar').
+    /// To specify an empty list, use --no-include-tags instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    include_tag: Vec<String>,
+
+    /// Use an empty include list of tag names for the contract preview schema.
+    /// To specify a non-empty list, use --include-tag instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    no_include_tags: bool,
+
+    /// List of tag names to exclude from the contract preview schema (e.g. '--exclude-tag foo --exclude-tag bar').
+    /// To specify an empty list, use --no-exclude-tags instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    exclude_tag: Vec<String>,
+
+    /// Use an empty exclude list of tag names for the contract preview schema.
+    /// To specify a non-empty list, use --exclude-tag instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    no_exclude_tags: bool,
+
+    /// Automatically hide types that can never be reached in operations on the contract preview schema.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    hide_unreachable_types: bool,
+
+    /// Do not automatically hide types that can never be reached in operations on the contract preview schema.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    no_hide_unreachable_types: bool,
+
+    /// Start the build and return immediately with a job ID, instead of
+    /// waiting for it to complete.
+    ///
+    /// Every preview build runs asynchronously on the server; without this
+    /// flag, Rover starts the build and polls until it finishes. With this
+    /// flag, Rover only starts the build (check on it later with --build-id).
+    #[arg(long = "async")]
+    asynchronous: bool,
+
+    /// Check the status of a previously started job instead of starting a new
+    /// one. Checks once, without polling.
+    #[arg(
+        long = "build-id",
+        conflicts_with_all = [
+            "asynchronous",
+            "include_tag",
+            "no_include_tags",
+            "exclude_tag",
+            "no_exclude_tags",
+            "hide_unreachable_types",
+            "no_hide_unreachable_types",
+        ]
+    )]
+    build_id: Option<String>,
+}
+
+impl Preview {
+    pub async fn run(
+        &self,
+        client_config: StudioClientConfig,
+        checks_timeout_seconds: u64,
+        stderr: &impl Print,
+    ) -> RoverResult<RoverOutput> {
+        let client = client_config.get_authenticated_client(&self.profile)?;
+        let graph_ref = self.graph.graph_ref.clone();
+
+        if let Some(build_id) = &self.build_id {
+            stderr.print(&StyledText::plain(format!(
+                "Checking status of contract preview job {} on {} using credentials from the {} profile.",
+                stderr.paint(Style::Link, build_id),
+                stderr.paint(Style::Link, graph_ref.to_string()),
+                stderr.paint(Style::Command, &self.profile.profile_name)
+            )));
+            let preview_response = preview::result(
+                ContractPreviewStatusInput {
+                    graph_ref,
+                    build_id: build_id.clone(),
+                },
+                &client,
+            )
+            .await?;
+            return Ok(RoverOutput::CliOutput(Box::new(ContractPreviewOutput(
+                preview_response,
+            ))));
+        }
+
+        stderr.print(&StyledText::plain(format!(
+            "Previewing contract schema for {} using credentials from the {} profile.",
+            stderr.paint(Style::Link, graph_ref.to_string()),
+            stderr.paint(Style::Command, &self.profile.profile_name)
+        )));
+
+        // contractPreviewAsync: filter the variant's already-composed
+        // supergraph. Filtering is mandatory here.
+        let input = ContractPreviewInput {
+            graph_ref: graph_ref.clone(),
+            filter_config: self.required_filter_config()?,
+        };
+        let started = preview::start(input, &client).await?;
+
+        if self.asynchronous {
+            return Ok(RoverOutput::CliOutput(Box::new(ContractPreviewOutput(
+                started,
+            ))));
+        }
+
+        stderr.print(&StyledText::plain(format!(
+            "Waiting for the build to complete... or press Ctrl+C and check later with {}.",
+            stderr.paint(
+                Style::Command,
+                format!(
+                    "`rover contract preview {} --build-id {}`",
+                    graph_ref, started.build_id
+                )
+            )
+        )));
+
+        let preview_response = preview::poll(
+            ContractPreviewStatusInput {
+                graph_ref,
+                build_id: started.build_id,
+            },
+            &client,
+            checks_timeout_seconds,
+        )
+        .await?;
+
+        Ok(RoverOutput::CliOutput(Box::new(ContractPreviewOutput(
+            preview_response,
+        ))))
+    }
+
+    /// Builds the filter config from the paired include/exclude/hide flags,
+    /// enforcing that exactly one flag from each pair was provided.
+    ///
+    /// This is enforced at runtime rather than with `ArgGroup::required(true)`
+    /// (as `contract publish` does) because the pairs are not required in
+    /// `--build-id` mode.
+    fn required_filter_config(&self) -> RoverResult<ContractFilterConfig> {
+        if self.include_tag.is_empty() && !self.no_include_tags {
+            return Err(RoverError::new(anyhow!(
+                "You must specify either --include-tag <TAG> or --no-include-tags."
+            )));
+        }
+        if self.exclude_tag.is_empty() && !self.no_exclude_tags {
+            return Err(RoverError::new(anyhow!(
+                "You must specify either --exclude-tag <TAG> or --no-exclude-tags."
+            )));
+        }
+        if !self.hide_unreachable_types && !self.no_hide_unreachable_types {
+            return Err(RoverError::new(anyhow!(
+                "You must specify either --hide-unreachable-types or --no-hide-unreachable-types."
+            )));
+        }
+        Ok(ContractFilterConfig {
+            include: self.include_tag.clone(),
+            exclude: self.exclude_tag.clone(),
+            hide_unreachable_types: self.hide_unreachable_types,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `Preview` with every include/exclude/hide flag explicitly decided,
+    /// except `--build-id` which changes to polling. Individual tests override
+    /// one field at a time to exercise each validation branch.
+    fn valid_preview() -> Preview {
+        Preview {
+            graph: GraphRefOpt {
+                graph_ref: "test-graph@current".parse().unwrap(),
+            },
+            profile: ProfileOpt::default(),
+            include_tag: vec!["foo".to_string()],
+            no_include_tags: false,
+            exclude_tag: Vec::new(),
+            no_exclude_tags: true,
+            hide_unreachable_types: true,
+            no_hide_unreachable_types: false,
+            asynchronous: false,
+            build_id: None,
+        }
+    }
+
+    #[test]
+    fn required_filter_config_builds_config_when_all_three_pairs_are_decided() {
+        let config = valid_preview().required_filter_config().unwrap();
+        assert_eq!(config.include, vec!["foo".to_string()]);
+        assert_eq!(config.exclude, Vec::<String>::new());
+        assert!(config.hide_unreachable_types);
+    }
+
+    #[test]
+    fn required_filter_config_allows_no_include_tags_for_an_empty_include_list() {
+        let preview = Preview {
+            include_tag: Vec::new(),
+            no_include_tags: true,
+            ..valid_preview()
+        };
+        let config = preview.required_filter_config().unwrap();
+        assert_eq!(config.include, Vec::<String>::new());
+    }
+
+    #[test]
+    fn required_filter_config_errors_when_include_tags_are_undecided() {
+        let preview = Preview {
+            include_tag: Vec::new(),
+            no_include_tags: false,
+            ..valid_preview()
+        };
+        let err = preview.required_filter_config().unwrap_err();
+        assert!(err.to_string().contains("--include-tag"));
+    }
+
+    #[test]
+    fn required_filter_config_errors_when_exclude_tags_are_undecided() {
+        let preview = Preview {
+            exclude_tag: Vec::new(),
+            no_exclude_tags: false,
+            ..valid_preview()
+        };
+        let err = preview.required_filter_config().unwrap_err();
+        assert!(err.to_string().contains("--exclude-tag"));
+    }
+
+    #[test]
+    fn required_filter_config_errors_when_hide_unreachable_types_is_undecided() {
+        let preview = Preview {
+            hide_unreachable_types: false,
+            no_hide_unreachable_types: false,
+            ..valid_preview()
+        };
+        let err = preview.required_filter_config().unwrap_err();
+        assert!(err.to_string().contains("--hide-unreachable-types"));
+    }
+}

--- a/src/command/contract/preview/output.rs
+++ b/src/command/contract/preview/output.rs
@@ -1,0 +1,124 @@
+use rover_client::shared::{AsyncBuildStatus, PreviewJobResponse};
+use rover_std::Style;
+
+use crate::command::CliOutput;
+
+/// [`CliOutput`] implementation for `rover contract preview`.
+#[derive(Debug)]
+pub(super) struct ContractPreviewOutput(pub(super) PreviewJobResponse);
+
+impl CliOutput for ContractPreviewOutput {
+    fn exit_code(&self) -> i32 {
+        match self.0.status {
+            AsyncBuildStatus::ComposeFailed | AsyncBuildStatus::FilterFailed => 1,
+            AsyncBuildStatus::Pending | AsyncBuildStatus::Running | AsyncBuildStatus::Success => 0,
+        }
+    }
+
+    fn text(&self) -> String {
+        let preview_response = &self.0;
+        let mut lines = vec![
+            format!("Build id: {}", &preview_response.build_id),
+            format!("Status: {}", &preview_response.status),
+        ];
+        match preview_response.status {
+            AsyncBuildStatus::Pending | AsyncBuildStatus::Running => {
+                let hint = format!(
+                    "`rover contract preview {} --build-id {}`",
+                    preview_response.graph_ref, preview_response.build_id
+                );
+                lines.push(format!(
+                    "Check the result with {}",
+                    Style::Command.paint(hint)
+                ));
+            }
+            AsyncBuildStatus::Success => {
+                if let Some(api_schema) = &preview_response.api_schema {
+                    lines.push("Schema:".to_string());
+                    lines.push(String::new());
+                    lines.push(api_schema.clone());
+                }
+            }
+            AsyncBuildStatus::ComposeFailed | AsyncBuildStatus::FilterFailed => {
+                lines.extend(preview_response.errors.iter().cloned());
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rover_studio::types::GraphRef;
+
+    use super::*;
+
+    fn response(status: AsyncBuildStatus) -> PreviewJobResponse {
+        PreviewJobResponse {
+            graph_ref: GraphRef::new("my-graph", Some("current")).unwrap(),
+            build_id: "build-123".to_string(),
+            status,
+            api_schema: None,
+            supergraph_schema: None,
+            errors: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn exit_code_is_zero_for_in_progress_and_success_statuses() {
+        for status in [
+            AsyncBuildStatus::Pending,
+            AsyncBuildStatus::Running,
+            AsyncBuildStatus::Success,
+        ] {
+            assert_eq!(ContractPreviewOutput(response(status)).exit_code(), 0);
+        }
+    }
+
+    #[test]
+    fn exit_code_is_nonzero_for_terminal_failure_statuses() {
+        for status in [
+            AsyncBuildStatus::ComposeFailed,
+            AsyncBuildStatus::FilterFailed,
+        ] {
+            assert_eq!(ContractPreviewOutput(response(status)).exit_code(), 1);
+        }
+    }
+
+    #[test]
+    fn text_for_pending_hints_at_checking_back_with_the_build_id() {
+        let text = temp_env::with_var("NO_COLOR", Some("1"), || {
+            ContractPreviewOutput(response(AsyncBuildStatus::Pending)).text()
+        });
+        assert!(text.contains("rover contract preview my-graph@current --build-id build-123"));
+    }
+
+    #[test]
+    fn text_for_success_includes_the_schema() {
+        let mut mock_response = response(AsyncBuildStatus::Success);
+        mock_response.api_schema = Some("type Query { hello: String }".to_string());
+        let text = ContractPreviewOutput(mock_response).text();
+        assert!(text.contains("type Query { hello: String }"));
+    }
+
+    #[test]
+    fn text_for_failure_includes_the_errors() {
+        let mut mock_response = response(AsyncBuildStatus::ComposeFailed);
+        mock_response.errors = vec!["[Accounts] -> Things went really wrong".to_string()];
+        let text = ContractPreviewOutput(mock_response).text();
+        assert!(text.contains("[Accounts] -> Things went really wrong"));
+    }
+
+    #[test]
+    fn json_serializes_the_response() {
+        let json = ContractPreviewOutput(response(AsyncBuildStatus::Success))
+            .json()
+            .unwrap();
+        assert_eq!(json["build_id"], "build-123");
+        assert_eq!(json["status"], "SUCCESS");
+    }
+}

--- a/src/command/contract/preview/output.rs
+++ b/src/command/contract/preview/output.rs
@@ -118,7 +118,12 @@ mod tests {
         let json = ContractPreviewOutput(response(AsyncBuildStatus::Success))
             .json()
             .unwrap();
-        assert_that!(json["build_id"]).is_equal_to(serde_json::json!("build-123"));
-        assert_that!(json["status"]).is_equal_to(serde_json::json!("SUCCESS"));
+        assert_that!(json).is_equal_to(serde_json::json!({
+            "build_id": "build-123",
+            "status": "SUCCESS",
+            "api_schema": null,
+            "supergraph_schema": null,
+            "errors": []
+        }));
     }
 }

--- a/src/command/contract/preview/output.rs
+++ b/src/command/contract/preview/output.rs
@@ -54,6 +54,8 @@ impl CliOutput for ContractPreviewOutput {
 #[cfg(test)]
 mod tests {
     use rover_studio::types::GraphRef;
+    use rstest::rstest;
+    use speculoos::prelude::*;
 
     use super::*;
 
@@ -68,25 +70,14 @@ mod tests {
         }
     }
 
-    #[test]
-    fn exit_code_is_zero_for_in_progress_and_success_statuses() {
-        for status in [
-            AsyncBuildStatus::Pending,
-            AsyncBuildStatus::Running,
-            AsyncBuildStatus::Success,
-        ] {
-            assert_eq!(ContractPreviewOutput(response(status)).exit_code(), 0);
-        }
-    }
-
-    #[test]
-    fn exit_code_is_nonzero_for_terminal_failure_statuses() {
-        for status in [
-            AsyncBuildStatus::ComposeFailed,
-            AsyncBuildStatus::FilterFailed,
-        ] {
-            assert_eq!(ContractPreviewOutput(response(status)).exit_code(), 1);
-        }
+    #[rstest]
+    #[case::pending(AsyncBuildStatus::Pending, 0)]
+    #[case::running(AsyncBuildStatus::Running, 0)]
+    #[case::success(AsyncBuildStatus::Success, 0)]
+    #[case::compose_failed(AsyncBuildStatus::ComposeFailed, 1)]
+    #[case::filter_failed(AsyncBuildStatus::FilterFailed, 1)]
+    fn exit_code_matches_status(#[case] status: AsyncBuildStatus, #[case] expected: i32) {
+        assert_that!(ContractPreviewOutput(response(status)).exit_code()).is_equal_to(expected);
     }
 
     #[test]
@@ -94,7 +85,10 @@ mod tests {
         let text = temp_env::with_var("NO_COLOR", Some("1"), || {
             ContractPreviewOutput(response(AsyncBuildStatus::Pending)).text()
         });
-        assert!(text.contains("rover contract preview my-graph@current --build-id build-123"));
+        assert_that!(text).is_equal_to(
+            "Build id: build-123\nStatus: PENDING\nCheck the result with `rover contract preview my-graph@current --build-id build-123`"
+                .to_string(),
+        );
     }
 
     #[test]
@@ -102,7 +96,10 @@ mod tests {
         let mut mock_response = response(AsyncBuildStatus::Success);
         mock_response.api_schema = Some("type Query { hello: String }".to_string());
         let text = ContractPreviewOutput(mock_response).text();
-        assert!(text.contains("type Query { hello: String }"));
+        assert_that!(text).is_equal_to(
+            "Build id: build-123\nStatus: SUCCESS\nSchema:\n\ntype Query { hello: String }"
+                .to_string(),
+        );
     }
 
     #[test]
@@ -110,7 +107,10 @@ mod tests {
         let mut mock_response = response(AsyncBuildStatus::ComposeFailed);
         mock_response.errors = vec!["[Accounts] -> Things went really wrong".to_string()];
         let text = ContractPreviewOutput(mock_response).text();
-        assert!(text.contains("[Accounts] -> Things went really wrong"));
+        assert_that!(text).is_equal_to(
+            "Build id: build-123\nStatus: COMPOSE_FAILED\n[Accounts] -> Things went really wrong"
+                .to_string(),
+        );
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
         let json = ContractPreviewOutput(response(AsyncBuildStatus::Success))
             .json()
             .unwrap();
-        assert_eq!(json["build_id"], "build-123");
-        assert_eq!(json["status"], "SUCCESS");
+        assert_that!(json["build_id"]).is_equal_to(serde_json::json!("build-123"));
+        assert_that!(json["status"]).is_equal_to(serde_json::json!("SUCCESS"));
     }
 }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

REG-1909 Contract Preview 3b

CLI-consumer PR (stacked on REG-1909 Contract Preview 2b) wiring up `rover contract preview`.

- `rover contract preview` previews a contract by applying include/exclude/hide-unreachable-types filters to a graph variant's current composed schema, without publishing a contract variant.
- Runs asynchronously on the server; by default Rover polls until the build completes (or `APOLLO_CHECKS_TIMEOUT_SECONDS` elapses), or pass `--async` to just start the build and check on it later with `--build-id`.
- Exits non-zero when the build ends in `COMPOSE_FAILED`/`FILTER_FAILED`, so it can be used as a CI gate.
- Output rendering goes through a dedicated `ContractPreviewOutput: CliOutput` struct (`src/command/contract/preview/output.rs`) rather than a new `RoverOutput` variant, per AGENTS.md.

Also brings this command's print calls up to date with the simplified `rover-print` `Print::print` signature (no longer returns a `Result`) that landed on `main` after this branch was first written.

[ ] A CHANGELOG.md entry is not needed for this PR
