### PR TITLE
REG-1909 Docs 4

### DIFF
--- a/docs/source/commands/contracts.mdx
+++ b/docs/source/commands/contracts.mdx
@@ -247,7 +247,7 @@ A tag name to include in [contract filters](/graphos/delivery/contracts/#contrac
 
 To specify an empty include list, enable `--no-include-tags`.
 
-One of `--include-tag` or `--no-include-tags` is required.
+One of `--include-tag` or `--no-include-tags` is required when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -261,7 +261,7 @@ One of `--include-tag` or `--no-include-tags` is required.
 
 Specifies an empty [include list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
 
-One of `--include-tag` or `--no-include-tags` is **required**.
+One of `--include-tag` or `--no-include-tags` is **required** when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -281,7 +281,7 @@ A tag name to exclude when filtering. For details, see the [contract filters](/g
 
 To specify an empty exclude list, enable `--no-exclude-tags`.
 
-One of `--exclude-tag` or `--no-exclude-tags` is required.
+One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -295,7 +295,7 @@ One of `--exclude-tag` or `--no-exclude-tags` is required.
 
 Use this to specify an empty [contract filter list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
 
-One of `--exclude-tag` or `--no-exclude-tags` is **required**.
+One of `--exclude-tag` or `--no-exclude-tags` is **required** when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -309,7 +309,7 @@ One of `--exclude-tag` or `--no-exclude-tags` is **required**.
 
 If provided, the preview automatically hides types that are unreachable from contract schema's root fields. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
 
-Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -323,7 +323,7 @@ Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
 
 If provided, the preview doesn't automatically hide types that are unreachable from the contract schema's root fields.
 
-Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -347,7 +347,7 @@ Optional. If provided, Rover starts the preview build and immediately returns wi
 </td>
 <td>
 
-Optional. Check the status of a previously started preview build once, instead of starting a new one. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options following.
+Optional. Check the status of a previously started preview build once, instead of starting a new one. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options preceding.
 
 </td>
 </tr>

--- a/docs/source/commands/contracts.mdx
+++ b/docs/source/commands/contracts.mdx
@@ -199,13 +199,13 @@ Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
 </tbody>
 </table>
 
-## Preview a contract
+## Previewing a contract
 
 ### `contract preview`
 
 <AuthNotice />
 
-Before publishing a contract to GraphOS, preview the contract schema that a given filter produces, without publishing a contract variant.
+Before publishing a contract to GraphOS, preview the contract schema that your filter produces, without publishing a contract variant.
 
 Use the `contract preview` command to view the resulting schema:
 
@@ -221,7 +221,7 @@ The argument `my-graph@my-source-variant` in the example above is a [graph ref](
 
 Preview builds run asynchronously on GraphOS. By default, Rover starts the build and polls its status until it completes, then prints the resulting schema. See [Running previews asynchronously](#running-previews-asynchronously) below to instead return immediately with a build ID and check the result later.
 
-Options include:
+The command supports the following options:
 
 <table class="field-table">
 <thead>
@@ -245,7 +245,7 @@ A tag name to include in [contract filters](/graphos/delivery/contracts/#contrac
 --include-tag foo --include-tag bar
 ```
 
-To specify an empty include list, enable `--no-include-tags`.
+To specify an empty include list, use `--no-include-tags`.
 
 One of `--include-tag` or `--no-include-tags` is required when starting a new preview build (not used with `--build-id`).
 
@@ -259,9 +259,9 @@ One of `--include-tag` or `--no-include-tags` is required when starting a new pr
 </td>
 <td>
 
-Specifies an empty [include list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
+Specify an empty [include list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
 
-One of `--include-tag` or `--no-include-tags` is **required** when starting a new preview build (not used with `--build-id`).
+One of `--include-tag` or `--no-include-tags` is required when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -279,7 +279,7 @@ A tag name to exclude when filtering. For details, see the [contract filters](/g
 --exclude-tag foo --exclude-tag bar
 ```
 
-To specify an empty exclude list, enable `--no-exclude-tags`.
+To specify an empty exclude list, use `--no-exclude-tags`.
 
 One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new preview build (not used with `--build-id`).
 
@@ -295,7 +295,7 @@ One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new pr
 
 Use this to specify an empty [contract filter list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
 
-One of `--exclude-tag` or `--no-exclude-tags` is **required** when starting a new preview build (not used with `--build-id`).
+One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -307,9 +307,9 @@ One of `--exclude-tag` or `--no-exclude-tags` is **required** when starting a ne
 </td>
 <td>
 
-If provided, the preview automatically hides types that are unreachable from contract schema's root fields. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+If provided, the preview automatically hides types that are unreachable from contract schema's root fields. For details, see the [contract filters documentation](/graphos/delivery/contracts/#contract-filters).
 
-Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when starting a new preview build (not used with `--build-id`).
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when you start a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -321,9 +321,9 @@ Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when 
 </td>
 <td>
 
-If provided, the preview doesn't automatically hide types that are unreachable from the contract schema's root fields.
+If provided, the preview doesn't automatically hide types that are unreachable from contract schema's root fields.
 
-Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when starting a new preview build (not used with `--build-id`).
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when you start a new preview build (not used with `--build-id`).
 
 </td>
 </tr>
@@ -335,7 +335,7 @@ Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when 
 </td>
 <td>
 
-Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Check the build's status later with `--build-id`.
+Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Use `--build-id` to check the build's status later.
 
 </td>
 </tr>
@@ -347,14 +347,14 @@ Optional. If provided, Rover starts the preview build and immediately returns wi
 </td>
 <td>
 
-Optional. Check the status of a previously started preview build once, instead of starting a new one. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options preceding.
+Optional. Use this to check the status of a previously started preview build once, instead of starting a new one. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options preceding.
 
 </td>
 </tr>
 </tbody>
 </table>
 
-#### Running previews asynchronously
+#### Run previews asynchronously
 
 For long-running preview builds, use the `--async` flag to start the build and return a build ID immediately.
 
@@ -363,13 +363,13 @@ rover contract preview my-graph@my-source-variant \
   --include-tag foo --no-exclude-tags --hide-unreachable-types --async
 ```
 
-Check the status of the build later with `--build-id`:
+Use `--build-id` to check the status of the build later:
 
 ```bash
 rover contract preview my-graph@my-source-variant --build-id <BUILD_ID>
 ```
 
-By default (without `--async`), Rover CLI polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) elapses, whichever comes first. If Rover CLI times out while polling, the build itself may still complete in the background—check back with `--build-id`.
+By default (without `--async`), Rover CLI polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) elapses, whichever comes first. If Rover CLI times out while polling, the build itself may still complete in the background—use `--build-id` to check back.
 
 ## Fetching contract details
 

--- a/docs/source/commands/contracts.mdx
+++ b/docs/source/commands/contracts.mdx
@@ -84,7 +84,7 @@ The source variant must belong to the same graph as the contract variant. It mus
 </td>
 <td>
 
-A tag name to [include](/graphos/delivery/contracts/#contract-filters) when filtering. To include multiple tag names, specify `--include-tag` multiple times:
+A tag name to include when filtering. To include multiple tag names, specify `--include-tag` multiple times. For details, see the [contract filters documentation](https://www.apollographql.com/docs/graphos/delivery/contracts/#contract-filters).
 
 ```bash
 --include-tag foo --include-tag bar
@@ -98,7 +98,7 @@ Every tag name **must**:
 * Include only letters, numbers, underscores (`_`), hyphens (`-`), or slashes (`/`).
 * Have a maximum of 128 characters.
 
-One of `--include-tag` or `--no-include-tags` is **required**.
+Specify either `--include-tag` or `--no-include-tags`.
 
 </td>
 </tr>
@@ -112,7 +112,7 @@ One of `--include-tag` or `--no-include-tags` is **required**.
 
 Specifies an empty [include list](/graphos/delivery/contracts/#contract-filters) for the published contract.
 
-One of `--include-tag` or `--no-include-tags` is **required**.
+Provide either `--include-tag` or `--no-include-tags`.
 
 </td>
 </tr>
@@ -124,7 +124,7 @@ One of `--include-tag` or `--no-include-tags` is **required**.
 </td>
 <td>
 
-A tag name to [exclude](/graphos/delivery/contracts/#contract-filters) when filtering. To exclude multiple tag names, specify `--exclude-tag` multiple times:
+Provide a tag name to exclude when filtering. To exclude multiple tag names, specify `--exclude-tag` multiple times. For details, see the [contract filters documentation](/graphos/delivery/contracts/#contract-filters).
 
 ```
 --exclude-tag foo --exclude-tag bar
@@ -138,7 +138,7 @@ Every tag name **must**:
 * Include only letters, numbers, underscores (`_`), hyphens (`-`), or slashes (`/`).
 * Have a maximum of 128 characters.
 
-One of `--exclude-tag` or `--no-exclude-tags` is **required**.
+Specify either `--exclude-tag` or `--no-exclude-tags`.
 
 </td>
 </tr>
@@ -152,7 +152,7 @@ One of `--exclude-tag` or `--no-exclude-tags` is **required**.
 
 Specifies an empty [exclude list](/graphos/delivery/contracts/#contract-filters) for the published contract.
 
-One of `--exclude-tag` or `--no-exclude-tags` is **required**.
+Provide either `--exclude-tag` or `--no-exclude-tags`.
 
 </td>
 </tr>
@@ -166,7 +166,7 @@ One of `--exclude-tag` or `--no-exclude-tags` is **required**.
 
 If provided, the contract automatically [hides](/graphos/delivery/contracts/#contract-filters) types that are unreachable from the contract schema's root fields.
 
-One of `--hide-unreachable-types` or `--no-hide-unreachable-types` is **required**.
+Specify either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
 
 </td>
 </tr>
@@ -180,7 +180,7 @@ One of `--hide-unreachable-types` or `--no-hide-unreachable-types` is **required
 
 If provided, the contract doesn't automatically hide types that are unreachable from the contract schema's root fields.
 
-One of `--hide-unreachable-types` or `--no-hide-unreachable-types` is **required**.
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
 
 </td>
 </tr>
@@ -198,6 +198,178 @@ One of `--hide-unreachable-types` or `--no-hide-unreachable-types` is **required
 </tr>
 </tbody>
 </table>
+
+## Preview a contract
+
+### `contract preview`
+
+<AuthNotice />
+
+Before publishing a contract to GraphOS, preview the contract schema that a given filter produces, without publishing a contract variant.
+
+Use the `contract preview` command to view the resulting schema:
+
+```bash
+rover contract preview my-graph@my-source-variant \
+  --include-tag foo \
+  --include-tag bar \
+  --exclude-tag baz \
+  --hide-unreachable-types
+```
+
+The argument `my-graph@my-source-variant` in the example above is a [graph ref](../conventions/#graph-refs) that specifies the ID of the graph and the [source variant](/graphos/delivery/contracts/#2-fed1-enable-variant-support-for-tag) whose already-composed supergraph schema you want to filter.
+
+Preview builds run asynchronously on GraphOS. By default, Rover starts the build and polls its status until it completes, then prints the resulting schema. See [Running previews asynchronously](#running-previews-asynchronously) below to instead return immediately with a build ID and check the result later.
+
+Options include:
+
+<table class="field-table">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr class="required">
+<td>
+
+###### `--include-tag`
+
+</td>
+<td>
+
+A tag name to include in [contract filters](/graphos/delivery/contracts/#contract-filters) when filtering. To include multiple tag names, specify `--include-tag` multiple times:
+
+```bash
+--include-tag foo --include-tag bar
+```
+
+To specify an empty include list, enable `--no-include-tags`.
+
+One of `--include-tag` or `--no-include-tags` is required.
+
+</td>
+</tr>
+<tr class="required">
+<td>
+
+###### `--no-include-tags`
+
+</td>
+<td>
+
+Specifies an empty [include list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
+
+One of `--include-tag` or `--no-include-tags` is **required**.
+
+</td>
+</tr>
+<tr class="required">
+<td>
+
+###### `--exclude-tag`
+
+</td>
+<td>
+
+A tag name to exclude when filtering. For details, see the [contract filters](/graphos/delivery/contracts/#contract-filters) documentation. To exclude multiple tag names, specify `--exclude-tag` multiple times:
+
+```bash
+--exclude-tag foo --exclude-tag bar
+```
+
+To specify an empty exclude list, enable `--no-exclude-tags`.
+
+One of `--exclude-tag` or `--no-exclude-tags` is required.
+
+</td>
+</tr>
+<tr class="required">
+<td>
+
+###### `--no-exclude-tags`
+
+</td>
+<td>
+
+Use this to specify an empty [contract filter list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
+
+One of `--exclude-tag` or `--no-exclude-tags` is **required**.
+
+</td>
+</tr>
+<tr class="required">
+<td>
+
+###### `--hide-unreachable-types`
+
+</td>
+<td>
+
+If provided, the preview automatically hides types that are unreachable from contract schema's root fields. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
+
+</td>
+</tr>
+<tr class="required">
+<td>
+
+###### `--no-hide-unreachable-types`
+
+</td>
+<td>
+
+If provided, the preview doesn't automatically hide types that are unreachable from the contract schema's root fields.
+
+Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--async`
+
+</td>
+<td>
+
+Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Check the build's status later with `--build-id`.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--build-id`
+
+</td>
+<td>
+
+Optional. Check the status of a previously started preview build once, instead of starting a new one. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options following.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+#### Running previews asynchronously
+
+For long-running preview builds, use the `--async` flag to start the build and return a build ID immediately.
+
+```bash
+rover contract preview my-graph@my-source-variant \
+  --include-tag foo --no-exclude-tags --hide-unreachable-types --async
+```
+
+Check the status of the build later with `--build-id`:
+
+```bash
+rover contract preview my-graph@my-source-variant --build-id <BUILD_ID>
+```
+
+By default (without `--async`), Rover CLI polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) elapses, whichever comes first. If Rover CLI times out while polling, the build itself may still complete in the background—check back with `--build-id`.
 
 ## Fetching contract details
 

--- a/docs/source/commands/contracts.mdx
+++ b/docs/source/commands/contracts.mdx
@@ -205,7 +205,7 @@ Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types`.
 
 <AuthNotice />
 
-Before publishing a contract to GraphOS, preview the contract schema that your filter produces, without publishing a contract variant.
+Before you publish a contract to GraphOS, preview the contract schema that your filter produces, without publishing a contract variant.
 
 Use the `contract preview` command to view the resulting schema:
 
@@ -261,7 +261,7 @@ One of `--include-tag` or `--no-include-tags` is required when starting a new pr
 
 Specify an empty [include list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
 
-One of `--include-tag` or `--no-include-tags` is required when starting a new preview build (not used with `--build-id`).
+Starting a new preview build requires one of `--include-tag` or `--no-include-tags` (not used with `--build-id`).
 
 </td>
 </tr>
@@ -293,9 +293,9 @@ One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new pr
 </td>
 <td>
 
-Use this to specify an empty [contract filter list](/graphos/delivery/contracts/#contract-filters) for the previewed contract.
+Use this to specify an empty [contract filter list](/graphos/delivery/contracts/#contract-filters) for your previewed contract.
 
-One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new preview build (not used with `--build-id`).
+Starting a new preview build requires one of `--exclude-tag` or `--no-exclude-tags` (not used with `--build-id`).
 
 </td>
 </tr>
@@ -307,7 +307,7 @@ One of `--exclude-tag` or `--no-exclude-tags` is required when starting a new pr
 </td>
 <td>
 
-If provided, the preview automatically hides types that are unreachable from contract schema's root fields. For details, see the [contract filters documentation](/graphos/delivery/contracts/#contract-filters).
+If provided, the preview automatically hides types that are unreachable from your contract schema's root fields. For details, see the [contract filters documentation](/graphos/delivery/contracts/#contract-filters).
 
 Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when you start a new preview build (not used with `--build-id`).
 
@@ -321,7 +321,7 @@ Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when 
 </td>
 <td>
 
-If provided, the preview doesn't automatically hide types that are unreachable from contract schema's root fields.
+If provided, the preview doesn't automatically hide types that are unreachable from your contract schema's root fields.
 
 Provide either `--hide-unreachable-types` or `--no-hide-unreachable-types` when you start a new preview build (not used with `--build-id`).
 
@@ -347,14 +347,14 @@ Optional. If provided, Rover starts the preview build and immediately returns wi
 </td>
 <td>
 
-Optional. Use this to check the status of a previously started preview build once, instead of starting a new one. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options preceding.
+Optional. Use this to check the status of a previously started preview build. You can't combine this with `--async` or the include/exclude/hide-unreachable-types options preceding.
 
 </td>
 </tr>
 </tbody>
 </table>
 
-#### Run previews asynchronously
+#### Running previews asynchronously
 
 For long-running preview builds, use the `--async` flag to start the build and return a build ID immediately.
 
@@ -369,7 +369,7 @@ Use `--build-id` to check the status of the build later:
 rover contract preview my-graph@my-source-variant --build-id <BUILD_ID>
 ```
 
-By default (without `--async`), Rover CLI polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) elapses, whichever comes first. If Rover CLI times out while polling, the build itself may still complete in the background—use `--build-id` to check back.
+By default (without `--async`), Rover CLI polls your build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) elapses, whichever comes first. If Rover CLI times out while polling, your build may still complete in the background. Use `--build-id` to check its status again.
 
 ## Fetching contract details
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -579,7 +579,7 @@ By default, this command flags all violations in your local schema.
 
 <AuthNotice />
 
-Always preview supergraph schema before publishing subgraph changes to ensure successful composition without affecting your production graph.
+Always preview your supergraph schema before publishing subgraph changes to ensure successful composition without affecting your production graph.
 
 Run the `subgraph preview` command:
 
@@ -587,7 +587,7 @@ Run the `subgraph preview` command:
 rover subgraph preview my-graph@my-variant
 ```
 
-The argument `my-graph@my-variant` in the preceding example is a [graph ref](../conventions/#graph-refs) that specifies the ID of the graph and [variant](/graphos/graphs/#variants) whose subgraphs you want to build a preview from.
+The argument `my-graph@my-variant` in the preceding example is a [graph ref](../conventions/#graph-refs) that specifies the ID of the graph and [variant](/graphos/graphs/#variants) whose subgraphs you want to use for the preview.
 
 By default, `subgraph preview` composes the variant's subgraphs exactly as they're currently published. Use `--subgraph-changes` to preview the effect of hypothetical subgraph changes first (see [Previewing subgraph changes](#previewing-subgraph-changes) below). You can also provide the `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` options to preview a contract filter on top of composition.
 
@@ -611,7 +611,7 @@ Preview builds run asynchronously on GraphOS. By default, Rover starts the build
 </td>
 <td>
 
-Optional. The path to a YAML file describing hypothetical changes to one or more subgraphs to apply before composing. You can also provide `-`, in which case the command reads the file from `stdin`. For details, see the section on [previewing subgraph changes](#previewing-subgraph-changes).
+Optional. The path to a YAML file describing hypothetical changes to one or more subgraphs to apply before composing. You can also provide `-`, in which case the command reads the file from `stdin`. For details, see [previewing subgraph changes](#previewing-subgraph-changes).
 
 </td>
 </tr>
@@ -623,13 +623,13 @@ Optional. The path to a YAML file describing hypothetical changes to one or more
 </td>
 <td>
 
-Optional. A tag name to include when filtering. To include multiple tag names, specify `--include-tag` multiple times. For details, see the documentation for [contract filters](/graphos/delivery/contracts/#contract-filters).
+Optional. A tag name to include when filtering. To include multiple tag names, specify `--include-tag` multiple times. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
 
 ```bash
 --include-tag foo --include-tag bar
 ```
 
-Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and their `--no-*` counterparts) to preview composition only, with no filtering applied. If you provide any one of them, configure all three—use `--no-include-tags` to set an empty include list.
+Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and their `--no-*` counterparts) to preview composition only, with no filtering applied. If you provide any one of them, configure all three.
 
 </td>
 </tr>
@@ -641,7 +641,7 @@ Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and thei
 </td>
 <td>
 
-Sets an empty include list for the previewed contract schema. To adopt a non-empty list, use `--include-tag` instead. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+Sets an empty include list for the previewed contract schema. To use a non-empty list, use `--include-tag` instead. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
 
 </td>
 </tr>
@@ -683,7 +683,7 @@ Specify an empty [exclude list](/graphos/delivery/contracts/#contract-filters) f
 </td>
 <td>
 
-Automatically [hide](/graphos/delivery/contracts/#contract-filters) types that can never be reached in operations on your previewed contract schema.
+Automatically [hides](/graphos/delivery/contracts/#contract-filters) types that can never be reached in operations on your previewed contract schema.
 
 </td>
 </tr>
@@ -707,8 +707,7 @@ Disable the automatic hiding of types that can never be reached in operations on
 </td>
 <td>
 
-Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Check on the build's status later with `--build-id`.
-
+Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Use `--build-id` to check on the build's status later.
 </td>
 </tr>
 <tr>
@@ -726,7 +725,7 @@ Optional. Check the status of a previously started preview build a single time, 
 </tbody>
 </table>
 
-#### Preview subgraph changes
+#### Previewing subgraph changes
 
 Use `--subgraph-changes` to preview what composition produces if you change or remove one or more subgraphs first, without publishing those changes. Provide a YAML file with a `subgraphs` map keyed by subgraph name:
 
@@ -748,13 +747,13 @@ Each subgraph entry can set:
 
 - `routing_url`: a hypothetical new routing URL for the subgraph. Omit to keep the subgraph's currently published URL.
 - `schema`: a hypothetical new schema for the subgraph, either `file: <path>` (a local `.graphql`/`.gql` file) or `sdl: "<inline SDL>"`. Omit to keep the subgraph's currently published schema.
-- `remove: true`: Preview composition as if the subgraph had been removed. Do not combine with `routing_url` or `schema`.
+- `remove: true`: Preview composition as if the subgraph had been removed. Don't combine with `routing_url` or `schema`.
 
 Every subgraph entry must set at least one of `routing_url`, `schema`, or `remove: true`. Subgraphs you don't mention in the file compose exactly as they're currently published.
 
-#### Run previews asynchronously
+#### Running previews asynchronously
 
-For long-running preview builds, use `--async` to start the build and return a build ID immediately. This is the recommended approach for large schemas to avoid local timeouts.
+For long-running preview builds, use `--async` to start the build and return a build ID immediately. This approach helps large schemas avoid local timeouts.
 
 ```bash
 rover subgraph preview my-graph@my-variant --subgraph-changes ./changes.yaml --async
@@ -766,7 +765,7 @@ Check the build status later with `--build-id`:
 rover subgraph preview my-graph@my-variant --build-id <BUILD_ID>
 ```
 
-By default (without `--async`), Rover polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) passes, whichever comes first. If Rover times out while polling, the build itself might still complete in the background—check the build's status later with `--build-id`.
+By default (without `--async`), Rover polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) passes. If Rover times out, your build may still complete in the background. Check your build's status later with `--build-id`.
 
 ## Deleting a subgraph
 

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -573,6 +573,201 @@ By default, this command flags all violations in your local schema.
 </tbody>
 </table>
 
+## Previewing a supergraph
+
+### `subgraph preview`
+
+<AuthNotice />
+
+Always preview your supergraph schema before publishing subgraph changes to ensure successful composition without affecting your production graph.
+
+Run the `subgraph preview` command:
+
+```bash
+rover subgraph preview my-graph@my-variant
+```
+
+The argument `my-graph@my-variant` in the preceding example is a [graph ref](../conventions/#graph-refs) that specifies the ID of the graph and [variant](/graphos/graphs/#variants) whose subgraphs you want to build a preview from.
+
+By default, `subgraph preview` composes the variant's subgraphs exactly as they're currently published. Use `--subgraph-changes` to preview the effect of hypothetical subgraph changes first (see [Previewing subgraph changes](#previewing-subgraph-changes) below). You can also provide the `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` options to preview a contract filter on top of composition.
+
+Preview builds run asynchronously on GraphOS. By default, Rover starts the build and polls its status until it's complete, then prints the resulting schema. For details, see [Running previews asynchronously](#running-previews-asynchronously).
+
+#### Options
+
+<table class="field-table">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+###### `--subgraph-changes`
+
+</td>
+<td>
+
+Optional. The path to a YAML file describing hypothetical changes to one or more subgraphs to apply before composing. You can also provide `-`, in which case the command reads the file from `stdin`. For details, see [Previewing subgraph changes](#previewing-subgraph-changes).
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--include-tag`
+
+</td>
+<td>
+
+Optional. A tag name to include when filtering. To include multiple tag names, specify `--include-tag` multiple times. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+
+```bash
+--include-tag foo --include-tag bar
+```
+
+Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and their `--no-*` counterparts) to preview composition only, with no filtering applied. If you provide any one of them, decide all three—use `--no-include-tags` to set an empty include list.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--no-include-tags`
+
+</td>
+<td>
+
+Sets an empty include list for the previewed contract schema. To use a non-empty list, use `--include-tag` instead. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### The `--exclude-tag` option
+
+</td>
+<td>
+
+Specify a tag name to [exclude tag names](/graphos/delivery/contracts/#contract-filters) when filtering. To exclude multiple tag names, specify `--exclude-tag` multiple times:
+
+```bash
+--exclude-tag foo --exclude-tag bar
+```
+
+Use `--no-exclude-tags` to specify an empty exclude list.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### The `--no-exclude-tags` option
+
+</td>
+<td>
+
+Specify an empty [exclude list](/graphos/delivery/contracts/#contract-filters) for the previewed contract schema. Use `--exclude-tag` to specify a non-empty list.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### The `--hide-unreachable-types` option
+
+</td>
+<td>
+
+Automatically [hides](/graphos/delivery/contracts/#contract-filters) types that can never be reached in operations on your previewed contract schema.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--no-hide-unreachable-types`
+
+</td>
+<td>
+
+Disable the automatic hiding of types that can never be reached in operations on your previewed contract schema.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--async`
+
+</td>
+<td>
+
+Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Check on your build's status later with `--build-id`.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `--build-id`
+
+</td>
+<td>
+
+Optional. Check the status of a previously started preview build a single time, instead of starting a new one. Don't combine with `--subgraph-changes`, `--async`, or the include/exclude/hide-unreachable-types options preceding.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+#### Previewing subgraph changes
+
+Use `--subgraph-changes` to preview what composition produces if you change or remove one or more subgraphs first, without publishing those changes. Provide a YAML file with a `subgraphs` map keyed by subgraph name:
+
+```yaml title="changes.yaml"
+subgraphs:
+  foo:
+    routing_url: https://example.com  # optional; omit to keep the existing URL
+    schema:
+      file: ./foo.graphql              # or `sdl: "type Query { ... }"` inline
+  bar:
+    remove: true
+```
+
+```bash
+rover subgraph preview my-graph@my-variant --subgraph-changes ./changes.yaml
+```
+
+Each subgraph entry can set:
+
+- `routing_url`: a hypothetical new routing URL for the subgraph. Omit to keep the subgraph's currently published URL.
+- `schema`: a hypothetical new schema for the subgraph, either `file: <path>` (a local `.graphql`/`.gql` file) or `sdl: "<inline SDL>"`. Omit to keep the subgraph's currently published schema.
+- `remove: true`: Preview composition as if the subgraph had been removed. Do not combine with `routing_url` or `schema`
+
+Every subgraph entry must set at least one of `routing_url`, `schema`, or `remove: true`. Subgraphs you don't mention in the file compose exactly as they're currently published.
+
+#### Running previews asynchronously
+
+For long-running preview builds, use `--async` to start the build and return a build ID immediately.
+
+```bash
+rover subgraph preview my-graph@my-variant --subgraph-changes ./changes.yaml --async
+```
+
+Check back on the build later with `--build-id`:
+
+```bash
+rover subgraph preview my-graph@my-variant --build-id <BUILD_ID>
+```
+
+By default (without `--async`), Rover polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) passes, whichever comes first. If Rover times out while polling, the build itself might still complete in the background—check your build's status later with `--build-id`.
+
 ## Deleting a subgraph
 
 ### `subgraph delete`

--- a/docs/source/commands/subgraphs.mdx
+++ b/docs/source/commands/subgraphs.mdx
@@ -573,13 +573,13 @@ By default, this command flags all violations in your local schema.
 </tbody>
 </table>
 
-## Previewing a supergraph
+## Previewing a graph
 
 ### `subgraph preview`
 
 <AuthNotice />
 
-Always preview your supergraph schema before publishing subgraph changes to ensure successful composition without affecting your production graph.
+Always preview supergraph schema before publishing subgraph changes to ensure successful composition without affecting your production graph.
 
 Run the `subgraph preview` command:
 
@@ -591,7 +591,7 @@ The argument `my-graph@my-variant` in the preceding example is a [graph ref](../
 
 By default, `subgraph preview` composes the variant's subgraphs exactly as they're currently published. Use `--subgraph-changes` to preview the effect of hypothetical subgraph changes first (see [Previewing subgraph changes](#previewing-subgraph-changes) below). You can also provide the `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` options to preview a contract filter on top of composition.
 
-Preview builds run asynchronously on GraphOS. By default, Rover starts the build and polls its status until it's complete, then prints the resulting schema. For details, see [Running previews asynchronously](#running-previews-asynchronously).
+Preview builds run asynchronously on GraphOS. By default, Rover starts the build and polls its status until it completes, then prints the resulting schema. For details, see [Running previews asynchronously](#running-previews-asynchronously).
 
 #### Options
 
@@ -611,7 +611,7 @@ Preview builds run asynchronously on GraphOS. By default, Rover starts the build
 </td>
 <td>
 
-Optional. The path to a YAML file describing hypothetical changes to one or more subgraphs to apply before composing. You can also provide `-`, in which case the command reads the file from `stdin`. For details, see [Previewing subgraph changes](#previewing-subgraph-changes).
+Optional. The path to a YAML file describing hypothetical changes to one or more subgraphs to apply before composing. You can also provide `-`, in which case the command reads the file from `stdin`. For details, see the section on [previewing subgraph changes](#previewing-subgraph-changes).
 
 </td>
 </tr>
@@ -623,13 +623,13 @@ Optional. The path to a YAML file describing hypothetical changes to one or more
 </td>
 <td>
 
-Optional. A tag name to include when filtering. To include multiple tag names, specify `--include-tag` multiple times. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+Optional. A tag name to include when filtering. To include multiple tag names, specify `--include-tag` multiple times. For details, see the documentation for [contract filters](/graphos/delivery/contracts/#contract-filters).
 
 ```bash
 --include-tag foo --include-tag bar
 ```
 
-Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and their `--no-*` counterparts) to preview composition only, with no filtering applied. If you provide any one of them, decide all three—use `--no-include-tags` to set an empty include list.
+Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and their `--no-*` counterparts) to preview composition only, with no filtering applied. If you provide any one of them, configure all three—use `--no-include-tags` to set an empty include list.
 
 </td>
 </tr>
@@ -641,14 +641,14 @@ Omit all of `--include-tag`/`--exclude-tag`/`--hide-unreachable-types` (and thei
 </td>
 <td>
 
-Sets an empty include list for the previewed contract schema. To use a non-empty list, use `--include-tag` instead. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
+Sets an empty include list for the previewed contract schema. To adopt a non-empty list, use `--include-tag` instead. For details, see [contract filters](/graphos/delivery/contracts/#contract-filters).
 
 </td>
 </tr>
 <tr>
 <td>
 
-###### The `--exclude-tag` option
+###### `--exclude-tag` option
 
 </td>
 <td>
@@ -666,7 +666,7 @@ Use `--no-exclude-tags` to specify an empty exclude list.
 <tr>
 <td>
 
-###### The `--no-exclude-tags` option
+###### `--no-exclude-tags` option
 
 </td>
 <td>
@@ -678,12 +678,12 @@ Specify an empty [exclude list](/graphos/delivery/contracts/#contract-filters) f
 <tr>
 <td>
 
-###### The `--hide-unreachable-types` option
+###### `--hide-unreachable-types` option
 
 </td>
 <td>
 
-Automatically [hides](/graphos/delivery/contracts/#contract-filters) types that can never be reached in operations on your previewed contract schema.
+Automatically [hide](/graphos/delivery/contracts/#contract-filters) types that can never be reached in operations on your previewed contract schema.
 
 </td>
 </tr>
@@ -707,7 +707,7 @@ Disable the automatic hiding of types that can never be reached in operations on
 </td>
 <td>
 
-Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Check on your build's status later with `--build-id`.
+Optional. If provided, Rover starts the preview build and immediately returns with a build ID, instead of waiting for it to complete. Check on the build's status later with `--build-id`.
 
 </td>
 </tr>
@@ -726,7 +726,7 @@ Optional. Check the status of a previously started preview build a single time, 
 </tbody>
 </table>
 
-#### Previewing subgraph changes
+#### Preview subgraph changes
 
 Use `--subgraph-changes` to preview what composition produces if you change or remove one or more subgraphs first, without publishing those changes. Provide a YAML file with a `subgraphs` map keyed by subgraph name:
 
@@ -748,25 +748,25 @@ Each subgraph entry can set:
 
 - `routing_url`: a hypothetical new routing URL for the subgraph. Omit to keep the subgraph's currently published URL.
 - `schema`: a hypothetical new schema for the subgraph, either `file: <path>` (a local `.graphql`/`.gql` file) or `sdl: "<inline SDL>"`. Omit to keep the subgraph's currently published schema.
-- `remove: true`: Preview composition as if the subgraph had been removed. Do not combine with `routing_url` or `schema`
+- `remove: true`: Preview composition as if the subgraph had been removed. Do not combine with `routing_url` or `schema`.
 
 Every subgraph entry must set at least one of `routing_url`, `schema`, or `remove: true`. Subgraphs you don't mention in the file compose exactly as they're currently published.
 
-#### Running previews asynchronously
+#### Run previews asynchronously
 
-For long-running preview builds, use `--async` to start the build and return a build ID immediately.
+For long-running preview builds, use `--async` to start the build and return a build ID immediately. This is the recommended approach for large schemas to avoid local timeouts.
 
 ```bash
 rover subgraph preview my-graph@my-variant --subgraph-changes ./changes.yaml --async
 ```
 
-Check back on the build later with `--build-id`:
+Check the build status later with `--build-id`:
 
 ```bash
 rover subgraph preview my-graph@my-variant --build-id <BUILD_ID>
 ```
 
-By default (without `--async`), Rover polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) passes, whichever comes first. If Rover times out while polling, the build itself might still complete in the background—check your build's status later with `--build-id`.
+By default (without `--async`), Rover polls the build's status until it completes or [`APOLLO_CHECKS_TIMEOUT_SECONDS`](../configuring/#supported-environment-variables) passes, whichever comes first. If Rover times out while polling, the build itself might still complete in the background—check the build's status later with `--build-id`.
 
 ## Deleting a subgraph
 

--- a/docs/source/configuring.mdx
+++ b/docs/source/configuring.mdx
@@ -396,7 +396,7 @@ If present, an environment variable's value takes precedence over all other meth
 |-----------------------------|----------------|
 | `APOLLO_HOME` | The path to the parent directory of Rover's binary. The default value is your operating system's default home directory. Rover will install itself in a folder called `.rover` inside the directory specified. |
 | `APOLLO_CONFIG_HOME` | The path where Rover's configuration is stored. The default value is your operating system's default configuration directory. |
-| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, the Rover CLI polls an asynchronous check or preview build before timing out. Applies to `graph check`, `subgraph check`, the checks run by `graph publish` and `subgraph publish`, and to `subgraph preview` and `contract preview`. Defaults to 300 (5 minutes). |
+| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, Rover CLI polls an asynchronous check or preview build before timing out. Applies to `graph check`, `subgraph check`, the checks run by `graph publish` and `subgraph publish`, and to `subgraph preview` and `contract preview`. Defaults to 300 (5 minutes). |
 | `APOLLO_GRAPH_REF` | A graph ref passed to `rover dev` command. [Learn more](./commands/dev#understanding---graph-ref-vs-apollo_graph_ref) |
 | `APOLLO_KEY` | The API key that Rover should use to authenticate with GraphOS Studio. |
 | `APOLLO_TELEMETRY_DISABLED` | Set to `true` if you don't want Rover to collect anonymous usage data. |

--- a/docs/source/configuring.mdx
+++ b/docs/source/configuring.mdx
@@ -396,7 +396,7 @@ If present, an environment variable's value takes precedence over all other meth
 |-----------------------------|----------------|
 | `APOLLO_HOME` | The path to the parent directory of Rover's binary. The default value is your operating system's default home directory. Rover will install itself in a folder called `.rover` inside the directory specified. |
 | `APOLLO_CONFIG_HOME` | The path where Rover's configuration is stored. The default value is your operating system's default configuration directory. |
-| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, Rover CLI polls an asynchronous check or preview build before timing out. Applies to `graph check`, `subgraph check`, the checks run by `graph publish` and `subgraph publish`, and to `subgraph preview` and `contract preview`. Defaults to 300 (5 minutes). |
+| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, Rover CLI polls an asynchronous check or preview build before timing out. Applies to `graph check`, `subgraph check`, the checks run by `graph publish` and `subgraph publish`, and to `subgraph preview` and `contract preview`. Defaults to `300` (5 minutes). |
 | `APOLLO_GRAPH_REF` | A graph ref passed to `rover dev` command. [Learn more](./commands/dev#understanding---graph-ref-vs-apollo_graph_ref) |
 | `APOLLO_KEY` | The API key that Rover should use to authenticate with GraphOS Studio. |
 | `APOLLO_TELEMETRY_DISABLED` | Set to `true` if you don't want Rover to collect anonymous usage data. |

--- a/docs/source/configuring.mdx
+++ b/docs/source/configuring.mdx
@@ -396,7 +396,7 @@ If present, an environment variable's value takes precedence over all other meth
 |-----------------------------|----------------|
 | `APOLLO_HOME` | The path to the parent directory of Rover's binary. The default value is your operating system's default home directory. Rover will install itself in a folder called `.rover` inside the directory specified. |
 | `APOLLO_CONFIG_HOME` | The path where Rover's configuration is stored. The default value is your operating system's default configuration directory. |
-| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, the Rover CLI polls a subgraph check, subgraph preview, or contract preview before timing out. Defaults to 300 (5 minutes). |
+| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, the Rover CLI polls an asynchronous check or preview build before timing out. Applies to `graph check`, `subgraph check`, the checks run by `graph publish` and `subgraph publish`, and to `subgraph preview` and `contract preview`. Defaults to 300 (5 minutes). |
 | `APOLLO_GRAPH_REF` | A graph ref passed to `rover dev` command. [Learn more](./commands/dev#understanding---graph-ref-vs-apollo_graph_ref) |
 | `APOLLO_KEY` | The API key that Rover should use to authenticate with GraphOS Studio. |
 | `APOLLO_TELEMETRY_DISABLED` | Set to `true` if you don't want Rover to collect anonymous usage data. |

--- a/docs/source/configuring.mdx
+++ b/docs/source/configuring.mdx
@@ -396,6 +396,7 @@ If present, an environment variable's value takes precedence over all other meth
 |-----------------------------|----------------|
 | `APOLLO_HOME` | The path to the parent directory of Rover's binary. The default value is your operating system's default home directory. Rover will install itself in a folder called `.rover` inside the directory specified. |
 | `APOLLO_CONFIG_HOME` | The path where Rover's configuration is stored. The default value is your operating system's default configuration directory. |
+| `APOLLO_CHECKS_TIMEOUT_SECONDS` | How long, in seconds, the Rover CLI polls a subgraph check, subgraph preview, or contract preview before timing out. Defaults to 300 (5 minutes). |
 | `APOLLO_GRAPH_REF` | A graph ref passed to `rover dev` command. [Learn more](./commands/dev#understanding---graph-ref-vs-apollo_graph_ref) |
 | `APOLLO_KEY` | The API key that Rover should use to authenticate with GraphOS Studio. |
 | `APOLLO_TELEMETRY_DISABLED` | Set to `true` if you don't want Rover to collect anonymous usage data. |


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/rover/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!

We hope you will find this to be a positive experience! Open source
contribution can be intimidating and we hope to alleviate that pain as much
as possible. Without following these guidelines, you may be missing context
that can help you succeed with your contribution, which is why we encourage
discussion first. Ultimately, there is no guarantee that we will be able to
merge your pull-request, but by following these guidelines we can try to
avoid disappointment.

-->

REG-1909 Docs

Documents `rover contract preview` and `rover subgraph preview` in `docs/source/commands/contracts.mdx` and `docs/source/commands/subgraphs.mdx`, plus a note about `APOLLO_CHECKS_TIMEOUT_SECONDS` polling in `docs/source/configuring.mdx`.

Kept separate from the code PRs per AGENTS.md: `docs/source/*` ships on merge to `main` outside the normal release process, so merging this before the commands exist in a released binary would publish docs for a feature users can't run yet. Land this once both preview stacks have shipped (REG-1909 Contract Preview 3b, REG-1909 Subgraph Preview 3a).

[ ] A CHANGELOG.md entry is not needed for this PR
