### PR TITLE
fix(client): report rejected-but-well-formed API keys as invalid, not malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+- **Stop reporting a malformed API key when the format is fine - @SharkBaitDLS fixes #1171**
+
+  A revoked, expired, or unrecognized API key used to fail with `error[E014]: The API key you provided is malformed.`, sending you off to fix a format that was already correct. `E014` is now reserved for keys that genuinely aren't shaped like `user:my-username:secretkey` or `service:graph-id:secretkey`. Anything else the registry turns down reports `error[E013]: The registry did not recognize the provided API key`, so you're pointed at whether the key is still valid rather than at how it looks. Introspecting your own subgraph no longer blames your Apollo credentials either.
+
 - **Fix interactive confirmation prompts not waiting for input when stdout (but not stdin) is redirected - fixes #1455**
 
   `y/N` confirmation prompts (the ELv2 license acceptance prompt, `rover graph delete`/`rover subgraph delete` confirmations) checked whether *stdout* was attached to a terminal before reading an answer. Redirecting stdout while leaving stdin interactive made the prompt print, then immediately read an empty answer instead of waiting for input, defaulting to "no" and erroring out. Prompts now read from stdin directly, gated on stdin's own terminal status.

--- a/crates/houston/src/api_key.rs
+++ b/crates/houston/src/api_key.rs
@@ -1,0 +1,155 @@
+//! The shape of a registry API key.
+
+use std::fmt;
+
+/// What a registry API key authenticates as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiKeyActor {
+    /// A Personal API Key (`user:...`), belonging to a person.
+    User,
+
+    /// A graph API key (`service:...`), scoped to one graph.
+    Graph,
+
+    /// Something else. Not an error: the registry is free to introduce actors that this
+    /// version of Rover predates, and a key Rover doesn't recognize may still be valid.
+    Other,
+}
+
+/// An API key that doesn't match the shape the registry documents.
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[error("an API key must have three non-empty parts separated by colons")]
+pub struct MalformedApiKey;
+
+/// A registry API key in the `actor:id:secret` shape the registry documents:
+/// `user:my-username:secretkey` or `service:graph-id:secretkey`.
+///
+/// Borrows the key it was parsed from, so the secret is never copied.
+///
+/// Parsing is deliberately not enforced when a credential is loaded. Only the registry can say
+/// whether a key works, and refusing to send one Rover merely finds surprising would turn a
+/// cosmetic disagreement into a hard failure. Callers parse when they want the shape, and treat
+/// [`MalformedApiKey`] as evidence about a rejection that already happened.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ApiKey<'a> {
+    actor: ApiKeyActor,
+    id: &'a str,
+    secret: &'a str,
+}
+
+impl<'a> ApiKey<'a> {
+    /// What the key authenticates as.
+    pub const fn actor(&self) -> ApiKeyActor {
+        self.actor
+    }
+
+    /// The username or graph id the key belongs to.
+    pub const fn id(&self) -> &'a str {
+        self.id
+    }
+
+    /// The secret portion. Treat as sensitive: never log or display it.
+    pub const fn secret(&self) -> &'a str {
+        self.secret
+    }
+}
+
+impl<'a> TryFrom<&'a str> for ApiKey<'a> {
+    type Error = MalformedApiKey;
+
+    /// A colon inside the secret is tolerated, since a working key that Rover calls malformed is
+    /// worse than a broken one it fails to spot.
+    fn try_from(key: &'a str) -> Result<ApiKey<'a>, MalformedApiKey> {
+        let mut parts = key.splitn(3, ':');
+        let (Some(actor), Some(id), Some(secret)) = (parts.next(), parts.next(), parts.next())
+        else {
+            return Err(MalformedApiKey);
+        };
+        if actor.is_empty() || id.is_empty() || secret.is_empty() {
+            return Err(MalformedApiKey);
+        }
+        Ok(ApiKey {
+            actor: match actor {
+                "user" => ApiKeyActor::User,
+                "service" => ApiKeyActor::Graph,
+                _ => ApiKeyActor::Other,
+            },
+            id,
+            secret,
+        })
+    }
+}
+
+/// Redacts the secret, so an [`ApiKey`] can be logged without leaking the key it came from.
+impl fmt::Debug for ApiKey<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiKey")
+            .field("actor", &self.actor)
+            .field("id", &self.id)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use speculoos::prelude::*;
+
+    use super::*;
+
+    #[rstest]
+    #[case::personal_key(
+        "user:my-username:secretkey",
+        ApiKeyActor::User,
+        "my-username",
+        "secretkey"
+    )]
+    #[case::graph_key(
+        "service:graph-id:secretkey",
+        ApiKeyActor::Graph,
+        "graph-id",
+        "secretkey"
+    )]
+    #[case::unknown_actor("robot:some-id:secretkey", ApiKeyActor::Other, "some-id", "secretkey")]
+    #[case::colon_in_the_secret(
+        "user:my-username:secret:key",
+        ApiKeyActor::User,
+        "my-username",
+        "secret:key"
+    )]
+    fn parses_the_documented_shape(
+        #[case] key: &str,
+        #[case] actor: ApiKeyActor,
+        #[case] id: &str,
+        #[case] secret: &str,
+    ) {
+        let parsed = ApiKey::try_from(key).expect("should have parsed");
+
+        assert_that!(parsed.actor()).is_equal_to(actor);
+        assert_that!(parsed.id()).is_equal_to(id);
+        assert_that!(parsed.secret()).is_equal_to(secret);
+    }
+
+    #[rstest]
+    #[case::no_colons("not-a-real-key")]
+    #[case::too_few_parts("user:secretkey")]
+    #[case::empty_actor(":my-username:secretkey")]
+    #[case::empty_id("user::secretkey")]
+    #[case::empty_secret("user:my-username:")]
+    #[case::empty_key("")]
+    fn rejects_anything_else(#[case] key: &str) {
+        assert_that!(ApiKey::try_from(key)).is_equal_to(Err(MalformedApiKey));
+    }
+
+    // The whole point of the manual Debug impl.
+    #[test]
+    fn debug_does_not_leak_the_secret() {
+        let parsed = ApiKey::try_from("user:my-username:secretkey").unwrap();
+
+        let rendered = format!("{parsed:?}");
+
+        assert_that!(rendered).does_not_contain("secretkey");
+        assert_that!(rendered).contains("my-username");
+    }
+}

--- a/crates/houston/src/lib.rs
+++ b/crates/houston/src/lib.rs
@@ -2,10 +2,13 @@
 
 //! Utilities for configuring the rover CLI tool.
 
+mod api_key;
 mod config;
 mod error;
 mod profile;
 
+/// The shape of a registry API key.
+pub use api_key::{ApiKey, ApiKeyActor, MalformedApiKey};
 pub use config::Config;
 pub use error::HoustonProblem;
 pub use profile::mask_key;

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -7,7 +7,7 @@ use rover_std::Fs;
 use sensitive::Sensitive;
 use serde::{Deserialize, Serialize};
 
-use crate::{Config, HoustonProblem};
+use crate::{ApiKey, Config, HoustonProblem, MalformedApiKey};
 
 /// Collects configuration related to a profile.
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,6 +40,27 @@ pub struct Credential {
     /// Unix timestamp at which an OAuth access token expires. Always `None`
     /// unless `origin` is [`CredentialOrigin::OauthAuthorizationPkce`].
     pub expires_at: Option<i64>,
+}
+
+impl Credential {
+    /// This credential's API key, parsed, or `None` when it authenticates with an OAuth access
+    /// token instead. An OAuth token has no key shape to speak of, and its format isn't
+    /// something the user can act on.
+    pub fn api_key(&self) -> Option<Result<ApiKey<'_>, MalformedApiKey>> {
+        match self.origin {
+            CredentialOrigin::OauthAuthorizationPkce(_)
+            | CredentialOrigin::OauthClientCredentials => None,
+            CredentialOrigin::EnvVar | CredentialOrigin::ConfigFile(_) => {
+                Some(ApiKey::try_from(self.api_key.as_str()))
+            }
+        }
+    }
+
+    /// Whether this credential is an API key that doesn't match the shape the registry
+    /// documents, and so could not have been accepted whatever else is wrong.
+    pub fn has_malformed_api_key(&self) -> bool {
+        matches!(self.api_key(), Some(Err(MalformedApiKey)))
+    }
 }
 
 /// A profile's stored OAuth session (both tokens), as opposed to
@@ -297,6 +318,39 @@ mod tests {
 
     use super::*;
     use crate::Config;
+
+    fn credential(api_key: &str, origin: CredentialOrigin) -> Credential {
+        Credential {
+            api_key: api_key.to_string(),
+            origin,
+            expires_at: None,
+        }
+    }
+
+    // The shape table lives with the parser in `api_key`; what matters here is which origins
+    // have a key to parse at all, and that the verdict is passed through.
+    #[rstest]
+    #[case::env_var(CredentialOrigin::EnvVar)]
+    #[case::config_file(CredentialOrigin::ConfigFile("default".to_string()))]
+    fn api_key_is_parsed_for_the_origins_that_carry_one(#[case] origin: CredentialOrigin) {
+        let well_formed = credential("user:my-username:secretkey", origin.clone());
+        assert_that!(well_formed.api_key().unwrap().unwrap().id()).is_equal_to("my-username");
+        assert_that!(well_formed.has_malformed_api_key()).is_false();
+
+        let malformed = credential("not-a-real-key", origin);
+        assert_that!(malformed.api_key().unwrap()).is_equal_to(Err(MalformedApiKey));
+        assert_that!(malformed.has_malformed_api_key()).is_true();
+    }
+
+    #[rstest]
+    #[case::authorization_pkce(CredentialOrigin::OauthAuthorizationPkce("default".to_string()))]
+    #[case::client_credentials(CredentialOrigin::OauthClientCredentials)]
+    fn an_oauth_access_token_has_no_api_key_to_parse(#[case] origin: CredentialOrigin) {
+        let credential = credential("an-access-token", origin);
+
+        assert_that!(credential.api_key()).is_none();
+        assert_that!(credential.has_malformed_api_key()).is_false();
+    }
 
     #[fixture]
     fn test_config(#[default(None)] override_api_key: Option<String>) -> (Config, TempDir) {

--- a/crates/houston/src/profile/mod.rs
+++ b/crates/houston/src/profile/mod.rs
@@ -42,6 +42,30 @@ pub struct Credential {
     pub expires_at: Option<i64>,
 }
 
+impl Credential {
+    /// Whether this credential is a legacy API key that doesn't match the `actor:id:secret`
+    /// shape the registry documents (`user:my-username:secretkey`, `service:graph-id:secretkey`).
+    ///
+    /// A colon inside the secret is tolerated: wrongly calling a working key malformed is worse
+    /// than failing to spot a broken one, and only the registry knows for certain. OAuth access
+    /// tokens are never malformed here - their shape isn't something the user can act on.
+    pub fn has_malformed_api_key(&self) -> bool {
+        match self.origin {
+            CredentialOrigin::OauthAuthorizationPkce(_)
+            | CredentialOrigin::OauthClientCredentials => false,
+            CredentialOrigin::EnvVar | CredentialOrigin::ConfigFile(_) => {
+                let mut parts = self.api_key.splitn(3, ':');
+                let well_formed = matches!(
+                    (parts.next(), parts.next(), parts.next()),
+                    (Some(actor), Some(id), Some(secret))
+                        if !actor.is_empty() && !id.is_empty() && !secret.is_empty()
+                );
+                !well_formed
+            }
+        }
+    }
+}
+
 /// A profile's stored OAuth session (both tokens), as opposed to
 /// [`Credential`] which only carries the token used to authenticate.
 #[derive(Clone, Debug)]
@@ -297,6 +321,41 @@ mod tests {
 
     use super::*;
     use crate::Config;
+
+    fn credential(api_key: &str, origin: CredentialOrigin) -> Credential {
+        Credential {
+            api_key: api_key.to_string(),
+            origin,
+            expires_at: None,
+        }
+    }
+
+    #[rstest]
+    #[case::personal_key("user:my-username:secretkey", false)]
+    #[case::service_key("service:graph-id:secretkey", false)]
+    #[case::colon_in_the_secret("user:my-username:secret:key", false)]
+    #[case::no_colons("not-a-real-key", true)]
+    #[case::too_few_parts("user:secretkey", true)]
+    #[case::empty_id("user::secretkey", true)]
+    #[case::empty_secret("user:my-username:", true)]
+    #[case::empty_key("", true)]
+    fn has_malformed_api_key_follows_the_documented_key_shape(
+        #[case] api_key: &str,
+        #[case] expected: bool,
+    ) {
+        let credential = credential(api_key, CredentialOrigin::EnvVar);
+
+        assert_that!(credential.has_malformed_api_key()).is_equal_to(expected);
+    }
+
+    #[rstest]
+    #[case::authorization_pkce(CredentialOrigin::OauthAuthorizationPkce("default".to_string()))]
+    #[case::client_credentials(CredentialOrigin::OauthClientCredentials)]
+    fn has_malformed_api_key_ignores_oauth_access_tokens(#[case] origin: CredentialOrigin) {
+        let credential = credential("an-access-token", origin);
+
+        assert_that!(credential.has_malformed_api_key()).is_false();
+    }
 
     #[fixture]
     fn test_config(#[default(None)] override_api_key: Option<String>) -> (Config, TempDir) {

--- a/crates/rover-client/src/blocking/client.rs
+++ b/crates/rover-client/src/blocking/client.rs
@@ -205,7 +205,7 @@ impl GraphQLClient {
         match response.json::<GraphQLResponse<Q::ResponseData>>().await {
             Ok(response_body) => {
                 if let Some(response_body_errors) = response_body.errors {
-                    handle_graphql_body_errors(response_body_errors)?;
+                    handle_graphql_body_errors(response_body_errors, endpoint_kind)?;
                 }
                 match response_status {
                     StatusCode::OK => {
@@ -236,13 +236,28 @@ impl GraphQLClient {
     }
 }
 
-fn handle_graphql_body_errors(errors: Vec<GraphQLError>) -> Result<(), RoverClientError> {
+/// Studio's response to any rejected credential. The status is in the message because it never
+/// was a status on the response: Studio answers `200` and puts the status line in the body.
+const REJECTED_CREDENTIAL_MESSAGE: &str = "406: Not Acceptable";
+
+fn handle_graphql_body_errors(
+    errors: Vec<GraphQLError>,
+    endpoint_kind: EndpointKind,
+) -> Result<(), RoverClientError> {
     if errors.is_empty() {
         Ok(())
     } else {
         tracing::debug!("GraphQL response errors: {:?}", errors);
-        if errors[0].message == "406: Not Acceptable" {
-            Err(RoverClientError::MalformedKey)
+        // The message says nothing about _why_ the credential was refused, so `StudioClient`
+        // refines this where it can. Only Studio speaks this protocol: a customer's own
+        // subgraph could return the same message for unrelated reasons.
+        // See https://github.com/apollographql/rover/issues/1171.
+        let credential_rejected = endpoint_kind == EndpointKind::ApolloStudio
+            && errors
+                .iter()
+                .any(|error| error.message == REJECTED_CREDENTIAL_MESSAGE);
+        if credential_rejected {
+            Err(RoverClientError::InvalidKey)
         } else {
             Err(RoverClientError::GraphQl {
                 msg: errors
@@ -279,23 +294,52 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn it_is_ok_on_empty_errors() {
-        let errors = vec![];
-        assert!(handle_graphql_body_errors(errors).is_ok());
-    }
-
-    #[test]
-    fn it_returns_malformed_key() {
-        let errors = vec![GraphQLError {
-            message: "406: Not Acceptable".to_string(),
+    fn rejected_credential_error() -> GraphQLError {
+        GraphQLError {
+            message: REJECTED_CREDENTIAL_MESSAGE.to_string(),
             locations: None,
             extensions: None,
             path: None,
-        }];
-        let expected_error = RoverClientError::MalformedKey.to_string();
-        let actual_error = handle_graphql_body_errors(errors).unwrap_err().to_string();
-        assert_eq!(actual_error, expected_error);
+        }
+    }
+
+    #[test]
+    fn it_is_ok_on_empty_errors() {
+        let errors = vec![];
+        assert!(handle_graphql_body_errors(errors, EndpointKind::ApolloStudio).is_ok());
+    }
+
+    #[test]
+    fn it_returns_invalid_key_when_studio_rejects_the_credential() {
+        let error = handle_graphql_body_errors(
+            vec![rejected_credential_error()],
+            EndpointKind::ApolloStudio,
+        )
+        .unwrap_err();
+        assert!(matches!(error, RoverClientError::InvalidKey));
+    }
+
+    #[test]
+    fn it_returns_invalid_key_when_the_rejection_is_not_the_first_error() {
+        let errors = vec![
+            GraphQLError {
+                message: "Something went wrong".to_string(),
+                locations: None,
+                extensions: None,
+                path: None,
+            },
+            rejected_credential_error(),
+        ];
+        let error = handle_graphql_body_errors(errors, EndpointKind::ApolloStudio).unwrap_err();
+        assert!(matches!(error, RoverClientError::InvalidKey));
+    }
+
+    #[test]
+    fn it_does_not_blame_the_api_key_for_non_studio_endpoints() {
+        let error =
+            handle_graphql_body_errors(vec![rejected_credential_error()], EndpointKind::Customer)
+                .unwrap_err();
+        assert!(matches!(error, RoverClientError::GraphQl { .. }));
     }
 
     #[test]
@@ -318,7 +362,9 @@ mod tests {
             msg: format!("{}\n{}", errors[0].message, errors[1].message),
         }
         .to_string();
-        let actual_error = handle_graphql_body_errors(errors).unwrap_err().to_string();
+        let actual_error = handle_graphql_body_errors(errors, EndpointKind::ApolloStudio)
+            .unwrap_err()
+            .to_string();
         assert_eq!(actual_error, expected_error);
     }
 

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -79,6 +79,7 @@ impl StudioClient {
         self.client
             .post::<Q>(variables, &mut header_map, EndpointKind::ApolloStudio)
             .await
+            .map_err(|err| self.refine_rejected_credential_error(err))
     }
 
     /// Client method for making a GraphQL request to Apollo Studio.
@@ -93,6 +94,21 @@ impl StudioClient {
         self.client
             .post_no_retry::<Q>(variables, &mut header_map, EndpointKind::ApolloStudio)
             .await
+            .map_err(|err| self.refine_rejected_credential_error(err))
+    }
+
+    /// Upgrades a registry rejection to [`RoverClientError::MalformedKey`] when the key we
+    /// sent couldn't have been accepted in the first place.
+    ///
+    /// Runs only _after_ a rejection rather than pre-flight, so Rover never refuses to send a
+    /// key that Studio would have accepted.
+    fn refine_rejected_credential_error(&self, err: RoverClientError) -> RoverClientError {
+        match err {
+            RoverClientError::InvalidKey if self.credential.has_malformed_api_key() => {
+                RoverClientError::MalformedKey
+            }
+            err => err,
+        }
     }
 
     /// Function for building a [HeaderMap] for making http requests. Use for making
@@ -231,5 +247,62 @@ mod tests {
             .is_some()
             .is_equal_to(&HeaderValue::from_static("Bearer an-access-token"));
         assert_that!(headers.get("x-api-key")).is_none();
+    }
+
+    fn client_with(api_key: &str, origin: CredentialOrigin) -> StudioClient {
+        StudioClient::new(
+            Credential {
+                api_key: api_key.to_string(),
+                origin,
+                expires_at: None,
+            },
+            "https://example.com",
+            "test-version",
+            false,
+            ReqwestClient::new(),
+            Duration::from_secs(1),
+        )
+    }
+
+    #[test]
+    fn a_rejected_credential_is_reported_as_malformed_when_the_key_shape_is_wrong() {
+        let client = client_with("not-a-real-key", CredentialOrigin::EnvVar);
+
+        let refined = client.refine_rejected_credential_error(RoverClientError::InvalidKey);
+
+        assert!(matches!(refined, RoverClientError::MalformedKey));
+    }
+
+    // Revoked, expired, and unrecognized keys all land here.
+    #[test]
+    fn a_rejected_credential_stays_invalid_when_the_key_shape_is_fine() {
+        let client = client_with("user:my-username:secretkey", CredentialOrigin::EnvVar);
+
+        let refined = client.refine_rejected_credential_error(RoverClientError::InvalidKey);
+
+        assert!(matches!(refined, RoverClientError::InvalidKey));
+    }
+
+    #[test]
+    fn a_rejected_oauth_token_is_never_reported_as_malformed() {
+        let client = client_with(
+            "an-access-token",
+            CredentialOrigin::OauthAuthorizationPkce("default".to_string()),
+        );
+
+        let refined = client.refine_rejected_credential_error(RoverClientError::InvalidKey);
+
+        assert!(matches!(refined, RoverClientError::InvalidKey));
+    }
+
+    #[test]
+    fn unrelated_errors_pass_through_untouched() {
+        let client = client_with("not-a-real-key", CredentialOrigin::EnvVar);
+
+        let refined = client.refine_rejected_credential_error(RoverClientError::GraphQl {
+            msg: "Something went wrong".to_string(),
+        });
+
+        assert!(matches!(refined, RoverClientError::GraphQl { .. }));
     }
 }

--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -238,7 +238,7 @@ pub enum RoverClientError {
 
     /// This error occurs when a user has a malformed API key
     #[error(
-        "The API key you provided is malformed. An API key must have three parts separated by a colon."
+        "The API key you provided is malformed. An API key must have three non-empty parts separated by colons."
     )]
     MalformedKey,
 


### PR DESCRIPTION
[ ] A CHANGELOG.md entry is not needed for this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>