### PR TITLE
fix(client): wire the rejected-credential layer into the Studio stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover init` only checked that a pasted key began with `user:`, so a truncated key was accepted and saved, then failed on the next request. It now checks the whole key, and says which thing is wrong: a key that isn't shaped like a key at all asks you for a valid one, while a graph key gets the guidance for clearing `APOLLO_KEY` and stored profiles. A key pasted with a trailing newline is no longer saved with it. `rover init` also stops reusing an `APOLLO_KEY` that looks like a graph key but is truncated.
 
+- **Report an API key the registry refuses outright, not just one it names in a response - @SharkBaitDLS**
+
+  Commands on Rover's newer request stack could only recognize a rejected API key when the registry said so in the body of its response. When it refused the request outright instead, the failure surfaced as an internal error rather than `E013`/`E014`. Those commands now report a refused request as `E013`/`E014` too, matching the rest of Rover.
+
 - **Report a rejected API key as `E013` instead of an internal error - @SharkBaitDLS part of #1171**
 
   When the registry turned down an API key, several commands reported it as an internal error carrying no error code at all, while others reported `E013` — so the same key gave different diagnostics depending on which command you ran. `rover graph fetch`, `rover client check`, `rover graph-artifact list-tags`, and remote subgraph fetching during composition now report it the same way as the rest. `rover graph validate-operations` and `rover subgraph fetch-all` continue to report `E033` where a rejection could equally mean your key is valid but lacks permission for that operation. Failures that aren't about your credentials are unaffected.

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -8,7 +8,9 @@ use reqwest::{
 };
 use rover_graphql::{GraphQLLayer, GraphQLService};
 use rover_http::{retry::RetryPolicy, HttpService, ReqwestService};
-use rover_studio::service::{HttpStudioServiceError, HttpStudioServiceLayer};
+use rover_studio::service::{
+    rejected_credential::RejectedCredentialLayer, HttpStudioServiceError, HttpStudioServiceLayer,
+};
 use tower::{retry::RetryLayer, util::BoxCloneServiceLayer, ServiceBuilder, ServiceExt};
 use url::Url;
 
@@ -164,12 +166,20 @@ impl StudioClient {
     ) -> Result<GraphQLService<HttpService>, InitStudioServiceError> {
         let service = ServiceBuilder::new()
             .layer(GraphQLLayer::default())
-            .layer(BoxCloneServiceLayer::new(HttpStudioServiceLayer::new(
-                Url::from_str(&self.graphql_endpoint)?,
-                self.credential.clone(),
-                self.version.to_string(),
-                self.is_sudo,
-            )?))
+            .layer(BoxCloneServiceLayer::new(
+                // Inside the box so `HttpService`'s error type - and this function's return
+                // type - stay as they are, and above the retry layer so a rejection is never
+                // handed to the retry policy.
+                ServiceBuilder::new()
+                    .layer(HttpStudioServiceLayer::new(
+                        Url::from_str(&self.graphql_endpoint)?,
+                        self.credential.clone(),
+                        self.version.to_string(),
+                        self.is_sudo,
+                    )?)
+                    .layer(RejectedCredentialLayer::new(self.credential.clone()))
+                    .into_inner(),
+            ))
             .layer(RetryLayer::new(RetryPolicy::new(self.retry_period)))
             .service(
                 ReqwestService::builder()

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -7,7 +7,7 @@ use houston as config;
 use reqwest::Client;
 use rover_client::blocking::StudioClient;
 use rover_http::{HttpService, ReqwestService};
-use rover_studio::service::HttpStudioServiceLayer;
+use rover_studio::service::{HttpStudioServiceLayer, rejected_credential::RejectedCredentialLayer};
 use serde::Serialize;
 use tower::{ServiceBuilder, ServiceExt};
 use url::Url;
@@ -244,10 +244,11 @@ impl StudioClientConfig {
         let service = ServiceBuilder::new()
             .layer(HttpStudioServiceLayer::new(
                 Url::from_str(&self.uri)?,
-                credential,
+                credential.clone(),
                 self.version.clone(),
                 self.is_sudo,
             )?)
+            .layer(RejectedCredentialLayer::new(credential))
             .service(ReqwestService::builder().client(client).build()?)
             .boxed_clone();
         Ok(service)


### PR DESCRIPTION
[ ] A CHANGELOG.md entry is not needed for this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>