### PR TITLE
maint(init): grade API keys with houston's parser instead of a prefix check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `y/N` confirmation prompts (the ELv2 license acceptance prompt, `rover graph delete`/`rover subgraph delete` confirmations) checked whether *stdout* was attached to a terminal before reading an answer. Redirecting stdout while leaving stdin interactive made the prompt print, then immediately read an empty answer instead of waiting for input, defaulting to "no" and erroring out. Prompts now read from stdin directly, gated on stdin's own terminal status.
 
+- **Catch a bad API key while `rover init` is still asking for one - @SharkBaitDLS**
+
+  `rover init` only checked that a pasted key began with `user:`, so a truncated key was accepted and saved, then failed on the next request. It now checks the whole key, and says which thing is wrong: a key that isn't shaped like a key at all asks you for a valid one, while a graph key gets the guidance for clearing `APOLLO_KEY` and stored profiles. A key pasted with a trailing newline is no longer saved with it. `rover init` also stops reusing an `APOLLO_KEY` that looks like a graph key but is truncated.
+
 - **Show successful build and operation check sections in plain-text check output - fixes #1816**
 
   `rover subgraph check` and `rover graph check` now show explicit `Build Check [PASSED]` and `Operation Check [PASSED]` sections even when no schema changes or operation warnings were found. This makes successful check results visible alongside linter and other check sections.

--- a/src/command/init/authentication/errors.rs
+++ b/src/command/init/authentication/errors.rs
@@ -5,7 +5,7 @@ use std::{error::Error, fmt};
 pub enum AuthenticationError {
     /// When the key is empty
     EmptyKey,
-    /// When the API key format is invalid (doesn't start with "user:")
+    /// When the key doesn't parse as `actor:id:secret` at all
     InvalidKeyFormat,
     /// When the key is valid format but doesn't authenticate
     AuthenticationFailed(String),

--- a/src/command/init/mod.rs
+++ b/src/command/init/mod.rs
@@ -25,6 +25,7 @@ pub mod transitions;
 use std::path::PathBuf;
 
 use clap::Parser;
+use houston::{ApiKey, ApiKeyActor};
 #[cfg(feature = "composition-js")]
 use rover_client::RoverClientError;
 #[cfg(feature = "composition-js")]
@@ -854,7 +855,11 @@ This MCP server provides AI-accessible tools for your Apollo graph.
         // Get or create Apollo service key
         // First check if APOLLO_KEY is already set in environment
         let apollo_key = if let Ok(key) = std::env::var("APOLLO_KEY") {
-            if key.starts_with("service:") {
+            let is_graph_key = matches!(
+                ApiKey::try_from(key.as_str()),
+                Ok(parsed) if parsed.actor() == ApiKeyActor::Graph
+            );
+            if is_graph_key {
                 println!(
                     "{}",
                     Style::Success.paint("✓ Using existing APOLLO_KEY from environment")

--- a/src/command/init/options/project_authentication.rs
+++ b/src/command/init/options/project_authentication.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use config::Profile;
 use dialoguer::{Password, theme::ColorfulTheme};
-use houston as config;
+use houston::{self as config, ApiKey, ApiKeyActor, MalformedApiKey};
 use rover_std::{hyperlink, successln};
 use serde::{Deserialize, Serialize};
 
@@ -37,14 +37,26 @@ impl ProjectAuthenticationOpt {
 
         let api_key = match password_result {
             Ok(input) => {
+                // Store what we validated: the key was previously checked trimmed and saved
+                // untrimmed, so a pasted trailing newline reached the request headers.
+                let input = input.trim().to_string();
                 if input.is_empty() {
                     return Err(auth_error_to_rover_error(AuthenticationError::EmptyKey));
                 }
 
-                if !input.trim().starts_with("user:") {
-                    return Err(auth_error_to_rover_error(
-                        AuthenticationError::InvalidKeyFormat,
-                    ));
+                // Parsing tells the two failures apart, which `starts_with` couldn't: a garbled
+                // key needs replacing, while a graph key needs the `APOLLO_KEY` guidance that
+                // `NotUserKey` carries.
+                match ApiKey::try_from(input.as_str()) {
+                    Err(MalformedApiKey) => {
+                        return Err(auth_error_to_rover_error(
+                            AuthenticationError::InvalidKeyFormat,
+                        ));
+                    }
+                    Ok(key) if key.actor() != ApiKeyActor::User => {
+                        return Err(auth_error_to_rover_error(AuthenticationError::NotUserKey));
+                    }
+                    Ok(_) => {}
                 }
 
                 input

--- a/src/command/init/tests/authentication_tests.rs
+++ b/src/command/init/tests/authentication_tests.rs
@@ -1,3 +1,7 @@
+use houston::{ApiKey, ApiKeyActor, MalformedApiKey};
+use rstest::rstest;
+use speculoos::prelude::*;
+
 use crate::command::init::authentication::{AuthenticationError, auth_error_to_rover_error};
 
 // ARCHITECTURE TESTS: Error Conversion System
@@ -77,72 +81,24 @@ fn test_system_errors_guide_to_support() {
 
 // TYPE-BASED AUTHENTICATION TESTS
 
-struct ApiKey {
-    key_type: KeyType,
-}
-
-enum KeyType {
-    User,
-    Graph,
-    Invalid,
-}
-
-impl ApiKey {
-    // Parse the key string into a strongly-typed representation
-    fn parse(key: &str) -> Self {
-        if key.is_empty() {
-            return ApiKey {
-                key_type: KeyType::Invalid,
-            };
-        }
-
-        if key.starts_with("user:") {
-            ApiKey {
-                key_type: KeyType::User,
-            }
-        } else if key.starts_with("graph:") {
-            ApiKey {
-                key_type: KeyType::Graph,
-            }
-        } else {
-            ApiKey {
-                key_type: KeyType::Invalid,
-            }
-        }
-    }
-
-    // Type-safe validation that only user keys are acceptable
-    const fn validate_is_user_key(&self) -> Result<(), AuthenticationError> {
-        match self.key_type {
-            KeyType::User => Ok(()),
-            KeyType::Graph => Err(AuthenticationError::NotUserKey),
-            KeyType::Invalid => Err(AuthenticationError::InvalidKeyFormat),
-        }
+/// How `rover init` grades a pasted key, mirroring `ProjectAuthenticationOpt::prompt_for_api_key`.
+fn validate_is_user_key(key: &str) -> Result<(), AuthenticationError> {
+    match ApiKey::try_from(key) {
+        Err(MalformedApiKey) => Err(AuthenticationError::InvalidKeyFormat),
+        Ok(parsed) if parsed.actor() != ApiKeyActor::User => Err(AuthenticationError::NotUserKey),
+        Ok(_) => Ok(()),
     }
 }
 
-#[test]
-fn test_type_safe_key_validation() {
-    // Valid user key
-    let user_key = ApiKey::parse("user:test1234");
-    assert!(matches!(user_key.key_type, KeyType::User));
-    assert!(user_key.validate_is_user_key().is_ok());
-
-    // Graph key (wrong type for user authentication)
-    let graph_key = ApiKey::parse("graph:test1234");
-    assert!(matches!(graph_key.key_type, KeyType::Graph));
-    let err = graph_key.validate_is_user_key().unwrap_err();
-    assert!(matches!(err, AuthenticationError::NotUserKey));
-
-    // Invalid key format
-    let invalid_key = ApiKey::parse("invalid_key");
-    assert!(matches!(invalid_key.key_type, KeyType::Invalid));
-    let err = invalid_key.validate_is_user_key().unwrap_err();
-    assert!(matches!(err, AuthenticationError::InvalidKeyFormat));
-
-    // Empty key
-    let empty_key = ApiKey::parse("");
-    assert!(matches!(empty_key.key_type, KeyType::Invalid));
-    let err = empty_key.validate_is_user_key().unwrap_err();
-    assert!(matches!(err, AuthenticationError::InvalidKeyFormat));
+#[rstest]
+#[case::user_key("user:my-username:secretkey", None)]
+// `service:`, not `graph:` - the prefix this test used to check for never existed.
+#[case::graph_key("service:graph-id:secretkey", Some(AuthenticationError::NotUserKey))]
+#[case::unknown_actor("robot:some-id:secretkey", Some(AuthenticationError::NotUserKey))]
+// Shaped like a user key but unusable, which `starts_with("user:")` used to wave through.
+#[case::truncated_user_key("user:test1234", Some(AuthenticationError::InvalidKeyFormat))]
+#[case::not_a_key("invalid_key", Some(AuthenticationError::InvalidKeyFormat))]
+#[case::empty("", Some(AuthenticationError::InvalidKeyFormat))]
+fn test_type_safe_key_validation(#[case] key: &str, #[case] expected: Option<AuthenticationError>) {
+    assert_that!(validate_is_user_key(key).err()).is_equal_to(expected);
 }

--- a/src/command/init/tests/project_authentication_tests.rs
+++ b/src/command/init/tests/project_authentication_tests.rs
@@ -1,3 +1,5 @@
+use houston::{ApiKey, ApiKeyActor, MalformedApiKey};
+
 use crate::command::init::{
     authentication::AuthenticationError, options::ProjectAuthenticationOpt,
 };
@@ -34,20 +36,24 @@ impl AuthWorkflowSimulation {
             return;
         }
 
-        if !key.starts_with("user:") {
-            self.error = Some(AuthenticationError::InvalidKeyFormat);
-            return;
+        match ApiKey::try_from(key) {
+            Err(MalformedApiKey) => {
+                self.error = Some(AuthenticationError::InvalidKeyFormat);
+                return;
+            }
+            Ok(parsed) if parsed.actor() != ApiKeyActor::User => {
+                self.error = Some(AuthenticationError::NotUserKey);
+                return;
+            }
+            Ok(_) => {}
         }
 
         // Simulate authentication with service
         match key {
-            "user:valid_key" => {
+            "user:someone:valid_key" => {
                 self.authenticated = true;
             }
-            "user:graph_mistake" => {
-                self.error = Some(AuthenticationError::NotUserKey);
-            }
-            "user:invalid_credentials" => {
+            "user:someone:invalid_credentials" => {
                 self.error = Some(AuthenticationError::AuthenticationFailed(
                     "Invalid credentials".to_string(),
                 ));
@@ -88,7 +94,7 @@ impl AuthWorkflowSimulation {
 fn test_successful_authentication_flow() {
     let mut workflow = AuthWorkflowSimulation::new();
 
-    workflow.enter_key("user:valid_key");
+    workflow.enter_key("user:someone:valid_key");
 
     assert!(workflow.authenticated);
     assert_eq!(
@@ -131,7 +137,7 @@ fn test_invalid_format_authentication_flow() {
 fn test_graph_key_authentication_flow() {
     let mut workflow = AuthWorkflowSimulation::new();
 
-    workflow.enter_key("user:graph_mistake");
+    workflow.enter_key("service:graph-id:secretkey");
 
     assert!(!workflow.authenticated);
     assert_eq!(workflow.error, Some(AuthenticationError::NotUserKey));
@@ -146,7 +152,7 @@ fn test_graph_key_authentication_flow() {
 fn test_invalid_credentials_authentication_flow() {
     let mut workflow = AuthWorkflowSimulation::new();
 
-    workflow.enter_key("user:invalid_credentials");
+    workflow.enter_key("user:someone:invalid_credentials");
 
     assert!(!workflow.authenticated);
     assert!(matches!(
@@ -164,7 +170,7 @@ fn test_invalid_credentials_authentication_flow() {
 fn test_system_error_authentication_flow() {
     let mut workflow = AuthWorkflowSimulation::new();
 
-    workflow.enter_key("user:system_error_key");
+    workflow.enter_key("user:someone:system_error_key");
 
     assert!(!workflow.authenticated);
     assert!(matches!(

--- a/src/command/init/transitions.rs
+++ b/src/command/init/transitions.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, env, fs::read_dir, path::PathBuf};
 
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
-use houston::Profile;
+use houston::{ApiKeyActor, Profile};
 use rover_client::{
     RoverClientError,
     operations::init::{create_graph::*, memberships},
@@ -94,11 +94,11 @@ impl UserAuthenticated {
         profile: &ProfileOpt,
     ) -> RoverResult<bool> {
         let credential = Profile::get_credential(&profile.profile_name, &client_config.config)?;
-        if credential.api_key.starts_with("user:") {
-            return Ok(true);
-        }
 
-        Ok(false)
+        Ok(matches!(
+            credential.api_key(),
+            Some(Ok(key)) if key.actor() == ApiKeyActor::User
+        ))
     }
 }
 


### PR DESCRIPTION
`rover init` decided what a key was by looking at its prefix, in three places
plus two test doubles. Now that houston parses a key into actor, id and
secret, each of those defers to it.

The prefix check accepted anything starting with `user:`, so a truncated key
was saved from the prompt and failed on the next request, and an `APOLLO_KEY`
like `service:oops` was reused as a graph key. Both are now caught. Parsing
also separates two failures the prefix check had to conflate: a key that
isn't shaped like a key gets `InvalidKeyFormat`, while a key that parses but
isn't a user key gets `NotUserKey` and the `APOLLO_KEY`/profile-clearing
guidance that variant already carried.

The prompt now stores the key it validated. It checked `input.trim()` and
saved `input`, so a pasted trailing newline reached the request headers.

The test double in authentication_tests.rs had reimplemented this parsing and
only ever exercised itself -- and looked for a `graph:` prefix, which Rover
has never issued. It now drives the real type, which is what makes its
coverage worth having.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

