### PR TITLE
fix(dev): restore --license flag for rover dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+- **Restore the `--license` flag on `rover dev` - @SharkBaitDLS**
+
+  `rover dev --license <path>` let you start a local router session with an [offline enterprise license](https://www.apollographql.com/docs/router/enterprise-features/#offline-enterprise-license), no GraphOS credentials or network calls required. The flag survived a `rover dev` internals rewrite, and kept appearing in `--help` and linking to real router docs, but the code that actually read it was deleted along the way — passing `--license` silently did nothing. It's wired back up now, forwarded to the router the same way it always was, independent of whatever `--graph-ref`/`APOLLO_KEY` credentials are also resolved.
+
 - **Fail immediately on errors that a retry can't fix - @SharkBaitDLS**
 
   A rejected API key, a permissions failure, or a bad endpoint URL used to be retried repeatedly for the full `--client-timeout` (30 seconds by default) before Rover said anything, so a mistyped key or URL took the better part of a minute to report. These now fail as soon as the answer comes back. Rate limits and server errors are still retried, since those do clear up on their own.

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -291,6 +291,7 @@ impl Dev {
                 api_key_override,
                 log_level,
                 supergraph_output,
+                self.opts.supergraph_opts.license.clone(),
             )
             .await?
             .watch_for_changes(write_file_impl, composition_messages)

--- a/src/command/dev/router/binary.rs
+++ b/src/command/dev/router/binary.rs
@@ -161,6 +161,29 @@ pub struct RunRouterBinary<Spawn: Send> {
     log_level: Option<Level>,
     env: HashMap<String, String>,
     listen_address: RouterAddress,
+    license: Option<Utf8PathBuf>,
+}
+
+impl<Spawn: Send> RunRouterBinary<Spawn> {
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![
+            "--supergraph".to_string(),
+            self.supergraph_schema_path.to_string(),
+            "--hot-reload".to_string(),
+            "--config".to_string(),
+            self.config_path.to_string(),
+            "--log".to_string(),
+            self.log_level.unwrap_or(Level::INFO).to_string(),
+            "--dev".to_string(),
+            "--listen".to_string(),
+            self.listen_address.to_string(),
+        ];
+        if let Some(license) = &self.license {
+            args.push("--license".to_string());
+            args.push(license.to_string());
+        }
+        args
+    }
 }
 
 impl<Spawn> SubtaskHandleUnit for RunRouterBinary<Spawn>
@@ -178,18 +201,7 @@ where
         let mut spawn = self.spawn.clone();
         let cancellation_token = cancellation_token.unwrap_or_default();
         tokio::task::spawn(async move {
-            let args = vec![
-                "--supergraph".to_string(),
-                self.supergraph_schema_path.to_string(),
-                "--hot-reload".to_string(),
-                "--config".to_string(),
-                self.config_path.to_string(),
-                "--log".to_string(),
-                self.log_level.unwrap_or(Level::INFO).to_string(),
-                "--dev".to_string(),
-                "--listen".to_string(),
-                self.listen_address.to_string(),
-            ];
+            let args = self.args();
 
             let child = spawn
                 .ready()
@@ -298,5 +310,58 @@ where
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, net::IpAddr};
+
+    use camino::Utf8PathBuf;
+    use semver::Version;
+
+    use super::*;
+    use crate::command::dev::router::config::{RouterAddress, RouterHost, RouterPort};
+
+    struct MockSpawn;
+
+    fn test_binary() -> RunRouterBinary<MockSpawn> {
+        let router_address = RouterAddress::new(
+            Some(RouterHost::Default(IpAddr::V4(std::net::Ipv4Addr::new(
+                127, 0, 0, 1,
+            )))),
+            Some(RouterPort::Default(4000)),
+        );
+        RunRouterBinary::<MockSpawn>::builder()
+            .router_binary(RouterBinary::new(
+                Utf8PathBuf::from("/fake/path"),
+                Version::parse("1.0.0").unwrap(),
+            ))
+            .config_path(Utf8PathBuf::from("/fake/config.yaml"))
+            .supergraph_schema_path(Utf8PathBuf::from("/fake/schema.graphql"))
+            .spawn(MockSpawn)
+            .listen_address(router_address)
+            .env(HashMap::new())
+            .build()
+    }
+
+    #[test]
+    fn args_omit_license_when_not_set() {
+        let binary = test_binary();
+        assert!(!binary.args().contains(&"--license".to_string()));
+    }
+
+    #[test]
+    fn args_include_license_when_set() {
+        let binary = RunRouterBinary {
+            license: Some(Utf8PathBuf::from("/fake/license.jwt")),
+            ..test_binary()
+        };
+        let args = binary.args();
+        let license_flag_index = args
+            .iter()
+            .position(|arg| arg == "--license")
+            .expect("--license flag should be present");
+        assert_eq!(args[license_flag_index + 1], "/fake/license.jwt");
     }
 }

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -158,6 +158,7 @@ impl RunRouter<state::Run> {
         api_key_override: Option<String>,
         log_level: Option<Level>,
         supergraph_output: Option<Utf8PathBuf>,
+        license: Option<Utf8PathBuf>,
     ) -> Result<RunRouter<state::Watch>, RunRouterBinaryError>
     where
         Spawn: Service<ExecCommandConfig, Response = Child> + Send + Clone + 'static,
@@ -220,6 +221,7 @@ impl RunRouter<state::Run> {
             .env(env.clone())
             .and_log_level(log_level)
             .listen_address(listen_address)
+            .and_license(license)
             .spawn(spawn)
             .build();
 

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -449,3 +449,115 @@ telemetry:
     // Assert router started successfully and responded to GraphQL introspection
     assert_that(&graphql_result).is_ok();
 }
+
+/// Regression test: `--license <path>` used to be silently ignored (never read anywhere after a
+/// prior `rover dev` rewrite), so passing a bogus path had no effect and the router started up
+/// fine. Now that it's forwarded to the router's argv, a bogus license file makes the router
+/// itself reject it and fail to start -- proving the flag actually reaches the router.
+#[ignore]
+#[tokio::test]
+#[traced_test]
+#[serial]
+async fn e2e_test_bogus_license_file_is_forwarded_to_router() {
+    let temp_dir = TempDir::new().expect("Could not create temp directory");
+    let temp_path = temp_dir.path();
+    let isolated_apollo_home = TempDir::new().expect("Could not create isolated APOLLO_HOME");
+
+    let schema = r#"
+type Query {
+    hello: String
+}
+"#;
+    std::fs::write(temp_path.join("schema.graphql"), schema)
+        .expect("Could not write schema.graphql");
+
+    let bogus_license_path = temp_path.join("license.jwt");
+    std::fs::write(&bogus_license_path, "not-a-real-license")
+        .expect("Could not write bogus license file");
+
+    let (supergraph_listener, port) = reserve_local_port().expect("No ports free");
+    let (health_listener, health_port) =
+        reserve_local_port().expect("No ports free for health check");
+
+    std::fs::write(
+        temp_path.join("supergraph.yaml"),
+        r#"
+federation_version: =2.4.7
+subgraphs:
+  api:
+    routing_url: http://localhost:4001
+    schema:
+      file: schema.graphql
+"#,
+    )
+    .expect("Could not write supergraph.yaml");
+
+    std::fs::write(
+        temp_path.join("router.yaml"),
+        format!("health_check:\n  listen: 127.0.0.1:{health_port}\n"),
+    )
+    .expect("Could not write router.yaml");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+    cmd.args([
+        "dev",
+        "--supergraph-config",
+        "supergraph.yaml",
+        "--router-config",
+        "router.yaml",
+        "--supergraph-port",
+        &port.to_string(),
+        "--elv2-license",
+        "accept",
+        "--license",
+        bogus_license_path.to_str().expect("valid utf8 path"),
+    ]);
+    cmd.current_dir(temp_path);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env_remove("APOLLO_KEY");
+    cmd.env_remove("APOLLO_GRAPH_REF");
+    cmd.env("APOLLO_HOME", isolated_apollo_home.path());
+    if let Ok(v) = env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_COMPOSITION_VERSION", v);
+    }
+    if let Ok(v) = env::var("APOLLO_ROVER_DEV_ROUTER_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_ROUTER_VERSION", v);
+    }
+
+    drop(supergraph_listener);
+    drop(health_listener);
+    let mut child = cmd.spawn().expect("Failed to spawn rover dev");
+
+    let client = Client::new();
+    let router_url = format!("http://localhost:{port}");
+    // The router should fail fast on the bogus license rather than ever becoming healthy.
+    let graphql_result =
+        test_graphql_connection(&client, &router_url, ROVER_DEV_TIMEOUT, Some(&mut child)).await;
+
+    // The router should have already exited on its own after rejecting the bogus license, but
+    // shut down defensively in case it (or `rover dev` itself) is still running.
+    #[cfg(unix)]
+    {
+        let _ = Command::new("kill")
+            .args(["-INT", &child.id().to_string()])
+            .output();
+    }
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &child.id().to_string()])
+            .output();
+    }
+
+    let output = child.wait_with_output().expect("Failed to get output");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_that(&graphql_result).is_err();
+    assert_that(&combined).does_not_contain("Your supergraph is running!");
+}


### PR DESCRIPTION
- [ ] A CHANGELOG.md entry is not needed for this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>