### PR TITLE
feat(dev): print startup notice when rover dev has no GraphOS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover auth logout` revokes the OAuth session stored by `rover auth login` for the given `--profile` (or "default") — the access token and, if one was issued, the refresh token (RFC 7009) — then removes the local credential. Revocation is best-effort: if the OAuth server can't be reached, Rover still clears the local credential and warns instead of leaving you stuck "logged in" locally. Only meaningful for profiles logged in via `rover auth login`; running it against a profile holding a Personal API Key (from `rover config auth`) errors and points you at `rover config delete` instead. Only compiled in when built with `--features oauth`, matching `rover auth login`.
 
+- **Print a one-time startup notice when `rover dev` runs with no GraphOS credentials - @SharkBaitDLS**
+
+  `rover dev` has always been able to compose and run a local router session with no API key, graph ref, or offline license — but running it that way gave no confirmation that this was expected, intentional behavior rather than a misconfiguration. It now prints `Running without GraphOS credentials. GraphOS Router Enterprise features and @connect are disabled. Pass --graph-ref, set APOLLO_KEY/APOLLO_GRAPH_REF, or pass --license to enable them.` once at startup, but only when nothing else already explained the gap (e.g. a `--graph-ref` or non-default `--profile` that couldn't resolve credentials still gets its existing, more specific warning instead).
+
 ## 🐛 Fixes
 
 - **Restore the `--license` flag on `rover dev` - @SharkBaitDLS**

--- a/src/command/dev/do_dev.rs
+++ b/src/command/dev/do_dev.rs
@@ -166,6 +166,12 @@ impl Dev {
 
         let api_key_override = std::env::var(RoverEnvKey::Key.to_string()).ok();
         let home_override = std::env::var(RoverEnvKey::Home.to_string()).ok();
+        // Not part of Rover's own config surface (RoverEnvKey) -- Rover never reads this value
+        // itself. It's inherited by the spawned router process because child processes inherit
+        // the parent's environment by default (see router::binary's use of Command::envs, which
+        // never calls env_clear), so a graph ref can reach the router this way without
+        // `--graph-ref` ever being set.
+        let graph_ref_in_env = std::env::var("APOLLO_GRAPH_REF").is_ok();
 
         // Set up an updater config, but only if we're not overriding the version ourselves. If
         // we are then we don't need one, so it becomes None.
@@ -292,6 +298,7 @@ impl Dev {
                 log_level,
                 supergraph_output,
                 self.opts.supergraph_opts.license.clone(),
+                graph_ref_in_env,
             )
             .await?
             .watch_for_changes(write_file_impl, composition_messages)

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -43,6 +43,11 @@ use crate::{
     },
 };
 
+struct AuthEnv {
+    env: HashMap<String, String>,
+    credential_warning_emitted: bool,
+}
+
 pub struct RunRouter<S> {
     pub(crate) state: S,
 }
@@ -213,16 +218,12 @@ impl RunRouter<state::Run> {
                 err: Box::new(err),
             })?;
 
-        let (env, credential_warning_emitted) =
-            self.auth_env(profile, home_override, api_key_override);
-        let has_graph_ref =
-            has_usable_graph_ref(self.state.remote_config.is_some(), graph_ref_in_env);
-        if should_print_credential_free_notice(has_graph_ref, &license, credential_warning_emitted)
-        {
-            infoln!(
-                "Running without GraphOS credentials. GraphOS Router Enterprise features and @connect are disabled. Pass --graph-ref, set APOLLO_KEY/APOLLO_GRAPH_REF, or pass --license to enable them."
-            );
-        }
+        let AuthEnv {
+            env,
+            credential_warning_emitted,
+        } = self.auth_env(profile, home_override, api_key_override);
+        self.notify_if_credential_free(graph_ref_in_env, &license, credential_warning_emitted);
+
         let listen_address = *self.state.config.address();
         let run_router_binary = RunRouterBinary::builder()
             .router_binary(self.state.binary.clone())
@@ -257,12 +258,36 @@ impl RunRouter<state::Run> {
         })
     }
 
+    /// Per Rover-428 spec FR8/FR9: prints only when there are truly no usable credentials (an API key and a
+    /// graph ref) from any source, no offline license, and no other credential-related warning has
+    /// already covered the same gap.
+    fn notify_if_credential_free(
+        &self,
+        graph_ref_in_env: bool,
+        license: &Option<Utf8PathBuf>,
+        already_warned: bool,
+    ) {
+        if license.is_none() && !self.has_usable_graph_ref(graph_ref_in_env) && !already_warned {
+            infoln!(
+                "Running without GraphOS credentials. GraphOS Router Enterprise features and @connect are disabled. Pass --graph-ref, set APOLLO_KEY/APOLLO_GRAPH_REF, or pass --license to enable them."
+            );
+        }
+    }
+
+    /// A graph ref reaches the spawned router either because `--graph-ref` resolved a
+    /// `RemoteRouterConfig`, or because a bare `APOLLO_GRAPH_REF` env var is set: the router process
+    /// inherits Rover's environment (see `router::binary`'s use of `Command::envs`, which never
+    /// calls `env_clear`), so that env var reaches the router even with no `--graph-ref` flag.
+    const fn has_usable_graph_ref(&self, graph_ref_in_env: bool) -> bool {
+        self.state.remote_config.is_some() || graph_ref_in_env
+    }
+
     fn auth_env(
         &self,
         profile: ProfileOpt,
         home_override: Option<String>,
         api_key_override: Option<String>,
-    ) -> (HashMap<String, String>, bool) {
+    ) -> AuthEnv {
         let mut env = HashMap::from_iter([("APOLLO_ROVER".to_string(), "true".to_string())]);
         let mut credential_warning_emitted = false;
 
@@ -300,7 +325,10 @@ impl RunRouter<state::Run> {
                 };
             }
         }
-        (env, credential_warning_emitted)
+        AuthEnv {
+            env,
+            credential_warning_emitted,
+        }
     }
 
     async fn wait_for_healthy_router(
@@ -376,25 +404,6 @@ impl RunRouter<state::Run> {
             RunRouterBinaryError::HealthCheckFailed
         })?
     }
-}
-
-/// A graph ref reaches the spawned router either because `--graph-ref` resolved a
-/// `RemoteRouterConfig`, or because a bare `APOLLO_GRAPH_REF` env var is set: the router process
-/// inherits Rover's environment (see `router::binary`'s use of `Command::envs`, which never
-/// calls `env_clear`), so that env var reaches the router even with no `--graph-ref` flag.
-const fn has_usable_graph_ref(remote_config_present: bool, graph_ref_in_env: bool) -> bool {
-    remote_config_present || graph_ref_in_env
-}
-
-/// Per spec FR8/FR9: fires only when there are truly no usable credentials (an API key and a
-/// graph ref) from any source, no offline license, and no other credential-related warning has
-/// already covered the same gap.
-const fn should_print_credential_free_notice(
-    has_graph_ref: bool,
-    license: &Option<Utf8PathBuf>,
-    credential_warning_emitted: bool,
-) -> bool {
-    license.is_none() && !has_graph_ref && !credential_warning_emitted
 }
 
 impl RunRouter<state::Watch> {
@@ -575,59 +584,41 @@ mod state {
 #[cfg(test)]
 mod tests {
     use camino::Utf8PathBuf;
+    use semver::Version;
 
-    use super::{has_usable_graph_ref, should_print_credential_free_notice};
+    use super::{RouterAddress, RunRouter, RunRouterConfig, state};
+    use crate::{command::dev::router::binary::RouterBinary, utils::effect::read_file::FsReadFile};
 
-    #[test]
-    fn graph_ref_reaches_router_via_ambient_env_without_the_flag() {
+    async fn test_run_router() -> RunRouter<state::Run> {
+        let config = RunRouterConfig::default()
+            .with_address(RouterAddress::default())
+            .with_config(&FsReadFile::default(), None)
+            .await
+            .expect("building a default router config with no file to read should not fail");
+        RunRouter {
+            state: state::Run {
+                binary: RouterBinary::new(
+                    Utf8PathBuf::from("/fake/path"),
+                    Version::parse("1.0.0").unwrap(),
+                ),
+                config,
+                config_path: None,
+                remote_config: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn graph_ref_reaches_router_via_ambient_env_without_the_flag() {
         // A bare APOLLO_GRAPH_REF env var (no --graph-ref flag, so no RemoteRouterConfig) still
         // reaches the router via inherited environment -- it must count as a usable graph ref.
-        assert!(has_usable_graph_ref(false, true));
+        let run_router = test_run_router().await;
+        assert!(run_router.has_usable_graph_ref(true));
     }
 
-    #[test]
-    fn no_usable_graph_ref_when_neither_source_is_present() {
-        assert!(!has_usable_graph_ref(false, false));
-    }
-
-    #[test]
-    fn prints_when_fully_unconfigured() {
-        // Fully offline development: no --graph-ref, no --license, no resolvable credential.
-        assert!(should_print_credential_free_notice(false, &None, false));
-    }
-
-    #[test]
-    fn does_not_print_when_license_supplied() {
-        // Offline enterprise license: no credentials, but --license is present.
-        assert!(!should_print_credential_free_notice(
-            false,
-            &Some(Utf8PathBuf::from("/tmp/license.jwt")),
-            false
-        ));
-    }
-
-    #[test]
-    fn does_not_print_when_graph_ref_supplied() {
-        // Valid credentials (--graph-ref + a working key), and broken/partial credentials
-        // (--graph-ref set but the resolvable key isn't a graph key) both go through
-        // RemoteRouterConfig, which has already either succeeded or warned.
-        assert!(!should_print_credential_free_notice(true, &None, false));
-        assert!(!should_print_credential_free_notice(true, &None, true));
-    }
-
-    #[test]
-    fn does_not_print_when_another_credential_warning_already_fired() {
-        // A non-default --profile whose credential couldn't be retrieved already warns in
-        // auth_env; the notice must not also fire for the same gap.
-        assert!(!should_print_credential_free_notice(false, &None, true));
-    }
-
-    #[test]
-    fn does_not_print_when_license_and_graph_ref_both_supplied() {
-        assert!(!should_print_credential_free_notice(
-            true,
-            &Some(Utf8PathBuf::from("/tmp/license.jwt")),
-            false
-        ));
+    #[tokio::test]
+    async fn no_usable_graph_ref_when_neither_source_is_present() {
+        let run_router = test_run_router().await;
+        assert!(!run_router.has_usable_graph_ref(false));
     }
 }

--- a/src/command/dev/router/run.rs
+++ b/src/command/dev/router/run.rs
@@ -159,6 +159,7 @@ impl RunRouter<state::Run> {
         log_level: Option<Level>,
         supergraph_output: Option<Utf8PathBuf>,
         license: Option<Utf8PathBuf>,
+        graph_ref_in_env: bool,
     ) -> Result<RunRouter<state::Watch>, RunRouterBinaryError>
     where
         Spawn: Service<ExecCommandConfig, Response = Child> + Send + Clone + 'static,
@@ -212,7 +213,16 @@ impl RunRouter<state::Run> {
                 err: Box::new(err),
             })?;
 
-        let env = self.auth_env(profile, home_override, api_key_override);
+        let (env, credential_warning_emitted) =
+            self.auth_env(profile, home_override, api_key_override);
+        let has_graph_ref =
+            has_usable_graph_ref(self.state.remote_config.is_some(), graph_ref_in_env);
+        if should_print_credential_free_notice(has_graph_ref, &license, credential_warning_emitted)
+        {
+            infoln!(
+                "Running without GraphOS credentials. GraphOS Router Enterprise features and @connect are disabled. Pass --graph-ref, set APOLLO_KEY/APOLLO_GRAPH_REF, or pass --license to enable them."
+            );
+        }
         let listen_address = *self.state.config.address();
         let run_router_binary = RunRouterBinary::builder()
             .router_binary(self.state.binary.clone())
@@ -252,8 +262,9 @@ impl RunRouter<state::Run> {
         profile: ProfileOpt,
         home_override: Option<String>,
         api_key_override: Option<String>,
-    ) -> HashMap<String, String> {
+    ) -> (HashMap<String, String>, bool) {
         let mut env = HashMap::from_iter([("APOLLO_ROVER".to_string(), "true".to_string())]);
+        let mut credential_warning_emitted = false;
 
         // We set the APOLLO_KEY here, but it might be overridden by RemoteRouterConfig. That
         // struct takes the who_am_i service, gets an identity, and checks whether the
@@ -282,13 +293,14 @@ impl RunRouter<state::Run> {
                                 "Could not retrieve APOLLO_KEY for profile {}.\n{}\nContinuing to load router without an APOLLO_KEY",
                                 profile.profile_name,
                                 err
-                            )
+                            );
+                            credential_warning_emitted = true;
                         }
                     }
                 };
             }
         }
-        env
+        (env, credential_warning_emitted)
     }
 
     async fn wait_for_healthy_router(
@@ -364,6 +376,25 @@ impl RunRouter<state::Run> {
             RunRouterBinaryError::HealthCheckFailed
         })?
     }
+}
+
+/// A graph ref reaches the spawned router either because `--graph-ref` resolved a
+/// `RemoteRouterConfig`, or because a bare `APOLLO_GRAPH_REF` env var is set: the router process
+/// inherits Rover's environment (see `router::binary`'s use of `Command::envs`, which never
+/// calls `env_clear`), so that env var reaches the router even with no `--graph-ref` flag.
+const fn has_usable_graph_ref(remote_config_present: bool, graph_ref_in_env: bool) -> bool {
+    remote_config_present || graph_ref_in_env
+}
+
+/// Per spec FR8/FR9: fires only when there are truly no usable credentials (an API key and a
+/// graph ref) from any source, no offline license, and no other credential-related warning has
+/// already covered the same gap.
+const fn should_print_credential_free_notice(
+    has_graph_ref: bool,
+    license: &Option<Utf8PathBuf>,
+    credential_warning_emitted: bool,
+) -> bool {
+    license.is_none() && !has_graph_ref && !credential_warning_emitted
 }
 
 impl RunRouter<state::Watch> {
@@ -538,5 +569,65 @@ mod state {
         #[allow(unused)]
         pub hot_reload_schema_path: Utf8PathBuf,
         pub env: HashMap<String, String>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+
+    use super::{has_usable_graph_ref, should_print_credential_free_notice};
+
+    #[test]
+    fn graph_ref_reaches_router_via_ambient_env_without_the_flag() {
+        // A bare APOLLO_GRAPH_REF env var (no --graph-ref flag, so no RemoteRouterConfig) still
+        // reaches the router via inherited environment -- it must count as a usable graph ref.
+        assert!(has_usable_graph_ref(false, true));
+    }
+
+    #[test]
+    fn no_usable_graph_ref_when_neither_source_is_present() {
+        assert!(!has_usable_graph_ref(false, false));
+    }
+
+    #[test]
+    fn prints_when_fully_unconfigured() {
+        // Fully offline development: no --graph-ref, no --license, no resolvable credential.
+        assert!(should_print_credential_free_notice(false, &None, false));
+    }
+
+    #[test]
+    fn does_not_print_when_license_supplied() {
+        // Offline enterprise license: no credentials, but --license is present.
+        assert!(!should_print_credential_free_notice(
+            false,
+            &Some(Utf8PathBuf::from("/tmp/license.jwt")),
+            false
+        ));
+    }
+
+    #[test]
+    fn does_not_print_when_graph_ref_supplied() {
+        // Valid credentials (--graph-ref + a working key), and broken/partial credentials
+        // (--graph-ref set but the resolvable key isn't a graph key) both go through
+        // RemoteRouterConfig, which has already either succeeded or warned.
+        assert!(!should_print_credential_free_notice(true, &None, false));
+        assert!(!should_print_credential_free_notice(true, &None, true));
+    }
+
+    #[test]
+    fn does_not_print_when_another_credential_warning_already_fired() {
+        // A non-default --profile whose credential couldn't be retrieved already warns in
+        // auth_env; the notice must not also fire for the same gap.
+        assert!(!should_print_credential_free_notice(false, &None, true));
+    }
+
+    #[test]
+    fn does_not_print_when_license_and_graph_ref_both_supplied() {
+        assert!(!should_print_credential_free_notice(
+            true,
+            &Some(Utf8PathBuf::from("/tmp/license.jwt")),
+            false
+        ));
     }
 }

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -450,6 +450,118 @@ telemetry:
     assert_that(&graphql_result).is_ok();
 }
 
+const CREDENTIAL_FREE_NOTICE: &str = "Running without GraphOS credentials. GraphOS Router Enterprise features and @connect are disabled. Pass --graph-ref, set APOLLO_KEY/APOLLO_GRAPH_REF, or pass --license to enable them.";
+
+/// Spec FR8/FR9/FR10: `rover dev` prints a one-time startup notice when it has no usable
+/// GraphOS credentials (no `--graph-ref`, no `APOLLO_KEY`/`APOLLO_GRAPH_REF`, no `--license`).
+/// The test isolates the spawned process from whatever credentials happen to be configured on
+/// the machine running the test (a real profile, ambient `APOLLO_KEY`/`APOLLO_GRAPH_REF`) so the
+/// assertion holds regardless of the local/CI environment.
+#[ignore]
+#[tokio::test]
+#[traced_test]
+#[serial]
+async fn e2e_test_prints_notice_when_no_credentials_are_configured() {
+    let temp_dir = TempDir::new().expect("Could not create temp directory");
+    let temp_path = temp_dir.path();
+    let isolated_apollo_home = TempDir::new().expect("Could not create isolated APOLLO_HOME");
+
+    let schema = r#"
+type Query {
+    hello: String
+}
+"#;
+    std::fs::write(temp_path.join("schema.graphql"), schema)
+        .expect("Could not write schema.graphql");
+
+    let (supergraph_listener, port) = reserve_local_port().expect("No ports free");
+    let (health_listener, health_port) =
+        reserve_local_port().expect("No ports free for health check");
+
+    std::fs::write(
+        temp_path.join("supergraph.yaml"),
+        r#"
+federation_version: =2.4.7
+subgraphs:
+  api:
+    routing_url: http://localhost:4001
+    schema:
+      file: schema.graphql
+"#,
+    )
+    .expect("Could not write supergraph.yaml");
+
+    std::fs::write(
+        temp_path.join("router.yaml"),
+        format!("health_check:\n  listen: 127.0.0.1:{health_port}\n"),
+    )
+    .expect("Could not write router.yaml");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+    cmd.args([
+        "dev",
+        "--supergraph-config",
+        "supergraph.yaml",
+        "--router-config",
+        "router.yaml",
+        "--supergraph-port",
+        &port.to_string(),
+        "--elv2-license",
+        "accept",
+    ]);
+    cmd.current_dir(temp_path);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    // Isolate this process from whatever credentials are actually configured wherever this test
+    // runs, so the "no credentials" assertion below is deterministic.
+    cmd.env_remove("APOLLO_KEY");
+    cmd.env_remove("APOLLO_GRAPH_REF");
+    cmd.env("APOLLO_HOME", isolated_apollo_home.path());
+    if let Ok(v) = env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_COMPOSITION_VERSION", v);
+    }
+    if let Ok(v) = env::var("APOLLO_ROVER_DEV_ROUTER_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_ROUTER_VERSION", v);
+    }
+
+    drop(supergraph_listener);
+    drop(health_listener);
+    let mut child = cmd.spawn().expect("Failed to spawn rover dev");
+
+    let client = Client::new();
+    let router_url = format!("http://localhost:{port}");
+    let graphql_result =
+        test_graphql_connection(&client, &router_url, ROVER_DEV_TIMEOUT, Some(&mut child)).await;
+
+    #[cfg(unix)]
+    {
+        let _ = Command::new("kill")
+            .args(["-INT", &child.id().to_string()])
+            .output();
+    }
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &child.id().to_string()])
+            .output();
+    }
+
+    let output = child.wait_with_output().expect("Failed to get output");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_that(&graphql_result).is_ok();
+    assert_eq!(
+        combined.matches(CREDENTIAL_FREE_NOTICE).count(),
+        1,
+        "expected the credential-free notice exactly once, got:\n{combined}"
+    );
+}
+
 /// Regression test: `--license <path>` used to be silently ignored (never read anywhere after a
 /// prior `rover dev` rewrite), so passing a bogus path had no effect and the router started up
 /// fine. Now that it's forwarded to the router's argv, a bogus license file makes the router

--- a/tests/e2e/dev.rs
+++ b/tests/e2e/dev.rs
@@ -672,4 +672,114 @@ subgraphs:
 
     assert_that(&graphql_result).is_err();
     assert_that(&combined).does_not_contain("Your supergraph is running!");
+    // A valid --license present, even a rejected one, means the credential-free notice's
+    // condition never held in the first place -- it must not print alongside the router's own
+    // license-rejection error.
+    assert_that(&combined).does_not_contain(CREDENTIAL_FREE_NOTICE);
+}
+
+/// Spec FR9: the credential-free notice must not fire when a different credential-related
+/// warning already covers the same gap -- here, a non-default `--profile` whose credential
+/// can't be resolved. Exactly one of the two messages should ever appear for a given session.
+#[ignore]
+#[tokio::test]
+#[traced_test]
+#[serial]
+async fn e2e_test_unresolvable_profile_warning_suppresses_credential_free_notice() {
+    let temp_dir = TempDir::new().expect("Could not create temp directory");
+    let temp_path = temp_dir.path();
+    // Left empty so the named profile below has nothing to resolve.
+    let isolated_apollo_home = TempDir::new().expect("Could not create isolated APOLLO_HOME");
+
+    let schema = r#"
+type Query {
+    hello: String
+}
+"#;
+    std::fs::write(temp_path.join("schema.graphql"), schema)
+        .expect("Could not write schema.graphql");
+
+    let (supergraph_listener, port) = reserve_local_port().expect("No ports free");
+    let (health_listener, health_port) =
+        reserve_local_port().expect("No ports free for health check");
+
+    std::fs::write(
+        temp_path.join("supergraph.yaml"),
+        r#"
+federation_version: =2.4.7
+subgraphs:
+  api:
+    routing_url: http://localhost:4001
+    schema:
+      file: schema.graphql
+"#,
+    )
+    .expect("Could not write supergraph.yaml");
+
+    std::fs::write(
+        temp_path.join("router.yaml"),
+        format!("health_check:\n  listen: 127.0.0.1:{health_port}\n"),
+    )
+    .expect("Could not write router.yaml");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("rover"));
+    cmd.args([
+        "dev",
+        "--supergraph-config",
+        "supergraph.yaml",
+        "--router-config",
+        "router.yaml",
+        "--supergraph-port",
+        &port.to_string(),
+        "--elv2-license",
+        "accept",
+        "--profile",
+        "e2e-test-nonexistent-profile",
+    ]);
+    cmd.current_dir(temp_path);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env_remove("APOLLO_KEY");
+    cmd.env_remove("APOLLO_GRAPH_REF");
+    cmd.env("APOLLO_HOME", isolated_apollo_home.path());
+    if let Ok(v) = env::var("APOLLO_ROVER_DEV_COMPOSITION_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_COMPOSITION_VERSION", v);
+    }
+    if let Ok(v) = env::var("APOLLO_ROVER_DEV_ROUTER_VERSION") {
+        cmd.env("APOLLO_ROVER_DEV_ROUTER_VERSION", v);
+    }
+
+    drop(supergraph_listener);
+    drop(health_listener);
+    let mut child = cmd.spawn().expect("Failed to spawn rover dev");
+
+    let client = Client::new();
+    let router_url = format!("http://localhost:{port}");
+    let graphql_result =
+        test_graphql_connection(&client, &router_url, ROVER_DEV_TIMEOUT, Some(&mut child)).await;
+
+    #[cfg(unix)]
+    {
+        let _ = Command::new("kill")
+            .args(["-INT", &child.id().to_string()])
+            .output();
+    }
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &child.id().to_string()])
+            .output();
+    }
+
+    let output = child.wait_with_output().expect("Failed to get output");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_that(&graphql_result).is_ok();
+    assert_that(&combined).contains("Could not retrieve APOLLO_KEY for profile");
+    assert_that(&combined).does_not_contain(CREDENTIAL_FREE_NOTICE);
 }


### PR DESCRIPTION
- [ ] A CHANGELOG.md entry is not needed for this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>