### PR TITLE
Add persisted query bulk deletion schema and a per-attempt-timeout client service

### DIFF
--- a/crates/rover-client/.schema/schema.graphql
+++ b/crates/rover-client/.schema/schema.graphql
@@ -493,6 +493,41 @@ type BuildSuccess {
   coreSchema: CoreSchema!
 }
 
+"""A bulk deletion job that failed."""
+type BulkDeletionFailure {
+  """A human-readable description of why the job failed."""
+  error: String!
+}
+
+"""Whether an in-flight bulk deletion job is queued or actively running."""
+enum BulkDeletionJobStatus {
+  """The job is queued and has not yet started running."""
+  PENDING
+
+  """The job is actively running."""
+  RUNNING
+}
+
+"""A bulk deletion job that has not yet finished."""
+type BulkDeletionPending {
+  """The number of operations deleted so far by this job."""
+  operationsDeletedSoFar: Int!
+
+  """Whether the job is queued (PENDING) or running (RUNNING)."""
+  status: BulkDeletionJobStatus!
+}
+
+"""
+The status of an asynchronous bulk deletion job, as returned by PersistedQueryList.bulkDeletionStatus.
+"""
+union BulkDeletionStatus = BulkDeletionFailure | BulkDeletionPending | BulkDeletionSuccess
+
+"""A bulk deletion job that finished successfully."""
+type BulkDeletionSuccess {
+  """The build produced by this deletion job's final chunk."""
+  build: PersistedQueryListBuild
+}
+
 """
 The result of a failed call to PersistedQueryListMutation.delete due to linked variant(s).
 """
@@ -4836,6 +4871,20 @@ type PersistedQueriesPublishOperationCounts {
   updated: Int!
 }
 
+"""Filter options for persisted query operations"""
+input PersistedQueryFilterInput {
+  """Only include operations whose client name is included in this list"""
+  clients: [String]
+
+  """
+  Only include operations whose last published date is before or after the given date
+  """
+  lastPublishedAt: TimestampFilterInput
+
+  """Only include operations whose names contain this case-insensitive substring"""
+  name: String
+}
+
 """Full identifier for an operation in a Persisted Query List."""
 input PersistedQueryIdInput {
   """
@@ -4877,6 +4926,11 @@ input PersistedQueryInput {
 
 """A Persisted Query List for a graph."""
 type PersistedQueryList {
+  """
+  Polls the status of an asynchronous bulk deletion job started by PersistedQueryListMutation.startBulkDeletion. Returns null if no job with this ID exists, for example because the ID is unrecognized or the job's record has since expired.
+  """
+  bulkDeletionStatus(id: ID!): BulkDeletionStatus
+
   """The current build of this PQL."""
   currentBuild: PersistedQueryListBuild!
 
@@ -4945,10 +4999,32 @@ type PersistedQueryListMutation {
   ): PublishOperationsResultOrError!
 
   """
+  Starts an asynchronous job to delete all operations matching the given filter (minus any excluded operations) from this Persisted Query List. Returns a job ID to poll via PersistedQueryList.bulkDeletionStatus. Disabled behind a feature flag; once enabled for a graph, a bulk deletion already running for a list will return that job's existing ID instead of starting a second one.
+  """
+  startBulkDeletion(
+    """Operations to exclude from deletion, even if they match the filter"""
+    exclude: [PersistedQueryIdInput!]
+
+    """Filter criteria to select operations for deletion"""
+    filter: PersistedQueryFilterInput!
+  ): StartBulkDeletionResultOrError!
+
+  """
   Updates the name and/or description of the specified Persisted Query List.
   """
   updateMetadata(description: String, name: String): UpdatePersistedQueryListMetadataResultOrError!
 }
+
+"""The result of a successful call to PersistedQueryListMutation.startBulkDeletion."""
+type StartBulkDeletionResult {
+  """
+  The ID of the started (or already-active) bulk deletion job. Poll PersistedQueryList.bulkDeletionStatus with this ID.
+  """
+  jobId: ID!
+}
+
+"""The result/error union returned by PersistedQueryListMutation.startBulkDeletion."""
+union StartBulkDeletionResultOrError = PermissionError | StartBulkDeletionResult
 
 """An error related to an organization's Apollo Studio plan."""
 type PlanError {
@@ -7430,6 +7506,14 @@ enum TimeseriesReportResolution {
 ISO 8601, extended format with nanoseconds, Zulu (or "[+-]seconds" as a string or number relative to now)
 """
 scalar Timestamp
+
+input TimestampFilterInput {
+  """The start of the range"""
+  from: Timestamp
+
+  """The end of the range"""
+  to: Timestamp
+}
 
 type TopOperationRecord {
   """The graph this operation was reported from."""

--- a/crates/rover-client/src/blocking/studio_client.rs
+++ b/crates/rover-client/src/blocking/studio_client.rs
@@ -7,11 +7,15 @@ use reqwest::{
     Client as ReqwestClient,
 };
 use rover_graphql::{GraphQLLayer, GraphQLService};
-use rover_http::{retry::RetryPolicy, HttpService, ReqwestService};
+use rover_http::{retry::RetryPolicy, timeout::TimeoutLayer, HttpService, ReqwestService};
 use rover_studio::service::{
     rejected_credential::RejectedCredentialLayer, HttpStudioServiceError, HttpStudioServiceLayer,
 };
-use tower::{retry::RetryLayer, util::BoxCloneServiceLayer, ServiceBuilder, ServiceExt};
+use tower::{
+    retry::RetryLayer,
+    util::{option_layer, BoxCloneServiceLayer},
+    ServiceBuilder, ServiceExt,
+};
 use url::Url;
 
 use crate::{
@@ -164,6 +168,30 @@ impl StudioClient {
     pub fn studio_graphql_service(
         &self,
     ) -> Result<GraphQLService<HttpService>, InitStudioServiceError> {
+        self.build_studio_graphql_service(None)
+    }
+
+    /// Same as [`StudioClient::studio_graphql_service`], but bounds each individual
+    /// HTTP attempt with `attempt_timeout`, nested inside the retry so a single hung
+    /// attempt can't consume the entire retry budget. Use this for operations that
+    /// poll or otherwise need an explicit per-attempt timeout rather than relying on
+    /// the ambient `--client-timeout` floor alone.
+    pub fn studio_graphql_service_with_timeout(
+        &self,
+        attempt_timeout: Duration,
+    ) -> Result<GraphQLService<HttpService>, InitStudioServiceError> {
+        self.build_studio_graphql_service(Some(attempt_timeout))
+    }
+
+    /// Shared builder behind [`StudioClient::studio_graphql_service`] and
+    /// [`StudioClient::studio_graphql_service_with_timeout`]. `attempt_timeout` of
+    /// `None` layers in a no-op [`tower::layer::util::Identity`] instead of a
+    /// [`TimeoutLayer`], so the two callers stay behaviorally identical to having
+    /// their own independent builder chains.
+    fn build_studio_graphql_service(
+        &self,
+        attempt_timeout: Option<Duration>,
+    ) -> Result<GraphQLService<HttpService>, InitStudioServiceError> {
         let service = ServiceBuilder::new()
             .layer(GraphQLLayer::default())
             .layer(BoxCloneServiceLayer::new(
@@ -181,6 +209,7 @@ impl StudioClient {
                     .into_inner(),
             ))
             .layer(RetryLayer::new(RetryPolicy::new(self.retry_period)))
+            .layer(option_layer(attempt_timeout.map(TimeoutLayer::new)))
             .service(
                 ReqwestService::builder()
                     .client(self.reqwest_client.clone())


### PR DESCRIPTION
Adds the GraphQL schema for Persisted Query List bulk deletion (`startBulkDeletion`, `bulkDeletionStatus`, and the types/inputs they use) to Rover's cached schema, and a new `StudioClient::studio_graphql_service_with_timeout` method.

`studio_graphql_service` already composes a `RetryLayer`, but has no per-attempt `TimeoutLayer`, so a single hung HTTP attempt can consume the entire retry budget. `studio_graphql_service_with_timeout` nests a `TimeoutLayer` inside the retry to fix that, for callers that opt in, without changing behavior for `studio_graphql_service`'s existing callers — both methods now delegate to one shared builder, with the timeout applied via `tower::util::option_layer` so there's no duplicated `ServiceBuilder` chain.

**Note for reviewers:** the `startBulkDeletion`/`bulkDeletionStatus` fields added here match the schema merged for the backend work, but aren't fully live yet — `bulkDeletionStatus` is currently a stub that always returns `null`, and `startBulkDeletion` is behind an off-by-default feature flag. This PR is safe to review and merge on its own (nothing consumes the new schema fields yet); the top of this stack (#3660) can't be exercised end-to-end against a real job until that backend work ships.

Part of REG-2090 (bulk-delete support for `rover persisted-queries`).

- [x] A CHANGELOG.md entry is not needed for this PR
