### PR TITLE
Add start_bulk_deletion and bulk_deletion_status rover-client operations

### DIFF
--- a/crates/rover-client/src/error.rs
+++ b/crates/rover-client/src/error.rs
@@ -311,6 +311,17 @@ pub enum RoverClientError {
         frontend_url_root: String,
     },
 
+    #[error("Could not find a bulk deletion job with ID '{job_id}'. It may have already expired.")]
+    BulkDeletionJobNotFound { job_id: String },
+
+    #[error("Bulk deletion job '{job_id}' failed: {error}")]
+    BulkDeletionJobFailed { job_id: String, error: String },
+
+    #[error(
+        "Bulk deletion job '{job_id}' reported a status this version of Rover doesn't recognize. Try updating Rover."
+    )]
+    UnknownBulkDeletionJobStatus { job_id: String },
+
     #[error("Offline licences are not enabled for your organization.")]
     OfflineLicenseNotEnabled,
 

--- a/crates/rover-client/src/operations/persisted_queries/bulk_deletion_status/bulk_deletion_status_query.graphql
+++ b/crates/rover-client/src/operations/persisted_queries/bulk_deletion_status/bulk_deletion_status_query.graphql
@@ -1,0 +1,25 @@
+query BulkDeletionStatusQuery($graphId: ID!, $listId: ID!, $jobId: ID!) {
+  frontendUrlRoot
+  graph(id: $graphId) {
+    persistedQueryList(id: $listId) {
+      bulkDeletionStatus(id: $jobId) {
+        __typename
+        ... on BulkDeletionPending {
+          status
+          operationsDeletedSoFar
+        }
+        ... on BulkDeletionSuccess {
+          build {
+            revision
+            list {
+              name
+            }
+          }
+        }
+        ... on BulkDeletionFailure {
+          error
+        }
+      }
+    }
+  }
+}

--- a/crates/rover-client/src/operations/persisted_queries/bulk_deletion_status/mod.rs
+++ b/crates/rover-client/src/operations/persisted_queries/bulk_deletion_status/mod.rs
@@ -1,0 +1,69 @@
+mod service;
+
+use std::time::Duration;
+
+use graphql_client::GraphQLQuery;
+pub use service::BulkDeletionStatus;
+
+/// Default per-attempt timeout for a single `bulkDeletionStatus` poll. This is a
+/// lightweight status read (unlike, say, a full check-workflow result fetch), so a
+/// single attempt should be fast; no observed latency data exists for this new
+/// operation yet, so this is a conservative starting point rather than a measured
+/// value. Callers are expected to poll this repeatedly rather than block on one call.
+pub const DEFAULT_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(GraphQLQuery, Debug)]
+// The paths are relative to the directory where your `Cargo.toml` is located.
+// Both json and the GraphQL schema language are supported as sources for the schema
+#[graphql(
+    query_path = "src/operations/persisted_queries/bulk_deletion_status/bulk_deletion_status_query.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Serialize, Deserialize, Clone",
+    deprecated = "warn"
+)]
+pub(crate) struct BulkDeletionStatusQuery;
+
+type QueryVariables = bulk_deletion_status_query::Variables;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BulkDeletionStatusInput {
+    pub graph_id: String,
+    pub list_id: String,
+    pub job_id: String,
+}
+
+impl From<BulkDeletionStatusInput> for QueryVariables {
+    fn from(input: BulkDeletionStatusInput) -> Self {
+        Self {
+            graph_id: input.graph_id,
+            list_id: input.list_id,
+            job_id: input.job_id,
+        }
+    }
+}
+
+/// Whether an in-flight bulk deletion job is queued or actively running.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BulkDeletionJobStatus {
+    Pending,
+    Running,
+}
+
+/// The current status of a bulk deletion job, as returned by a single poll.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum BulkDeletionStatusResponse {
+    /// The job has not yet finished.
+    Pending {
+        status: BulkDeletionJobStatus,
+        operations_deleted_so_far: i64,
+    },
+    /// The job finished successfully.
+    Success {
+        /// The revision of the build produced by this job's final chunk, if the
+        /// list had any builds prior to (or as a result of) this deletion.
+        revision: Option<i64>,
+        list_name: Option<String>,
+    },
+    /// The job failed.
+    Failure { error: String },
+}

--- a/crates/rover-client/src/operations/persisted_queries/bulk_deletion_status/service.rs
+++ b/crates/rover-client/src/operations/persisted_queries/bulk_deletion_status/service.rs
@@ -1,0 +1,312 @@
+use std::{future::Future, pin::Pin};
+
+use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+use tower::Service;
+
+use crate::{
+    operations::persisted_queries::bulk_deletion_status::{
+        bulk_deletion_status_query,
+        bulk_deletion_status_query::BulkDeletionStatusQueryGraphPersistedQueryListBulkDeletionStatus::{
+            BulkDeletionFailure, BulkDeletionPending, BulkDeletionSuccess,
+        },
+        BulkDeletionJobStatus, BulkDeletionStatusInput, BulkDeletionStatusQuery,
+        BulkDeletionStatusResponse,
+    },
+    RoverClientError,
+};
+
+/// A [`Service`] that polls the status of an asynchronous bulk deletion job against a
+/// Persisted Query List, layered over the studio GraphQL service.
+#[derive(Clone)]
+pub struct BulkDeletionStatus<S: Clone> {
+    inner: S,
+}
+
+impl<S: Clone> BulkDeletionStatus<S> {
+    pub const fn new(inner: S) -> BulkDeletionStatus<S> {
+        BulkDeletionStatus { inner }
+    }
+}
+
+impl<S, Fut> Service<BulkDeletionStatusInput> for BulkDeletionStatus<S>
+where
+    S: Service<
+            GraphQLRequest<BulkDeletionStatusQuery>,
+            Response = bulk_deletion_status_query::ResponseData,
+            Error = GraphQLServiceError<bulk_deletion_status_query::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = BulkDeletionStatusResponse;
+    type Error = RoverClientError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        tower::Service::<GraphQLRequest<BulkDeletionStatusQuery>>::poll_ready(&mut self.inner, cx)
+            .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))
+    }
+
+    fn call(&mut self, input: BulkDeletionStatusInput) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let graph_id = input.graph_id.clone();
+        let list_id = input.list_id.clone();
+        let job_id = input.job_id.clone();
+        let fut = async move {
+            let response_data = inner.call(GraphQLRequest::new(input.into())).await?;
+            get_response_from_data(response_data, graph_id, list_id, job_id)
+        };
+        Box::pin(fut)
+    }
+}
+
+fn get_response_from_data(
+    data: bulk_deletion_status_query::ResponseData,
+    graph_id: String,
+    list_id: String,
+    job_id: String,
+) -> Result<BulkDeletionStatusResponse, RoverClientError> {
+    let graph = data.graph.ok_or(RoverClientError::GraphIdNotFound {
+        graph_id: graph_id.clone(),
+    })?;
+    let persisted_query_list =
+        graph
+            .persisted_query_list
+            .ok_or(RoverClientError::PersistedQueryListIdNotFound {
+                graph_id,
+                list_id,
+                frontend_url_root: data.frontend_url_root,
+            })?;
+
+    match persisted_query_list.bulk_deletion_status {
+        None => Err(RoverClientError::BulkDeletionJobNotFound { job_id }),
+        Some(BulkDeletionPending(pending)) => {
+            let status = match pending.status {
+                bulk_deletion_status_query::BulkDeletionJobStatus::PENDING => {
+                    BulkDeletionJobStatus::Pending
+                }
+                bulk_deletion_status_query::BulkDeletionJobStatus::RUNNING => {
+                    BulkDeletionJobStatus::Running
+                }
+                // An unrecognized status is a forward-compatibility gap, not "still
+                // running": silently treating it as Running would poll forever under
+                // a misleading progress message instead of surfacing the mismatch.
+                bulk_deletion_status_query::BulkDeletionJobStatus::Other(_) => {
+                    return Err(RoverClientError::UnknownBulkDeletionJobStatus { job_id });
+                }
+            };
+            Ok(BulkDeletionStatusResponse::Pending {
+                status,
+                operations_deleted_so_far: pending.operations_deleted_so_far,
+            })
+        }
+        Some(BulkDeletionSuccess(success)) => Ok(BulkDeletionStatusResponse::Success {
+            revision: success.build.as_ref().map(|build| build.revision),
+            list_name: success.build.map(|build| build.list.name),
+        }),
+        Some(BulkDeletionFailure(failure)) => Ok(BulkDeletionStatusResponse::Failure {
+            error: failure.error,
+        }),
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+pub mod mock {
+    use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+
+    use super::{bulk_deletion_status_query, BulkDeletionStatusQuery};
+
+    pub type BulkDeletionStatusReq = GraphQLRequest<BulkDeletionStatusQuery>;
+    pub type BulkDeletionStatusResp = bulk_deletion_status_query::ResponseData;
+    pub type BulkDeletionStatusErr = GraphQLServiceError<bulk_deletion_status_query::ResponseData>;
+
+    rover_tower::mock_service!(
+        BulkDeletionStatusInner,
+        BulkDeletionStatusReq,
+        BulkDeletionStatusResp,
+        BulkDeletionStatusErr
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future;
+    use rover_tower::test::{expect_poll_ready, MockCloneService};
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    use super::{
+        mock::{BulkDeletionStatusResp, MockBulkDeletionStatusInnerService},
+        *,
+    };
+
+    fn input() -> BulkDeletionStatusInput {
+        BulkDeletionStatusInput {
+            graph_id: "my-graph".to_string(),
+            list_id: "my-list".to_string(),
+            job_id: "job-123".to_string(),
+        }
+    }
+
+    async fn poll(
+        data: BulkDeletionStatusResp,
+    ) -> Result<BulkDeletionStatusResponse, RoverClientError> {
+        let mut mock = MockBulkDeletionStatusInnerService::new();
+        expect_poll_ready!(mock);
+        mock.expect_call()
+            .returning(move |_| future::ready(Ok(data.clone())));
+
+        BulkDeletionStatus::new(MockCloneService::new(mock))
+            .oneshot(input())
+            .await
+    }
+
+    #[tokio::test]
+    async fn call_reports_pending_progress() {
+        let data: BulkDeletionStatusResp = serde_json::from_value(json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "graph": {
+                "persistedQueryList": {
+                    "bulkDeletionStatus": {
+                        "__typename": "BulkDeletionPending",
+                        "status": "RUNNING",
+                        "operationsDeletedSoFar": 4200
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let response = poll(data).await.unwrap();
+
+        assert_eq!(
+            response,
+            BulkDeletionStatusResponse::Pending {
+                status: BulkDeletionJobStatus::Running,
+                operations_deleted_so_far: 4200,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn call_fails_on_an_unrecognized_job_status_instead_of_polling_forever() {
+        let data: BulkDeletionStatusResp = serde_json::from_value(json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "graph": {
+                "persistedQueryList": {
+                    "bulkDeletionStatus": {
+                        "__typename": "BulkDeletionPending",
+                        "status": "SOME_FUTURE_STATUS",
+                        "operationsDeletedSoFar": 0
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let result = poll(data).await;
+
+        assert!(matches!(
+            result,
+            Err(RoverClientError::UnknownBulkDeletionJobStatus { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn call_reports_success_with_the_final_revision() {
+        let data: BulkDeletionStatusResp = serde_json::from_value(json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "graph": {
+                "persistedQueryList": {
+                    "bulkDeletionStatus": {
+                        "__typename": "BulkDeletionSuccess",
+                        "build": {
+                            "revision": 7,
+                            "list": { "name": "my-list" }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let response = poll(data).await.unwrap();
+
+        assert_eq!(
+            response,
+            BulkDeletionStatusResponse::Success {
+                revision: Some(7),
+                list_name: Some("my-list".to_string()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn call_reports_failure_with_the_server_error_message() {
+        let data: BulkDeletionStatusResp = serde_json::from_value(json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "graph": {
+                "persistedQueryList": {
+                    "bulkDeletionStatus": {
+                        "__typename": "BulkDeletionFailure",
+                        "error": "the Spanner transaction ran out of retries"
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let response = poll(data).await.unwrap();
+
+        assert_eq!(
+            response,
+            BulkDeletionStatusResponse::Failure {
+                error: "the Spanner transaction ran out of retries".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn call_fails_when_the_job_id_is_unrecognized_or_expired() {
+        let data: BulkDeletionStatusResp = serde_json::from_value(json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "graph": {
+                "persistedQueryList": {
+                    "bulkDeletionStatus": null
+                }
+            }
+        }))
+        .unwrap();
+
+        let result = poll(data).await;
+
+        assert!(matches!(
+            result,
+            Err(RoverClientError::BulkDeletionJobNotFound { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn call_fails_when_the_list_is_not_found() {
+        let data: BulkDeletionStatusResp = serde_json::from_value(json!({
+            "frontendUrlRoot": "https://studio.apollographql.com",
+            "graph": {
+                "persistedQueryList": null
+            }
+        }))
+        .unwrap();
+
+        let result = poll(data).await;
+
+        assert!(matches!(
+            result,
+            Err(RoverClientError::PersistedQueryListIdNotFound { .. })
+        ));
+    }
+}

--- a/crates/rover-client/src/operations/persisted_queries/mod.rs
+++ b/crates/rover-client/src/operations/persisted_queries/mod.rs
@@ -1,3 +1,5 @@
+pub mod bulk_deletion_status;
 pub mod name;
 pub mod publish;
 pub mod resolve;
+pub mod start_bulk_deletion;

--- a/crates/rover-client/src/operations/persisted_queries/start_bulk_deletion/mod.rs
+++ b/crates/rover-client/src/operations/persisted_queries/start_bulk_deletion/mod.rs
@@ -1,0 +1,113 @@
+mod service;
+
+use std::time::Duration;
+
+use graphql_client::GraphQLQuery;
+pub use service::StartBulkDeletion;
+
+// `graphql_client` maps the custom `Timestamp` scalar to whatever Rust type is named
+// `Timestamp` in this module; Rover treats it as an opaque RFC 3339 string end to end.
+type Timestamp = String;
+
+/// Default per-attempt timeout for `startBulkDeletion`. This mutation only enqueues a
+/// job (the actual deletion work happens asynchronously server-side), so a single
+/// attempt should be fast; no observed latency data exists for this new operation yet,
+/// so this is a conservative starting point rather than a measured value.
+pub const DEFAULT_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(GraphQLQuery, Debug)]
+// The paths are relative to the directory where your `Cargo.toml` is located.
+// Both json and the GraphQL schema language are supported as sources for the schema
+#[graphql(
+    query_path = "src/operations/persisted_queries/start_bulk_deletion/start_bulk_deletion_mutation.graphql",
+    schema_path = ".schema/schema.graphql",
+    response_derives = "Eq, PartialEq, Debug, Clone, Serialize, Deserialize",
+    deprecated = "warn"
+)]
+pub(crate) struct StartBulkDeletionMutation;
+
+type MutationVariables = start_bulk_deletion_mutation::Variables;
+type MutationFilterInput = start_bulk_deletion_mutation::PersistedQueryFilterInput;
+type MutationTimestampFilterInput = start_bulk_deletion_mutation::TimestampFilterInput;
+type MutationIdInput = start_bulk_deletion_mutation::PersistedQueryIdInput;
+
+/// Filter criteria selecting which operations of a Persisted Query List a bulk
+/// deletion job should delete.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct PersistedQueryDeletionFilter {
+    /// Only include operations whose client name is included in this list.
+    pub clients: Option<Vec<String>>,
+    /// Only include operations whose names contain this case-insensitive substring.
+    pub name_contains: Option<String>,
+    /// Only include operations last published at or after this RFC 3339 timestamp.
+    pub last_published_after: Option<String>,
+    /// Only include operations last published at or before this RFC 3339 timestamp.
+    pub last_published_before: Option<String>,
+}
+
+/// Full identifier for an operation in a Persisted Query List, used to exclude a
+/// specific operation from an otherwise-matching bulk deletion filter.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PersistedQueryId {
+    pub id: String,
+    pub client_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct StartBulkDeletionInput {
+    pub graph_id: String,
+    pub list_id: String,
+    pub filter: PersistedQueryDeletionFilter,
+    pub exclude: Vec<PersistedQueryId>,
+}
+
+impl From<StartBulkDeletionInput> for MutationVariables {
+    fn from(input: StartBulkDeletionInput) -> Self {
+        let exclude = if input.exclude.is_empty() {
+            None
+        } else {
+            Some(
+                input
+                    .exclude
+                    .into_iter()
+                    .map(|id| MutationIdInput {
+                        id: id.id,
+                        client_name: id.client_name,
+                    })
+                    .collect(),
+            )
+        };
+        Self {
+            graph_id: input.graph_id,
+            list_id: input.list_id,
+            filter: MutationFilterInput {
+                clients: input.filter.clients.map(|clients| {
+                    clients
+                        .into_iter()
+                        .map(Some)
+                        .collect::<Vec<Option<String>>>()
+                }),
+                name: input.filter.name_contains,
+                last_published_at: if input.filter.last_published_after.is_none()
+                    && input.filter.last_published_before.is_none()
+                {
+                    None
+                } else {
+                    Some(MutationTimestampFilterInput {
+                        from: input.filter.last_published_after,
+                        to: input.filter.last_published_before,
+                    })
+                },
+            },
+            exclude,
+        }
+    }
+}
+
+/// The result of a successful call to `startBulkDeletion`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct StartBulkDeletionResponse {
+    /// The ID of the started (or already-active) bulk deletion job. Poll
+    /// `bulk_deletion_status::run` with this ID.
+    pub job_id: String,
+}

--- a/crates/rover-client/src/operations/persisted_queries/start_bulk_deletion/service.rs
+++ b/crates/rover-client/src/operations/persisted_queries/start_bulk_deletion/service.rs
@@ -1,0 +1,204 @@
+use std::{future::Future, pin::Pin};
+
+use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+use tower::Service;
+
+use crate::{
+    operations::persisted_queries::start_bulk_deletion::{
+        start_bulk_deletion_mutation,
+        start_bulk_deletion_mutation::StartBulkDeletionMutationGraphPersistedQueryListStartBulkDeletion::{
+            PermissionError, StartBulkDeletionResult,
+        },
+        StartBulkDeletionInput, StartBulkDeletionMutation, StartBulkDeletionResponse,
+    },
+    RoverClientError,
+};
+
+/// A [`Service`] that starts an asynchronous bulk deletion job against a Persisted
+/// Query List, layered over the studio GraphQL service.
+#[derive(Clone)]
+pub struct StartBulkDeletion<S: Clone> {
+    inner: S,
+}
+
+impl<S: Clone> StartBulkDeletion<S> {
+    pub const fn new(inner: S) -> StartBulkDeletion<S> {
+        StartBulkDeletion { inner }
+    }
+}
+
+impl<S, Fut> Service<StartBulkDeletionInput> for StartBulkDeletion<S>
+where
+    S: Service<
+            GraphQLRequest<StartBulkDeletionMutation>,
+            Response = start_bulk_deletion_mutation::ResponseData,
+            Error = GraphQLServiceError<start_bulk_deletion_mutation::ResponseData>,
+            Future = Fut,
+        > + Clone
+        + Send
+        + 'static,
+    Fut: Future<Output = Result<S::Response, S::Error>> + Send,
+{
+    type Response = StartBulkDeletionResponse;
+    type Error = RoverClientError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        tower::Service::<GraphQLRequest<StartBulkDeletionMutation>>::poll_ready(&mut self.inner, cx)
+            .map_err(|err| RoverClientError::ServiceReady(Box::new(err)))
+    }
+
+    fn call(&mut self, input: StartBulkDeletionInput) -> Self::Future {
+        let cloned = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, cloned);
+        let graph_id = input.graph_id.clone();
+        let fut = async move {
+            let response_data = inner.call(GraphQLRequest::new(input.into())).await?;
+            get_response_from_data(response_data, graph_id)
+        };
+        Box::pin(fut)
+    }
+}
+
+fn get_response_from_data(
+    data: start_bulk_deletion_mutation::ResponseData,
+    graph_id: String,
+) -> Result<StartBulkDeletionResponse, RoverClientError> {
+    let graph = data
+        .graph
+        .ok_or(RoverClientError::GraphIdNotFound { graph_id })?;
+
+    match graph.persisted_query_list.start_bulk_deletion {
+        PermissionError(error) => Err(RoverClientError::PermissionError { msg: error.message }),
+        StartBulkDeletionResult(result) => Ok(StartBulkDeletionResponse {
+            job_id: result.job_id,
+        }),
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+pub mod mock {
+    use rover_graphql::{GraphQLRequest, GraphQLServiceError};
+
+    use super::{start_bulk_deletion_mutation, StartBulkDeletionMutation};
+
+    pub type StartBulkDeletionReq = GraphQLRequest<StartBulkDeletionMutation>;
+    pub type StartBulkDeletionResp = start_bulk_deletion_mutation::ResponseData;
+    pub type StartBulkDeletionErr = GraphQLServiceError<start_bulk_deletion_mutation::ResponseData>;
+
+    rover_tower::mock_service!(
+        StartBulkDeletionInner,
+        StartBulkDeletionReq,
+        StartBulkDeletionResp,
+        StartBulkDeletionErr
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future;
+    use rover_tower::test::{expect_poll_ready, MockCloneService};
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    use super::{
+        mock::{MockStartBulkDeletionInnerService, StartBulkDeletionResp},
+        *,
+    };
+    use crate::operations::persisted_queries::start_bulk_deletion::PersistedQueryDeletionFilter;
+
+    fn input() -> StartBulkDeletionInput {
+        StartBulkDeletionInput {
+            graph_id: "my-graph".to_string(),
+            list_id: "my-list".to_string(),
+            filter: PersistedQueryDeletionFilter {
+                clients: Some(vec!["web".to_string()]),
+                ..Default::default()
+            },
+            exclude: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn call_returns_the_job_id_on_success() {
+        let data: StartBulkDeletionResp = serde_json::from_value(json!({
+            "graph": {
+                "persistedQueryList": {
+                    "startBulkDeletion": {
+                        "__typename": "StartBulkDeletionResult",
+                        "jobId": "job-123"
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let mut mock = MockStartBulkDeletionInnerService::new();
+        expect_poll_ready!(mock);
+        mock.expect_call()
+            .returning(move |_| future::ready(Ok(data.clone())));
+
+        let response = StartBulkDeletion::new(MockCloneService::new(mock))
+            .oneshot(input())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response,
+            StartBulkDeletionResponse {
+                job_id: "job-123".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn call_surfaces_a_permission_error() {
+        let data: StartBulkDeletionResp = serde_json::from_value(json!({
+            "graph": {
+                "persistedQueryList": {
+                    "startBulkDeletion": {
+                        "__typename": "PermissionError",
+                        "message": "you do not have access to this list"
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let mut mock = MockStartBulkDeletionInnerService::new();
+        expect_poll_ready!(mock);
+        mock.expect_call()
+            .returning(move |_| future::ready(Ok(data.clone())));
+
+        let result = StartBulkDeletion::new(MockCloneService::new(mock))
+            .oneshot(input())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(RoverClientError::PermissionError { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn call_fails_when_the_graph_is_not_found() {
+        let data: StartBulkDeletionResp = serde_json::from_value(json!({ "graph": null })).unwrap();
+
+        let mut mock = MockStartBulkDeletionInnerService::new();
+        expect_poll_ready!(mock);
+        mock.expect_call()
+            .returning(move |_| future::ready(Ok(data.clone())));
+
+        let result = StartBulkDeletion::new(MockCloneService::new(mock))
+            .oneshot(input())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(RoverClientError::GraphIdNotFound { .. })
+        ));
+    }
+}

--- a/crates/rover-client/src/operations/persisted_queries/start_bulk_deletion/start_bulk_deletion_mutation.graphql
+++ b/crates/rover-client/src/operations/persisted_queries/start_bulk_deletion/start_bulk_deletion_mutation.graphql
@@ -1,0 +1,20 @@
+mutation StartBulkDeletionMutation(
+  $graphId: ID!
+  $listId: ID!
+  $filter: PersistedQueryFilterInput!
+  $exclude: [PersistedQueryIdInput!]
+) {
+  graph(id: $graphId) {
+    persistedQueryList(id: $listId) {
+      startBulkDeletion(filter: $filter, exclude: $exclude) {
+        __typename
+        ... on PermissionError {
+          message
+        }
+        ... on StartBulkDeletionResult {
+          jobId
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds two `rover-client` operations under `persisted_queries`, each following the Tower `Service` pattern (`mod.rs` holds the `GraphQLQuery` derive plus the input/response types it exports, `service.rs` holds only the `Service` wrapper):

- `start_bulk_deletion` submits a job via `PersistedQueryListMutation.startBulkDeletion(filter, exclude)` and returns its ID. Submitting again while a job is already active for the list returns that job's existing ID rather than starting a second one.
- `bulk_deletion_status` polls `PersistedQueryList.bulkDeletionStatus(id)` and maps its `BulkDeletionPending`/`Success`/`Failure` union into a plain response enum:
  - an unrecognized or expired job ID (the query returns `null`) surfaces as `RoverClientError::BulkDeletionJobNotFound`
  - a failed job surfaces as `BulkDeletionJobFailed`
  - a job status value this version of Rover doesn't recognize surfaces as `UnknownBulkDeletionJobStatus`, rather than being silently treated as "still running" and polled forever

Both operations default to a conservative per-attempt timeout (documented as such — there's no observed latency data for either yet) via `studio_graphql_service_with_timeout`, added in #3658.

Stacked on #3658. Part of REG-2090.

- [x] A CHANGELOG.md entry is not needed for this PR
