### PR TITLE
Add rover persisted-queries bulk-delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover auth login --no-browser` uses the OAuth 2.0 Device Authorization Grant (RFC 8628) instead of the local browser/redirect-server flow: it prints a verification URL and code to enter from any device, then polls until you approve the request, for headless or browser-less environments. Ignores `--no-open`, since there's no local browser step to skip. The device authorization endpoint can be overridden with `--oauth-device-authorization-url`, matching the other OAuth endpoint overrides.
 
+- **Add `rover persisted-queries bulk-delete` - @bgaudiosi**
+
+  New command that starts an asynchronous bulk deletion job against a Persisted Query List (`startBulkDeletion`) and polls its status (`bulkDeletionStatus`) until it finishes, printing the number of operations deleted so far as it goes. Deletion happens entirely server-side: interrupting this command does not cancel the job. Pass `--no-wait` to submit the job and print its job ID immediately instead of waiting, and `--job-id` to resume watching a job started earlier. Operations to delete are selected with `--client-name`, `--name-contains`, `--published-after`, and `--published-before`, with `--exclude` available to carve out specific operations, given as `ID` or `ID:CLIENT_NAME`.
+
 - **Add `rover auth logout`, gated behind the experimental `oauth` feature flag - @dotdat**
 
   `rover auth logout` revokes the OAuth session stored by `rover auth login` for the given `--profile` (or "default") — the access token and, if one was issued, the refresh token (RFC 7009) — then removes the local credential. Revocation is best-effort: if the OAuth server can't be reached, Rover still clears the local credential and warns instead of leaving you stuck "logged in" locally. Only meaningful for profiles logged in via `rover auth login`; running it against a profile holding a Personal API Key (from `rover config auth`) errors and points you at `rover config delete` instead. Only compiled in when built with `--features oauth`, matching `rover auth login`.

--- a/src/command/persisted_queries/bulk_delete/mod.rs
+++ b/src/command/persisted_queries/bulk_delete/mod.rs
@@ -1,0 +1,306 @@
+mod output;
+
+use std::{str::FromStr, time::Duration};
+
+use clap::Parser;
+use output::BulkDeleteOutput;
+use rover_client::{
+    RoverClientError,
+    blocking::StudioClient,
+    operations::persisted_queries::{
+        bulk_deletion_status::{
+            self, BulkDeletionJobStatus, BulkDeletionStatus, BulkDeletionStatusInput,
+            BulkDeletionStatusResponse,
+        },
+        start_bulk_deletion::{
+            self, PersistedQueryDeletionFilter, PersistedQueryId, StartBulkDeletion,
+            StartBulkDeletionInput,
+        },
+    },
+};
+use rover_print::print::PrintExt;
+use serde::Serialize;
+use tower::{Service, ServiceExt};
+
+use super::identify::identify_persisted_query_list;
+use crate::{
+    RoverOutput, RoverResult,
+    options::{OptionalGraphRefOpt, ProfileOpt},
+    utils::client::StudioClientConfig,
+};
+
+/// How long to wait between polls of `bulkDeletionStatus`. Deliberately not
+/// user-configurable: the CLI has no chunking or retry policy of its own, so the
+/// only knobs that matter are the durable submit/poll API and this progress cadence.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// An operation ID paired with the optional client name that distinguishes it, parsed
+/// from `ID` or `ID:CLIENT_NAME` (see `BulkDelete::exclude`'s doc for why the client
+/// name matters).
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+struct ExcludeOperation {
+    id: String,
+    client_name: Option<String>,
+}
+
+impl FromStr for ExcludeOperation {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.split_once(':') {
+            Some((id, client_name)) => ExcludeOperation {
+                id: id.to_string(),
+                client_name: Some(client_name.to_string()),
+            },
+            None => ExcludeOperation {
+                id: s.to_string(),
+                client_name: None,
+            },
+        })
+    }
+}
+
+/// Start (or resume watching) an asynchronous bulk deletion job against a Persisted
+/// Query List.
+///
+/// Deletion happens server-side: Rover submits the job and polls for its status.
+/// Interrupting this command (e.g. with Ctrl-C) does not cancel the job — resume
+/// watching it later with `--job-id`.
+#[derive(Debug, Serialize, Parser)]
+pub struct BulkDelete {
+    #[clap(flatten)]
+    graph: OptionalGraphRefOpt,
+
+    /// The Graph ID the list to delete from belongs to.
+    #[serde(skip_serializing)]
+    #[arg(long, conflicts_with = "graph_ref")]
+    graph_id: Option<String>,
+
+    /// The list ID to delete operations from.
+    #[serde(skip_serializing)]
+    #[arg(long, conflicts_with = "graph_ref")]
+    list_id: Option<String>,
+
+    /// Resume watching an already-started bulk deletion job instead of starting a new one.
+    #[arg(
+        long,
+        conflicts_with_all = ["client_name", "name_contains", "published_after", "published_before", "exclude", "no_wait"]
+    )]
+    job_id: Option<String>,
+
+    /// Only delete operations whose client name is one of these. May be passed multiple times.
+    #[arg(long = "client-name")]
+    client_name: Vec<String>,
+
+    /// Only delete operations whose name contains this case-insensitive substring.
+    #[arg(long)]
+    name_contains: Option<String>,
+
+    /// Only delete operations last published at or after this RFC 3339 timestamp.
+    #[arg(long)]
+    published_after: Option<String>,
+
+    /// Only delete operations last published at or before this RFC 3339 timestamp.
+    #[arg(long)]
+    published_before: Option<String>,
+
+    /// An operation to exclude from deletion, even if it matches the filter, given as
+    /// `ID` or `ID:CLIENT_NAME`. Operations are identified by id AND client name, not
+    /// id alone, so a bare ID only excludes the operation published with no client
+    /// name; if the one you mean to protect has a client name, include it
+    /// (`id:client-name`) or it will be deleted despite being "excluded". May be
+    /// passed multiple times.
+    #[arg(long = "exclude", value_name = "ID[:CLIENT_NAME]")]
+    exclude: Vec<ExcludeOperation>,
+
+    /// Submit the bulk deletion job and print its job ID immediately, without
+    /// waiting for it to finish.
+    #[arg(long)]
+    no_wait: bool,
+
+    #[clap(flatten)]
+    profile: ProfileOpt,
+}
+
+impl BulkDelete {
+    pub async fn run<P: PrintExt>(
+        &self,
+        client_config: StudioClientConfig,
+        stderr: &P,
+    ) -> RoverResult<RoverOutput> {
+        let client = client_config.get_authenticated_client(&self.profile)?;
+
+        let (graph_id, list_id, list_name) = identify_persisted_query_list(
+            &self.graph,
+            &self.graph_id,
+            &self.list_id,
+            "deleting operations from",
+            &client,
+        )
+        .await?;
+
+        let job_id = match &self.job_id {
+            Some(job_id) => job_id.clone(),
+            None => {
+                self.submit(&client, &graph_id, &list_id, &list_name, stderr)
+                    .await?
+            }
+        };
+
+        if self.no_wait {
+            return Ok(RoverOutput::CliOutput(Box::new(
+                BulkDeleteOutput::Submitted { job_id },
+            )));
+        }
+
+        self.poll(&client, &graph_id, &list_id, job_id, list_name, stderr)
+            .await
+    }
+
+    /// Submits a new bulk deletion job for the filter/exclude criteria given on the
+    /// command line, and returns its job ID.
+    async fn submit<P: PrintExt>(
+        &self,
+        client: &StudioClient,
+        graph_id: &str,
+        list_id: &str,
+        list_name: &str,
+        stderr: &P,
+    ) -> RoverResult<String> {
+        let filter = PersistedQueryDeletionFilter {
+            clients: (!self.client_name.is_empty()).then(|| self.client_name.clone()),
+            name_contains: self.name_contains.clone(),
+            last_published_after: self.published_after.clone(),
+            last_published_before: self.published_before.clone(),
+        };
+        let exclude = self
+            .exclude
+            .iter()
+            .map(|exclude| PersistedQueryId {
+                id: exclude.id.clone(),
+                client_name: exclude.client_name.clone(),
+            })
+            .collect();
+
+        let inner = client
+            .studio_graphql_service_with_timeout(start_bulk_deletion::DEFAULT_ATTEMPT_TIMEOUT)?;
+        let mut service = StartBulkDeletion::new(inner);
+        let response = service
+            .ready()
+            .await?
+            .call(StartBulkDeletionInput {
+                graph_id: graph_id.to_string(),
+                list_id: list_id.to_string(),
+                filter,
+                exclude,
+            })
+            .await?;
+
+        stderr.infoln(format!(
+            "Started bulk deletion job {} for list {} ({}).",
+            response.job_id, list_name, graph_id
+        ));
+
+        Ok(response.job_id)
+    }
+
+    /// Polls `bulkDeletionStatus` until the job reaches a terminal state, printing
+    /// progress as it goes.
+    async fn poll<P: PrintExt>(
+        &self,
+        client: &StudioClient,
+        graph_id: &str,
+        list_id: &str,
+        job_id: String,
+        list_name: String,
+        stderr: &P,
+    ) -> RoverResult<RoverOutput> {
+        let inner = client
+            .studio_graphql_service_with_timeout(bulk_deletion_status::DEFAULT_ATTEMPT_TIMEOUT)?;
+        let mut service = BulkDeletionStatus::new(inner);
+
+        loop {
+            let status = service
+                .ready()
+                .await?
+                .call(BulkDeletionStatusInput {
+                    graph_id: graph_id.to_string(),
+                    list_id: list_id.to_string(),
+                    job_id: job_id.clone(),
+                })
+                .await?;
+
+            match status {
+                BulkDeletionStatusResponse::Pending {
+                    status,
+                    operations_deleted_so_far,
+                } => {
+                    let status = match status {
+                        BulkDeletionJobStatus::Pending => "queued",
+                        BulkDeletionJobStatus::Running => "running",
+                    };
+                    stderr.infoln(format!(
+                        "{operations_deleted_so_far} operations deleted so far ({status})..."
+                    ));
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+                BulkDeletionStatusResponse::Success {
+                    revision,
+                    list_name: latest_list_name,
+                } => {
+                    return Ok(RoverOutput::CliOutput(Box::new(
+                        BulkDeleteOutput::Success {
+                            job_id,
+                            // Prefer the name straight off this poll: it's always
+                            // current, whereas `list_name` was captured before the
+                            // job ran (or in a prior invocation, when resuming via
+                            // --job-id) and could be stale if the list was renamed
+                            // meanwhile. It's `None` only when nothing changed (no
+                            // build was produced), in which case the earlier name
+                            // is the best one available.
+                            list_name: latest_list_name.unwrap_or(list_name),
+                            revision,
+                        },
+                    )));
+                }
+                BulkDeletionStatusResponse::Failure { error } => {
+                    return Err(RoverClientError::BulkDeletionJobFailed { job_id, error }.into());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use speculoos::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn exclude_operation_parses_a_bare_id_with_no_client_name() {
+        let parsed: ExcludeOperation = "abc123".parse().unwrap();
+        assert_that!(parsed).is_equal_to(ExcludeOperation {
+            id: "abc123".to_string(),
+            client_name: None,
+        });
+    }
+
+    #[test]
+    fn exclude_operation_parses_an_id_and_client_name() {
+        let parsed: ExcludeOperation = "abc123:web".parse().unwrap();
+        assert_that!(parsed).is_equal_to(ExcludeOperation {
+            id: "abc123".to_string(),
+            client_name: Some("web".to_string()),
+        });
+    }
+
+    #[test]
+    fn exclude_operation_keeps_a_colon_containing_client_name_intact() {
+        let parsed: ExcludeOperation = "abc123:studio:web".parse().unwrap();
+        assert_that!(parsed).is_equal_to(ExcludeOperation {
+            id: "abc123".to_string(),
+            client_name: Some("studio:web".to_string()),
+        });
+    }
+}

--- a/src/command/persisted_queries/bulk_delete/output.rs
+++ b/src/command/persisted_queries/bulk_delete/output.rs
@@ -1,0 +1,101 @@
+use crate::command::output::CliOutput;
+
+/// Output of `rover persisted-queries bulk-delete`.
+#[derive(Debug)]
+pub enum BulkDeleteOutput {
+    /// The job was submitted (or resumed) and `--no-wait` was passed, so Rover
+    /// exited without waiting for it to finish.
+    Submitted { job_id: String },
+    /// The job ran to completion.
+    Success {
+        job_id: String,
+        list_name: String,
+        /// The revision produced by the job's final chunk. `None` means no
+        /// operations matched the filter, so nothing was deleted and no new
+        /// revision was created.
+        revision: Option<i64>,
+    },
+}
+
+impl CliOutput for BulkDeleteOutput {
+    fn text(&self) -> String {
+        match self {
+            BulkDeleteOutput::Submitted { job_id } => format!(
+                "Started bulk deletion job {job_id}. It will keep running on the server even if this command is interrupted; resume watching it with `--job-id {job_id}`."
+            ),
+            BulkDeleteOutput::Success {
+                list_name,
+                revision: Some(revision),
+                ..
+            } => format!("Bulk deletion finished. {list_name} is now at revision {revision}."),
+            BulkDeleteOutput::Success {
+                list_name,
+                revision: None,
+                ..
+            } => format!(
+                "Bulk deletion finished. No operations in {list_name} matched the filter; nothing was deleted."
+            ),
+        }
+    }
+
+    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        match self {
+            BulkDeleteOutput::Submitted { job_id } => Ok(serde_json::json!({
+                "status": "submitted",
+                "job_id": job_id,
+            })),
+            BulkDeleteOutput::Success {
+                job_id,
+                list_name,
+                revision,
+            } => Ok(serde_json::json!({
+                "status": "success",
+                "job_id": job_id,
+                "list_name": list_name,
+                "revision": revision,
+            })),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use speculoos::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn text_output_reports_the_final_revision() {
+        let out = BulkDeleteOutput::Success {
+            job_id: "job-123".to_string(),
+            list_name: "my-list".to_string(),
+            revision: Some(7),
+        };
+        assert_that!(out.text())
+            .is_equal_to("Bulk deletion finished. my-list is now at revision 7.".to_string());
+    }
+
+    #[test]
+    fn text_output_reports_no_changes_when_nothing_matched() {
+        let out = BulkDeleteOutput::Success {
+            job_id: "job-123".to_string(),
+            list_name: "my-list".to_string(),
+            revision: None,
+        };
+        assert_that!(out.text()).is_equal_to(
+            "Bulk deletion finished. No operations in my-list matched the filter; nothing was deleted."
+                .to_string(),
+        );
+    }
+
+    #[test]
+    fn json_output_includes_the_job_id_when_submitted() {
+        let out = BulkDeleteOutput::Submitted {
+            job_id: "job-123".to_string(),
+        };
+        assert_that!(out.json().unwrap()).is_equal_to(serde_json::json!({
+            "status": "submitted",
+            "job_id": "job-123",
+        }));
+    }
+}

--- a/src/command/persisted_queries/identify.rs
+++ b/src/command/persisted_queries/identify.rs
@@ -1,0 +1,70 @@
+use anyhow::anyhow;
+use rover_client::{
+    blocking::StudioClient,
+    operations::persisted_queries::{
+        name::{self, PersistedQueryListNameInput},
+        resolve::{self, ResolvePersistedQueryListInput},
+    },
+};
+
+use crate::{RoverResult, options::OptionalGraphRefOpt};
+
+/// Resolves the graph ID, Persisted Query List ID, and list name a command should
+/// operate against, from either a graph ref or an explicit `--graph-id`/`--list-id`
+/// pair. Shared by every `persisted-queries` command that identifies a list this way
+/// (`publish`, `bulk-delete`).
+///
+/// `action` is interpolated into the error message shown when the identification is
+/// ambiguous or incomplete, e.g. `"publishing operations to"` or `"deleting operations
+/// from"`.
+pub(crate) async fn identify_persisted_query_list(
+    graph: &OptionalGraphRefOpt,
+    graph_id: &Option<String>,
+    list_id: &Option<String>,
+    action: &str,
+    client: &StudioClient,
+) -> RoverResult<(String, String, String)> {
+    match (&graph.graph_ref, graph_id, list_id) {
+        (Some(graph_ref), None, None) => {
+            let persisted_query_list = resolve::run(
+                ResolvePersistedQueryListInput {
+                    graph_ref: graph_ref.clone(),
+                },
+                client,
+            )
+            .await?;
+            Ok((
+                graph_ref.graph_id().to_string(),
+                persisted_query_list.id,
+                persisted_query_list.name,
+            ))
+        }
+        (None, Some(graph_id), Some(list_id)) => {
+            let list_name = name::run(
+                PersistedQueryListNameInput {
+                    graph_id: graph_id.clone(),
+                    list_id: list_id.clone(),
+                },
+                client,
+            )
+            .await?
+            .name;
+            Ok((graph_id.to_string(), list_id.to_string(), list_name))
+        }
+        (None, Some(graph_id), None) => Err(anyhow!(
+            "You must specify a --list-id <LIST_ID> when {action} --graph-id {graph_id}, or, if a list is linked to a specific variant, you can leave --graph-id unspecified, and pass a full graph ref as a positional argument."
+        )
+        .into()),
+        (None, None, Some(list_id)) => Err(anyhow!(
+            "You must specify a --graph-id <GRAPH_ID> when {action} --list-id {list_id}, or, if {list_id} is linked to a specific variant, you can leave --list-id unspecified, and pass a full graph ref as a positional argument."
+        )
+        .into()),
+        (None, None, None) => Err(anyhow!(
+            "You must either specify a <GRAPH_REF> that has a linked persisted query list OR both a --graph-id <GRAPH_ID> and --list-id <LIST_ID>"
+        )
+        .into()),
+        (Some(_), Some(_), Some(_)) | (Some(_), Some(_), None) | (Some(_), None, Some(_)) => {
+            unreachable!("clap \"conflicts_with\" should make this impossible to reach")
+        }
+    }
+}

--- a/src/command/persisted_queries/mod.rs
+++ b/src/command/persisted_queries/mod.rs
@@ -1,6 +1,9 @@
+mod bulk_delete;
 mod generate;
+mod identify;
 mod publish;
 
+pub use bulk_delete::BulkDelete;
 use clap::Parser;
 pub use generate::Generate;
 pub use publish::Publish;
@@ -23,11 +26,14 @@ pub enum Command {
     Generate(persisted_queries::Generate),
     /// Persist a list of queries (or mutations) to a graph in Apollo Studio
     Publish(persisted_queries::Publish),
+    /// Start (or resume watching) an asynchronous bulk deletion job against a
+    /// Persisted Query List
+    BulkDelete(persisted_queries::BulkDelete),
 }
 
 impl PersistedQueries {
     pub const fn requires_client_config(&self) -> bool {
-        matches!(self.command, Command::Publish(_))
+        matches!(self.command, Command::Publish(_) | Command::BulkDelete(_))
     }
 
     pub async fn run<P: Print>(
@@ -40,6 +46,14 @@ impl PersistedQueries {
             Command::Publish(command) => {
                 command
                     .run(client_config.expect("publish requires client config"))
+                    .await
+            }
+            Command::BulkDelete(command) => {
+                command
+                    .run(
+                        client_config.expect("bulk-delete requires client config"),
+                        stderr,
+                    )
                     .await
             }
         }

--- a/src/command/persisted_queries/publish.rs
+++ b/src/command/persisted_queries/publish.rs
@@ -1,16 +1,12 @@
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use clap::Parser;
-use rover_client::operations::persisted_queries::{
-    name::{self, PersistedQueryListNameInput},
-    publish::{
-        self, ApolloPersistedQueryManifest, PersistedQueriesPublishInput,
-        RelayPersistedQueryManifest,
-    },
-    resolve::{self, ResolvePersistedQueryListInput},
+use rover_client::operations::persisted_queries::publish::{
+    self, ApolloPersistedQueryManifest, PersistedQueriesPublishInput, RelayPersistedQueryManifest,
 };
 use rover_std::Style;
 use serde::Serialize;
 
+use super::identify::identify_persisted_query_list;
 use crate::{
     RoverOutput, RoverResult,
     options::{OptionalGraphRefOpt, PersistedQueriesManifestFormat, ProfileOpt},
@@ -82,26 +78,14 @@ impl Publish {
             }
         }
 
-        let (graph_id, list_id, list_name) = match (&self.graph.graph_ref, &self.graph_id, &self.list_id) {
-            (Some(graph_ref), None, None) => {
-                let persisted_query_list = resolve::run(ResolvePersistedQueryListInput { graph_ref: graph_ref.clone() }, &client).await?;
-                (graph_ref.graph_id().to_string(), persisted_query_list.id, persisted_query_list.name)
-            },
-            (None, Some(graph_id), Some(list_id)) => {
-                let list_name = name::run(PersistedQueryListNameInput { graph_id: graph_id.clone(), list_id: list_id.clone() }, &client).await?.name;
-                (graph_id.to_string(), list_id.to_string(), list_name)
-            },
-            (None, Some(graph_id), None) => {
-                return Err(anyhow!("You must specify a --list-id <LIST_ID> when publishing operations to --graph-id {graph_id}, or, if a list is linked to a specific variant, you can leave --graph-id unspecified, and pass a full graph ref as a positional argument.").into())
-            }
-            (None, None, Some(list_id)) => {
-                return Err(anyhow!("You must specify a --graph-id <GRAPH_ID> when publishing operations to --list-id {list_id}, or, if {list_id} is linked to a specific variant, you can leave --list-id unspecified, and pass a full graph ref as a positional argument.").into())
-            }
-            (None, None, None) => {
-                return Err(anyhow!("You must either specify a <GRAPH_REF> that has a linked persisted query list OR both a --graph_id <GRAPH_ID> and --list_id <LIST_ID>").into())
-            },
-            (Some(_), Some(_), Some(_)) | (Some(_), Some(_), None) | (Some(_), None, Some(_)) => unreachable!("clap \"conflicts_with\" should make this impossible to reach")
-        };
+        let (graph_id, list_id, list_name) = identify_persisted_query_list(
+            &self.graph,
+            &self.graph_id,
+            &self.list_id,
+            "publishing operations to",
+            &client,
+        )
+        .await?;
 
         eprintln!(
             "Publishing operations to list {} for {} using credentials from the {} profile.",

--- a/src/error/metadata/mod.rs
+++ b/src/error/metadata/mod.rs
@@ -321,6 +321,9 @@ impl From<&mut anyhow::Error> for RoverErrorMetadata {
                     }),
                     None,
                 ),
+                RoverClientError::BulkDeletionJobNotFound { .. } => (None, None),
+                RoverClientError::BulkDeletionJobFailed { .. } => (None, None),
+                RoverClientError::UnknownBulkDeletionJobStatus { .. } => (None, None),
                 RoverClientError::RelayOperationParseFailures { .. } => (None, None),
                 RoverClientError::OfflineLicenseNotEnabled => (
                     Some(RoverErrorSuggestion::ContactApolloAccountManager),


### PR DESCRIPTION
Adds `rover persisted-queries bulk-delete`, which starts an asynchronous bulk deletion job against a Persisted Query List and polls it to completion, printing the number of operations deleted so far as it goes. Deletion happens entirely server-side, so interrupting this command does not cancel the job.

The list is identified the same way `publish` accepts it, either a graph ref or a `--graph-id`/`--list-id` pair; that identification logic is now shared via a new `identify_persisted_query_list` helper (moved out of `publish`, which previously had its own copy, rather than duplicated a second time here).

Operations to delete are selected with `--client-name`, `--name-contains`, `--published-after`, and `--published-before`. `--exclude` carves out specific operations from an otherwise-matching filter, given as `ID` or `ID:CLIENT_NAME` — a Persisted Query List identifies operations by ID *and* client name together, so a bare ID only protects the operation published with no client name.

`--no-wait` submits the job and prints its ID immediately instead of waiting, and `--job-id` resumes watching a job started earlier; `clap` rejects combining `--job-id` with any of the filter/exclude/`--no-wait` flags, since resuming doesn't submit anything.

Output goes through the `CliOutput` trait rather than a new `RoverOutput` variant, per the established pattern for new commands.

Stacked on #3659 (and #3658 below that). Closes REG-2090.

**Note for reviewers:** per the note on #3658, the backend fields this depends on aren't fully live yet, so this can't be verified end-to-end against a real job today — only against synthetic responses in the unit tests. Recommend holding this stack until that backend work ships, or merging with that understanding explicit.

- [ ] A CHANGELOG.md entry is not needed for this PR
