### PR TITLE
Widen downstream check response to a full per-variant list, bump JSON to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `CheckWorkflowResponse` UI concerns are moved higher up to the CLI binary. Its hand-rolled "N item(s)" pluralization now uses the `pluralizer` crate.
 
+- **Widen `subgraph check`'s downstream check response to a full per-variant list, bump `graph`/`subgraph check --format json` to version 3 - @dotdat**
+
+  `DownstreamCheckResponse` now carries every contract variant's blocking state and status instead of collapsing to a bare list of blocking variant names, so a passing or empty downstream check can render a summary instead of nothing. `subgraph check`'s existing call site is adapted to the new shape with no behavior change; `graph check` does not yet populate this field.
+
 - **Switch `graph publish`/`subgraph publish` from raw `eprintln!` to `rover-print` - @dotdat**
 
   Both commands now print their stderr status lines through `rover-print`'s `Print`/`PrintExt` trait via an injected printer, matching the pattern already used by `contract preview`/`subgraph preview`. No user-facing output change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **`rover subgraph check`'s JSON `downstream` task changes shape, bumping `json_version` to `"3"` - @dotdat**
 
-  The `downstream` task's `blocking_variants: [String]` field is replaced by `variants`, a list of per-contract-variant results (`graph_id`, `variant_name`, `blocking`, `fails_upstream_workflow`, `status`) instead of just the names of variants blocking the check. `json_version` in the response envelope moves from `"2"` to `"3"` to reflect the shape change.
+  The `downstream` task's `blocking_variants: [String]` field is replaced by `variants`, a list of per-contract-variant results (`graph_id`, `variant_name`, `blocking`, `fails_upstream_workflow`, `status`) instead of just the names of variants blocking the check. `json_version` in the response envelope moves from `"2"` to `"3"` to reflect the shape change. `rover graph check` shares the same response envelope and also moves to `"3"`, though its payload is unchanged for now. Text output changes too: a downstream check summary now always renders whenever a downstream task ran, even when nothing is blocking — "No contract variants configured for this graph." or "Checked N contract variants[, all passed]." — instead of staying silent unless something was blocking.
 
 - **Remove `rover cloud` commands - @dotdat**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [Unreleased]
 
-> Important: 2 potentially breaking changes below, indicated by **❗ BREAKING ❗**
+> Important: 3 potentially breaking changes below, indicated by **❗ BREAKING ❗**
 
 ## ❗ BREAKING ❗
+
+- **`rover subgraph check`'s JSON `downstream` task changes shape, bumping `json_version` to `"3"` - @dotdat**
+
+  The `downstream` task's `blocking_variants: [String]` field is replaced by `variants`, a list of per-contract-variant results (`graph_id`, `variant_name`, `blocking`, `fails_upstream_workflow`, `status`) instead of just the names of variants blocking the check. `json_version` in the response envelope moves from `"2"` to `"3"` to reflect the shape change.
 
 - **Remove `rover cloud` commands - @dotdat**
 
@@ -109,10 +113,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Move check-workflow text rendering out of `rover-client` - @dotdat**
 
   `CheckWorkflowResponse` UI concerns are moved higher up to the CLI binary. Its hand-rolled "N item(s)" pluralization now uses the `pluralizer` crate.
-
-- **Widen `subgraph check`'s downstream check response to a full per-variant list, bump `graph`/`subgraph check --format json` to version 3 - @dotdat**
-
-  `DownstreamCheckResponse` now carries every contract variant's blocking state and status instead of collapsing to a bare list of blocking variant names, so a passing or empty downstream check can render a summary instead of nothing. `subgraph check`'s existing call site is adapted to the new shape with no behavior change; `graph check` does not yet populate this field.
 
 - **Switch `graph publish`/`subgraph publish` from raw `eprintln!` to `rover-print` - @dotdat**
 

--- a/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
@@ -96,6 +96,7 @@ query SubgraphCheckWorkflowQuery($workflowId: ID!, $graphId: ID!) {
         ... on DownstreamCheckTask {
           results {
             __typename
+            downstreamGraphID
             downstreamVariantName
             failsUpstreamWorkflow
           }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/check_workflow_query.graphql
@@ -96,8 +96,12 @@ query SubgraphCheckWorkflowQuery($workflowId: ID!, $graphId: ID!) {
         ... on DownstreamCheckTask {
           results {
             __typename
+            blocking
             downstreamGraphID
             downstreamVariantName
+            downstreamWorkflow {
+              status
+            }
             failsUpstreamWorkflow
           }
         }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -20,8 +20,9 @@ use crate::{
     shared::{
         check_workflow_poll::{poll_check_workflow, PollState},
         CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, Diagnostic,
-        DownstreamCheckResponse, LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
-        ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange, Violation,
+        DownstreamCheckResponse, DownstreamVariantCheckResult, LintCheckResponse,
+        OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel,
+        ProposalsCoverage, RelatedProposal, SchemaChange, Violation,
     },
     RoverClientError,
 };
@@ -458,15 +459,24 @@ fn get_downstream_response_from_result(
 ) -> Option<DownstreamCheckResponse> {
     match results {
         Some(results) => {
-            let blocking_variants = results
+            // `blocking`/per-variant `status` require fields not yet selected by this
+            // query (see ROVER-460, which rebases on PR #3377's widened fragment); until
+            // then, `fails_upstream_workflow` alone determines blocking, matching prior
+            // behavior via `DownstreamCheckResponse::blocking_variants`'s first predicate.
+            let variants = results
                 .iter()
-                .filter(|result| result.fails_upstream_workflow.unwrap_or(false))
-                .map(|result| result.downstream_variant_name.clone())
+                .map(|result| DownstreamVariantCheckResult {
+                    graph_id: result.downstream_graph_id.clone(),
+                    variant_name: result.downstream_variant_name.clone(),
+                    blocking: false,
+                    fails_upstream_workflow: result.fails_upstream_workflow,
+                    status: CheckTaskStatus::PENDING,
+                })
                 .collect();
             Some(DownstreamCheckResponse {
                 task_status: task_status.into(),
                 target_url,
-                blocking_variants,
+                variants,
             })
         }
         None => None,
@@ -477,6 +487,7 @@ fn get_downstream_response_from_result(
 #[expect(clippy::panic)]
 mod tests {
     use serde_json::json;
+    use speculoos::prelude::*;
 
     use super::*;
 
@@ -724,5 +735,44 @@ mod tests {
 
         // Lint response should be None since result was null
         assert!(response.maybe_lint_response.is_none());
+    }
+
+    #[test]
+    fn downstream_result_maps_into_shared_variant_shape() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "failsUpstreamWorkflow": false
+                        }
+                    ]
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+        let subgraph = "test-subgraph".to_string();
+
+        let response = get_check_response_from_data(data, graph_ref, subgraph).unwrap();
+
+        let downstream = response
+            .maybe_downstream_response
+            .expect("expected downstream response");
+        assert_that!(&downstream.variants).has_length(1);
+        let variant = &downstream.variants[0];
+        assert_that!(&variant.graph_id).is_equal_to("test-graph".to_string());
+        assert_that!(&variant.variant_name).is_equal_to("mobile".to_string());
+        // `blocking`/per-variant `status` aren't queried yet (see ROVER-460).
+        assert_that!(&variant.blocking).is_false();
+        assert_that!(&variant.status).is_equal_to(CheckTaskStatus::PENDING);
+        assert_that!(&variant.fails_upstream_workflow).is_equal_to(Some(false));
     }
 }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -472,7 +472,11 @@ fn get_downstream_response_from_result(
                         Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
                         // Not yet initialized, or the downstream variant was deleted.
                         None => CheckTaskStatus::PENDING,
-                        _ => CheckTaskStatus::FAILED,
+                        // A status this client's schema snapshot doesn't recognize
+                        // (graphql_client's `Other(String)` fallback) -- degrade to the
+                        // neutral/pending summary rather than fabricating a
+                        // blocking-failure claim for something we don't understand.
+                        _ => CheckTaskStatus::PENDING,
                     },
                 })
                 .collect();
@@ -788,6 +792,7 @@ mod tests {
     #[case::passed(Some("PASSED"), CheckTaskStatus::PASSED)]
     #[case::pending(Some("PENDING"), CheckTaskStatus::PENDING)]
     #[case::not_yet_initialized(None, CheckTaskStatus::PENDING)]
+    #[case::unrecognized_status(Some("SOME_FUTURE_STATUS"), CheckTaskStatus::PENDING)]
     fn downstream_variant_status_mapping(
         graph_ref: GraphRef,
         #[case] downstream_workflow_status: Option<&str>,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -472,11 +472,11 @@ fn get_downstream_response_from_result(
                         Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
                         // Not yet initialized, or the downstream variant was deleted.
                         None => CheckTaskStatus::PENDING,
-                        // A status this client's schema snapshot doesn't recognize
-                        // (graphql_client's `Other(String)` fallback) -- degrade to the
-                        // neutral/pending summary rather than fabricating a
-                        // blocking-failure claim for something we don't understand.
-                        _ => CheckTaskStatus::PENDING,
+                        // A status this client's schema snapshot doesn't recognize.
+                        // Spelled out explicitly (rather than `_`) so a future schema
+                        // regen adding a real new variant is a compile error here,
+                        // not a silent fall-through to this same PENDING degrade.
+                        Some(CheckWorkflowStatus::Other(_)) => CheckTaskStatus::PENDING,
                     },
                 })
                 .collect();

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -459,18 +459,21 @@ fn get_downstream_response_from_result(
 ) -> Option<DownstreamCheckResponse> {
     match results {
         Some(results) => {
-            // `blocking`/per-variant `status` require fields not yet selected by this
-            // query (see ROVER-460, which rebases on PR #3377's widened fragment); until
-            // then, `fails_upstream_workflow` alone determines blocking, matching prior
-            // behavior via `DownstreamCheckResponse::blocking_variants`'s first predicate.
             let variants = results
-                .iter()
+                .into_iter()
                 .map(|result| DownstreamVariantCheckResult {
-                    graph_id: result.downstream_graph_id.clone(),
-                    variant_name: result.downstream_variant_name.clone(),
-                    blocking: false,
+                    graph_id: result.downstream_graph_id,
+                    variant_name: result.downstream_variant_name,
+                    blocking: result.blocking,
                     fails_upstream_workflow: result.fails_upstream_workflow,
-                    status: CheckTaskStatus::PENDING,
+                    status: match result.downstream_workflow.map(|workflow| workflow.status) {
+                        Some(CheckWorkflowStatus::FAILED) => CheckTaskStatus::FAILED,
+                        Some(CheckWorkflowStatus::PASSED) => CheckTaskStatus::PASSED,
+                        Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
+                        // Not yet initialized, or the downstream variant was deleted.
+                        None => CheckTaskStatus::PENDING,
+                        _ => CheckTaskStatus::FAILED,
+                    },
                 })
                 .collect();
             Some(DownstreamCheckResponse {
@@ -486,10 +489,16 @@ fn get_downstream_response_from_result(
 #[cfg(test)]
 #[expect(clippy::panic)]
 mod tests {
-    use serde_json::json;
+    use rstest::{fixture, rstest};
+    use serde_json::{json, Value};
     use speculoos::prelude::*;
 
     use super::*;
+
+    #[fixture]
+    fn graph_ref() -> GraphRef {
+        GraphRef::new("test-graph", Some("test-variant")).unwrap()
+    }
 
     #[tokio::test]
     async fn run_points_to_studio_when_result_fetch_fails() {
@@ -566,10 +575,9 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn test_get_check_response_from_data_with_passed_status() {
+    #[rstest]
+    fn test_get_check_response_from_data_with_passed_status(graph_ref: GraphRef) {
         let data = create_check_workflow_data(CheckWorkflowStatus::PASSED, json!([]));
-        let graph_ref = "test-graph@test-variant".parse().unwrap();
         let subgraph = "test-subgraph".to_string();
 
         let result = get_check_response_from_data(data, graph_ref, subgraph);
@@ -588,10 +596,9 @@ mod tests {
         assert!(response.maybe_downstream_response.is_none());
     }
 
-    #[test]
-    fn test_get_check_response_from_data_with_failed_status() {
+    #[rstest]
+    fn test_get_check_response_from_data_with_failed_status(graph_ref: GraphRef) {
         let data = create_check_workflow_data(CheckWorkflowStatus::FAILED, json!([]));
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
         let subgraph = "test-subgraph".to_string();
 
         let result = get_check_response_from_data(data, graph_ref.clone(), subgraph);
@@ -612,8 +619,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_get_check_response_preserves_composition_task_status() {
+    #[rstest]
+    fn test_get_check_response_preserves_composition_task_status(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -627,7 +634,6 @@ mod tests {
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
         let response =
             get_check_response_from_data(data, graph_ref, "test-subgraph".to_string()).unwrap();
@@ -638,8 +644,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_get_check_response_from_data_with_composition_errors() {
+    #[rstest]
+    fn test_get_check_response_from_data_with_composition_errors(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::FAILED,
             json!([
@@ -662,7 +668,6 @@ mod tests {
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
         let subgraph = "test-subgraph".to_string();
 
         let result = get_check_response_from_data(data, graph_ref.clone(), subgraph.clone());
@@ -682,8 +687,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_get_check_response_from_data_with_null_operations_result() {
+    #[rstest]
+    fn test_get_check_response_from_data_with_null_operations_result(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -696,7 +701,6 @@ mod tests {
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
         let subgraph = "test-subgraph".to_string();
 
         let result = get_check_response_from_data(data, graph_ref, subgraph);
@@ -709,8 +713,8 @@ mod tests {
         assert!(response.maybe_operations_response.is_none());
     }
 
-    #[test]
-    fn test_get_check_response_from_data_with_null_lint_result() {
+    #[rstest]
+    fn test_get_check_response_from_data_with_null_lint_result(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -724,7 +728,6 @@ mod tests {
             ]),
         );
 
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
         let subgraph = "test-subgraph".to_string();
 
         let result = get_check_response_from_data(data, graph_ref, subgraph);
@@ -737,8 +740,8 @@ mod tests {
         assert!(response.maybe_lint_response.is_none());
     }
 
-    #[test]
-    fn downstream_result_maps_into_shared_variant_shape() {
+    #[rstest]
+    fn downstream_result_maps_into_shared_variant_shape(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -746,33 +749,92 @@ mod tests {
                     "__typename": "DownstreamCheckTask",
                     "id": "downstream-task",
                     "status": "PASSED",
-                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
                     "results": [
                         {
                             "__typename": "DownstreamCheckResult",
+                            "blocking": true,
                             "downstreamGraphID": "test-graph",
                             "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "PASSED" },
                             "failsUpstreamWorkflow": false
                         }
                     ]
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
         let subgraph = "test-subgraph".to_string();
 
         let response = get_check_response_from_data(data, graph_ref, subgraph).unwrap();
 
-        let downstream = response
-            .maybe_downstream_response
-            .expect("expected downstream response");
-        assert_that!(&downstream.variants).has_length(1);
-        let variant = &downstream.variants[0];
-        assert_that!(&variant.graph_id).is_equal_to("test-graph".to_string());
-        assert_that!(&variant.variant_name).is_equal_to("mobile".to_string());
-        // `blocking`/per-variant `status` aren't queried yet (see ROVER-460).
-        assert_that!(&variant.blocking).is_false();
-        assert_that!(&variant.status).is_equal_to(CheckTaskStatus::PENDING);
-        assert_that!(&variant.fails_upstream_workflow).is_equal_to(Some(false));
+        let expected = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::PASSED,
+            target_url: Some(
+                "https://studio.apollographql.com/graph/test-graph/checks/downstream".to_string(),
+            ),
+            variants: vec![DownstreamVariantCheckResult {
+                graph_id: "test-graph".to_string(),
+                variant_name: "mobile".to_string(),
+                blocking: true,
+                fails_upstream_workflow: Some(false),
+                status: CheckTaskStatus::PASSED,
+            }],
+        };
+        assert_that!(&response.maybe_downstream_response).is_equal_to(Some(expected));
+    }
+
+    #[rstest]
+    #[case::failed(Some("FAILED"), CheckTaskStatus::FAILED)]
+    #[case::passed(Some("PASSED"), CheckTaskStatus::PASSED)]
+    #[case::pending(Some("PENDING"), CheckTaskStatus::PENDING)]
+    #[case::not_yet_initialized(None, CheckTaskStatus::PENDING)]
+    fn downstream_variant_status_mapping(
+        graph_ref: GraphRef,
+        #[case] downstream_workflow_status: Option<&str>,
+        #[case] expected_status: CheckTaskStatus,
+    ) {
+        let downstream_workflow = match downstream_workflow_status {
+            Some(status) => json!({ "status": status }),
+            None => Value::Null,
+        };
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetURL": null,
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            // Non-blocking, so a FAILED case here doesn't also trip
+                            // the check-failure behavior covered by other tests.
+                            "blocking": false,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": downstream_workflow,
+                            "failsUpstreamWorkflow": null
+                        }
+                    ]
+                }
+            ]),
+        );
+        let subgraph = "test-subgraph".to_string();
+
+        let response = get_check_response_from_data(data, graph_ref, subgraph).unwrap();
+
+        let expected = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::PASSED,
+            target_url: None,
+            variants: vec![DownstreamVariantCheckResult {
+                graph_id: "test-graph".to_string(),
+                variant_name: "mobile".to_string(),
+                blocking: false,
+                fails_upstream_workflow: None,
+                status: expected_status,
+            }],
+        };
+        assert_that!(&response.maybe_downstream_response).is_equal_to(Some(expected));
     }
 }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -760,8 +760,8 @@ mod tests {
                             "blocking": true,
                             "downstreamGraphID": "test-graph",
                             "downstreamVariantName": "mobile",
-                            "downstreamWorkflow": { "status": "PASSED" },
-                            "failsUpstreamWorkflow": false
+                            "downstreamWorkflow": { "status": "FAILED" },
+                            "failsUpstreamWorkflow": true
                         }
                     ]
                 }
@@ -780,8 +780,8 @@ mod tests {
                 graph_id: "test-graph".to_string(),
                 variant_name: "mobile".to_string(),
                 blocking: true,
-                fails_upstream_workflow: Some(false),
-                status: CheckTaskStatus::PASSED,
+                fails_upstream_workflow: Some(true),
+                status: CheckTaskStatus::FAILED,
             }],
         };
         assert_that!(&response.maybe_downstream_response).is_equal_to(Some(expected));

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -151,11 +151,22 @@ pub struct CustomCheckResponse {
     pub violations: Vec<Violation>,
 }
 
+/// The result of a single contract variant's downstream check, as part of a
+/// `graph check`/`subgraph check`'s downstream check task.
+#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+pub struct DownstreamVariantCheckResult {
+    pub graph_id: String,
+    pub variant_name: String,
+    pub blocking: bool,
+    pub fails_upstream_workflow: Option<bool>,
+    pub status: CheckTaskStatus,
+}
+
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
 pub struct DownstreamCheckResponse {
     pub task_status: CheckTaskStatus,
     pub target_url: Option<String>,
-    pub blocking_variants: Vec<String>,
+    pub variants: Vec<DownstreamVariantCheckResult>,
 }
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]

--- a/crates/rover-client/src/shared/mod.rs
+++ b/crates/rover-client/src/shared/mod.rs
@@ -13,9 +13,9 @@ pub(crate) use async_check_response::map_check_submission_error;
 pub use async_check_response::CheckRequestSuccessResult;
 pub use check_response::{
     ChangeSeverity, CheckConfig, CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse,
-    DownstreamCheckResponse, LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse,
-    ProposalsCheckSeverityLevel, ProposalsCoverage, RelatedProposal, SchemaChange,
-    ValidationPeriod, Violation,
+    DownstreamCheckResponse, DownstreamVariantCheckResult, LintCheckResponse,
+    OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel, ProposalsCoverage,
+    RelatedProposal, SchemaChange, ValidationPeriod, Violation,
 };
 pub use fetch_response::{FetchResponse, Sdl, SdlType};
 pub use filter_config::ContractFilterConfig;

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -415,6 +415,20 @@ mod test {
         }
     }
 
+    /// A variant the server has explicitly flagged as failing upstream,
+    /// independent of its own `blocking`/`status` fields -- `blocking: false`
+    /// and `status: PENDING` are deliberate so this only counts as blocking
+    /// via `fails_upstream_workflow`, not the `blocking && FAILED` predicate.
+    fn variant_failing_upstream(name: &str) -> DownstreamVariantCheckResult {
+        DownstreamVariantCheckResult {
+            graph_id: "my-graph".to_string(),
+            variant_name: name.to_string(),
+            blocking: false,
+            fails_upstream_workflow: Some(true),
+            status: CheckTaskStatus::PENDING,
+        }
+    }
+
     /// A response exercising every task type at once, each with at least one
     /// finding, so both the text and JSON renderers cover every branch.
     fn comprehensive_response() -> CheckWorkflowResponse {
@@ -585,6 +599,11 @@ mod test {
             variant("partner-api", false, CheckTaskStatus::FAILED),
         ],
         "Checked 2 contract variants."
+    )]
+    #[case::fails_upstream_workflow_flags_blocking_even_when_not_individually_blocking(
+        CheckTaskStatus::FAILED,
+        vec![variant_failing_upstream("mobile")],
+        "The downstream check task has encountered check failures for at least this blocking downstream variant: mobile."
     )]
     fn downstream_msg_summarizes_variants(
         #[case] task_status: CheckTaskStatus,

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -358,7 +358,12 @@ fn downstream_msg(response: &DownstreamCheckResponse) -> String {
 
     if response.variants.is_empty() {
         "No contract variants configured for this graph.".to_string()
-    } else if response.task_status == CheckTaskStatus::PASSED {
+    } else if response.task_status == CheckTaskStatus::PASSED
+        && response
+            .variants
+            .iter()
+            .all(|variant| variant.status == CheckTaskStatus::PASSED)
+    {
         format!(
             "Checked {}, all passed.",
             pluralize("contract variant", response.variants.len() as isize, true)
@@ -570,6 +575,14 @@ mod test {
         vec![
             variant("mobile", false, CheckTaskStatus::PENDING),
             variant("partner-api", false, CheckTaskStatus::PENDING),
+        ],
+        "Checked 2 contract variants."
+    )]
+    #[case::non_blocking_failed_variant_does_not_claim_all_passed(
+        CheckTaskStatus::PASSED,
+        vec![
+            variant("mobile", true, CheckTaskStatus::PASSED),
+            variant("partner-api", false, CheckTaskStatus::FAILED),
         ],
         "Checked 2 contract variants."
     )]

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -2,8 +2,8 @@ use comfy_table::{Attribute::Bold, Cell, CellAlignment::Center, Table, presets::
 use pluralizer::pluralize;
 use rover_client::shared::{
     CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, DownstreamCheckResponse,
-    LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel,
-    ProposalsCoverage,
+    DownstreamVariantCheckResult, LintCheckResponse, OperationCheckResponse,
+    ProposalsCheckResponse, ProposalsCheckSeverityLevel, ProposalsCoverage,
 };
 use rover_std::{Style, hyperlink};
 use serde_json::Value;
@@ -69,9 +69,7 @@ impl CliOutput for CheckWorkflowOutput<'_> {
             msg.push_str(custom_text(custom_response).as_str());
         }
 
-        if let Some(downstream_response) = &response.maybe_downstream_response
-            && !downstream_response.blocking_variants.is_empty()
-        {
+        if let Some(downstream_response) = &response.maybe_downstream_response {
             append_task_title(
                 &mut msg,
                 "Downstream Check",
@@ -327,31 +325,55 @@ fn custom_text(response: &CustomCheckResponse) -> String {
     msg
 }
 
+fn downstream_blocking_variants(
+    response: &DownstreamCheckResponse,
+) -> Vec<&DownstreamVariantCheckResult> {
+    response
+        .variants
+        .iter()
+        .filter(|variant| {
+            variant.fails_upstream_workflow.unwrap_or(false)
+                || (variant.blocking && variant.status == CheckTaskStatus::FAILED)
+        })
+        .collect()
+}
+
 fn downstream_msg(response: &DownstreamCheckResponse) -> String {
-    let variants = response.blocking_variants.join(",");
-    let plural_this = match response.blocking_variants.len() {
-        1 => "this",
-        _ => "these",
-    };
-    let plural = match response.blocking_variants.len() {
-        1 => "",
-        _ => "s",
-    };
-    format!(
-        "The downstream check task has encountered check failures for at least {} blocking downstream variant{}: {}.",
-        plural_this,
-        plural,
-        Style::Variant.paint(variants),
-    )
+    let blocking_variants = downstream_blocking_variants(response);
+    if !blocking_variants.is_empty() {
+        let variants = blocking_variants
+            .iter()
+            .map(|variant| variant.variant_name.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        let plural_this = match blocking_variants.len() {
+            1 => "this",
+            _ => "these",
+        };
+        let plural = match blocking_variants.len() {
+            1 => "",
+            _ => "s",
+        };
+        return format!(
+            "The downstream check task has encountered check failures for at least {} blocking downstream variant{}: {}.",
+            plural_this,
+            plural,
+            Style::Variant.paint(variants),
+        );
+    }
+
+    match response.variants.len() {
+        0 => "No contract variants configured for this graph.".to_string(),
+        1 => "Checked 1 contract variant, all passed.".to_string(),
+        count => format!("Checked {count} contract variants, all passed."),
+    }
 }
 
 fn downstream_text(response: &DownstreamCheckResponse) -> String {
     let mut msg = String::new();
 
-    if !response.blocking_variants.is_empty() {
-        msg.push_str(&downstream_msg(response));
-        msg.push('\n');
-    }
+    msg.push_str(&downstream_msg(response));
+    msg.push('\n');
 
     if let Some(url) = &response.target_url {
         msg.push_str("View downstream check details at: ");
@@ -367,8 +389,24 @@ mod test {
     use rover_client::shared::{
         ChangeSeverity, Diagnostic, RelatedProposal, SchemaChange, Violation,
     };
+    use rstest::rstest;
+    use speculoos::prelude::*;
 
     use super::*;
+
+    fn variant(
+        name: &str,
+        blocking: bool,
+        status: CheckTaskStatus,
+    ) -> DownstreamVariantCheckResult {
+        DownstreamVariantCheckResult {
+            graph_id: "my-graph".to_string(),
+            variant_name: name.to_string(),
+            blocking,
+            fails_upstream_workflow: None,
+            status,
+        }
+    }
 
     /// A response exercising every task type at once, each with at least one
     /// finding, so both the text and JSON renderers cover every branch.
@@ -443,7 +481,7 @@ mod test {
                 target_url: Some(
                     "https://studio.apollographql.com/graph/my-graph/checks/downstream".to_string(),
                 ),
-                blocking_variants: vec!["mobile".to_string()],
+                variants: vec![variant("mobile", true, CheckTaskStatus::FAILED)],
             }),
         }
     }
@@ -493,5 +531,36 @@ mod test {
             .json()
             .expect("check workflow JSON rendering cannot fail");
         insta::assert_json_snapshot!(json);
+    }
+
+    #[rstest]
+    #[case::no_contract_variants_configured(
+        vec![],
+        "No contract variants configured for this graph."
+    )]
+    #[case::all_contract_variants_passed(
+        vec![
+            variant("mobile", true, CheckTaskStatus::PASSED),
+            variant("partner-api", true, CheckTaskStatus::PASSED),
+        ],
+        "Checked 2 contract variants, all passed."
+    )]
+    #[case::one_blocking_contract_variant_failed(
+        vec![
+            variant("mobile", true, CheckTaskStatus::FAILED),
+            variant("partner-api", true, CheckTaskStatus::PASSED),
+        ],
+        "The downstream check task has encountered check failures for at least this blocking downstream variant: mobile."
+    )]
+    fn downstream_msg_summarizes_variants(
+        #[case] variants: Vec<DownstreamVariantCheckResult>,
+        #[case] expected: &str,
+    ) {
+        let response = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::PASSED,
+            target_url: None,
+            variants,
+        };
+        assert_that!(&downstream_msg(&response)).is_equal_to(expected.to_string());
     }
 }

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -415,15 +415,16 @@ mod test {
         }
     }
 
-    /// A variant the server has explicitly flagged as failing upstream,
-    /// independent of its own `blocking`/`status` fields -- `blocking: false`
-    /// and `status: PENDING` are deliberate so this only counts as blocking
-    /// via `fails_upstream_workflow`, not the `blocking && FAILED` predicate.
+    /// A variant the server has flagged as failing upstream while its
+    /// downstream workflow is still pending -- a state the server can
+    /// actually send (`failsUpstreamWorkflow` requires `blocking: true`, but
+    /// `status: PENDING` means `blocking && FAILED` still can't be what
+    /// counts this as blocking; only `fails_upstream_workflow` can be).
     fn variant_failing_upstream(name: &str) -> DownstreamVariantCheckResult {
         DownstreamVariantCheckResult {
             graph_id: "my-graph".to_string(),
             variant_name: name.to_string(),
-            blocking: false,
+            blocking: true,
             fails_upstream_workflow: Some(true),
             status: CheckTaskStatus::PENDING,
         }

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -362,10 +362,13 @@ fn downstream_msg(response: &DownstreamCheckResponse) -> String {
         );
     }
 
-    match response.variants.len() {
-        0 => "No contract variants configured for this graph.".to_string(),
-        1 => "Checked 1 contract variant, all passed.".to_string(),
-        count => format!("Checked {count} contract variants, all passed."),
+    if response.variants.is_empty() {
+        "No contract variants configured for this graph.".to_string()
+    } else {
+        format!(
+            "Checked {}, all passed.",
+            pluralize("contract variant", response.variants.len() as isize, true)
+        )
     }
 }
 

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -350,14 +350,11 @@ fn downstream_msg(response: &DownstreamCheckResponse) -> String {
             1 => "this",
             _ => "these",
         };
-        let plural = match blocking_variants.len() {
-            1 => "",
-            _ => "s",
-        };
+        let variant_word = pluralize("variant", blocking_variants.len() as isize, false);
         return format!(
-            "The downstream check task has encountered check failures for at least {} blocking downstream variant{}: {}.",
+            "The downstream check task has encountered check failures for at least {} blocking downstream {}: {}.",
             plural_this,
-            plural,
+            variant_word,
             Style::Variant.paint(variants),
         );
     }
@@ -554,6 +551,13 @@ mod test {
             variant("partner-api", true, CheckTaskStatus::PASSED),
         ],
         "The downstream check task has encountered check failures for at least this blocking downstream variant: mobile."
+    )]
+    #[case::multiple_blocking_contract_variants_failed(
+        vec![
+            variant("mobile", true, CheckTaskStatus::FAILED),
+            variant("partner-api", true, CheckTaskStatus::FAILED),
+        ],
+        "The downstream check task has encountered check failures for at least these blocking downstream variants: mobile,partner-api."
     )]
     fn downstream_msg_summarizes_variants(
         #[case] variants: Vec<DownstreamVariantCheckResult>,

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -358,9 +358,14 @@ fn downstream_msg(response: &DownstreamCheckResponse) -> String {
 
     if response.variants.is_empty() {
         "No contract variants configured for this graph.".to_string()
-    } else {
+    } else if response.task_status == CheckTaskStatus::PASSED {
         format!(
             "Checked {}, all passed.",
+            pluralize("contract variant", response.variants.len() as isize, true)
+        )
+    } else {
+        format!(
+            "Checked {}.",
             pluralize("contract variant", response.variants.len() as isize, true)
         )
     }
@@ -532,10 +537,12 @@ mod test {
 
     #[rstest]
     #[case::no_contract_variants_configured(
+        CheckTaskStatus::PASSED,
         vec![],
         "No contract variants configured for this graph."
     )]
     #[case::all_contract_variants_passed(
+        CheckTaskStatus::PASSED,
         vec![
             variant("mobile", true, CheckTaskStatus::PASSED),
             variant("partner-api", true, CheckTaskStatus::PASSED),
@@ -543,6 +550,7 @@ mod test {
         "Checked 2 contract variants, all passed."
     )]
     #[case::one_blocking_contract_variant_failed(
+        CheckTaskStatus::FAILED,
         vec![
             variant("mobile", true, CheckTaskStatus::FAILED),
             variant("partner-api", true, CheckTaskStatus::PASSED),
@@ -550,18 +558,28 @@ mod test {
         "The downstream check task has encountered check failures for at least this blocking downstream variant: mobile."
     )]
     #[case::multiple_blocking_contract_variants_failed(
+        CheckTaskStatus::FAILED,
         vec![
             variant("mobile", true, CheckTaskStatus::FAILED),
             variant("partner-api", true, CheckTaskStatus::FAILED),
         ],
         "The downstream check task has encountered check failures for at least these blocking downstream variants: mobile,partner-api."
     )]
+    #[case::pending_task_does_not_claim_all_passed(
+        CheckTaskStatus::PENDING,
+        vec![
+            variant("mobile", false, CheckTaskStatus::PENDING),
+            variant("partner-api", false, CheckTaskStatus::PENDING),
+        ],
+        "Checked 2 contract variants."
+    )]
     fn downstream_msg_summarizes_variants(
+        #[case] task_status: CheckTaskStatus,
         #[case] variants: Vec<DownstreamVariantCheckResult>,
         #[case] expected: &str,
     ) {
         let response = DownstreamCheckResponse {
-            task_status: CheckTaskStatus::PASSED,
+            task_status,
             target_url: None,
             variants,
         };

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -346,10 +346,7 @@ fn downstream_msg(response: &DownstreamCheckResponse) -> String {
             .map(|variant| variant.variant_name.as_str())
             .collect::<Vec<_>>()
             .join(",");
-        let plural_this = match blocking_variants.len() {
-            1 => "this",
-            _ => "these",
-        };
+        let plural_this = pluralize("this", blocking_variants.len() as isize, false);
         let variant_word = pluralize("variant", blocking_variants.len() as isize, false);
         return format!(
             "The downstream check task has encountered check failures for at least {} blocking downstream {}: {}.",

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -901,7 +901,7 @@ impl RoverOutput {
 
     pub(crate) fn get_json_version(&self) -> JsonVersion {
         match &self {
-            Self::CheckWorkflowResponse(_) => JsonVersion::Two,
+            Self::CheckWorkflowResponse(_) => JsonVersion::Three,
             _ => JsonVersion::default(),
         }
     }
@@ -1312,7 +1312,7 @@ mod tests {
             JsonOutput::from(&RoverOutput::CheckWorkflowResponse(mock_check_response));
         let expected_json = json!(
         {
-            "json_version": "2",
+            "json_version": "3",
             "data": {
                 "success": true,
                 "core_schema_modified": true,
@@ -1626,7 +1626,7 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
             }));
         let expected_json = json!(
         {
-            "json_version": "2",
+            "json_version": "3",
             "data": {
                 "success": false,
                 "core_schema_modified": false,

--- a/src/command/snapshots/rover__command__check_output__test__comprehensive_response_json_snapshot.snap
+++ b/src/command/snapshots/rover__command__check_output__test__comprehensive_response_json_snapshot.snap
@@ -67,8 +67,14 @@ expression: json
     "downstream": {
       "task_status": "FAILED",
       "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
-      "blocking_variants": [
-        "mobile"
+      "variants": [
+        {
+          "graph_id": "my-graph",
+          "variant_name": "mobile",
+          "blocking": true,
+          "fails_upstream_workflow": null,
+          "status": "FAILED"
+        }
       ]
     }
   }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -148,7 +148,7 @@ impl RoverError {
             Some(RoverClientError::CheckWorkflowFailure {
                 graph_ref: _,
                 check_response: _,
-            }) => JsonVersion::Two,
+            }) => JsonVersion::Three,
             _ => self.metadata.json_version.clone(),
         }
     }

--- a/src/options/output.rs
+++ b/src/options/output.rs
@@ -205,6 +205,6 @@ pub enum JsonVersion {
     #[serde(rename = "1")]
     #[default]
     One,
-    #[serde(rename = "2")]
-    Two,
+    #[serde(rename = "3")]
+    Three,
 }


### PR DESCRIPTION
`DownstreamCheckResponse` now carries every contract variant's blocking state and status instead of collapsing to a bare list of blocking variant names, so a passing or empty downstream check can render a summary instead of nothing.

This also bumps `CheckWorkflowResponse`'s JSON output to version 3 to reflect the shape change.