### PR TITLE
Report contract/downstream variant visibility on graph check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover subgraph delete`'s pre-confirmation build-error check now runs through this same async preview path instead of a synchronous dry-run mutation, avoiding a long-held server connection (and its timeout risk) while previewing the deletion of a subgraph from a large supergraph.
 
+- **Report contract variant visibility on `rover graph check` - @dotdat**
+
+  `rover graph check` now reports a downstream check summary for a graph's contract variants, in both text and JSON: how many were checked and their pass/fail breakdown, not just the names of variants that are blocking (previously, `graph check` reported nothing about contract variants at all). A blocking downstream contract failure now also makes `graph check` exit non-zero, matching `subgraph check`'s existing behavior.
+
 ## 🐛 Fixes
 
 - **Register the device-code grant type for `rover auth login --no-browser`'s OAuth client - @dotdat**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
  "quote",
  "sha3",
  "strum 0.28.0",
- "syn 3.0.5",
+ "syn 2.0.119",
  "unicode-ident",
  "void",
 ]
@@ -7263,7 +7263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -8110,9 +8110,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/crates/rover-client/src/operations/graph/check_workflow/check_workflow_query.graphql
+++ b/crates/rover-client/src/operations/graph/check_workflow/check_workflow_query.graphql
@@ -65,6 +65,18 @@ query GraphCheckWorkflowQuery($graph_id: ID!, $workflow_id: ID!) {
             }
           }
         }
+        ... on DownstreamCheckTask {
+          results {
+            __typename
+            blocking
+            downstreamGraphID
+            downstreamVariantName
+            downstreamWorkflow {
+              status
+            }
+            failsUpstreamWorkflow
+          }
+        }
       }
     }
   }

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -4,9 +4,10 @@ use rover_studio::types::GraphRef;
 use self::graph_check_workflow_query::{
     CheckWorkflowStatus, CheckWorkflowTaskStatus,
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOn::{
-        CustomCheckTask, LintCheckTask, OperationsCheckTask,
+        CustomCheckTask, DownstreamCheckTask, LintCheckTask, OperationsCheckTask,
     },
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnCustomCheckTaskResult,
+    GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnDownstreamCheckTaskResults,
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnLintCheckTaskResult,
     GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnOperationsCheckTaskResult,
 };
@@ -15,7 +16,8 @@ use crate::{
     operations::graph::check_workflow::types::{CheckWorkflowInput, QueryResponseData},
     shared::{
         check_workflow_poll::{poll_check_workflow, PollState},
-        CheckWorkflowResponse, CustomCheckResponse, Diagnostic, LintCheckResponse,
+        CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, Diagnostic,
+        DownstreamCheckResponse, DownstreamVariantCheckResult, LintCheckResponse,
         OperationCheckResponse, SchemaChange, Violation,
     },
     RoverClientError,
@@ -128,6 +130,12 @@ fn get_check_response_from_data(
         GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnCustomCheckTaskResult,
     > = None;
 
+    let mut downstream_status = None;
+    let mut downstream_target_url = None;
+    let mut downstream_result: Option<
+        Vec<GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnDownstreamCheckTaskResults>,
+    > = None;
+
     for task in check_workflow.tasks {
         match task.on {
             OperationsCheckTask(typed_task) => {
@@ -153,6 +161,13 @@ fn get_check_response_from_data(
                     custom_result = Some(result)
                 }
             }
+            DownstreamCheckTask(typed_task) => {
+                downstream_status = Some(task.status);
+                downstream_target_url = task.target_url;
+                if let Some(results) = typed_task.results {
+                    downstream_result = Some(results)
+                }
+            }
             _ => (),
         }
     }
@@ -163,6 +178,16 @@ fn get_check_response_from_data(
         graph_ref.graph_id(),
         graph_ref.variant()
     );
+
+    let maybe_downstream_response = get_downstream_response_from_result(
+        downstream_status,
+        downstream_target_url,
+        downstream_result,
+    );
+    let downstream_failed = maybe_downstream_response
+        .as_ref()
+        .map(|response| response.task_status == CheckTaskStatus::FAILED)
+        .unwrap_or(false);
 
     let check_response = CheckWorkflowResponse {
         default_target_url,
@@ -185,12 +210,16 @@ fn get_check_response_from_data(
             custom_result,
         ),
         maybe_proposals_response: None,
-        maybe_downstream_response: None,
+        maybe_downstream_response,
     };
 
     match check_workflow.status {
-        CheckWorkflowStatus::PASSED => Ok(check_response),
+        CheckWorkflowStatus::PASSED if !downstream_failed => Ok(check_response),
         CheckWorkflowStatus::FAILED => Err(RoverClientError::CheckWorkflowFailure {
+            graph_ref,
+            check_response: Box::new(check_response),
+        }),
+        CheckWorkflowStatus::PASSED => Err(RoverClientError::CheckWorkflowFailure {
             graph_ref,
             check_response: Box::new(check_response),
         }),
@@ -302,5 +331,258 @@ fn get_custom_response_from_result(
             })
         }
         None => None,
+    }
+}
+
+fn get_downstream_response_from_result(
+    task_status: Option<CheckWorkflowTaskStatus>,
+    target_url: Option<String>,
+    results: Option<
+        Vec<GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnDownstreamCheckTaskResults>,
+    >,
+) -> Option<DownstreamCheckResponse> {
+    match results {
+        Some(results) => {
+            let variants: Vec<DownstreamVariantCheckResult> = results
+                .into_iter()
+                .map(|result| DownstreamVariantCheckResult {
+                    graph_id: result.downstream_graph_id,
+                    variant_name: result.downstream_variant_name,
+                    blocking: result.blocking,
+                    fails_upstream_workflow: result.fails_upstream_workflow,
+                    status: match result.downstream_workflow.map(|workflow| workflow.status) {
+                        Some(CheckWorkflowStatus::FAILED) => CheckTaskStatus::FAILED,
+                        Some(CheckWorkflowStatus::PASSED) => CheckTaskStatus::PASSED,
+                        Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
+                        // Not yet initialized, or the downstream variant was deleted.
+                        None => CheckTaskStatus::PENDING,
+                        _ => CheckTaskStatus::FAILED,
+                    },
+                })
+                .collect();
+            // A blocking downstream contract workflow that has actually failed makes this
+            // task FAILED even if the task's own aggregate status hasn't caught up yet.
+            let has_blocking_failure = variants.iter().any(|variant| {
+                variant.fails_upstream_workflow.unwrap_or(false)
+                    || (variant.blocking && variant.status == CheckTaskStatus::FAILED)
+            });
+            let task_status = if has_blocking_failure {
+                CheckTaskStatus::FAILED
+            } else {
+                task_status.into()
+            };
+            Some(DownstreamCheckResponse {
+                task_status,
+                target_url,
+                variants,
+            })
+        }
+        None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rover_studio::types::GraphRef;
+    use rstest::rstest;
+    use serde_json::{json, Value};
+    use speculoos::prelude::*;
+
+    use super::*;
+    use crate::operations::graph::check_workflow::types::QueryResponseData;
+
+    fn create_check_workflow_data(
+        status: CheckWorkflowStatus,
+        tasks: serde_json::Value,
+    ) -> QueryResponseData {
+        serde_json::from_value(json!({
+            "graph": {
+                "checkWorkflow": {
+                    "id": "test-workflow",
+                    "status": status,
+                    "tasks": tasks
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn no_contract_variants_configured_still_passes() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": []
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+
+        let response = get_check_response_from_data(data, graph_ref).unwrap();
+
+        let downstream = response
+            .maybe_downstream_response
+            .expect("expected downstream response");
+        assert_that!(&downstream.task_status).is_equal_to(CheckTaskStatus::PASSED);
+        assert_that!(&downstream.variants).is_empty();
+    }
+
+    #[test]
+    fn all_contract_variants_passed() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": true,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "PASSED" },
+                            "failsUpstreamWorkflow": false
+                        },
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": true,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "partner-api",
+                            "downstreamWorkflow": { "status": "PASSED" },
+                            "failsUpstreamWorkflow": false
+                        }
+                    ]
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+
+        let result = get_check_response_from_data(data, graph_ref);
+
+        assert_that!(&result).is_ok();
+        let downstream = result
+            .unwrap()
+            .maybe_downstream_response
+            .expect("expected downstream response");
+        assert_that!(&downstream.task_status).is_equal_to(CheckTaskStatus::PASSED);
+        assert_that!(&downstream.variants).has_length(2);
+    }
+
+    #[test]
+    fn blocking_downstream_workflow_failure_fails_the_check() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": true,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "FAILED" },
+                            "failsUpstreamWorkflow": null
+                        }
+                    ]
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+
+        let result = get_check_response_from_data(data, graph_ref.clone());
+
+        assert_that!(&result).is_err();
+        match result.unwrap_err() {
+            RoverClientError::CheckWorkflowFailure {
+                graph_ref: returned_graph_ref,
+                check_response,
+            } => {
+                assert_that!(&returned_graph_ref).is_equal_to(&graph_ref);
+                let downstream = check_response
+                    .maybe_downstream_response
+                    .expect("expected downstream response");
+                assert_that!(&downstream.task_status).is_equal_to(CheckTaskStatus::FAILED);
+            }
+            other => panic!("Expected CheckWorkflowFailure error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn downstream_task_not_yet_initialized_has_no_response() {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PENDING",
+                    "targetUrl": null,
+                    "results": null
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+
+        let response = get_check_response_from_data(data, graph_ref).unwrap();
+
+        assert_that!(&response.maybe_downstream_response).is_none();
+    }
+
+    #[rstest]
+    #[case::failed(Some("FAILED"), CheckTaskStatus::FAILED)]
+    #[case::passed(Some("PASSED"), CheckTaskStatus::PASSED)]
+    #[case::pending(Some("PENDING"), CheckTaskStatus::PENDING)]
+    #[case::not_yet_initialized(None, CheckTaskStatus::PENDING)]
+    fn downstream_variant_status_mapping(
+        #[case] downstream_workflow_status: Option<&str>,
+        #[case] expected_status: CheckTaskStatus,
+    ) {
+        let downstream_workflow = match downstream_workflow_status {
+            Some(status) => json!({ "status": status }),
+            None => Value::Null,
+        };
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetUrl": null,
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            // Non-blocking, so a FAILED case here doesn't also trip
+                            // the fail-the-check behavior covered by the test above.
+                            "blocking": false,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": downstream_workflow,
+                            "failsUpstreamWorkflow": null
+                        }
+                    ]
+                }
+            ]),
+        );
+        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
+
+        let response = get_check_response_from_data(data, graph_ref).unwrap();
+
+        let downstream = response
+            .maybe_downstream_response
+            .expect("expected downstream response");
+        assert_that!(&downstream.variants[0].status).is_equal_to(expected_status);
     }
 }

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -384,12 +384,17 @@ fn get_downstream_response_from_result(
 #[cfg(test)]
 mod tests {
     use rover_studio::types::GraphRef;
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
     use serde_json::{json, Value};
     use speculoos::prelude::*;
 
     use super::*;
     use crate::operations::graph::check_workflow::types::QueryResponseData;
+
+    #[fixture]
+    fn graph_ref() -> GraphRef {
+        GraphRef::new("test-graph", Some("test-variant")).unwrap()
+    }
 
     fn create_check_workflow_data(
         status: CheckWorkflowStatus,
@@ -407,8 +412,8 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn no_contract_variants_configured_still_passes() {
+    #[rstest]
+    fn no_contract_variants_configured_still_passes(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -416,24 +421,26 @@ mod tests {
                     "__typename": "DownstreamCheckTask",
                     "id": "downstream-task",
                     "status": "PASSED",
-                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
                     "results": []
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
         let response = get_check_response_from_data(data, graph_ref).unwrap();
 
-        let downstream = response
-            .maybe_downstream_response
-            .expect("expected downstream response");
-        assert_that!(&downstream.task_status).is_equal_to(CheckTaskStatus::PASSED);
-        assert_that!(&downstream.variants).is_empty();
+        let expected = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::PASSED,
+            target_url: Some(
+                "https://studio.apollographql.com/graph/test-graph/checks/downstream".to_string(),
+            ),
+            variants: vec![],
+        };
+        assert_that!(&response.maybe_downstream_response).is_equal_to(Some(expected));
     }
 
-    #[test]
-    fn all_contract_variants_passed() {
+    #[rstest]
+    fn all_contract_variants_passed(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -441,7 +448,7 @@ mod tests {
                     "__typename": "DownstreamCheckTask",
                     "id": "downstream-task",
                     "status": "PASSED",
-                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
                     "results": [
                         {
                             "__typename": "DownstreamCheckResult",
@@ -463,21 +470,37 @@ mod tests {
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
         let result = get_check_response_from_data(data, graph_ref);
 
         assert_that!(&result).is_ok();
-        let downstream = result
-            .unwrap()
-            .maybe_downstream_response
-            .expect("expected downstream response");
-        assert_that!(&downstream.task_status).is_equal_to(CheckTaskStatus::PASSED);
-        assert_that!(&downstream.variants).has_length(2);
+        let expected = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::PASSED,
+            target_url: Some(
+                "https://studio.apollographql.com/graph/test-graph/checks/downstream".to_string(),
+            ),
+            variants: vec![
+                DownstreamVariantCheckResult {
+                    graph_id: "test-graph".to_string(),
+                    variant_name: "mobile".to_string(),
+                    blocking: true,
+                    fails_upstream_workflow: Some(false),
+                    status: CheckTaskStatus::PASSED,
+                },
+                DownstreamVariantCheckResult {
+                    graph_id: "test-graph".to_string(),
+                    variant_name: "partner-api".to_string(),
+                    blocking: true,
+                    fails_upstream_workflow: Some(false),
+                    status: CheckTaskStatus::PASSED,
+                },
+            ],
+        };
+        assert_that!(&result.unwrap().maybe_downstream_response).is_equal_to(Some(expected));
     }
 
-    #[test]
-    fn blocking_downstream_workflow_failure_fails_the_check() {
+    #[rstest]
+    fn blocking_downstream_workflow_failure_fails_the_check(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -485,7 +508,7 @@ mod tests {
                     "__typename": "DownstreamCheckTask",
                     "id": "downstream-task",
                     "status": "PASSED",
-                    "targetUrl": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
                     "results": [
                         {
                             "__typename": "DownstreamCheckResult",
@@ -499,7 +522,6 @@ mod tests {
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
         let result = get_check_response_from_data(data, graph_ref.clone());
 
@@ -510,17 +532,28 @@ mod tests {
                 check_response,
             } => {
                 assert_that!(&returned_graph_ref).is_equal_to(&graph_ref);
-                let downstream = check_response
-                    .maybe_downstream_response
-                    .expect("expected downstream response");
-                assert_that!(&downstream.task_status).is_equal_to(CheckTaskStatus::FAILED);
+                let expected = DownstreamCheckResponse {
+                    task_status: CheckTaskStatus::FAILED,
+                    target_url: Some(
+                        "https://studio.apollographql.com/graph/test-graph/checks/downstream"
+                            .to_string(),
+                    ),
+                    variants: vec![DownstreamVariantCheckResult {
+                        graph_id: "test-graph".to_string(),
+                        variant_name: "mobile".to_string(),
+                        blocking: true,
+                        fails_upstream_workflow: None,
+                        status: CheckTaskStatus::FAILED,
+                    }],
+                };
+                assert_that!(&check_response.maybe_downstream_response).is_equal_to(Some(expected));
             }
             other => panic!("Expected CheckWorkflowFailure error, got {other:?}"),
         }
     }
 
-    #[test]
-    fn downstream_task_not_yet_initialized_has_no_response() {
+    #[rstest]
+    fn downstream_task_not_yet_initialized_has_no_response(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
             CheckWorkflowStatus::PASSED,
             json!([
@@ -528,12 +561,11 @@ mod tests {
                     "__typename": "DownstreamCheckTask",
                     "id": "downstream-task",
                     "status": "PENDING",
-                    "targetUrl": null,
+                    "targetURL": null,
                     "results": null
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
         let response = get_check_response_from_data(data, graph_ref).unwrap();
 
@@ -546,6 +578,7 @@ mod tests {
     #[case::pending(Some("PENDING"), CheckTaskStatus::PENDING)]
     #[case::not_yet_initialized(None, CheckTaskStatus::PENDING)]
     fn downstream_variant_status_mapping(
+        graph_ref: GraphRef,
         #[case] downstream_workflow_status: Option<&str>,
         #[case] expected_status: CheckTaskStatus,
     ) {
@@ -560,7 +593,7 @@ mod tests {
                     "__typename": "DownstreamCheckTask",
                     "id": "downstream-task",
                     "status": "PASSED",
-                    "targetUrl": null,
+                    "targetURL": null,
                     "results": [
                         {
                             "__typename": "DownstreamCheckResult",
@@ -576,13 +609,20 @@ mod tests {
                 }
             ]),
         );
-        let graph_ref: GraphRef = "test-graph@test-variant".parse().unwrap();
 
         let response = get_check_response_from_data(data, graph_ref).unwrap();
 
-        let downstream = response
-            .maybe_downstream_response
-            .expect("expected downstream response");
-        assert_that!(&downstream.variants[0].status).is_equal_to(expected_status);
+        let expected = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::PASSED,
+            target_url: None,
+            variants: vec![DownstreamVariantCheckResult {
+                graph_id: "test-graph".to_string(),
+                variant_name: "mobile".to_string(),
+                blocking: false,
+                fails_upstream_workflow: None,
+                status: expected_status,
+            }],
+        };
+        assert_that!(&response.maybe_downstream_response).is_equal_to(Some(expected));
     }
 }

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -341,27 +341,8 @@ fn get_downstream_response_from_result(
 ) -> Option<DownstreamCheckResponse> {
     match results {
         Some(results) => {
-            let variants: Vec<DownstreamVariantCheckResult> = results
-                .into_iter()
-                .map(|result| DownstreamVariantCheckResult {
-                    graph_id: result.downstream_graph_id,
-                    variant_name: result.downstream_variant_name,
-                    blocking: result.blocking,
-                    fails_upstream_workflow: result.fails_upstream_workflow,
-                    status: match result.downstream_workflow.map(|workflow| workflow.status) {
-                        Some(CheckWorkflowStatus::FAILED) => CheckTaskStatus::FAILED,
-                        Some(CheckWorkflowStatus::PASSED) => CheckTaskStatus::PASSED,
-                        Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
-                        // Not yet initialized, or the downstream variant was deleted.
-                        None => CheckTaskStatus::PENDING,
-                        // A status this client's schema snapshot doesn't recognize.
-                        // Spelled out explicitly (rather than `_`) so a future schema
-                        // regen adding a real new variant is a compile error here,
-                        // not a silent fall-through to this same PENDING degrade.
-                        Some(CheckWorkflowStatus::Other(_)) => CheckTaskStatus::PENDING,
-                    },
-                })
-                .collect();
+            let variants: Vec<DownstreamVariantCheckResult> =
+                results.into_iter().map(Into::into).collect();
             // A blocking downstream contract workflow that has actually failed makes this
             // task FAILED even if the task's own aggregate status hasn't caught up yet.
             let has_blocking_failure = variants

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -556,6 +556,63 @@ mod tests {
         }
     }
 
+    /// Mirrors `blocking_downstream_workflow_failure_fails_the_check`, but isolates
+    /// the *other* half of `has_blocking_failure`'s OR: `blocking: false` and
+    /// `status: PASSED` mean the `blocking && FAILED` predicate can't be what
+    /// fails the check here -- only `fails_upstream_workflow` can.
+    #[rstest]
+    fn fails_upstream_workflow_alone_fails_the_check(graph_ref: GraphRef) {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": false,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "PASSED" },
+                            "failsUpstreamWorkflow": true
+                        }
+                    ]
+                }
+            ]),
+        );
+
+        let result = get_check_response_from_data(data, graph_ref.clone());
+
+        assert_that!(&result).is_err();
+        match result.unwrap_err() {
+            RoverClientError::CheckWorkflowFailure {
+                graph_ref: returned_graph_ref,
+                check_response,
+            } => {
+                assert_that!(&returned_graph_ref).is_equal_to(&graph_ref);
+                let expected = DownstreamCheckResponse {
+                    task_status: CheckTaskStatus::FAILED,
+                    target_url: Some(
+                        "https://studio.apollographql.com/graph/test-graph/checks/downstream"
+                            .to_string(),
+                    ),
+                    variants: vec![DownstreamVariantCheckResult {
+                        graph_id: "test-graph".to_string(),
+                        variant_name: "mobile".to_string(),
+                        blocking: false,
+                        fails_upstream_workflow: Some(true),
+                        status: CheckTaskStatus::PASSED,
+                    }],
+                };
+                assert_that!(&check_response.maybe_downstream_response).is_equal_to(Some(expected));
+            }
+            other => panic!("Expected CheckWorkflowFailure error, got {other:?}"),
+        }
+    }
+
     #[rstest]
     fn downstream_task_not_yet_initialized_has_no_response(graph_ref: GraphRef) {
         let data = create_check_workflow_data(

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -16,9 +16,9 @@ use crate::{
     operations::graph::check_workflow::types::{CheckWorkflowInput, QueryResponseData},
     shared::{
         check_workflow_poll::{poll_check_workflow, PollState},
-        CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, Diagnostic,
-        DownstreamCheckResponse, DownstreamVariantCheckResult, LintCheckResponse,
-        OperationCheckResponse, SchemaChange, Violation,
+        CheckWorkflowResponse, CustomCheckResponse, Diagnostic, DownstreamCheckResponse,
+        DownstreamVariantCheckResult, LintCheckResponse, OperationCheckResponse, SchemaChange,
+        Violation,
     },
     RoverClientError,
 };
@@ -343,21 +343,11 @@ fn get_downstream_response_from_result(
         Some(results) => {
             let variants: Vec<DownstreamVariantCheckResult> =
                 results.into_iter().map(Into::into).collect();
-            // A blocking downstream contract workflow that has actually failed makes this
-            // task FAILED even if the task's own aggregate status hasn't caught up yet.
-            let has_blocking_failure = variants
-                .iter()
-                .any(DownstreamVariantCheckResult::is_blocking_failure);
-            let task_status = if has_blocking_failure {
-                CheckTaskStatus::FAILED
-            } else {
-                task_status.into()
-            };
-            Some(DownstreamCheckResponse {
-                task_status,
-                target_url,
+            Some(DownstreamCheckResponse::new(
                 variants,
-            })
+                task_status.into(),
+                target_url,
+            ))
         }
         None => None,
     }
@@ -372,7 +362,9 @@ mod tests {
     use speculoos::prelude::*;
 
     use super::*;
-    use crate::operations::graph::check_workflow::types::QueryResponseData;
+    use crate::{
+        operations::graph::check_workflow::types::QueryResponseData, shared::CheckTaskStatus,
+    };
 
     #[fixture]
     fn graph_ref() -> GraphRef {

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -186,7 +186,7 @@ fn get_check_response_from_data(
     );
     let downstream_failed = maybe_downstream_response
         .as_ref()
-        .map(|response| response.task_status == CheckTaskStatus::FAILED)
+        .map(DownstreamCheckResponse::has_blocking_failure)
         .unwrap_or(false);
 
     let check_response = CheckWorkflowResponse {
@@ -215,14 +215,12 @@ fn get_check_response_from_data(
 
     match check_workflow.status {
         CheckWorkflowStatus::PASSED if !downstream_failed => Ok(check_response),
-        CheckWorkflowStatus::FAILED => Err(RoverClientError::CheckWorkflowFailure {
-            graph_ref,
-            check_response: Box::new(check_response),
-        }),
-        CheckWorkflowStatus::PASSED => Err(RoverClientError::CheckWorkflowFailure {
-            graph_ref,
-            check_response: Box::new(check_response),
-        }),
+        CheckWorkflowStatus::PASSED | CheckWorkflowStatus::FAILED => {
+            Err(RoverClientError::CheckWorkflowFailure {
+                graph_ref,
+                check_response: Box::new(check_response),
+            })
+        }
         _ => Err(RoverClientError::UnknownCheckWorkflowStatus),
     }
 }
@@ -366,10 +364,9 @@ fn get_downstream_response_from_result(
                 .collect();
             // A blocking downstream contract workflow that has actually failed makes this
             // task FAILED even if the task's own aggregate status hasn't caught up yet.
-            let has_blocking_failure = variants.iter().any(|variant| {
-                variant.fails_upstream_workflow.unwrap_or(false)
-                    || (variant.blocking && variant.status == CheckTaskStatus::FAILED)
-            });
+            let has_blocking_failure = variants
+                .iter()
+                .any(DownstreamVariantCheckResult::is_blocking_failure);
             let task_status = if has_blocking_failure {
                 CheckTaskStatus::FAILED
             } else {
@@ -386,6 +383,7 @@ fn get_downstream_response_from_result(
 }
 
 #[cfg(test)]
+#[expect(clippy::panic)]
 mod tests {
     use rover_studio::types::GraphRef;
     use rstest::{fixture, rstest};
@@ -611,6 +609,52 @@ mod tests {
             }
             other => panic!("Expected CheckWorkflowFailure error, got {other:?}"),
         }
+    }
+
+    /// The server can report the `DownstreamCheckTask` itself as `FAILED` for
+    /// reasons that don't make any individual variant a blocking failure (e.g.
+    /// a non-blocking contract variant failing). That alone shouldn't fail the
+    /// check -- only `has_blocking_failure` should.
+    #[rstest]
+    fn non_blocking_task_failure_does_not_fail_the_check(graph_ref: GraphRef) {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "FAILED",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": false,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "FAILED" },
+                            "failsUpstreamWorkflow": false
+                        }
+                    ]
+                }
+            ]),
+        );
+
+        let response = get_check_response_from_data(data, graph_ref).unwrap();
+
+        let expected = DownstreamCheckResponse {
+            task_status: CheckTaskStatus::FAILED,
+            target_url: Some(
+                "https://studio.apollographql.com/graph/test-graph/checks/downstream".to_string(),
+            ),
+            variants: vec![DownstreamVariantCheckResult {
+                graph_id: "test-graph".to_string(),
+                variant_name: "mobile".to_string(),
+                blocking: false,
+                fails_upstream_workflow: Some(false),
+                status: CheckTaskStatus::FAILED,
+            }],
+        };
+        assert_that!(&response.maybe_downstream_response).is_equal_to(Some(expected));
     }
 
     #[rstest]

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -356,11 +356,11 @@ fn get_downstream_response_from_result(
                         Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
                         // Not yet initialized, or the downstream variant was deleted.
                         None => CheckTaskStatus::PENDING,
-                        // A status this client's schema snapshot doesn't recognize
-                        // (graphql_client's `Other(String)` fallback) -- degrade to the
-                        // neutral/pending summary rather than fabricating a
-                        // blocking-failure claim for something we don't understand.
-                        _ => CheckTaskStatus::PENDING,
+                        // A status this client's schema snapshot doesn't recognize.
+                        // Spelled out explicitly (rather than `_`) so a future schema
+                        // regen adding a real new variant is a compile error here,
+                        // not a silent fall-through to this same PENDING degrade.
+                        Some(CheckWorkflowStatus::Other(_)) => CheckTaskStatus::PENDING,
                     },
                 })
                 .collect();

--- a/crates/rover-client/src/operations/graph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/runner.rs
@@ -356,7 +356,11 @@ fn get_downstream_response_from_result(
                         Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
                         // Not yet initialized, or the downstream variant was deleted.
                         None => CheckTaskStatus::PENDING,
-                        _ => CheckTaskStatus::FAILED,
+                        // A status this client's schema snapshot doesn't recognize
+                        // (graphql_client's `Other(String)` fallback) -- degrade to the
+                        // neutral/pending summary rather than fabricating a
+                        // blocking-failure claim for something we don't understand.
+                        _ => CheckTaskStatus::PENDING,
                     },
                 })
                 .collect();
@@ -577,6 +581,7 @@ mod tests {
     #[case::passed(Some("PASSED"), CheckTaskStatus::PASSED)]
     #[case::pending(Some("PENDING"), CheckTaskStatus::PENDING)]
     #[case::not_yet_initialized(None, CheckTaskStatus::PENDING)]
+    #[case::unrecognized_status(Some("SOME_FUTURE_STATUS"), CheckTaskStatus::PENDING)]
     fn downstream_variant_status_mapping(
         graph_ref: GraphRef,
         #[case] downstream_workflow_status: Option<&str>,

--- a/crates/rover-client/src/operations/graph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/graph/check_workflow/types.rs
@@ -10,7 +10,7 @@ use crate::{
     operations::graph::check_workflow::runner::{
         graph_check_workflow_query, graph_check_workflow_status_query,
     },
-    shared::{ChangeSeverity, CheckTaskStatus},
+    shared::{ChangeSeverity, CheckTaskStatus, DownstreamVariantCheckResult},
 };
 
 type QueryVariables = graph_check_workflow_query::Variables;
@@ -76,6 +76,32 @@ impl From<Option<CheckWorkflowTaskStatus>> for CheckTaskStatus {
             Some(CheckWorkflowTaskStatus::PASSED) => CheckTaskStatus::PASSED,
             Some(CheckWorkflowTaskStatus::PENDING) => CheckTaskStatus::PENDING,
             _ => CheckTaskStatus::FAILED,
+        }
+    }
+}
+
+pub(crate) type QueryDownstreamCheckResult =
+    graph_check_workflow_query::GraphCheckWorkflowQueryGraphCheckWorkflowTasksOnDownstreamCheckTaskResults;
+
+impl From<QueryDownstreamCheckResult> for DownstreamVariantCheckResult {
+    fn from(result: QueryDownstreamCheckResult) -> Self {
+        DownstreamVariantCheckResult {
+            graph_id: result.downstream_graph_id,
+            variant_name: result.downstream_variant_name,
+            blocking: result.blocking,
+            fails_upstream_workflow: result.fails_upstream_workflow,
+            status: match result.downstream_workflow.map(|workflow| workflow.status) {
+                Some(WorkflowStatus::FAILED) => CheckTaskStatus::FAILED,
+                Some(WorkflowStatus::PASSED) => CheckTaskStatus::PASSED,
+                Some(WorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
+                // Not yet initialized, or the downstream variant was deleted.
+                None => CheckTaskStatus::PENDING,
+                // A status this client's schema snapshot doesn't recognize.
+                // Spelled out explicitly (rather than `_`) so a future schema
+                // regen adding a real new variant is a compile error here,
+                // not a silent fall-through to this same PENDING degrade.
+                Some(WorkflowStatus::Other(_)) => CheckTaskStatus::PENDING,
+            },
         }
     }
 }

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -459,27 +459,8 @@ fn get_downstream_response_from_result(
 ) -> Option<DownstreamCheckResponse> {
     match results {
         Some(results) => {
-            let variants = results
-                .into_iter()
-                .map(|result| DownstreamVariantCheckResult {
-                    graph_id: result.downstream_graph_id,
-                    variant_name: result.downstream_variant_name,
-                    blocking: result.blocking,
-                    fails_upstream_workflow: result.fails_upstream_workflow,
-                    status: match result.downstream_workflow.map(|workflow| workflow.status) {
-                        Some(CheckWorkflowStatus::FAILED) => CheckTaskStatus::FAILED,
-                        Some(CheckWorkflowStatus::PASSED) => CheckTaskStatus::PASSED,
-                        Some(CheckWorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
-                        // Not yet initialized, or the downstream variant was deleted.
-                        None => CheckTaskStatus::PENDING,
-                        // A status this client's schema snapshot doesn't recognize.
-                        // Spelled out explicitly (rather than `_`) so a future schema
-                        // regen adding a real new variant is a compile error here,
-                        // not a silent fall-through to this same PENDING degrade.
-                        Some(CheckWorkflowStatus::Other(_)) => CheckTaskStatus::PENDING,
-                    },
-                })
-                .collect();
+            let variants: Vec<DownstreamVariantCheckResult> =
+                results.into_iter().map(Into::into).collect();
             Some(DownstreamCheckResponse {
                 task_status: task_status.into(),
                 target_url,

--- a/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/types.rs
@@ -8,7 +8,7 @@ use crate::{
     operations::subgraph::check_workflow::runner::{
         subgraph_check_workflow_query, subgraph_check_workflow_status_query,
     },
-    shared::{ChangeSeverity, CheckTaskStatus},
+    shared::{ChangeSeverity, CheckTaskStatus, DownstreamVariantCheckResult},
 };
 
 type QueryVariables = subgraph_check_workflow_query::Variables;
@@ -76,6 +76,31 @@ impl From<Option<CheckWorkflowTaskStatus>> for CheckTaskStatus {
             Some(CheckWorkflowTaskStatus::PASSED) => CheckTaskStatus::PASSED,
             Some(CheckWorkflowTaskStatus::PENDING) => CheckTaskStatus::PENDING,
             _ => CheckTaskStatus::FAILED,
+        }
+    }
+}
+
+pub(crate) type QueryDownstreamCheckResult = subgraph_check_workflow_query::SubgraphCheckWorkflowQueryGraphCheckWorkflowTasksOnDownstreamCheckTaskResults;
+
+impl From<QueryDownstreamCheckResult> for DownstreamVariantCheckResult {
+    fn from(result: QueryDownstreamCheckResult) -> Self {
+        DownstreamVariantCheckResult {
+            graph_id: result.downstream_graph_id,
+            variant_name: result.downstream_variant_name,
+            blocking: result.blocking,
+            fails_upstream_workflow: result.fails_upstream_workflow,
+            status: match result.downstream_workflow.map(|workflow| workflow.status) {
+                Some(WorkflowStatus::FAILED) => CheckTaskStatus::FAILED,
+                Some(WorkflowStatus::PASSED) => CheckTaskStatus::PASSED,
+                Some(WorkflowStatus::PENDING) => CheckTaskStatus::PENDING,
+                // Not yet initialized, or the downstream variant was deleted.
+                None => CheckTaskStatus::PENDING,
+                // A status this client's schema snapshot doesn't recognize.
+                // Spelled out explicitly (rather than `_`) so a future schema
+                // regen adding a real new variant is a compile error here,
+                // not a silent fall-through to this same PENDING degrade.
+                Some(WorkflowStatus::Other(_)) => CheckTaskStatus::PENDING,
+            },
         }
     }
 }

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -172,6 +172,12 @@ impl DownstreamVariantCheckResult {
     }
 }
 
+/// Production code should construct this via [`DownstreamCheckResponse::new`], not a
+/// struct literal, so `task_status` picks up the blocking-failure escalation -- a
+/// bare literal silently skips it, since all three fields are `pub` for test call
+/// sites that need to build specific (including deliberately non-escalated) expected
+/// values. `graph check` goes through `new`; `subgraph check` does not yet (its own
+/// escalation is intentionally a separate, not-yet-started follow-up).
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
 pub struct DownstreamCheckResponse {
     pub task_status: CheckTaskStatus,

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -180,6 +180,29 @@ pub struct DownstreamCheckResponse {
 }
 
 impl DownstreamCheckResponse {
+    /// Builds a downstream check response, escalating `task_status` to
+    /// `FAILED` when a blocking downstream contract workflow has actually
+    /// failed even if the task's own aggregate status hasn't caught up yet.
+    pub fn new(
+        variants: Vec<DownstreamVariantCheckResult>,
+        task_status: CheckTaskStatus,
+        target_url: Option<String>,
+    ) -> Self {
+        let task_status = if variants
+            .iter()
+            .any(DownstreamVariantCheckResult::is_blocking_failure)
+        {
+            CheckTaskStatus::FAILED
+        } else {
+            task_status
+        };
+        DownstreamCheckResponse {
+            task_status,
+            target_url,
+            variants,
+        }
+    }
+
     /// Whether any contract variant's downstream check failure should block
     /// the upstream check.
     pub fn has_blocking_failure(&self) -> bool {

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -162,11 +162,31 @@ pub struct DownstreamVariantCheckResult {
     pub status: CheckTaskStatus,
 }
 
+impl DownstreamVariantCheckResult {
+    /// Whether this variant's downstream check failure should block the
+    /// upstream check, either because Studio says it does directly, or
+    /// because it's a blocking variant whose own workflow failed.
+    pub fn is_blocking_failure(&self) -> bool {
+        self.fails_upstream_workflow.unwrap_or(false)
+            || (self.blocking && self.status == CheckTaskStatus::FAILED)
+    }
+}
+
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
 pub struct DownstreamCheckResponse {
     pub task_status: CheckTaskStatus,
     pub target_url: Option<String>,
     pub variants: Vec<DownstreamVariantCheckResult>,
+}
+
+impl DownstreamCheckResponse {
+    /// Whether any contract variant's downstream check failure should block
+    /// the upstream check.
+    pub fn has_blocking_failure(&self) -> bool {
+        self.variants
+            .iter()
+            .any(DownstreamVariantCheckResult::is_blocking_failure)
+    }
 }
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -331,10 +331,7 @@ fn downstream_blocking_variants(
     response
         .variants
         .iter()
-        .filter(|variant| {
-            variant.fails_upstream_workflow.unwrap_or(false)
-                || (variant.blocking && variant.status == CheckTaskStatus::FAILED)
-        })
+        .filter(|variant| variant.is_blocking_failure())
         .collect()
 }
 

--- a/tests/integration/graph/check.rs
+++ b/tests/integration/graph/check.rs
@@ -2,69 +2,49 @@ use std::fs;
 
 use assert_cmd::Command;
 use httpmock::{Method::POST, MockServer};
+use insta::assert_json_snapshot;
 use serde_json::Value;
+use serial_test::serial;
 
-/// Verifies that `rover graph check` fails the command, and correctly attributes the
-/// failure to the downstream task, when a blocking downstream contract check has
-/// actually failed -- even though the overall workflow status and the downstream
-/// task's own aggregate status both still report PASSED (Studio's aggregate status
-/// can lag behind the per-variant data in the same response). Exercises the
-/// `has_blocking_failure` escalation in `DownstreamCheckResponse::new`.
-#[test]
-fn graph_check_fails_on_blocking_downstream_contract_failure() {
+const CHECK_SUBMISSION_RESPONSE: &str = r#"{"data":{"graph":{"variant":{"submitCheckSchemaAsync":{
+    "__typename":"CheckRequestSuccess",
+    "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/1",
+    "workflowID":"workflow-1"
+}}}}}"#;
+
+const STATUS_POLL_RESPONSE: &str = r#"{"data":{"graph":{"checkWorkflow":{
+    "status":"PASSED",
+    "tasks":[{
+        "__typename":"DownstreamCheckTask",
+        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream"
+    }]
+}}}}"#;
+
+/// Starts a mock Studio server for `rover graph check`, wiring up the check-submission
+/// and status-poll responses common to every case, stubs the full workflow-fetch
+/// response with `workflow_fetch_response`, and runs the real `rover graph check`
+/// binary against it. Returns whether the command succeeded and its parsed JSON output.
+fn run_graph_check(workflow_fetch_response: &str) -> (bool, Value) {
     let server = MockServer::start();
 
-    server.mock(|when, then| {
+    let submission_mock = server.mock(|when, then| {
         when.method(POST).body_includes("GraphCheckMutation");
         then.status(200)
             .header("content-type", "application/json")
-            .body(
-                r#"{"data":{"graph":{"variant":{"submitCheckSchemaAsync":{
-                    "__typename":"CheckRequestSuccess",
-                    "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/1",
-                    "workflowID":"workflow-1"
-                }}}}}"#,
-            );
+            .body(CHECK_SUBMISSION_RESPONSE);
     });
-
-    server.mock(|when, then| {
+    let status_mock = server.mock(|when, then| {
         when.method(POST)
             .body_includes("GraphCheckWorkflowStatusQuery");
         then.status(200)
             .header("content-type", "application/json")
-            .body(
-                r#"{"data":{"graph":{"checkWorkflow":{
-                    "status":"PASSED",
-                    "tasks":[{
-                        "__typename":"DownstreamCheckTask",
-                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream"
-                    }]
-                }}}}"#,
-            );
+            .body(STATUS_POLL_RESPONSE);
     });
-
-    server.mock(|when, then| {
+    let fetch_mock = server.mock(|when, then| {
         when.method(POST).body_includes("GraphCheckWorkflowQuery");
         then.status(200)
             .header("content-type", "application/json")
-            .body(
-                r#"{"data":{"graph":{"checkWorkflow":{
-                    "status":"PASSED",
-                    "tasks":[{
-                        "__typename":"DownstreamCheckTask",
-                        "status":"PASSED",
-                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
-                        "results":[{
-                            "__typename":"DownstreamCheckResult",
-                            "blocking":true,
-                            "downstreamGraphID":"my-graph",
-                            "downstreamVariantName":"mobile",
-                            "downstreamWorkflow":{"status":"FAILED"},
-                            "failsUpstreamWorkflow":null
-                        }]
-                    }]
-                }}}}"#,
-            );
+            .body(workflow_fetch_response);
     });
 
     let temp = tempfile::tempdir().unwrap();
@@ -85,39 +65,46 @@ fn graph_check_fails_on_blocking_downstream_contract_failure() {
         .output()
         .unwrap();
 
-    assert!(
-        !output.status.success(),
-        "expected a nonzero exit code; stdout: {}",
-        String::from_utf8_lossy(&output.stdout)
+    submission_mock.assert();
+    status_mock.assert();
+    fetch_mock.assert();
+
+    let json = serde_json::from_slice(&output.stdout).unwrap();
+    (output.status.success(), json)
+}
+
+/// Verifies that `rover graph check` fails the command, and correctly attributes the
+/// failure to the downstream task, when a blocking downstream contract check has
+/// actually failed -- even though the overall workflow status and the downstream
+/// task's own aggregate status both still report PASSED (Studio's aggregate status
+/// can lag behind the per-variant data in the same response). Exercises the
+/// `has_blocking_failure` escalation in `DownstreamCheckResponse::new`; the error
+/// message attribution only holds because that escalation updates `task_status`, not
+/// just the exit gate.
+#[test]
+#[serial]
+fn graph_check_fails_on_blocking_downstream_contract_failure() {
+    let (success, json) = run_graph_check(
+        r#"{"data":{"graph":{"checkWorkflow":{
+            "status":"PASSED",
+            "tasks":[{
+                "__typename":"DownstreamCheckTask",
+                "status":"PASSED",
+                "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                "results":[{
+                    "__typename":"DownstreamCheckResult",
+                    "blocking":true,
+                    "downstreamGraphID":"my-graph",
+                    "downstreamVariantName":"mobile",
+                    "downstreamWorkflow":{"status":"FAILED"},
+                    "failsUpstreamWorkflow":null
+                }]
+            }]
+        }}}}"#,
     );
 
-    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(
-        json,
-        serde_json::json!({
-            "json_version": "3",
-            "data": {
-                "success": false,
-                "tasks": {
-                    "downstream": {
-                        "task_status": "FAILED",
-                        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
-                        "variants": [{
-                            "graph_id": "my-graph",
-                            "variant_name": "mobile",
-                            "blocking": true,
-                            "fails_upstream_workflow": null,
-                            "status": "FAILED"
-                        }]
-                    }
-                }
-            },
-            "error": {
-                "message": "The changes in the schema you proposed caused downstream checks to fail.",
-                "code": "E043"
-            }
-        })
-    );
+    assert!(!success, "expected a nonzero exit code; json: {json}");
+    assert_json_snapshot!(json);
 }
 
 /// Verifies that `rover graph check` succeeds when the downstream task's own aggregate
@@ -127,108 +114,27 @@ fn graph_check_fails_on_blocking_downstream_contract_failure() {
 /// `crates/rover-client/src/operations/graph/check_workflow/runner.rs`, but exercised
 /// through the real CLI end to end.
 #[test]
+#[serial]
 fn graph_check_succeeds_despite_non_blocking_task_status_failure() {
-    let server = MockServer::start();
-
-    server.mock(|when, then| {
-        when.method(POST).body_includes("GraphCheckMutation");
-        then.status(200)
-            .header("content-type", "application/json")
-            .body(
-                r#"{"data":{"graph":{"variant":{"submitCheckSchemaAsync":{
-                    "__typename":"CheckRequestSuccess",
-                    "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/1",
-                    "workflowID":"workflow-1"
-                }}}}}"#,
-            );
-    });
-
-    server.mock(|when, then| {
-        when.method(POST)
-            .body_includes("GraphCheckWorkflowStatusQuery");
-        then.status(200)
-            .header("content-type", "application/json")
-            .body(
-                r#"{"data":{"graph":{"checkWorkflow":{
-                    "status":"PASSED",
-                    "tasks":[{
-                        "__typename":"DownstreamCheckTask",
-                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream"
-                    }]
-                }}}}"#,
-            );
-    });
-
-    server.mock(|when, then| {
-        when.method(POST).body_includes("GraphCheckWorkflowQuery");
-        then.status(200)
-            .header("content-type", "application/json")
-            .body(
-                r#"{"data":{"graph":{"checkWorkflow":{
-                    "status":"PASSED",
-                    "tasks":[{
-                        "__typename":"DownstreamCheckTask",
-                        "status":"FAILED",
-                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
-                        "results":[{
-                            "__typename":"DownstreamCheckResult",
-                            "blocking":false,
-                            "downstreamGraphID":"my-graph",
-                            "downstreamVariantName":"mobile",
-                            "downstreamWorkflow":{"status":"FAILED"},
-                            "failsUpstreamWorkflow":false
-                        }]
-                    }]
-                }}}}"#,
-            );
-    });
-
-    let temp = tempfile::tempdir().unwrap();
-    let schema = temp.path().join("schema.graphql");
-    fs::write(&schema, "type Query { hello: String }").unwrap();
-
-    let output = Command::cargo_bin("rover")
-        .unwrap()
-        .env("APOLLO_KEY", "testkey")
-        .env("APOLLO_REGISTRY_URL", server.base_url())
-        .arg("graph")
-        .arg("check")
-        .arg("my-graph@current")
-        .arg("--schema")
-        .arg(&schema)
-        .arg("--format")
-        .arg("json")
-        .output()
-        .unwrap();
-
-    assert!(
-        output.status.success(),
-        "expected a zero exit code; stdout: {}",
-        String::from_utf8_lossy(&output.stdout)
+    let (success, json) = run_graph_check(
+        r#"{"data":{"graph":{"checkWorkflow":{
+            "status":"PASSED",
+            "tasks":[{
+                "__typename":"DownstreamCheckTask",
+                "status":"FAILED",
+                "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                "results":[{
+                    "__typename":"DownstreamCheckResult",
+                    "blocking":false,
+                    "downstreamGraphID":"my-graph",
+                    "downstreamVariantName":"mobile",
+                    "downstreamWorkflow":{"status":"FAILED"},
+                    "failsUpstreamWorkflow":false
+                }]
+            }]
+        }}}}"#,
     );
 
-    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(
-        json,
-        serde_json::json!({
-            "json_version": "3",
-            "data": {
-                "success": true,
-                "tasks": {
-                    "downstream": {
-                        "task_status": "FAILED",
-                        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
-                        "variants": [{
-                            "graph_id": "my-graph",
-                            "variant_name": "mobile",
-                            "blocking": false,
-                            "fails_upstream_workflow": false,
-                            "status": "FAILED"
-                        }]
-                    }
-                }
-            },
-            "error": null
-        })
-    );
+    assert!(success, "expected a zero exit code; json: {json}");
+    assert_json_snapshot!(json);
 }

--- a/tests/integration/graph/check.rs
+++ b/tests/integration/graph/check.rs
@@ -1,0 +1,234 @@
+use std::fs;
+
+use assert_cmd::Command;
+use httpmock::{Method::POST, MockServer};
+use serde_json::Value;
+
+/// Verifies that `rover graph check` fails the command, and correctly attributes the
+/// failure to the downstream task, when a blocking downstream contract check has
+/// actually failed -- even though the overall workflow status and the downstream
+/// task's own aggregate status both still report PASSED (Studio's aggregate status
+/// can lag behind the per-variant data in the same response). Exercises the
+/// `has_blocking_failure` escalation in `DownstreamCheckResponse::new`.
+#[test]
+fn graph_check_fails_on_blocking_downstream_contract_failure() {
+    let server = MockServer::start();
+
+    server.mock(|when, then| {
+        when.method(POST).body_includes("GraphCheckMutation");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(
+                r#"{"data":{"graph":{"variant":{"submitCheckSchemaAsync":{
+                    "__typename":"CheckRequestSuccess",
+                    "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/1",
+                    "workflowID":"workflow-1"
+                }}}}}"#,
+            );
+    });
+
+    server.mock(|when, then| {
+        when.method(POST)
+            .body_includes("GraphCheckWorkflowStatusQuery");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(
+                r#"{"data":{"graph":{"checkWorkflow":{
+                    "status":"PASSED",
+                    "tasks":[{
+                        "__typename":"DownstreamCheckTask",
+                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream"
+                    }]
+                }}}}"#,
+            );
+    });
+
+    server.mock(|when, then| {
+        when.method(POST).body_includes("GraphCheckWorkflowQuery");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(
+                r#"{"data":{"graph":{"checkWorkflow":{
+                    "status":"PASSED",
+                    "tasks":[{
+                        "__typename":"DownstreamCheckTask",
+                        "status":"PASSED",
+                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                        "results":[{
+                            "__typename":"DownstreamCheckResult",
+                            "blocking":true,
+                            "downstreamGraphID":"my-graph",
+                            "downstreamVariantName":"mobile",
+                            "downstreamWorkflow":{"status":"FAILED"},
+                            "failsUpstreamWorkflow":null
+                        }]
+                    }]
+                }}}}"#,
+            );
+    });
+
+    let temp = tempfile::tempdir().unwrap();
+    let schema = temp.path().join("schema.graphql");
+    fs::write(&schema, "type Query { hello: String }").unwrap();
+
+    let output = Command::cargo_bin("rover")
+        .unwrap()
+        .env("APOLLO_KEY", "testkey")
+        .env("APOLLO_REGISTRY_URL", server.base_url())
+        .arg("graph")
+        .arg("check")
+        .arg("my-graph@current")
+        .arg("--schema")
+        .arg(&schema)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected a nonzero exit code; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "json_version": "3",
+            "data": {
+                "success": false,
+                "tasks": {
+                    "downstream": {
+                        "task_status": "FAILED",
+                        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                        "variants": [{
+                            "graph_id": "my-graph",
+                            "variant_name": "mobile",
+                            "blocking": true,
+                            "fails_upstream_workflow": null,
+                            "status": "FAILED"
+                        }]
+                    }
+                }
+            },
+            "error": {
+                "message": "The changes in the schema you proposed caused downstream checks to fail.",
+                "code": "E043"
+            }
+        })
+    );
+}
+
+/// Verifies that `rover graph check` succeeds when the downstream task's own aggregate
+/// status is FAILED but no individual variant is actually a blocking failure -- pinning
+/// the exit-code gate to `has_blocking_failure`, not the raw (and here misleading)
+/// `task_status`. Mirrors `non_blocking_task_failure_does_not_fail_the_check` in
+/// `crates/rover-client/src/operations/graph/check_workflow/runner.rs`, but exercised
+/// through the real CLI end to end.
+#[test]
+fn graph_check_succeeds_despite_non_blocking_task_status_failure() {
+    let server = MockServer::start();
+
+    server.mock(|when, then| {
+        when.method(POST).body_includes("GraphCheckMutation");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(
+                r#"{"data":{"graph":{"variant":{"submitCheckSchemaAsync":{
+                    "__typename":"CheckRequestSuccess",
+                    "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/1",
+                    "workflowID":"workflow-1"
+                }}}}}"#,
+            );
+    });
+
+    server.mock(|when, then| {
+        when.method(POST)
+            .body_includes("GraphCheckWorkflowStatusQuery");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(
+                r#"{"data":{"graph":{"checkWorkflow":{
+                    "status":"PASSED",
+                    "tasks":[{
+                        "__typename":"DownstreamCheckTask",
+                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream"
+                    }]
+                }}}}"#,
+            );
+    });
+
+    server.mock(|when, then| {
+        when.method(POST).body_includes("GraphCheckWorkflowQuery");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(
+                r#"{"data":{"graph":{"checkWorkflow":{
+                    "status":"PASSED",
+                    "tasks":[{
+                        "__typename":"DownstreamCheckTask",
+                        "status":"FAILED",
+                        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                        "results":[{
+                            "__typename":"DownstreamCheckResult",
+                            "blocking":false,
+                            "downstreamGraphID":"my-graph",
+                            "downstreamVariantName":"mobile",
+                            "downstreamWorkflow":{"status":"FAILED"},
+                            "failsUpstreamWorkflow":false
+                        }]
+                    }]
+                }}}}"#,
+            );
+    });
+
+    let temp = tempfile::tempdir().unwrap();
+    let schema = temp.path().join("schema.graphql");
+    fs::write(&schema, "type Query { hello: String }").unwrap();
+
+    let output = Command::cargo_bin("rover")
+        .unwrap()
+        .env("APOLLO_KEY", "testkey")
+        .env("APOLLO_REGISTRY_URL", server.base_url())
+        .arg("graph")
+        .arg("check")
+        .arg("my-graph@current")
+        .arg("--schema")
+        .arg(&schema)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected a zero exit code; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "json_version": "3",
+            "data": {
+                "success": true,
+                "tasks": {
+                    "downstream": {
+                        "task_status": "FAILED",
+                        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                        "variants": [{
+                            "graph_id": "my-graph",
+                            "variant_name": "mobile",
+                            "blocking": false,
+                            "fails_upstream_workflow": false,
+                            "status": "FAILED"
+                        }]
+                    }
+                }
+            },
+            "error": null
+        })
+    );
+}

--- a/tests/integration/graph/mod.rs
+++ b/tests/integration/graph/mod.rs
@@ -1,0 +1,1 @@
+mod check;

--- a/tests/integration/graph/snapshots/main__integration__graph__check__graph_check_fails_on_blocking_downstream_contract_failure.snap
+++ b/tests/integration/graph/snapshots/main__integration__graph__check__graph_check_fails_on_blocking_downstream_contract_failure.snap
@@ -1,0 +1,29 @@
+---
+source: tests/integration/graph/check.rs
+expression: json
+---
+{
+  "json_version": "3",
+  "data": {
+    "tasks": {
+      "downstream": {
+        "task_status": "FAILED",
+        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+        "variants": [
+          {
+            "graph_id": "my-graph",
+            "variant_name": "mobile",
+            "blocking": true,
+            "fails_upstream_workflow": null,
+            "status": "FAILED"
+          }
+        ]
+      }
+    },
+    "success": false
+  },
+  "error": {
+    "message": "The changes in the schema you proposed caused downstream checks to fail.",
+    "code": "E043"
+  }
+}

--- a/tests/integration/graph/snapshots/main__integration__graph__check__graph_check_succeeds_despite_non_blocking_task_status_failure.snap
+++ b/tests/integration/graph/snapshots/main__integration__graph__check__graph_check_succeeds_despite_non_blocking_task_status_failure.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration/graph/check.rs
+expression: json
+---
+{
+  "json_version": "3",
+  "data": {
+    "tasks": {
+      "downstream": {
+        "task_status": "FAILED",
+        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+        "variants": [
+          {
+            "graph_id": "my-graph",
+            "variant_name": "mobile",
+            "blocking": false,
+            "fails_upstream_workflow": false,
+            "status": "FAILED"
+          }
+        ]
+      }
+    },
+    "success": true
+  },
+  "error": null
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod client;
 mod completion;
 mod dev;
+mod graph;
 mod info;
 mod installers;
 mod output;


### PR DESCRIPTION
rover graph check never selected DownstreamCheckTask data at all, so it reported nothing about a graph's contract variants. It now selects the same downstream-check fields subgraph check does, always renders a pass/fail summary (previously nothing rendered unless a variant was blocking), and fails the command when a blocking downstream contract workflow has actually failed, matching subgraph check's behavior.