### PR TITLE
Move check-workflow text rendering out of rover-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   Removes pluralization print concerns from rover-client and hoists them into the binary
 
+- **Move check-workflow text rendering out of `rover-client` - @dotdat**
+
+  `CheckWorkflowResponse` and its per-task response types' `get_output()`/`get_table()`/`get_msg()` methods — ANSI styling and hyperlink markup via `rover_std::Style`/`hyperlink`, not client/data logic — move from `rover-client`'s `shared::check_response` module to a new `CheckWorkflowOutput` (`impl CliOutput`) in the `rover` binary crate's `src/command/check_output.rs`. Also removes five `get_json()` methods on the per-task response types that were dead code (`CheckWorkflowResponse::get_json()` builds its own JSON directly and never called them). No user-facing behavior change.
+
 - **latest_plugin_versions.json migration - @dotdat**
 
   Rover's bundled copy of `latest_plugin_versions.json` has been deleted and its behavior has been moved into the Orbiter service, its only real consumer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `CheckWorkflowResponse` UI concerns are moved higher up to the CLI binary. Its hand-rolled "N item(s)" pluralization now uses the `pluralizer` crate.
 
+- **Switch `graph publish`/`subgraph publish` from raw `eprintln!` to `rover-print` - @dotdat**
+
+  Both commands now print their stderr status lines through `rover-print`'s `Print`/`PrintExt` trait via an injected printer, matching the pattern already used by `contract preview`/`subgraph preview`. No user-facing output change.
+
 - **latest_plugin_versions.json migration - @dotdat**
 
   Rover's bundled copy of `latest_plugin_versions.json` has been deleted and its behavior has been moved into the Orbiter service, its only real consumer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Move check-workflow text rendering out of `rover-client` - @dotdat**
 
-  `CheckWorkflowResponse` UI concerns are moved higher up to the CLI binary
+  `CheckWorkflowResponse` UI concerns are moved higher up to the CLI binary. Its hand-rolled "N item(s)" pluralization now uses the `pluralizer` crate.
 
 - **latest_plugin_versions.json migration - @dotdat**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Move check-workflow text rendering out of `rover-client` - @dotdat**
 
-  `CheckWorkflowResponse` and its per-task response types' `get_output()`/`get_table()`/`get_msg()` methods — ANSI styling and hyperlink markup via `rover_std::Style`/`hyperlink`, not client/data logic — move from `rover-client`'s `shared::check_response` module to a new `CheckWorkflowOutput` (`impl CliOutput`) in the `rover` binary crate's `src/command/check_output.rs`. Also removes five `get_json()` methods on the per-task response types that were dead code (`CheckWorkflowResponse::get_json()` builds its own JSON directly and never called them). No user-facing behavior change.
+  `CheckWorkflowResponse` UI concerns are moved higher up to the CLI binary
 
 - **latest_plugin_versions.json migration - @dotdat**
 

--- a/crates/rover-client/src/shared/check_response.rs
+++ b/crates/rover-client/src/shared/check_response.rs
@@ -3,8 +3,6 @@ use std::{
     str::FromStr,
 };
 
-use comfy_table::{presets::UTF8_FULL, Attribute::Bold, Cell, CellAlignment::Center, Table};
-use rover_std::{hyperlink, Style};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -30,67 +28,6 @@ pub struct CheckWorkflowResponse {
 }
 
 impl CheckWorkflowResponse {
-    pub fn get_output(&self) -> String {
-        let mut msg = String::new();
-
-        if let (Some(core_schema_modified), Some(core_schema_status)) = (
-            self.maybe_core_schema_modified,
-            self.maybe_core_schema_status.clone(),
-        ) {
-            Self::append_task_title(&mut msg, "Build Check", core_schema_status);
-            if core_schema_modified {
-                msg.push_str("There were no changes detected in the composed API schema, but the core schema was modified.")
-            } else {
-                msg.push_str("There were no changes detected in the composed schema.")
-            }
-        }
-
-        if let Some(operations_response) = &self.maybe_operations_response {
-            Self::append_task_title(
-                &mut msg,
-                "Operation Check",
-                operations_response.task_status.clone(),
-            );
-            msg.push_str(operations_response.get_output().as_str());
-        }
-
-        if let Some(lint_response) = &self.maybe_lint_response {
-            Self::append_task_title(&mut msg, "Linter Check", lint_response.task_status.clone());
-            msg.push_str(lint_response.get_output().as_str());
-        }
-
-        if let Some(proposals_response) = &self.maybe_proposals_response {
-            Self::append_task_title(
-                &mut msg,
-                "Proposals Check",
-                proposals_response.task_status.clone(),
-            );
-            msg.push_str(proposals_response.get_output().as_str());
-        }
-
-        if let Some(custom_response) = &self.maybe_custom_response {
-            Self::append_task_title(
-                &mut msg,
-                "Custom Check",
-                custom_response.task_status.clone(),
-            );
-            msg.push_str(custom_response.get_output().as_str());
-        }
-
-        if let Some(downstream_response) = &self.maybe_downstream_response {
-            if !downstream_response.blocking_variants.is_empty() {
-                Self::append_task_title(
-                    &mut msg,
-                    "Downstream Check",
-                    downstream_response.task_status.clone(),
-                );
-                msg.push_str(downstream_response.get_output().as_str());
-            }
-        }
-
-        msg.trim_end().to_string()
-    }
-
     pub fn get_json(&self) -> Value {
         let mut json_result: Value = json!({});
         let mut tasks: Value = json!({});
@@ -123,29 +60,6 @@ impl CheckWorkflowResponse {
 
         json_result
     }
-
-    fn append_task_title(msg: &mut String, title: &str, status: CheckTaskStatus) {
-        if !msg.is_empty() {
-            if !msg.ends_with('\n') {
-                msg.push('\n');
-            }
-            msg.push('\n');
-        }
-        msg.push_str(&Self::task_title(title, status));
-    }
-
-    fn task_title(title: &str, status: CheckTaskStatus) -> String {
-        format!(
-            "{} [{}]:\n",
-            Style::Heading.paint(title),
-            match status {
-                CheckTaskStatus::BLOCKED => status.as_ref().to_string(),
-                CheckTaskStatus::FAILED => Style::Failure.paint(status),
-                CheckTaskStatus::PASSED => Style::Success.paint(status),
-                CheckTaskStatus::PENDING => Style::Pending.paint(status),
-            }
-        )
-    }
 }
 
 /// CheckResponse is the return type of the
@@ -153,9 +67,9 @@ impl CheckWorkflowResponse {
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
 pub struct OperationCheckResponse {
     pub task_status: CheckTaskStatus,
-    target_url: Option<String>,
-    operation_check_count: u64,
-    changes: Vec<SchemaChange>,
+    pub target_url: Option<String>,
+    pub operation_check_count: u64,
+    pub changes: Vec<SchemaChange>,
     failure_count: u64,
 }
 
@@ -180,55 +94,6 @@ impl OperationCheckResponse {
             failure_count,
         }
     }
-
-    pub fn get_table(&self) -> String {
-        let mut table = Table::new();
-        table.load_style(UTF8_FULL);
-
-        table.set_header(
-            vec!["Change", "Code", "Description"]
-                .into_iter()
-                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
-        );
-        for check in &self.changes {
-            table.add_row(vec![
-                &check.severity.to_string(),
-                &check.code,
-                &check.description,
-            ]);
-        }
-
-        table.to_string()
-    }
-
-    pub fn get_output(&self) -> String {
-        let mut msg = String::new();
-
-        msg.push_str(&format!(
-            "Compared {} schema changes against {} operations.",
-            self.changes.len(),
-            self.operation_check_count
-        ));
-
-        msg.push('\n');
-
-        if self.changes.is_empty() {
-            msg.push_str("No schema changes detected.\n");
-        } else {
-            msg.push_str(&self.get_table());
-        }
-
-        if let Some(url) = &self.target_url {
-            msg.push_str("View operation check details at: ");
-            msg.push_str(&Style::Link.paint(url));
-        }
-
-        msg
-    }
-
-    pub fn get_json(&self) -> Value {
-        json!(self)
-    }
 }
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
@@ -238,75 +103,6 @@ pub struct LintCheckResponse {
     pub diagnostics: Vec<Diagnostic>,
     pub errors_count: u64,
     pub warnings_count: u64,
-}
-
-impl LintCheckResponse {
-    pub fn get_table(&self) -> String {
-        let mut table = Table::new();
-        table.load_style(UTF8_FULL);
-
-        table.set_header(
-            vec!["Level", "Coordinate", "Line", "Description"]
-                .into_iter()
-                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
-        );
-
-        for diagnostic in &self.diagnostics {
-            table.add_row(vec![
-                &diagnostic.level,
-                &diagnostic.coordinate,
-                &diagnostic.start_line.to_string(),
-                &diagnostic.message,
-            ]);
-        }
-
-        table.to_string()
-    }
-
-    pub fn get_output(&self) -> String {
-        let mut msg = String::new();
-
-        let error_msg = match self.errors_count {
-            0 => String::new(),
-            1 => "1 error".to_string(),
-            _ => format!("{} errors", self.errors_count),
-        };
-
-        let warning_msg = match self.warnings_count {
-            0 => String::new(),
-            1 => "1 warning".to_string(),
-            _ => format!("{} warnings", self.warnings_count),
-        };
-
-        let plural_errors = match (&error_msg[..], &warning_msg[..]) {
-            ("", "") => match self.diagnostics.len() {
-                1 => format!("{} rule ignored", self.diagnostics.len()),
-                _ => format!("{} rules ignored", self.diagnostics.len()),
-            },
-            ("", _) => warning_msg,
-            (_, "") => error_msg,
-            _ => format!("{error_msg} and {warning_msg}"),
-        };
-
-        if !self.diagnostics.is_empty() {
-            msg.push_str(&format!("Resulted in {plural_errors}."));
-            msg.push('\n');
-            msg.push_str(&self.get_table());
-        } else {
-            msg.push_str("No linting errors or warnings found.");
-            msg.push('\n');
-        }
-        if let Some(url) = &self.target_url {
-            msg.push_str("View linter check details at: ");
-            msg.push_str(&hyperlink(url.as_str()));
-        }
-
-        msg
-    }
-
-    pub fn get_json(&self) -> Value {
-        json!(self)
-    }
 }
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
@@ -340,62 +136,6 @@ pub struct ProposalsCheckResponse {
     pub related_proposals: Vec<RelatedProposal>,
 }
 
-impl ProposalsCheckResponse {
-    pub fn get_table(&self) -> String {
-        let mut table = Table::new();
-        table.load_style(UTF8_FULL);
-
-        table.set_header(
-            vec!["Status", "Proposal Name"]
-                .into_iter()
-                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
-        );
-
-        for proposal in &self.related_proposals {
-            table.add_row(vec![&proposal.status, &proposal.display_name]);
-        }
-
-        table.to_string()
-    }
-
-    pub fn get_msg(&self) -> String {
-        match self.proposal_coverage {
-            ProposalsCoverage::FULL => "All of the diffs in this change are associated with an approved Proposal.".to_string(),
-            ProposalsCoverage::PARTIAL | ProposalsCoverage::NONE => match self.severity_level {
-                ProposalsCheckSeverityLevel::ERROR => "Your check failed because some or all of the diffs in this change are not in an approved Proposal, and your schema check severity level is set to ERROR.".to_string(),
-                ProposalsCheckSeverityLevel::WARN => "Your check passed with warnings because some or all of the diffs in this change are not in an approved Proposal, and your schema check severity level is set to WARN.".to_string(),
-                ProposalsCheckSeverityLevel::OFF => "Proposal checks are disabled".to_string(),
-            },
-            ProposalsCoverage::OVERRIDDEN => "Proposal check results have been overridden in Studio".to_string(),
-            ProposalsCoverage::PENDING => "Proposal check has not completed".to_string(),
-        }
-    }
-
-    pub fn get_output(&self) -> String {
-        let mut msg = String::new();
-
-        if !self.related_proposals.is_empty() {
-            msg.push_str(&self.get_msg());
-            msg.push('\n');
-            msg.push_str(&self.get_table());
-        } else {
-            msg.push_str("Your proposals task did not return any approved proposals associated with these changes.");
-            msg.push('\n');
-        }
-
-        if let Some(url) = &self.target_url {
-            msg.push_str("View proposal check details at: ");
-            msg.push_str(&Style::Link.paint(url));
-        }
-
-        msg
-    }
-
-    pub fn get_json(&self) -> Value {
-        json!(self)
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Eq, PartialEq)]
 pub struct Violation {
     pub level: String,
@@ -411,109 +151,11 @@ pub struct CustomCheckResponse {
     pub violations: Vec<Violation>,
 }
 
-impl CustomCheckResponse {
-    pub fn get_table(&self) -> String {
-        let mut table = Table::new();
-        table.load_style(UTF8_FULL);
-
-        table.set_header(
-            vec!["Level", "Rule", "Line", "Message"]
-                .into_iter()
-                .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
-        );
-
-        for violation in &self.violations {
-            let coordinate = match &violation.start_line {
-                Some(message) => message.to_string(),
-                None => "".to_string(),
-            };
-            table.add_row(vec![
-                &violation.level,
-                &violation.rule,
-                &coordinate,
-                &violation.message,
-            ]);
-        }
-
-        table.to_string()
-    }
-
-    pub fn get_output(&self) -> String {
-        let mut msg = String::new();
-
-        let violation_msg = match self.violations.len() {
-            0 => "no violations".to_string(),
-            1 => "1 violation".to_string(),
-            _ => format!("{} violations", self.violations.len()),
-        };
-
-        if !self.violations.is_empty() {
-            msg.push_str(&format!("Resulted in {violation_msg}."));
-            msg.push('\n');
-            msg.push_str(&self.get_table());
-        } else {
-            msg.push_str("No custom check violations found.");
-            msg.push('\n');
-        }
-
-        if let Some(url) = &self.target_url {
-            msg.push_str("View custom check details at: ");
-            msg.push_str(&hyperlink(url.as_str()));
-        }
-
-        msg
-    }
-
-    pub fn get_json(&self) -> Value {
-        json!(self)
-    }
-}
-
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]
 pub struct DownstreamCheckResponse {
     pub task_status: CheckTaskStatus,
     pub target_url: Option<String>,
     pub blocking_variants: Vec<String>,
-}
-
-impl DownstreamCheckResponse {
-    pub fn get_msg(&self) -> String {
-        let variants = self.blocking_variants.join(",");
-        let plural_this = match self.blocking_variants.len() {
-            1 => "this",
-            _ => "these",
-        };
-        let plural = match self.blocking_variants.len() {
-            1 => "",
-            _ => "s",
-        };
-        format!(
-            "The downstream check task has encountered check failures for at least {} blocking downstream variant{}: {}.",
-            plural_this,
-            plural,
-            Style::Variant.paint(variants),
-        )
-    }
-
-    pub fn get_output(&self) -> String {
-        let mut msg = String::new();
-
-        if !self.blocking_variants.is_empty() {
-            msg.push_str(&self.get_msg());
-            msg.push('\n');
-        }
-
-        if let Some(url) = &self.target_url {
-            msg.push_str("View downstream check details at: ");
-            msg.push_str(&hyperlink(url.as_str()));
-        }
-
-        msg
-    }
-
-    pub fn get_json(&self) -> Value {
-        json!(self)
-    }
 }
 
 #[derive(Debug, Serialize, Clone, Eq, PartialEq)]

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -1,0 +1,492 @@
+use comfy_table::{Attribute::Bold, Cell, CellAlignment::Center, Table, presets::UTF8_FULL};
+use rover_client::shared::{
+    CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, DownstreamCheckResponse,
+    LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel,
+    ProposalsCoverage,
+};
+use rover_std::{Style, hyperlink};
+use serde_json::Value;
+
+use crate::command::CliOutput;
+
+/// [`CliOutput`] implementation for a `CheckWorkflowResponse` — the result of
+/// `graph check`/`subgraph check`, also reused for the inline check run by
+/// `graph publish`/`subgraph publish`.
+///
+/// Text/table rendering lives here (ANSI styling and hyperlink markup via
+/// `rover_std`), not on the shared rover-client type, because it's
+/// presentation logic, not client/data logic.
+#[derive(Debug)]
+pub(crate) struct CheckWorkflowOutput<'a>(pub &'a CheckWorkflowResponse);
+
+impl CliOutput for CheckWorkflowOutput<'_> {
+    fn text(&self) -> String {
+        let response = self.0;
+        let mut msg = String::new();
+
+        if let (Some(core_schema_modified), Some(core_schema_status)) = (
+            response.maybe_core_schema_modified,
+            response.maybe_core_schema_status.clone(),
+        ) {
+            append_task_title(&mut msg, "Build Check", core_schema_status);
+            if core_schema_modified {
+                msg.push_str("There were no changes detected in the composed API schema, but the core schema was modified.")
+            } else {
+                msg.push_str("There were no changes detected in the composed schema.")
+            }
+        }
+
+        if let Some(operations_response) = &response.maybe_operations_response {
+            append_task_title(
+                &mut msg,
+                "Operation Check",
+                operations_response.task_status.clone(),
+            );
+            msg.push_str(operations_text(operations_response).as_str());
+        }
+
+        if let Some(lint_response) = &response.maybe_lint_response {
+            append_task_title(&mut msg, "Linter Check", lint_response.task_status.clone());
+            msg.push_str(lint_text(lint_response).as_str());
+        }
+
+        if let Some(proposals_response) = &response.maybe_proposals_response {
+            append_task_title(
+                &mut msg,
+                "Proposals Check",
+                proposals_response.task_status.clone(),
+            );
+            msg.push_str(proposals_text(proposals_response).as_str());
+        }
+
+        if let Some(custom_response) = &response.maybe_custom_response {
+            append_task_title(
+                &mut msg,
+                "Custom Check",
+                custom_response.task_status.clone(),
+            );
+            msg.push_str(custom_text(custom_response).as_str());
+        }
+
+        if let Some(downstream_response) = &response.maybe_downstream_response
+            && !downstream_response.blocking_variants.is_empty()
+        {
+            append_task_title(
+                &mut msg,
+                "Downstream Check",
+                downstream_response.task_status.clone(),
+            );
+            msg.push_str(downstream_text(downstream_response).as_str());
+        }
+
+        msg.trim_end().to_string()
+    }
+
+    fn json(&self) -> Result<Value, serde_json::Error> {
+        Ok(self.0.get_json())
+    }
+}
+
+fn append_task_title(msg: &mut String, title: &str, status: CheckTaskStatus) {
+    if !msg.is_empty() {
+        if !msg.ends_with('\n') {
+            msg.push('\n');
+        }
+        msg.push('\n');
+    }
+    msg.push_str(&task_title(title, status));
+}
+
+fn task_title(title: &str, status: CheckTaskStatus) -> String {
+    format!(
+        "{} [{}]:\n",
+        Style::Heading.paint(title),
+        match status {
+            CheckTaskStatus::BLOCKED => status.as_ref().to_string(),
+            CheckTaskStatus::FAILED => Style::Failure.paint(status),
+            CheckTaskStatus::PASSED => Style::Success.paint(status),
+            CheckTaskStatus::PENDING => Style::Pending.paint(status),
+        }
+    )
+}
+
+fn operations_table(response: &OperationCheckResponse) -> String {
+    let mut table = Table::new();
+    table.load_style(UTF8_FULL);
+
+    table.set_header(
+        vec!["Change", "Code", "Description"]
+            .into_iter()
+            .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+    );
+    for check in &response.changes {
+        table.add_row(vec![
+            &check.severity.to_string(),
+            &check.code,
+            &check.description,
+        ]);
+    }
+
+    table.to_string()
+}
+
+fn operations_text(response: &OperationCheckResponse) -> String {
+    let mut msg = String::new();
+
+    msg.push_str(&format!(
+        "Compared {} schema changes against {} operations.",
+        response.changes.len(),
+        response.operation_check_count
+    ));
+
+    msg.push('\n');
+
+    if response.changes.is_empty() {
+        msg.push_str("No schema changes detected.\n");
+    } else {
+        msg.push_str(&operations_table(response));
+    }
+
+    if let Some(url) = &response.target_url {
+        msg.push_str("View operation check details at: ");
+        msg.push_str(&Style::Link.paint(url));
+    }
+
+    msg
+}
+
+fn lint_table(response: &LintCheckResponse) -> String {
+    let mut table = Table::new();
+    table.load_style(UTF8_FULL);
+
+    table.set_header(
+        vec!["Level", "Coordinate", "Line", "Description"]
+            .into_iter()
+            .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+    );
+
+    for diagnostic in &response.diagnostics {
+        table.add_row(vec![
+            &diagnostic.level,
+            &diagnostic.coordinate,
+            &diagnostic.start_line.to_string(),
+            &diagnostic.message,
+        ]);
+    }
+
+    table.to_string()
+}
+
+fn lint_text(response: &LintCheckResponse) -> String {
+    let mut msg = String::new();
+
+    let error_msg = match response.errors_count {
+        0 => String::new(),
+        1 => "1 error".to_string(),
+        _ => format!("{} errors", response.errors_count),
+    };
+
+    let warning_msg = match response.warnings_count {
+        0 => String::new(),
+        1 => "1 warning".to_string(),
+        _ => format!("{} warnings", response.warnings_count),
+    };
+
+    let plural_errors = match (&error_msg[..], &warning_msg[..]) {
+        ("", "") => match response.diagnostics.len() {
+            1 => format!("{} rule ignored", response.diagnostics.len()),
+            _ => format!("{} rules ignored", response.diagnostics.len()),
+        },
+        ("", _) => warning_msg,
+        (_, "") => error_msg,
+        _ => format!("{error_msg} and {warning_msg}"),
+    };
+
+    if !response.diagnostics.is_empty() {
+        msg.push_str(&format!("Resulted in {plural_errors}."));
+        msg.push('\n');
+        msg.push_str(&lint_table(response));
+    } else {
+        msg.push_str("No linting errors or warnings found.");
+        msg.push('\n');
+    }
+    if let Some(url) = &response.target_url {
+        msg.push_str("View linter check details at: ");
+        msg.push_str(&hyperlink(url.as_str()));
+    }
+
+    msg
+}
+
+fn proposals_table(response: &ProposalsCheckResponse) -> String {
+    let mut table = Table::new();
+    table.load_style(UTF8_FULL);
+
+    table.set_header(
+        vec!["Status", "Proposal Name"]
+            .into_iter()
+            .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+    );
+
+    for proposal in &response.related_proposals {
+        table.add_row(vec![&proposal.status, &proposal.display_name]);
+    }
+
+    table.to_string()
+}
+
+fn proposals_msg(response: &ProposalsCheckResponse) -> String {
+    match response.proposal_coverage {
+        ProposalsCoverage::FULL => "All of the diffs in this change are associated with an approved Proposal.".to_string(),
+        ProposalsCoverage::PARTIAL | ProposalsCoverage::NONE => match response.severity_level {
+            ProposalsCheckSeverityLevel::ERROR => "Your check failed because some or all of the diffs in this change are not in an approved Proposal, and your schema check severity level is set to ERROR.".to_string(),
+            ProposalsCheckSeverityLevel::WARN => "Your check passed with warnings because some or all of the diffs in this change are not in an approved Proposal, and your schema check severity level is set to WARN.".to_string(),
+            ProposalsCheckSeverityLevel::OFF => "Proposal checks are disabled".to_string(),
+        },
+        ProposalsCoverage::OVERRIDDEN => "Proposal check results have been overridden in Studio".to_string(),
+        ProposalsCoverage::PENDING => "Proposal check has not completed".to_string(),
+    }
+}
+
+fn proposals_text(response: &ProposalsCheckResponse) -> String {
+    let mut msg = String::new();
+
+    if !response.related_proposals.is_empty() {
+        msg.push_str(&proposals_msg(response));
+        msg.push('\n');
+        msg.push_str(&proposals_table(response));
+    } else {
+        msg.push_str(
+            "Your proposals task did not return any approved proposals associated with these changes.",
+        );
+        msg.push('\n');
+    }
+
+    if let Some(url) = &response.target_url {
+        msg.push_str("View proposal check details at: ");
+        msg.push_str(&Style::Link.paint(url));
+    }
+
+    msg
+}
+
+fn custom_table(response: &CustomCheckResponse) -> String {
+    let mut table = Table::new();
+    table.load_style(UTF8_FULL);
+
+    table.set_header(
+        vec!["Level", "Rule", "Line", "Message"]
+            .into_iter()
+            .map(|s| Cell::new(s).set_alignment(Center).add_attribute(Bold)),
+    );
+
+    for violation in &response.violations {
+        let coordinate = match &violation.start_line {
+            Some(message) => message.to_string(),
+            None => "".to_string(),
+        };
+        table.add_row(vec![
+            &violation.level,
+            &violation.rule,
+            &coordinate,
+            &violation.message,
+        ]);
+    }
+
+    table.to_string()
+}
+
+fn custom_text(response: &CustomCheckResponse) -> String {
+    let mut msg = String::new();
+
+    let violation_msg = match response.violations.len() {
+        0 => "no violations".to_string(),
+        1 => "1 violation".to_string(),
+        _ => format!("{} violations", response.violations.len()),
+    };
+
+    if !response.violations.is_empty() {
+        msg.push_str(&format!("Resulted in {violation_msg}."));
+        msg.push('\n');
+        msg.push_str(&custom_table(response));
+    } else {
+        msg.push_str("No custom check violations found.");
+        msg.push('\n');
+    }
+
+    if let Some(url) = &response.target_url {
+        msg.push_str("View custom check details at: ");
+        msg.push_str(&hyperlink(url.as_str()));
+    }
+
+    msg
+}
+
+fn downstream_msg(response: &DownstreamCheckResponse) -> String {
+    let variants = response.blocking_variants.join(",");
+    let plural_this = match response.blocking_variants.len() {
+        1 => "this",
+        _ => "these",
+    };
+    let plural = match response.blocking_variants.len() {
+        1 => "",
+        _ => "s",
+    };
+    format!(
+        "The downstream check task has encountered check failures for at least {} blocking downstream variant{}: {}.",
+        plural_this,
+        plural,
+        Style::Variant.paint(variants),
+    )
+}
+
+fn downstream_text(response: &DownstreamCheckResponse) -> String {
+    let mut msg = String::new();
+
+    if !response.blocking_variants.is_empty() {
+        msg.push_str(&downstream_msg(response));
+        msg.push('\n');
+    }
+
+    if let Some(url) = &response.target_url {
+        msg.push_str("View downstream check details at: ");
+        msg.push_str(&hyperlink(url.as_str()));
+    }
+
+    msg
+}
+
+#[cfg(test)]
+mod test {
+    use console::strip_ansi_codes;
+    use rover_client::shared::{
+        ChangeSeverity, Diagnostic, RelatedProposal, SchemaChange, Violation,
+    };
+
+    use super::*;
+
+    /// A response exercising every task type at once, each with at least one
+    /// finding, so both the text and JSON renderers cover every branch.
+    fn comprehensive_response() -> CheckWorkflowResponse {
+        CheckWorkflowResponse {
+            default_target_url:
+                "https://studio.apollographql.com/graph/my-graph/checks?variant=current".to_string(),
+            maybe_core_schema_modified: Some(true),
+            maybe_core_schema_status: Some(CheckTaskStatus::PASSED),
+            maybe_operations_response: Some(OperationCheckResponse::try_new(
+                CheckTaskStatus::FAILED,
+                Some(
+                    "https://studio.apollographql.com/graph/my-graph/checks/operations".to_string(),
+                ),
+                12,
+                vec![
+                    SchemaChange {
+                        code: "FIELD_REMOVED".to_string(),
+                        description: "Field `User.email` was removed".to_string(),
+                        severity: ChangeSeverity::FAIL,
+                    },
+                    SchemaChange {
+                        code: "FIELD_ADDED".to_string(),
+                        description: "Field `User.phone` was added".to_string(),
+                        severity: ChangeSeverity::PASS,
+                    },
+                ],
+            )),
+            maybe_lint_response: Some(LintCheckResponse {
+                task_status: CheckTaskStatus::PASSED,
+                target_url: Some(
+                    "https://studio.apollographql.com/graph/my-graph/checks/lint".to_string(),
+                ),
+                diagnostics: vec![Diagnostic {
+                    level: "WARNING".to_string(),
+                    message: "Field must be camelCase.".to_string(),
+                    coordinate: "Query.all_users".to_string(),
+                    rule: "FIELD_NAMES_SHOULD_BE_CAMEL_CASE".to_string(),
+                    start_line: 4,
+                    start_byte_offset: 10,
+                    end_byte_offset: 20,
+                }],
+                errors_count: 0,
+                warnings_count: 1,
+            }),
+            maybe_proposals_response: Some(ProposalsCheckResponse {
+                task_status: CheckTaskStatus::FAILED,
+                severity_level: ProposalsCheckSeverityLevel::ERROR,
+                proposal_coverage: ProposalsCoverage::PARTIAL,
+                target_url: Some(
+                    "https://studio.apollographql.com/graph/my-graph/checks/proposals".to_string(),
+                ),
+                related_proposals: vec![RelatedProposal {
+                    status: "OPEN".to_string(),
+                    display_name: "Add phone number".to_string(),
+                }],
+            }),
+            maybe_custom_response: Some(CustomCheckResponse {
+                task_status: CheckTaskStatus::FAILED,
+                target_url: Some(
+                    "https://studio.apollographql.com/graph/my-graph/checks/custom".to_string(),
+                ),
+                violations: vec![Violation {
+                    level: "ERROR".to_string(),
+                    message: "Fields must use camelCase.".to_string(),
+                    start_line: Some(7),
+                    rule: "NAMING_CONVENTION".to_string(),
+                }],
+            }),
+            maybe_downstream_response: Some(DownstreamCheckResponse {
+                task_status: CheckTaskStatus::FAILED,
+                target_url: Some(
+                    "https://studio.apollographql.com/graph/my-graph/checks/downstream".to_string(),
+                ),
+                blocking_variants: vec!["mobile".to_string()],
+            }),
+        }
+    }
+
+    /// The minimal response `graph check` produces when the workflow only
+    /// runs the build/composition step (no operations, lint, proposals,
+    /// custom checks, or contract variants configured).
+    fn build_only_response() -> CheckWorkflowResponse {
+        CheckWorkflowResponse {
+            default_target_url:
+                "https://studio.apollographql.com/graph/my-graph/checks?variant=current".to_string(),
+            maybe_core_schema_modified: Some(false),
+            maybe_core_schema_status: Some(CheckTaskStatus::PASSED),
+            maybe_operations_response: None,
+            maybe_lint_response: None,
+            maybe_proposals_response: None,
+            maybe_custom_response: None,
+            maybe_downstream_response: None,
+        }
+    }
+
+    #[test]
+    fn comprehensive_response_text_snapshot() {
+        let text =
+            strip_ansi_codes(&CheckWorkflowOutput(&comprehensive_response()).text()).to_string();
+        insta::assert_snapshot!(text);
+    }
+
+    #[test]
+    fn comprehensive_response_json_snapshot() {
+        let json = CheckWorkflowOutput(&comprehensive_response())
+            .json()
+            .expect("check workflow JSON rendering cannot fail");
+        insta::assert_json_snapshot!(json);
+    }
+
+    #[test]
+    fn build_only_response_text_snapshot() {
+        let text =
+            strip_ansi_codes(&CheckWorkflowOutput(&build_only_response()).text()).to_string();
+        insta::assert_snapshot!(text);
+    }
+
+    #[test]
+    fn build_only_response_json_snapshot() {
+        let json = CheckWorkflowOutput(&build_only_response())
+            .json()
+            .expect("check workflow JSON rendering cannot fail");
+        insta::assert_json_snapshot!(json);
+    }
+}

--- a/src/command/check_output.rs
+++ b/src/command/check_output.rs
@@ -1,4 +1,5 @@
 use comfy_table::{Attribute::Bold, Cell, CellAlignment::Center, Table, presets::UTF8_FULL};
+use pluralizer::pluralize;
 use rover_client::shared::{
     CheckTaskStatus, CheckWorkflowResponse, CustomCheckResponse, DownstreamCheckResponse,
     LintCheckResponse, OperationCheckResponse, ProposalsCheckResponse, ProposalsCheckSeverityLevel,
@@ -180,23 +181,27 @@ fn lint_table(response: &LintCheckResponse) -> String {
 fn lint_text(response: &LintCheckResponse) -> String {
     let mut msg = String::new();
 
-    let error_msg = match response.errors_count {
-        0 => String::new(),
-        1 => "1 error".to_string(),
-        _ => format!("{} errors", response.errors_count),
+    let error_msg = if response.errors_count > 0 {
+        pluralize("error", response.errors_count as isize, true)
+    } else {
+        String::new()
     };
 
-    let warning_msg = match response.warnings_count {
-        0 => String::new(),
-        1 => "1 warning".to_string(),
-        _ => format!("{} warnings", response.warnings_count),
+    let warning_msg = if response.warnings_count > 0 {
+        pluralize("warning", response.warnings_count as isize, true)
+    } else {
+        String::new()
     };
 
     let plural_errors = match (&error_msg[..], &warning_msg[..]) {
-        ("", "") => match response.diagnostics.len() {
-            1 => format!("{} rule ignored", response.diagnostics.len()),
-            _ => format!("{} rules ignored", response.diagnostics.len()),
-        },
+        // `pluralize` pluralizes whichever word it's given, so "rule" is
+        // pluralized on its own and "ignored" appended as an invariant
+        // suffix -- pluralizing the phrase "rule ignored" directly would
+        // instead (wrongly) pluralize its last word, giving "rule ignoreds".
+        ("", "") => format!(
+            "{} ignored",
+            pluralize("rule", response.diagnostics.len() as isize, true)
+        ),
         ("", _) => warning_msg,
         (_, "") => error_msg,
         _ => format!("{error_msg} and {warning_msg}"),
@@ -299,10 +304,10 @@ fn custom_table(response: &CustomCheckResponse) -> String {
 fn custom_text(response: &CustomCheckResponse) -> String {
     let mut msg = String::new();
 
-    let violation_msg = match response.violations.len() {
-        0 => "no violations".to_string(),
-        1 => "1 violation".to_string(),
-        _ => format!("{} violations", response.violations.len()),
+    let violation_msg = if response.violations.is_empty() {
+        "no violations".to_string()
+    } else {
+        pluralize("violation", response.violations.len() as isize, true)
     };
 
     if !response.violations.is_empty() {

--- a/src/command/graph/mod.rs
+++ b/src/command/graph/mod.rs
@@ -58,7 +58,12 @@ impl Graph {
             Command::Lint(command) => command.run(client_config).await,
             Command::Publish(command) => {
                 command
-                    .run(client_config, git_context, checks_timeout_seconds)
+                    .run(
+                        client_config,
+                        git_context,
+                        checks_timeout_seconds,
+                        &rover_print::print::stderr::default(),
+                    )
                     .await
             }
             Command::Introspect(command) => {

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 
 use crate::{
     RoverError, RoverOutput, RoverResult,
+    command::CliOutput,
     options::{CheckConfigOpts, GraphRefOpt, ProfileOpt, SchemaOpt},
     utils::client::StudioClientConfig,
 };
@@ -88,11 +89,17 @@ impl Publish {
             .await
             {
                 Ok(check_res) => {
-                    eprintln!("{}", check_res.get_output());
+                    eprintln!(
+                        "{}",
+                        crate::command::check_output::CheckWorkflowOutput(&check_res).text()
+                    );
                     eprintln!("{}", Style::Success.paint("Check passed. Publishing SDL"));
                 }
                 Err(RoverClientError::CheckWorkflowFailure { check_response, .. }) => {
-                    eprintln!("{}", check_response.get_output());
+                    eprintln!(
+                        "{}",
+                        crate::command::check_output::CheckWorkflowOutput(&check_response).text()
+                    );
                     eprintln!(
                         "{}",
                         Style::Failure.paint(

--- a/src/command/graph/publish.rs
+++ b/src/command/graph/publish.rs
@@ -9,7 +9,10 @@ use rover_client::{
     },
     shared::{CheckConfig, GitContext},
 };
-use rover_std::Style;
+use rover_print::{
+    print::{Print, PrintExt},
+    style::{Style, StyledText},
+};
 use serde::Serialize;
 
 use crate::{
@@ -49,6 +52,7 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
         checks_timeout_seconds: u64,
+        stderr: &impl Print,
     ) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
         let proposed_schema = self
@@ -56,10 +60,10 @@ impl Publish {
             .read_file_descriptor("SDL", &mut std::io::stdin())?;
 
         if self.check {
-            eprintln!(
+            stderr.print(&StyledText::plain(format!(
                 "Checking the proposed schema against {}",
-                Style::Link.paint(self.graph.graph_ref.to_string())
-            );
+                stderr.paint(Style::Link, self.graph.graph_ref.to_string())
+            )));
 
             let workflow_res = check::run(
                 CheckSchemaAsyncInput {
@@ -89,44 +93,41 @@ impl Publish {
             .await
             {
                 Ok(check_res) => {
-                    eprintln!(
-                        "{}",
-                        crate::command::check_output::CheckWorkflowOutput(&check_res).text()
-                    );
-                    eprintln!("{}", Style::Success.paint("Check passed. Publishing SDL"));
+                    stderr.print(&StyledText::plain(
+                        crate::command::check_output::CheckWorkflowOutput(&check_res).text(),
+                    ));
+                    stderr.print(&StyledText::new(
+                        Style::Success,
+                        "Check passed. Publishing SDL",
+                    ));
                 }
                 Err(RoverClientError::CheckWorkflowFailure { check_response, .. }) => {
-                    eprintln!(
-                        "{}",
-                        crate::command::check_output::CheckWorkflowOutput(&check_response).text()
-                    );
-                    eprintln!(
-                        "{}",
-                        Style::Failure.paint(
-                            "Schema check failed — no changes were published to the graph registry."
-                        )
-                    );
+                    stderr.print(&StyledText::plain(
+                        crate::command::check_output::CheckWorkflowOutput(&check_response).text(),
+                    ));
+                    stderr.print(&StyledText::new(
+                        Style::Failure,
+                        "Schema check failed — no changes were published to the graph registry.",
+                    ));
                     return Err(RoverError::new(anyhow!(
                         "Schema checks must pass before publishing. Fix the check failures above and try again."
                     )));
                 }
                 Err(e) => {
-                    eprintln!(
-                        "{}",
-                        Style::Failure.paint(
-                            "Schema check failed — no changes were published to the graph registry."
-                        )
-                    );
+                    stderr.print(&StyledText::new(
+                        Style::Failure,
+                        "Schema check failed — no changes were published to the graph registry.",
+                    ));
                     return Err(RoverError::new(e));
                 }
             }
         }
 
-        eprintln!(
+        stderr.print(&StyledText::plain(format!(
             "Publishing SDL to {} using credentials from the {} profile.",
-            Style::Link.paint(self.graph.graph_ref.to_string()),
-            Style::Command.paint(&self.profile.profile_name)
-        );
+            stderr.paint(Style::Link, self.graph.graph_ref.to_string()),
+            stderr.paint(Style::Command, &self.profile.profile_name)
+        )));
 
         tracing::debug!("Publishing \n{}", &proposed_schema);
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,6 +1,7 @@
 mod api_key;
 #[cfg(feature = "oauth")]
 pub mod auth;
+pub(crate) mod check_output;
 mod client;
 mod completion;
 mod config;

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -479,7 +479,9 @@ impl RoverOutput {
                     "Successfully created a new project from the '{template_id}' template in {path}\n Read the generated '{readme}' file for next steps.\n{forum_call_to_action}"
                 ))
             }
-            RoverOutput::CheckWorkflowResponse(check_response) => Some(check_response.get_output()),
+            RoverOutput::CheckWorkflowResponse(check_response) => {
+                Some(crate::command::check_output::CheckWorkflowOutput(check_response).text())
+            }
             RoverOutput::AsyncCheckResponse(check_response) => Some(format!(
                 "Check successfully started with workflow ID: {}\nView full details at {}",
                 check_response.workflow_id, check_response.target_url
@@ -762,7 +764,11 @@ impl RoverOutput {
             RoverOutput::TemplateUseSuccess { template_id, path } => {
                 json!({ "template_id": template_id, "path": path })
             }
-            RoverOutput::CheckWorkflowResponse(check_response) => check_response.get_json(),
+            RoverOutput::CheckWorkflowResponse(check_response) => {
+                crate::command::check_output::CheckWorkflowOutput(check_response)
+                    .json()
+                    .unwrap_or(Value::Null)
+            }
             RoverOutput::AsyncCheckResponse(check_response) => check_response.get_json(),
             RoverOutput::LintResponse(lint_response) => lint_response.get_json(),
             RoverOutput::Profiles(profiles) => json!({ "profiles": profiles }),

--- a/src/command/snapshots/rover__command__check_output__test__build_only_response_json_snapshot.snap
+++ b/src/command/snapshots/rover__command__check_output__test__build_only_response_json_snapshot.snap
@@ -1,0 +1,8 @@
+---
+source: src/command/check_output.rs
+expression: json
+---
+{
+  "core_schema_modified": false,
+  "tasks": {}
+}

--- a/src/command/snapshots/rover__command__check_output__test__build_only_response_text_snapshot.snap
+++ b/src/command/snapshots/rover__command__check_output__test__build_only_response_text_snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: src/command/check_output.rs
+expression: text
+---
+Build Check [PASSED]:
+There were no changes detected in the composed schema.

--- a/src/command/snapshots/rover__command__check_output__test__comprehensive_response_json_snapshot.snap
+++ b/src/command/snapshots/rover__command__check_output__test__comprehensive_response_json_snapshot.snap
@@ -1,0 +1,75 @@
+---
+source: src/command/check_output.rs
+expression: json
+---
+{
+  "core_schema_modified": true,
+  "tasks": {
+    "operations": {
+      "task_status": "FAILED",
+      "target_url": "https://studio.apollographql.com/graph/my-graph/checks/operations",
+      "operation_check_count": 12,
+      "changes": [
+        {
+          "code": "FIELD_REMOVED",
+          "description": "Field `User.email` was removed",
+          "severity": "FAIL"
+        },
+        {
+          "code": "FIELD_ADDED",
+          "description": "Field `User.phone` was added",
+          "severity": "PASS"
+        }
+      ],
+      "failure_count": 1
+    },
+    "lint": {
+      "task_status": "PASSED",
+      "target_url": "https://studio.apollographql.com/graph/my-graph/checks/lint",
+      "diagnostics": [
+        {
+          "level": "WARNING",
+          "message": "Field must be camelCase.",
+          "coordinate": "Query.all_users",
+          "start_line": 4,
+          "start_byte_offset": 10,
+          "end_byte_offset": 20,
+          "rule": "FIELD_NAMES_SHOULD_BE_CAMEL_CASE"
+        }
+      ],
+      "errors_count": 0,
+      "warnings_count": 1
+    },
+    "proposals": {
+      "task_status": "FAILED",
+      "severity_level": "ERROR",
+      "proposal_coverage": "PARTIAL",
+      "target_url": "https://studio.apollographql.com/graph/my-graph/checks/proposals",
+      "related_proposals": [
+        {
+          "status": "OPEN",
+          "display_name": "Add phone number"
+        }
+      ]
+    },
+    "custom": {
+      "task_status": "FAILED",
+      "target_url": "https://studio.apollographql.com/graph/my-graph/checks/custom",
+      "violations": [
+        {
+          "level": "ERROR",
+          "message": "Fields must use camelCase.",
+          "start_line": 7,
+          "rule": "NAMING_CONVENTION"
+        }
+      ]
+    },
+    "downstream": {
+      "task_status": "FAILED",
+      "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+      "blocking_variants": [
+        "mobile"
+      ]
+    }
+  }
+}

--- a/src/command/snapshots/rover__command__check_output__test__comprehensive_response_text_snapshot.snap
+++ b/src/command/snapshots/rover__command__check_output__test__comprehensive_response_text_snapshot.snap
@@ -1,0 +1,44 @@
+---
+source: src/command/check_output.rs
+expression: text
+---
+Build Check [PASSED]:
+There were no changes detected in the composed API schema, but the core schema was modified.
+
+Operation Check [FAILED]:
+Compared 2 schema changes against 12 operations.
+┌────────┬───────────────┬────────────────────────────────┐
+│ Change ┆      Code     ┆           Description          │
+╞════════╪═══════════════╪════════════════════════════════╡
+│ FAIL   ┆ FIELD_REMOVED ┆ Field `User.email` was removed │
+├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ PASS   ┆ FIELD_ADDED   ┆ Field `User.phone` was added   │
+└────────┴───────────────┴────────────────────────────────┘View operation check details at: https://studio.apollographql.com/graph/my-graph/checks/operations
+
+Linter Check [PASSED]:
+Resulted in 1 warning.
+┌─────────┬─────────────────┬──────┬──────────────────────────┐
+│  Level  ┆    Coordinate   ┆ Line ┆        Description       │
+╞═════════╪═════════════════╪══════╪══════════════════════════╡
+│ WARNING ┆ Query.all_users ┆ 4    ┆ Field must be camelCase. │
+└─────────┴─────────────────┴──────┴──────────────────────────┘View linter check details at: https://studio.apollographql.com/graph/my-graph/checks/lint
+
+Proposals Check [FAILED]:
+Your check failed because some or all of the diffs in this change are not in an approved Proposal, and your schema check severity level is set to ERROR.
+┌────────┬──────────────────┐
+│ Status ┆   Proposal Name  │
+╞════════╪══════════════════╡
+│ OPEN   ┆ Add phone number │
+└────────┴──────────────────┘View proposal check details at: https://studio.apollographql.com/graph/my-graph/checks/proposals
+
+Custom Check [FAILED]:
+Resulted in 1 violation.
+┌───────┬───────────────────┬──────┬────────────────────────────┐
+│ Level ┆        Rule       ┆ Line ┆           Message          │
+╞═══════╪═══════════════════╪══════╪════════════════════════════╡
+│ ERROR ┆ NAMING_CONVENTION ┆ 7    ┆ Fields must use camelCase. │
+└───────┴───────────────────┴──────┴────────────────────────────┘View custom check details at: https://studio.apollographql.com/graph/my-graph/checks/custom
+
+Downstream Check [FAILED]:
+The downstream check task has encountered check failures for at least this blocking downstream variant: mobile.
+View downstream check details at: https://studio.apollographql.com/graph/my-graph/checks/downstream

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -90,7 +90,12 @@ impl Subgraph {
             }
             Command::Publish(command) => {
                 command
-                    .run(client_config, git_context, checks_timeout_seconds)
+                    .run(
+                        client_config,
+                        git_context,
+                        checks_timeout_seconds,
+                        &rover_print::print::stderr::default(),
+                    )
                     .await
             }
         }

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 
 use crate::{
     RoverError, RoverErrorSuggestion, RoverOutput, RoverResult,
+    command::CliOutput,
     options::{CheckConfigOpts, GraphRefOpt, OptionalSchemaOpt, ProfileOpt, SubgraphOpt},
     utils::client::StudioClientConfig,
 };
@@ -152,11 +153,17 @@ impl Publish {
             .await
             {
                 Ok(check_res) => {
-                    eprintln!("{}", check_res.get_output());
+                    eprintln!(
+                        "{}",
+                        crate::command::check_output::CheckWorkflowOutput(&check_res).text()
+                    );
                     eprintln!("{}", Style::Success.paint("Check passed. Publishing SDL"));
                 }
                 Err(RoverClientError::CheckWorkflowFailure { check_response, .. }) => {
-                    eprintln!("{}", check_response.get_output());
+                    eprintln!(
+                        "{}",
+                        crate::command::check_output::CheckWorkflowOutput(&check_response).text()
+                    );
                     eprintln!(
                         "{}",
                         Style::Failure.paint(

--- a/src/command/subgraph/publish.rs
+++ b/src/command/subgraph/publish.rs
@@ -14,7 +14,11 @@ use rover_client::{
     },
     shared::{CheckConfig, GitContext},
 };
-use rover_std::Style;
+use rover_print::{
+    print::{Print, PrintExt},
+    style::{Style, StyledText},
+};
+use rover_std::Style as StdStyle;
 use serde::Serialize;
 
 use crate::{
@@ -80,6 +84,7 @@ impl Publish {
         client_config: StudioClientConfig,
         git_context: GitContext,
         checks_timeout_seconds: u64,
+        stderr: &impl Print,
     ) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
 
@@ -117,11 +122,11 @@ impl Publish {
         };
 
         if self.check {
-            eprintln!(
+            stderr.print(&StyledText::plain(format!(
                 "Checking the proposed schema for subgraph {} against {}",
-                Style::Link.paint(&self.subgraph.subgraph_name),
-                Style::Link.paint(self.graph.graph_ref.to_string())
-            );
+                stderr.paint(Style::Link, &self.subgraph.subgraph_name),
+                stderr.paint(Style::Link, self.graph.graph_ref.to_string())
+            )));
 
             let workflow_res = check::run(
                 SubgraphCheckAsyncInput {
@@ -153,45 +158,42 @@ impl Publish {
             .await
             {
                 Ok(check_res) => {
-                    eprintln!(
-                        "{}",
-                        crate::command::check_output::CheckWorkflowOutput(&check_res).text()
-                    );
-                    eprintln!("{}", Style::Success.paint("Check passed. Publishing SDL"));
+                    stderr.print(&StyledText::plain(
+                        crate::command::check_output::CheckWorkflowOutput(&check_res).text(),
+                    ));
+                    stderr.print(&StyledText::new(
+                        Style::Success,
+                        "Check passed. Publishing SDL",
+                    ));
                 }
                 Err(RoverClientError::CheckWorkflowFailure { check_response, .. }) => {
-                    eprintln!(
-                        "{}",
-                        crate::command::check_output::CheckWorkflowOutput(&check_response).text()
-                    );
-                    eprintln!(
-                        "{}",
-                        Style::Failure.paint(
-                            "Schema check failed — no changes were published to the graph registry."
-                        )
-                    );
+                    stderr.print(&StyledText::plain(
+                        crate::command::check_output::CheckWorkflowOutput(&check_response).text(),
+                    ));
+                    stderr.print(&StyledText::new(
+                        Style::Failure,
+                        "Schema check failed — no changes were published to the graph registry.",
+                    ));
                     return Err(RoverError::new(anyhow!(
                         "Schema checks must pass before publishing. Fix the check failures above and try again."
                     )));
                 }
                 Err(e) => {
-                    eprintln!(
-                        "{}",
-                        Style::Failure.paint(
-                            "Schema check failed — no changes were published to the graph registry."
-                        )
-                    );
+                    stderr.print(&StyledText::new(
+                        Style::Failure,
+                        "Schema check failed — no changes were published to the graph registry.",
+                    ));
                     return Err(RoverError::new(e));
                 }
             }
         }
 
-        eprintln!(
+        stderr.print(&StyledText::plain(format!(
             "Publishing SDL to {} (subgraph: {}) using credentials from the {} profile.",
-            Style::Link.paint(self.graph.graph_ref.to_string()),
-            Style::Link.paint(&self.subgraph.subgraph_name),
-            Style::Command.paint(&self.profile.profile_name)
-        );
+            stderr.paint(Style::Link, self.graph.graph_ref.to_string()),
+            stderr.paint(Style::Link, &self.subgraph.subgraph_name),
+            stderr.paint(Style::Command, &self.profile.profile_name)
+        )));
 
         tracing::debug!("Publishing \n{}", &schema);
 
@@ -289,7 +291,7 @@ impl Publish {
                     tracing::debug!("Parsed URL: {}", parsed_url.to_string());
                     let reason = format!(
                         "`{}` is not a valid routing URL. The `{}` protocol is not supported by the router. Valid protocols are `http` and `https`.",
-                        Style::Link.paint(routing_url),
+                        StdStyle::Link.paint(routing_url),
                         parsed_url.scheme()
                     );
                     if !["http", "https", "unix"].contains(&parsed_url.scheme()) {
@@ -323,7 +325,7 @@ impl Publish {
                     tracing::debug!("Parse error: {}", parse_error.to_string());
                     let reason = format!(
                         "`{}` is not a valid routing URL.",
-                        Style::Link.paint(routing_url)
+                        StdStyle::Link.paint(routing_url)
                     );
                     if is_atty {
                         Self::prompt_for_publish(
@@ -364,7 +366,11 @@ impl Publish {
         reason: &str,
         writer: &mut dyn io::Write,
     ) -> RoverResult<()> {
-        writeln!(writer, "{} {reason}", Style::WarningPrefix.paint("WARN:"),)?;
+        writeln!(
+            writer,
+            "{} {reason}",
+            StdStyle::WarningPrefix.paint("WARN:"),
+        )?;
         Ok(())
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -17,7 +17,7 @@ use rover_std::Style;
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 use serde_json::{Value, json};
 
-use crate::options::JsonVersion;
+use crate::{command::CliOutput, options::JsonVersion};
 
 /// A specialized `Error` type for Rover that wraps `anyhow`
 /// and provides some extra `Metadata` for end users depending
@@ -103,7 +103,10 @@ impl RoverError {
             Some(RoverClientError::CheckWorkflowFailure {
                 graph_ref: _,
                 check_response,
-            }) => stdoutln!("{}", check_response.get_output())?,
+            }) => stdoutln!(
+                "{}",
+                crate::command::check_output::CheckWorkflowOutput(check_response).text()
+            )?,
             Some(RoverClientError::LintFailures { lint_response }) => {
                 stdoutln!("{}", lint_response.get_ariadne()?)?
             }


### PR DESCRIPTION
CheckWorkflowResponse and its per-task response types had `get_output()`/`get_table()`/`get_msg()` methods in `rover-client` that did ANSI styling and hyperlink markup via `rover_std::Style`/`hyperlink`.

This was CLI presentation, not client logic. These are now moved upward with no behavior change.