### PR TITLE
REG-1909: Adds `rover subgraph preview`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover contract preview` previews a contract by applying include/exclude/hide-unreachable-types filters to a graph variant's current composed schema, without publishing a contract variant. It runs asynchronously on the server; by default Rover polls until the build completes (or `APOLLO_CHECKS_TIMEOUT_SECONDS` elapses), or pass `--async` to just start the build and check on it later with `--build-id`. Exits non-zero if composition or filtering fails.
 
+- **Add `rover subgraph preview` - @sirdodger**
+
+  `rover subgraph preview` composes a preview supergraph from hypothetical subgraph changes described by a `--subgraph-changes` YAML file (add/update a subgraph's schema or routing URL, or mark one `remove: true`), with optional include/exclude/hide-unreachable-types contract filters, without publishing anything. It runs asynchronously on the server; by default Rover polls until the build completes (or `APOLLO_CHECKS_TIMEOUT_SECONDS` elapses), or pass `--async` to just start the build and check on it later with `--build-id`. Exits non-zero if composition or filtering fails.
+
+  `rover subgraph delete`'s pre-confirmation build-error check now runs through this same async preview path instead of a synchronous dry-run mutation, avoiding a long-held server connection (and its timeout risk) while previewing the deletion of a subgraph from a large supergraph.
+
 ## 🐛 Fixes
 
 - **Surface the underlying GraphQL errors when a response has no `data` field - @sirdodger**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7195,7 +7195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",

--- a/crates/rover-client/src/operations/subgraph/delete/delete_mutation.graphql
+++ b/crates/rover-client/src/operations/subgraph/delete/delete_mutation.graphql
@@ -2,13 +2,11 @@ mutation SubgraphDeleteMutation(
   $graph_id: ID!
   $variant: String!
   $subgraph: String!
-  $dry_run: Boolean!
 ) {
   graph(id: $graph_id) {
     removeImplementingServiceAndTriggerComposition(
       graphVariant: $variant
       name: $subgraph
-      dryRun: $dry_run
     ) {
       errors {
         message

--- a/crates/rover-client/src/operations/subgraph/delete/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/mod.rs
@@ -1,5 +1,5 @@
 mod runner;
 mod types;
 
-pub use runner::run;
+pub use runner::{check, run};
 pub use types::{SubgraphDeleteInput, SubgraphDeleteResponse};

--- a/crates/rover-client/src/operations/subgraph/delete/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/runner.rs
@@ -1,8 +1,17 @@
 use apollo_federation_types::rover::{BuildError, BuildErrors};
 use graphql_client::*;
 use rover_studio::types::GraphRef;
+use tower::{Service, ServiceExt};
 
-use crate::{blocking::StudioClient, operations::subgraph::delete::types::*, RoverClientError};
+use crate::{
+    blocking::StudioClient,
+    operations::subgraph::{
+        delete::types::*,
+        preview::{ComposeAndFilterPreviewInput, SubgraphChange},
+    },
+    shared::{AsyncBuildStatus, PreviewJobResponse},
+    RoverClientError,
+};
 
 #[derive(GraphQLQuery)]
 // The paths are relative to the directory where your `Cargo.toml` is located.
@@ -28,6 +37,42 @@ pub async fn run(
     let response_data = client.post::<SubgraphDeleteMutation>(input.into()).await?;
     let data = get_delete_data_from_response(response_data, graph_ref)?;
     Ok(build_response(data))
+}
+
+/// Preview the composition impact of deleting a subgraph, via the same async
+/// `composeAndFilterPreviewAsync` build `rover subgraph preview` uses, using
+/// an already-composed `Service`.
+pub async fn check<S>(
+    input: SubgraphDeleteInput,
+    mut run_service: S,
+) -> Result<SubgraphDeleteResponse, RoverClientError>
+where
+    S: Service<
+        ComposeAndFilterPreviewInput,
+        Response = PreviewJobResponse,
+        Error = RoverClientError,
+    >,
+{
+    let service = run_service.ready().await?;
+    let preview_response = service
+        .call(ComposeAndFilterPreviewInput {
+            graph_ref: input.graph_ref,
+            filter_config: None,
+            subgraph_changes: vec![SubgraphChange {
+                name: input.subgraph,
+                info: None,
+            }],
+        })
+        .await?;
+
+    Ok(SubgraphDeleteResponse {
+        supergraph_was_updated: preview_response.status == AsyncBuildStatus::Success,
+        build_errors: preview_response
+            .errors
+            .into_iter()
+            .map(|message| BuildError::composition_error(None, Some(message), None, None))
+            .collect(),
+    })
 }
 
 fn get_delete_data_from_response(
@@ -58,11 +103,94 @@ fn build_response(response: MutationComposition) -> SubgraphDeleteResponse {
     }
 }
 
+#[cfg(any(test, feature = "testing"))]
+pub mod mock {
+    use super::{ComposeAndFilterPreviewInput, PreviewJobResponse, RoverClientError};
+
+    rover_tower::mock_service!(
+        ComposeAndFilterPreviewRun,
+        ComposeAndFilterPreviewInput,
+        PreviewJobResponse,
+        RoverClientError
+    );
+}
+
 #[cfg(test)]
 mod tests {
+    use futures::future;
+    use rover_tower::test::expect_poll_ready;
+    use rstest::{fixture, rstest};
     use serde_json::json;
+    use speculoos::prelude::*;
 
-    use super::*;
+    use super::{mock::MockComposeAndFilterPreviewRunService, *};
+    use crate::shared::AsyncBuildStatus;
+
+    #[fixture]
+    fn test_input() -> SubgraphDeleteInput {
+        SubgraphDeleteInput {
+            graph_ref: "test-graph@test-variant".parse().unwrap(),
+            subgraph: "accounts".to_string(),
+        }
+    }
+
+    fn preview_response(status: AsyncBuildStatus, errors: Vec<String>) -> PreviewJobResponse {
+        PreviewJobResponse {
+            graph_ref: "test-graph@test-variant".parse().unwrap(),
+            build_id: "build-123".to_string(),
+            status,
+            api_schema: None,
+            supergraph_schema: None,
+            errors,
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn check_reports_success_when_composition_succeeds(test_input: SubgraphDeleteInput) {
+        let mut mock = MockComposeAndFilterPreviewRunService::new();
+        expect_poll_ready!(mock);
+        mock.expect_call().return_once(|_| {
+            future::ready(Ok(preview_response(AsyncBuildStatus::Success, Vec::new())))
+        });
+
+        let response = check(test_input, mock).await;
+
+        assert_that!(response)
+            .is_ok()
+            .is_equal_to(SubgraphDeleteResponse {
+                supergraph_was_updated: true,
+                build_errors: BuildErrors::new(),
+            });
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn check_reports_build_errors_when_composition_fails(test_input: SubgraphDeleteInput) {
+        let mut mock = MockComposeAndFilterPreviewRunService::new();
+        expect_poll_ready!(mock);
+        mock.expect_call().return_once(|_| {
+            future::ready(Ok(preview_response(
+                AsyncBuildStatus::ComposeFailed,
+                vec!["accounts is required by products".to_string()],
+            )))
+        });
+
+        let response = check(test_input, mock).await;
+
+        assert_that!(response)
+            .is_ok()
+            .is_equal_to(SubgraphDeleteResponse {
+                supergraph_was_updated: false,
+                build_errors: vec![BuildError::composition_error(
+                    None,
+                    Some("accounts is required by products".to_string()),
+                    None,
+                    None,
+                )]
+                .into(),
+            });
+    }
 
     #[test]
     fn get_delete_data_from_response_works() {

--- a/crates/rover-client/src/operations/subgraph/delete/types.rs
+++ b/crates/rover-client/src/operations/subgraph/delete/types.rs
@@ -14,7 +14,6 @@ pub(crate) type MutationCompositionErrors = subgraph_delete_mutation::SubgraphDe
 pub struct SubgraphDeleteInput {
     pub graph_ref: GraphRef,
     pub subgraph: String,
-    pub dry_run: bool,
 }
 
 /// this struct contains all the info needed to print the result of the delete.
@@ -36,7 +35,6 @@ impl From<SubgraphDeleteInput> for MutationVariables {
             graph_id,
             variant,
             subgraph: input.subgraph,
-            dry_run: input.dry_run,
         }
     }
 }

--- a/crates/rover-client/src/operations/subgraph/preview/mod.rs
+++ b/crates/rover-client/src/operations/subgraph/preview/mod.rs
@@ -268,6 +268,22 @@ pub async fn poll(
         })
 }
 
+/// Builds the default `Service` for running a full compose-and-filter
+/// preview (start, then poll until finished), layered over `client`'s
+/// Studio GraphQL service.
+pub fn compose_and_filter_preview_run_service(
+    client: &StudioClient,
+    checks_timeout_seconds: u64,
+) -> impl Service<
+    ComposeAndFilterPreviewInput,
+    Response = PreviewJobResponse,
+    Error = RoverClientError,
+> + '_ {
+    tower::service_fn(move |input: ComposeAndFilterPreviewInput| {
+        run(input, client, checks_timeout_seconds)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/src/command/subgraph/delete.rs
+++ b/src/command/subgraph/delete.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use rover_client::operations::subgraph::delete::{self, SubgraphDeleteInput};
+use rover_client::operations::subgraph::{
+    delete::{self, SubgraphDeleteInput},
+    preview,
+};
 use rover_std::{Style, prompt};
 use serde::Serialize;
 
@@ -28,7 +31,11 @@ pub struct Delete {
 }
 
 impl Delete {
-    pub async fn run(&self, client_config: StudioClientConfig) -> RoverResult<RoverOutput> {
+    pub async fn run(
+        &self,
+        client_config: StudioClientConfig,
+        checks_timeout_seconds: u64,
+    ) -> RoverResult<RoverOutput> {
         let client = client_config.get_authenticated_client(&self.profile)?;
         eprintln!(
             "Checking for build errors resulting from deleting subgraph {} from {} using credentials from the {} profile.",
@@ -40,23 +47,20 @@ impl Delete {
         // this is probably the normal path -- preview a subgraph delete
         // and make the user confirm it manually.
         if !self.confirm {
-            let dry_run = true;
-            // run delete with dryRun, so we can preview build errors
-            let delete_dry_run_response = delete::run(
+            let delete_check_response = delete::check(
                 SubgraphDeleteInput {
                     graph_ref: self.graph.graph_ref.clone(),
                     subgraph: self.subgraph.subgraph_name.clone(),
-                    dry_run,
                 },
-                &client,
+                preview::compose_and_filter_preview_run_service(&client, checks_timeout_seconds),
             )
             .await?;
 
             RoverOutput::SubgraphDeleteResponse {
                 graph_ref: self.graph.graph_ref.clone(),
                 subgraph: self.subgraph.subgraph_name.clone(),
-                dry_run,
-                delete_response: delete_dry_run_response,
+                dry_run: true,
+                delete_response: delete_check_response,
             }
             .get_stdout()?;
 
@@ -67,13 +71,10 @@ impl Delete {
             }
         }
 
-        let dry_run = false;
-
         let delete_response = delete::run(
             SubgraphDeleteInput {
                 graph_ref: self.graph.graph_ref.clone(),
                 subgraph: self.subgraph.subgraph_name.clone(),
-                dry_run,
             },
             &client,
         )
@@ -82,7 +83,7 @@ impl Delete {
         Ok(RoverOutput::SubgraphDeleteResponse {
             graph_ref: self.graph.graph_ref.clone(),
             subgraph: self.subgraph.subgraph_name.clone(),
-            dry_run,
+            dry_run: false,
             delete_response,
         })
     }

--- a/src/command/subgraph/mod.rs
+++ b/src/command/subgraph/mod.rs
@@ -4,6 +4,7 @@ mod fetch;
 pub mod introspect;
 mod lint;
 mod list;
+mod preview;
 mod publish;
 
 use clap::Parser;
@@ -20,17 +21,20 @@ pub struct Subgraph {
 
 #[derive(Debug, Serialize, Parser)]
 pub enum Command {
-    /// Check for build errors and breaking changes caused by an updated subgraph schema
-    /// against the federated graph in the Apollo graph registry
+    /// Check for build errors and breaking changes caused by an updated
+    /// subgraph schema against the federated graph in the Apollo graph
+    /// registry
     Check(check::Check),
 
-    /// Delete a subgraph from the Apollo registry and trigger composition in the graph router
+    /// Delete a subgraph from the Apollo registry and trigger composition in
+    /// the graph router
     Delete(delete::Delete),
 
     /// Fetch a subgraph schema from the Apollo graph registry
     Fetch(fetch::Fetch),
 
-    /// Introspect a running subgraph endpoint to retrieve its schema definition (SDL)
+    /// Introspect a running subgraph endpoint to retrieve its schema
+    /// definition (SDL)
     Introspect(introspect::Introspect),
 
     /// Lint a subgraph schema
@@ -39,7 +43,12 @@ pub enum Command {
     /// List all subgraphs for a federated graph
     List(list::List),
 
-    /// Publish an updated subgraph schema to the Apollo graph registry and trigger composition in the graph router
+    /// Preview the supergraph schema (and optionally a contract filter)
+    /// produced by hypothetical subgraph changes (without publishing them)
+    Preview(preview::Preview),
+
+    /// Publish an updated subgraph schema to the Apollo graph registry and
+    /// trigger composition in the graph router
     Publish(publish::Publish),
 }
 
@@ -57,7 +66,7 @@ impl Subgraph {
                     .run(client_config, git_context, checks_timeout_seconds)
                     .await
             }
-            Command::Delete(command) => command.run(client_config).await,
+            Command::Delete(command) => command.run(client_config, checks_timeout_seconds).await,
             Command::Introspect(command) => {
                 command
                     .run(
@@ -70,6 +79,15 @@ impl Subgraph {
             Command::Fetch(command) => command.run(client_config).await,
             Command::Lint(command) => command.run(client_config).await,
             Command::List(command) => command.run(client_config).await,
+            Command::Preview(command) => {
+                command
+                    .run(
+                        client_config,
+                        checks_timeout_seconds,
+                        &rover_print::print::stderr::default(),
+                    )
+                    .await
+            }
             Command::Publish(command) => {
                 command
                     .run(client_config, git_context, checks_timeout_seconds)

--- a/src/command/subgraph/preview/mod.rs
+++ b/src/command/subgraph/preview/mod.rs
@@ -1,0 +1,498 @@
+mod output;
+
+use std::collections::BTreeMap;
+
+use anyhow::anyhow;
+use camino::Utf8PathBuf;
+use clap::{ArgGroup, Parser};
+use output::SubgraphPreviewOutput;
+use rover_client::operations::subgraph::preview::{
+    self, ComposeAndFilterPreviewInput, ComposeAndFilterPreviewStatusInput, ContractFilterConfig,
+    SubgraphChange, SubgraphChangeInfo,
+};
+use rover_print::{
+    print::{Print, PrintExt},
+    style::{Style, StyledText},
+};
+use rover_std::Fs;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    RoverError, RoverOutput, RoverResult,
+    options::{GraphRefOpt, ProfileOpt},
+    utils::{client::StudioClientConfig, parsers::FileDescriptorType},
+};
+
+#[derive(Debug, Serialize, Parser)]
+#[clap(
+    group = ArgGroup::new("include_tags_group")
+        .args(&["include_tag", "no_include_tags"]),
+    group = ArgGroup::new("exclude_tags_group")
+        .args(&["exclude_tag", "no_exclude_tags"]),
+    group = ArgGroup::new("hide_unreachable_types_group")
+        .args(&["hide_unreachable_types", "no_hide_unreachable_types"])
+)]
+pub struct Preview {
+    /// Required to identify graph and check permissions even though buildId is unique.
+    #[clap(flatten)]
+    graph: GraphRefOpt,
+
+    #[clap(flatten)]
+    profile: ProfileOpt,
+
+    /// Preview with these subgraphs hypothetically changed or removed first,
+    /// as described by a YAML file (or `-` for stdin).
+    ///
+    /// The file has a `subgraphs` map keyed by subgraph name, e.g.:
+    ///
+    ///   subgraphs:
+    ///     foo:
+    ///       routing_url: https://example.com  # optional; omit to keep the existing URL
+    ///       schema:
+    ///         file: ./foo.graphql              # or `sdl: "type Query { ... }"` inline
+    ///     bar:
+    ///       remove: true
+    ///
+    /// A subgraph entry may set `remove: true` to preview composition as if
+    /// the subgraph had been removed.
+    #[arg(long = "subgraph-changes", value_name = "FILE", verbatim_doc_comment)]
+    #[serde(skip_serializing)]
+    subgraph_changes_file: Option<FileDescriptorType>,
+
+    /// List of tag names to include in the previewed contract schema (e.g. '--include-tag foo --include-tag bar').
+    /// Omit all of --include-tag/--exclude-tag/--hide-unreachable-types (and their --no-* counterparts)
+    /// to preview composition only, with no filtering applied.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    include_tag: Vec<String>,
+
+    /// Use an empty include list of tag names for the previewed contract schema.
+    /// To specify a non-empty list, use --include-tag instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    no_include_tags: bool,
+
+    /// List of tag names to exclude from the previewed contract schema (e.g. '--exclude-tag foo --exclude-tag bar').
+    /// To specify an empty list, use --no-exclude-tags instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    exclude_tag: Vec<String>,
+
+    /// Use an empty exclude list of tag names for the previewed contract schema.
+    /// To specify a non-empty list, use --exclude-tag instead.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    no_exclude_tags: bool,
+
+    /// Automatically hide types that can never be reached in operations on the previewed contract schema.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    hide_unreachable_types: bool,
+
+    /// Do not automatically hide types that can never be reached in operations on the previewed contract schema.
+    #[arg(long)]
+    #[serde(skip_serializing)]
+    no_hide_unreachable_types: bool,
+
+    /// Start the build and return immediately with a job ID, instead of
+    /// waiting for it to complete.
+    ///
+    /// Omit this flag to have Rover poll for the preview to complete.
+    /// Polling will timeout after APOLLO_CHECKS_TIMEOUT_SECONDS
+    #[arg(long = "async")]
+    asynchronous: bool,
+
+    /// Check the status of a previously started job instead of starting a new
+    /// one. Checks once, without polling.
+    #[arg(
+        long = "build-id",
+        conflicts_with_all = [
+            "asynchronous",
+            "include_tag",
+            "no_include_tags",
+            "exclude_tag",
+            "no_exclude_tags",
+            "hide_unreachable_types",
+            "no_hide_unreachable_types",
+            "subgraph_changes_file",
+        ]
+    )]
+    build_id: Option<String>,
+}
+
+/// The `--subgraph-changes` file format: a `subgraphs` map keyed by subgraph
+/// name. Modeled after `supergraph.yaml`'s `subgraphs` map but unlike that
+/// format, fields are optional and keep existing values if omitted, has an
+/// explicit `remove` field, and `schema` only supports inline SDL or a local
+/// file (not a remote URL)
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SubgraphChangesFile {
+    subgraphs: BTreeMap<String, SubgraphChangeEntry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SubgraphChangeEntry {
+    #[serde(default)]
+    remove: bool,
+    routing_url: Option<String>,
+    schema: Option<SubgraphSchemaSource>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SubgraphSchemaSource {
+    File { file: Utf8PathBuf },
+    Sdl { sdl: String },
+}
+
+impl SubgraphSchemaSource {
+    fn read(self, subgraph_name: &str) -> RoverResult<String> {
+        match self {
+            SubgraphSchemaSource::Sdl { sdl } => Ok(sdl),
+            SubgraphSchemaSource::File { file } => Fs::read_file(&file).map_err(|err| {
+                RoverError::new(anyhow!(
+                    "Could not read schema file for subgraph '{subgraph_name}': {err}"
+                ))
+            }),
+        }
+    }
+}
+
+impl SubgraphChangeEntry {
+    fn into_subgraph_change(self, name: String) -> RoverResult<SubgraphChange> {
+        if self.remove {
+            if self.routing_url.is_some() || self.schema.is_some() {
+                return Err(RoverError::new(anyhow!(
+                    "Subgraph '{name}' has `remove: true` but also specifies routing_url/schema — a removed subgraph can't also have changes."
+                )));
+            }
+            return Ok(SubgraphChange { name, info: None });
+        }
+
+        let schema_document = self.schema.map(|source| source.read(&name)).transpose()?;
+
+        if self.routing_url.is_none() && schema_document.is_none() {
+            return Err(RoverError::new(anyhow!(
+                "Subgraph '{name}' in --subgraph-changes must specify at least one of routing_url, schema, or remove: true."
+            )));
+        }
+
+        Ok(SubgraphChange {
+            name,
+            info: Some(SubgraphChangeInfo {
+                routing_url: self.routing_url,
+                schema_document,
+            }),
+        })
+    }
+}
+
+impl Preview {
+    pub async fn run(
+        &self,
+        client_config: StudioClientConfig,
+        checks_timeout_seconds: u64,
+        stderr: &impl Print,
+    ) -> RoverResult<RoverOutput> {
+        let client = client_config.get_authenticated_client(&self.profile)?;
+        let graph_ref = self.graph.graph_ref.clone();
+
+        if let Some(build_id) = &self.build_id {
+            stderr.print(&StyledText::plain(format!(
+                "Checking status of subgraph preview job {} on {} using credentials from the {} profile.",
+                stderr.paint(Style::Link, build_id),
+                stderr.paint(Style::Link, graph_ref.to_string()),
+                stderr.paint(Style::Command, &self.profile.profile_name)
+            )));
+            let preview_response = preview::result(
+                ComposeAndFilterPreviewStatusInput {
+                    graph_ref,
+                    build_id: build_id.clone(),
+                },
+                preview::compose_and_filter_preview_result_service(&client)?,
+            )
+            .await?;
+            return Ok(RoverOutput::CliOutput(Box::new(SubgraphPreviewOutput(
+                preview_response,
+            ))));
+        }
+
+        stderr.print(&StyledText::plain(format!(
+            "Previewing composed schema for {} using credentials from the {} profile.",
+            stderr.paint(Style::Link, graph_ref.to_string()),
+            stderr.paint(Style::Command, &self.profile.profile_name)
+        )));
+
+        let input = ComposeAndFilterPreviewInput {
+            graph_ref: graph_ref.clone(),
+            filter_config: self.filter_config()?,
+            subgraph_changes: self.subgraph_changes()?,
+        };
+        let started = preview::start(
+            input,
+            preview::compose_and_filter_preview_start_service(&client)?,
+        )
+        .await?;
+
+        if self.asynchronous {
+            return Ok(RoverOutput::CliOutput(Box::new(SubgraphPreviewOutput(
+                started,
+            ))));
+        }
+
+        stderr.print(&StyledText::plain(format!(
+            "Waiting for the preview to complete... or press Ctrl+C and check later with {}.",
+            stderr.paint(
+                Style::Command,
+                format!(
+                    "`rover subgraph preview {} --build-id {}`",
+                    graph_ref, started.build_id
+                )
+            )
+        )));
+
+        let preview_response = preview::poll(
+            ComposeAndFilterPreviewStatusInput {
+                graph_ref,
+                build_id: started.build_id,
+            },
+            &client,
+            checks_timeout_seconds,
+        )
+        .await?;
+
+        Ok(RoverOutput::CliOutput(Box::new(SubgraphPreviewOutput(
+            preview_response,
+        ))))
+    }
+
+    /// Builds the filter config from the paired include/exclude/hide flags.
+    /// Omitting all six is allowed (compose-only preview, no filtering).
+    /// Supplying any one of the three pairs requires all three.
+    fn filter_config(&self) -> RoverResult<Option<ContractFilterConfig>> {
+        let no_filter_flags_given = self.include_tag.is_empty()
+            && !self.no_include_tags
+            && self.exclude_tag.is_empty()
+            && !self.no_exclude_tags
+            && !self.hide_unreachable_types
+            && !self.no_hide_unreachable_types;
+
+        if no_filter_flags_given {
+            return Ok(None);
+        }
+
+        if self.include_tag.is_empty() && !self.no_include_tags {
+            return Err(RoverError::new(anyhow!(
+                "You must specify either --include-tag <TAG> or --no-include-tags."
+            )));
+        }
+        if self.exclude_tag.is_empty() && !self.no_exclude_tags {
+            return Err(RoverError::new(anyhow!(
+                "You must specify either --exclude-tag <TAG> or --no-exclude-tags."
+            )));
+        }
+        if !self.hide_unreachable_types && !self.no_hide_unreachable_types {
+            return Err(RoverError::new(anyhow!(
+                "You must specify either --hide-unreachable-types or --no-hide-unreachable-types."
+            )));
+        }
+        Ok(Some(ContractFilterConfig {
+            include: self.include_tag.clone(),
+            exclude: self.exclude_tag.clone(),
+            hide_unreachable_types: self.hide_unreachable_types,
+        }))
+    }
+
+    /// Parse `--subgraph-changes` into the list of per-subgraph changes to preview.
+    fn subgraph_changes(&self) -> RoverResult<Vec<SubgraphChange>> {
+        let Some(file_descriptor) = &self.subgraph_changes_file else {
+            return Ok(Vec::new());
+        };
+
+        let contents =
+            file_descriptor.read_file_descriptor("subgraph changes", &mut std::io::stdin())?;
+
+        let parsed: SubgraphChangesFile = serde_yaml::from_str(&contents)
+            .map_err(|err| RoverError::new(anyhow!("Invalid --subgraph-changes file: {err}")))?;
+
+        parsed
+            .subgraphs
+            .into_iter()
+            .map(|(name, entry)| entry.into_subgraph_change(name))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_fs::prelude::*;
+
+    use super::*;
+
+    /// A `Preview` with no filter flags and no `--subgraph-changes` file, the
+    /// "compose only" baseline. Individual tests override one field at a
+    /// time to exercise each validation branch.
+    fn valid_preview() -> Preview {
+        Preview {
+            graph: GraphRefOpt {
+                graph_ref: "test-graph@current".parse().unwrap(),
+            },
+            profile: ProfileOpt::default(),
+            subgraph_changes_file: None,
+            include_tag: Vec::new(),
+            no_include_tags: false,
+            exclude_tag: Vec::new(),
+            no_exclude_tags: false,
+            hide_unreachable_types: false,
+            no_hide_unreachable_types: false,
+            asynchronous: false,
+            build_id: None,
+        }
+    }
+
+    #[test]
+    fn filter_config_is_none_when_no_flags_are_given() {
+        assert_eq!(valid_preview().filter_config().unwrap(), None);
+    }
+
+    #[test]
+    fn filter_config_builds_config_when_all_three_pairs_are_decided() {
+        let preview = Preview {
+            include_tag: vec!["foo".to_string()],
+            no_exclude_tags: true,
+            hide_unreachable_types: true,
+            ..valid_preview()
+        };
+        let config = preview.filter_config().unwrap().unwrap();
+        assert_eq!(config.include, vec!["foo".to_string()]);
+        assert_eq!(config.exclude, Vec::<String>::new());
+        assert!(config.hide_unreachable_types);
+    }
+
+    #[test]
+    fn filter_config_errors_when_only_some_of_the_pairs_are_decided() {
+        // --no-include-tags is decided, but exclude/hide are left ambiguous;
+        // supplying any one flag requires all three to be decided.
+        let preview = Preview {
+            no_include_tags: true,
+            ..valid_preview()
+        };
+        let err = preview.filter_config().unwrap_err();
+        assert!(err.to_string().contains("--exclude-tag"));
+    }
+
+    #[test]
+    fn subgraph_changes_is_empty_without_a_file() {
+        assert_eq!(valid_preview().subgraph_changes().unwrap(), Vec::new());
+    }
+
+    /// Writes `contents` to a temp `--subgraph-changes` file and returns a
+    /// `Preview` pointed at it. The `TempDir` must outlive the returned
+    /// `Preview`'s use, hence returning both.
+    fn preview_with_changes_file(contents: &str) -> (assert_fs::TempDir, Preview) {
+        let fixture = assert_fs::TempDir::new().unwrap();
+        let file = fixture.child("subgraph-changes.yaml");
+        file.write_str(contents).unwrap();
+        let path = Utf8PathBuf::try_from(file.path().to_path_buf()).unwrap();
+        let preview = Preview {
+            subgraph_changes_file: Some(FileDescriptorType::File(path)),
+            ..valid_preview()
+        };
+        (fixture, preview)
+    }
+
+    #[test]
+    fn subgraph_changes_parses_inline_sdl_and_routing_url() {
+        let (_fixture, preview) = preview_with_changes_file(
+            "subgraphs:\n  foo:\n    routing_url: https://example.com\n    schema:\n      sdl: \"type Query { hello: String }\"\n",
+        );
+
+        let changes = preview.subgraph_changes().unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].name, "foo");
+        let info = changes[0].info.as_ref().unwrap();
+        assert_eq!(info.routing_url, Some("https://example.com".to_string()));
+        assert_eq!(
+            info.schema_document,
+            Some("type Query { hello: String }".to_string())
+        );
+    }
+
+    #[test]
+    fn subgraph_changes_reads_schema_from_a_file_path() {
+        let fixture = assert_fs::TempDir::new().unwrap();
+        let schema_file = fixture.child("foo.graphql");
+        schema_file.write_str("type Query { hi: String }").unwrap();
+
+        let changes_file = fixture.child("subgraph-changes.yaml");
+        changes_file
+            .write_str(&format!(
+                "subgraphs:\n  foo:\n    schema:\n      file: {}\n",
+                schema_file.path().display()
+            ))
+            .unwrap();
+        let path = Utf8PathBuf::try_from(changes_file.path().to_path_buf()).unwrap();
+        let preview = Preview {
+            subgraph_changes_file: Some(FileDescriptorType::File(path)),
+            ..valid_preview()
+        };
+
+        let changes = preview.subgraph_changes().unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(
+            changes[0].info.as_ref().unwrap().schema_document,
+            Some("type Query { hi: String }".to_string())
+        );
+    }
+
+    #[test]
+    fn subgraph_changes_parses_remove() {
+        let (_fixture, preview) =
+            preview_with_changes_file("subgraphs:\n  bar:\n    remove: true\n");
+
+        let changes = preview.subgraph_changes().unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].name, "bar");
+        assert_eq!(changes[0].info, None);
+    }
+
+    #[test]
+    fn subgraph_changes_rejects_remove_combined_with_routing_url() {
+        let (_fixture, preview) = preview_with_changes_file(
+            "subgraphs:\n  bar:\n    remove: true\n    routing_url: https://example.com\n",
+        );
+
+        let err = preview.subgraph_changes().unwrap_err();
+        assert!(err.to_string().contains("remove: true"));
+    }
+
+    #[test]
+    fn subgraph_changes_rejects_an_entry_with_no_fields_set() {
+        let (_fixture, preview) = preview_with_changes_file("subgraphs:\n  bar: {}\n");
+
+        let err = preview.subgraph_changes().unwrap_err();
+        assert!(err.to_string().contains("must specify at least one of"));
+    }
+
+    #[test]
+    fn subgraph_changes_rejects_unknown_top_level_keys() {
+        // `subgraph:` (singular) instead of `subgraphs:` should error rather
+        // than silently produce an empty change list.
+        let (_fixture, preview) =
+            preview_with_changes_file("subgraph:\n  bar:\n    remove: true\n");
+
+        let err = preview.subgraph_changes().unwrap_err();
+        assert!(err.to_string().contains("Invalid --subgraph-changes file"));
+    }
+
+    #[test]
+    fn subgraph_changes_rejects_unknown_entry_fields() {
+        let (_fixture, preview) =
+            preview_with_changes_file("subgraphs:\n  bar:\n    routing_ur: https://example.com\n");
+
+        let err = preview.subgraph_changes().unwrap_err();
+        assert!(err.to_string().contains("Invalid --subgraph-changes file"));
+    }
+}

--- a/src/command/subgraph/preview/output.rs
+++ b/src/command/subgraph/preview/output.rs
@@ -1,0 +1,154 @@
+use rover_client::shared::{AsyncBuildStatus, PreviewJobResponse};
+use rover_std::Style;
+
+use crate::command::CliOutput;
+
+/// [`CliOutput`] implementation for `rover subgraph preview`.
+#[derive(Debug)]
+pub(super) struct SubgraphPreviewOutput(pub(super) PreviewJobResponse);
+
+impl CliOutput for SubgraphPreviewOutput {
+    fn exit_code(&self) -> i32 {
+        match self.0.status {
+            AsyncBuildStatus::ComposeFailed | AsyncBuildStatus::FilterFailed => 1,
+            AsyncBuildStatus::Pending | AsyncBuildStatus::Running | AsyncBuildStatus::Success => 0,
+        }
+    }
+
+    fn text(&self) -> String {
+        let preview_response = &self.0;
+        let mut lines = vec![
+            format!("Build id: {}", &preview_response.build_id),
+            format!("Status: {}", &preview_response.status),
+        ];
+        match preview_response.status {
+            AsyncBuildStatus::Pending | AsyncBuildStatus::Running => {
+                let hint = format!(
+                    "`rover subgraph preview {} --build-id {}`",
+                    preview_response.graph_ref, preview_response.build_id
+                );
+                lines.push(format!(
+                    "Check the result with {}",
+                    Style::Command.paint(hint)
+                ));
+            }
+            AsyncBuildStatus::Success => {
+                if let Some(api_schema) = &preview_response.api_schema {
+                    lines.push("Schema:".to_string());
+                    lines.push(String::new());
+                    lines.push(api_schema.clone());
+                }
+            }
+            AsyncBuildStatus::ComposeFailed | AsyncBuildStatus::FilterFailed => {
+                lines.extend(preview_response.errors.iter().cloned());
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use rover_studio::types::GraphRef;
+    use serde_json::json;
+
+    use super::*;
+
+    fn response(status: AsyncBuildStatus) -> PreviewJobResponse {
+        PreviewJobResponse {
+            graph_ref: GraphRef::new("my-graph", Some("current")).unwrap(),
+            build_id: "build-123".to_string(),
+            status,
+            api_schema: None,
+            supergraph_schema: None,
+            errors: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn exit_code_is_zero_for_in_progress_and_success_statuses() {
+        for status in [
+            AsyncBuildStatus::Pending,
+            AsyncBuildStatus::Running,
+            AsyncBuildStatus::Success,
+        ] {
+            assert_eq!(SubgraphPreviewOutput(response(status)).exit_code(), 0);
+        }
+    }
+
+    #[test]
+    fn exit_code_is_nonzero_for_terminal_failure_statuses() {
+        for status in [
+            AsyncBuildStatus::ComposeFailed,
+            AsyncBuildStatus::FilterFailed,
+        ] {
+            assert_eq!(SubgraphPreviewOutput(response(status)).exit_code(), 1);
+        }
+    }
+
+    #[test]
+    fn text_for_pending_hints_at_checking_back_with_the_build_id() {
+        let text = temp_env::with_var("NO_COLOR", Some("1"), || {
+            SubgraphPreviewOutput(response(AsyncBuildStatus::Pending)).text()
+        });
+        assert_eq!(
+            text,
+            indoc! {"
+                Build id: build-123
+                Status: PENDING
+                Check the result with `rover subgraph preview my-graph@current --build-id build-123`"}
+        );
+    }
+
+    #[test]
+    fn text_for_success_includes_the_schema() {
+        let mut mock_response = response(AsyncBuildStatus::Success);
+        mock_response.api_schema = Some("type Query { hello: String }".to_string());
+        let text = SubgraphPreviewOutput(mock_response).text();
+        assert_eq!(
+            text,
+            indoc! {"
+                Build id: build-123
+                Status: SUCCESS
+                Schema:
+
+                type Query { hello: String }"}
+        );
+    }
+
+    #[test]
+    fn text_for_failure_includes_the_errors() {
+        let mut mock_response = response(AsyncBuildStatus::ComposeFailed);
+        mock_response.errors = vec!["[Accounts] -> Things went really wrong".to_string()];
+        let text = SubgraphPreviewOutput(mock_response).text();
+        assert_eq!(
+            text,
+            indoc! {"
+                Build id: build-123
+                Status: COMPOSE_FAILED
+                [Accounts] -> Things went really wrong"}
+        );
+    }
+
+    #[test]
+    fn json_serializes_the_response() {
+        let response_json = SubgraphPreviewOutput(response(AsyncBuildStatus::Success))
+            .json()
+            .unwrap();
+        assert_eq!(
+            response_json,
+            json!({
+                "build_id": "build-123",
+                "status": "SUCCESS",
+                "api_schema": null,
+                "supergraph_schema": null,
+                "errors": []
+            })
+        );
+    }
+}


### PR DESCRIPTION
REG-1909 Subgraph Preview 3a

CLI-consumer PR (stacked on REG-1909 Subgraph Preview 2a) wiring up rover subgraph preview, and swapping rover subgraph delete's pre-confirmation check to use it.

rover subgraph preview composes a preview supergraph from hypothetical subgraph changes described by a --subgraph-changes YAML file (add/update a subgraph's schema or routing URL, or mark one remove: true), with optional contract filters, without publishing anything. Same async/--build-id/poll UX and non-zero exit-on-failure as rover contract preview (REG-1909 Contract Preview 3b).
rover subgraph delete's pre-confirmation build-error check now runs through this same async preview path (delete::check) instead of a synchronous removeImplementingServiceAndTriggerComposition(dryRun: true) call. Holding that dry-run mutation open for the duration of composition blocked the server connection and risked timing out on large supergraphs — the same reason this whole feature is async.
This swap touches crates/rover-client/src/operations/subgraph/delete/* (a breaking change to the existing SubgraphDeleteInput/runner shape) as well as the CLI. It's bundled into this PR rather than the crate-impl PR (REG-1909 Subgraph Preview 2a) because splitting it further would leave an intermediate commit in the stack that doesn't build (the rover binary crate's existing subgraph delete command depends on the old shape until this PR's CLI change lands).
Output rendering goes through a dedicated SubgraphPreviewOutput: CliOutput struct (src/command/subgraph/preview/output.rs) rather than a new RoverOutput variant, per AGENTS.md.
Also brings this command's print calls up to date with the simplified rover-print Print::print signature that landed on main after this branch was first written.

[ ] A CHANGELOG.md entry is not needed for this PR