### PR TITLE
Hoist PersistedQueriesOperationCounts text rendering out of rover-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🛠 Maintenance
 
-- **Relocate `latest_plugin_versions.json` ownership to orbiter - @dotdat**
+- **Stop baking "N operation(s)" text into a `rover-client` type - @dotdat**
+
+  `PersistedQueriesOperationCounts::added_str()`/`updated_str()`/`removed_str()` (and the `ops_str()` helper behind them) pre-rendered "N operation(s)" text inside `rover-client` for one caller — `persisted-queries publish`'s text output — the same pattern this repo already moved off of for `graph check`/`subgraph check`. They're removed; `rover-client`'s `PersistedQueriesOperationCounts` now only carries the raw counts, and `src/command/output.rs` renders the text itself via the `pluralizer` crate. Same rendered output, no user-facing change.
 
   Rover's bundled copy of `latest_plugin_versions.json` has been deleted and its behavior has been moved into the Orbiter service, its only real consumer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Stop baking "N operation(s)" text into a `rover-client` type - @dotdat**
 
-  `PersistedQueriesOperationCounts::added_str()`/`updated_str()`/`removed_str()` (and the `ops_str()` helper behind them) pre-rendered "N operation(s)" text inside `rover-client` for one caller — `persisted-queries publish`'s text output — the same pattern this repo already moved off of for `graph check`/`subgraph check`. They're removed; `rover-client`'s `PersistedQueriesOperationCounts` now only carries the raw counts, and `src/command/output.rs` renders the text itself via the `pluralizer` crate. Same rendered output, no user-facing change.
+  Removes pluralization print concerns from rover-client and hoists them into the binary
+
+- **latest_plugin_versions.json migration - @dotdat**
 
   Rover's bundled copy of `latest_plugin_versions.json` has been deleted and its behavior has been moved into the Orbiter service, its only real consumer.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba91f619216e76a5eb2515783f7ec2e271938b51aadac592f4930517f4626863"
 dependencies = [
  "heck",
- "indexmap 1.9.3",
+ "indexmap 2.14.1",
  "itertools 0.15.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2131,7 +2131,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2274,7 +2274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3513,7 +3513,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4343,7 +4343,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4843,7 +4843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5055,6 +5055,16 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "polling"
@@ -5328,7 +5338,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5753,6 +5763,7 @@ dependencies = [
  "mockall",
  "opener",
  "os_info",
+ "pluralizer",
  "portpicker",
  "predicates",
  "rand 0.10.2",
@@ -6158,7 +6169,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6171,7 +6182,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6229,7 +6240,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7195,10 +7206,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7243,7 +7254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8294,7 +8305,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ os_type = "2"
 pathfinding = "4"
 pastey = "0.2.1"
 pin-project = "1.1.10"
+pluralizer = "0.5.0"
 predicates = "3"
 pretty_assertions = "1"
 rand = "0.10"
@@ -284,6 +285,7 @@ lazycell = { workspace = true }
 lazy_static = { workspace = true }
 opener = { workspace = true }
 os_info = { workspace = true }
+pluralizer = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/rover-client/src/operations/persisted_queries/publish/types.rs
+++ b/crates/rover-client/src/operations/persisted_queries/publish/types.rs
@@ -276,28 +276,8 @@ pub struct PersistedQueriesOperationCounts {
 }
 
 impl PersistedQueriesOperationCounts {
-    pub fn added_str(&self) -> Option<String> {
-        Self::ops_str(self.added)
-    }
-
-    pub fn updated_str(&self) -> Option<String> {
-        Self::ops_str(self.updated)
-    }
-
-    pub fn removed_str(&self) -> Option<String> {
-        Self::ops_str(self.removed)
-    }
-
     pub const fn total(&self) -> i64 {
         self.added + self.identical + self.unaffected + self.updated - self.removed
-    }
-
-    fn ops_str(n: i64) -> Option<String> {
-        match n {
-            0 => None,
-            1 => Some("1 operation".to_string()),
-            n => Some(format!("{n} operations")),
-        }
     }
 }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -7,6 +7,7 @@ use std::{
 use calm_io::{stderr, stderrln};
 use camino::Utf8PathBuf;
 use comfy_table::{Attribute::Bold, Cell, CellAlignment::Center};
+use pluralizer::pluralize;
 use rover_client::{
     RoverClientError,
     operations::{
@@ -169,6 +170,13 @@ pub enum RoverOutput {
         new_name: String,
     },
     CliOutput(Box<dyn CliOutput>),
+}
+
+/// Renders one of `PersistedQueriesOperationCounts`' fields as "N operation(s)"
+/// text, or `None` if the count is zero. Lives here rather than on the
+/// rover-client type itself since it's presentation logic, not client data.
+fn operation_count_str(n: i64) -> Option<String> {
+    (n != 0).then(|| pluralize("operation", n as isize, true))
 }
 
 impl RoverOutput {
@@ -523,9 +531,9 @@ impl RoverOutput {
                     let mut result = "Successfully ".to_string();
 
                     result.push_str(&match (
-                            response.operation_counts.added_str().map(|s| Style::Command.paint(s)),
-                            response.operation_counts.updated_str().map(|s| Style::Command.paint(s)),
-                            response.operation_counts.removed_str().map(|s| Style::Command.paint(s)),
+                            operation_count_str(response.operation_counts.added).map(|s| Style::Command.paint(s)),
+                            operation_count_str(response.operation_counts.updated).map(|s| Style::Command.paint(s)),
+                            operation_count_str(response.operation_counts.removed).map(|s| Style::Command.paint(s)),
                         ) {
                             (Some(added), Some(updated), Some(removed)) => format!(
                                 "added {added}, updated {updated}, and removed {removed}, creating"
@@ -2242,6 +2250,37 @@ View custom check details at: https://studio.apollographql.com/graph/my-graph/va
             "error": null
         });
         assert_json_eq!(expected_json, actual_json);
+    }
+
+    #[test]
+    fn pq_publish_new_revision_response_text() {
+        let operation_counts = PersistedQueriesOperationCounts {
+            added: 5,
+            identical: 3,
+            removed: 0,
+            unaffected: 2,
+            updated: 2,
+        };
+        let mock_publish_response = PersistedQueriesPublishResponse {
+            revision: 2,
+            graph_id: "graph_id".to_string(),
+            list_id: "list_id".to_string(),
+            list_name: "my list".to_string(),
+            total_published_operations: 10,
+            unchanged: false,
+            operation_counts,
+        };
+
+        let actual_text = RoverOutput::PersistedQueriesPublishResponse(mock_publish_response)
+            .get_stdout()
+            .expect("Expected response to be Ok")
+            .expect("Expected response to exist");
+        let actual_text = strip_ansi_codes(&actual_text);
+
+        assert_eq!(
+            actual_text,
+            "Successfully added 5 operations and updated 2 operations, creating revision 2 of my list, which contains 12 operations."
+        );
     }
 
     #[test]


### PR DESCRIPTION
Removing additional print concerns from `rover-client`