### PR TITLE
feat(persisted-queries): add `--preserve-comments` to `generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   `rover auth login --no-browser` uses the OAuth 2.0 Device Authorization Grant (RFC 8628) instead of the local browser/redirect-server flow: it prints a verification URL and code to enter from any device, then polls until you approve the request, for headless or browser-less environments. Ignores `--no-open`, since there's no local browser step to skip. The device authorization endpoint can be overridden with `--oauth-device-authorization-url`, matching the other OAuth endpoint overrides.
 
+- **Add `--preserve-comments` to `rover persisted-queries generate` - @ebylund**
+
+  Keeps the contiguous comment block directly above each operation in the generated operation body, instead of dropping it during normalization. Comments elsewhere in a document are still dropped. Off by default; manifests generated without the flag are byte-for-byte unchanged. Because an operation's ID is a hash of its body, enabling this changes the ID of every operation that has a preceding comment, so every client generating a manifest for the same graph must enable it too.
+
 - **Add `rover auth logout`, gated behind the experimental `oauth` feature flag - @dotdat**
 
   `rover auth logout` revokes the OAuth session stored by `rover auth login` for the given `--profile` (or "default") — the access token and, if one was issued, the refresh token (RFC 7009) — then removes the local credential. Revocation is best-effort: if the OAuth server can't be reached, Rover still clears the local credential and warns instead of leaving you stuck "logged in" locally. Only meaningful for profiles logged in via `rover auth login`; running it against a profile holding a Personal API Key (from `rover config auth`) errors and points you at `rover config delete` instead. Only compiled in when built with `--features oauth`, matching `rover auth login`.

--- a/src/command/persisted_queries/generate/manifest/mod.rs
+++ b/src/command/persisted_queries/generate/manifest/mod.rs
@@ -20,8 +20,11 @@ pub(super) struct PersistedQueryManifest {
 }
 
 impl PersistedQueryManifest {
-    pub(super) fn from_files(files: Vec<Utf8PathBuf>) -> RoverResult<Self> {
-        let parsed_inputs = ParsedInputs::from_files(files)?;
+    pub(super) fn from_files(
+        files: Vec<Utf8PathBuf>,
+        preserve_comments: bool,
+    ) -> RoverResult<Self> {
+        let parsed_inputs = ParsedInputs::from_files(files, preserve_comments)?;
         let operations = parsed_inputs.generate_operations()?;
         Ok(Self {
             format: MANIFEST_FORMAT,

--- a/src/command/persisted_queries/generate/manifest/operation/comments.rs
+++ b/src/command/persisted_queries/generate/manifest/operation/comments.rs
@@ -1,0 +1,112 @@
+/// Extracts the contiguous block of comment lines immediately preceding the
+/// definition that starts at `definition_offset` in `source`.
+///
+/// Any non-comment line, including a blank one, ends the block. Comment lines
+/// are returned in source order with surrounding whitespace trimmed, so the
+/// result is stable regardless of how the source was indented.
+///
+/// GraphQL treats comments as ignored tokens, so `apollo-compiler` discards
+/// them during parsing and they cannot be recovered from the AST. Reading them
+/// back out of the original source text is the only option, which is why this
+/// works on byte offsets rather than on parsed nodes.
+pub(super) fn extract_leading_comments(source: &str, definition_offset: usize) -> Option<String> {
+    let definition_line_start = source[..definition_offset]
+        .rfind('\n')
+        .map_or(0, |newline| newline + 1);
+
+    // Walk backwards over the run of comment lines directly above the
+    // definition, then restore top-to-bottom order.
+    let mut lines = Vec::new();
+    let mut cursor = definition_line_start;
+    while cursor > 0 {
+        let line_start = source[..cursor - 1]
+            .rfind('\n')
+            .map_or(0, |newline| newline + 1);
+        let line = source[line_start..cursor].trim();
+        if !line.starts_with('#') {
+            break;
+        }
+        lines.push(line);
+        cursor = line_start;
+    }
+
+    if lines.is_empty() {
+        return None;
+    }
+
+    lines.reverse();
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use speculoos::prelude::*;
+
+    use super::extract_leading_comments;
+
+    fn extract(source: &str) -> Option<String> {
+        let offset = source
+            .find("query ")
+            .expect("test source must contain an operation");
+        extract_leading_comments(source, offset)
+    }
+
+    #[test]
+    fn single_comment_line_is_extracted() {
+        assert_that!(extract("# @meta fci_tier: TIER_1\nquery GetFoo { id }"))
+            .is_equal_to(Some("# @meta fci_tier: TIER_1".to_string()));
+    }
+
+    #[test]
+    fn contiguous_comment_lines_keep_source_order() {
+        assert_that!(extract(
+            "# first\n# @meta fci_tier: TIER_1\n# last\nquery GetFoo { id }"
+        ))
+        .is_equal_to(Some(
+            "# first\n# @meta fci_tier: TIER_1\n# last".to_string(),
+        ));
+    }
+
+    #[test]
+    fn blank_line_ends_the_block() {
+        assert_that!(extract("# detached\n\nquery GetFoo { id }")).is_none();
+    }
+
+    #[test]
+    fn preceding_definition_ends_the_block() {
+        assert_that!(extract(
+            "# on the fragment\nfragment F on Product { id }\nquery GetFoo { ...F }"
+        ))
+        .is_none();
+    }
+
+    #[test]
+    fn indentation_is_normalized() {
+        assert_that!(extract("    # @meta fci_tier: TIER_1\nquery GetFoo { id }"))
+            .is_equal_to(Some("# @meta fci_tier: TIER_1".to_string()));
+    }
+
+    #[test]
+    fn carriage_returns_are_trimmed() {
+        assert_that!(extract("# @meta fci_tier: TIER_1\r\nquery GetFoo { id }"))
+            .is_equal_to(Some("# @meta fci_tier: TIER_1".to_string()));
+    }
+
+    #[test]
+    fn comment_on_the_first_line_is_extracted() {
+        assert_that!(extract("#@meta fci_tier: TIER_1\nquery GetFoo { id }"))
+            .is_equal_to(Some("#@meta fci_tier: TIER_1".to_string()));
+    }
+
+    #[test]
+    fn definition_on_the_first_line_has_no_comments() {
+        assert_that!(extract("query GetFoo { id }")).is_none();
+    }
+
+    #[test]
+    fn trailing_comment_from_a_previous_operation_is_not_captured() {
+        let source = "query GetBar { id } # trailing\nquery GetFoo { id }";
+        let offset = source.rfind("query ").unwrap();
+        assert_that!(extract_leading_comments(source, offset)).is_none();
+    }
+}

--- a/src/command/persisted_queries/generate/manifest/operation/mod.rs
+++ b/src/command/persisted_queries/generate/manifest/operation/mod.rs
@@ -1,3 +1,4 @@
+mod comments;
 mod parsed_fragment;
 mod parsed_inputs;
 mod parsed_operation;
@@ -18,16 +19,156 @@ mod tests {
     }
 
     fn parsed_inputs_from_files(files: &[(&str, &str)]) -> ParsedInputs {
+        parsed_inputs_from_files_with_comments(files, false)
+    }
+
+    fn parsed_inputs_from_files_with_comments(
+        files: &[(&str, &str)],
+        preserve_comments: bool,
+    ) -> ParsedInputs {
         let temp = tempfile::tempdir().unwrap();
         let mut inputs = ParsedInputs::default();
         for (filename, source) in files {
             let file = Utf8PathBuf::from_path_buf(temp.path().join(filename)).unwrap();
             std::fs::create_dir_all(file.parent().unwrap()).unwrap();
             std::fs::write(&file, source).unwrap();
-            let parsed_file = ParsedInputs::from_file(&file).unwrap();
+            let parsed_file = ParsedInputs::from_file(&file, preserve_comments).unwrap();
             inputs.merge(parsed_file).unwrap();
         }
         inputs
+    }
+
+    #[test]
+    fn preserved_comments_appear_above_the_operation_body() {
+        let inputs = parsed_inputs_from_files_with_comments(
+            &[(
+                "ops.graphql",
+                indoc::indoc! {"
+                    # Home feed entry point.
+                    # @meta fci_tier: TIER_1
+                    query GetHomeFeed($userId: ID!) {
+                      homeFeed(userId: $userId) { id }
+                    }
+                "},
+            )],
+            true,
+        );
+
+        let operations = inputs.generate_operations().unwrap();
+
+        assert_that!(operations.len()).is_equal_to(1);
+        assert_that!(operations[0].body.as_str()).is_equal_to(indoc::indoc! {"
+            # Home feed entry point.
+            # @meta fci_tier: TIER_1
+            query GetHomeFeed($userId: ID!) {
+              homeFeed(userId: $userId) {
+                id
+              }
+            }"});
+    }
+
+    #[test]
+    fn comments_are_dropped_unless_preservation_is_enabled() {
+        let source = "# @meta fci_tier: TIER_1\nquery GetFoo { id }";
+
+        let dropped = parsed_inputs_from_files_with_comments(&[("ops.graphql", source)], false)
+            .generate_operations()
+            .unwrap();
+        let preserved = parsed_inputs_from_files_with_comments(&[("ops.graphql", source)], true)
+            .generate_operations()
+            .unwrap();
+
+        assert_that!(dropped[0].body.as_str()).is_equal_to(indoc::indoc! {"
+            query GetFoo {
+              id
+            }"});
+        assert_that!(preserved[0].body.as_str()).is_equal_to(indoc::indoc! {"
+            # @meta fci_tier: TIER_1
+            query GetFoo {
+              id
+            }"});
+    }
+
+    #[test]
+    fn preserving_comments_changes_only_annotated_operation_ids() {
+        let source = indoc::indoc! {"
+            # @meta fci_tier: TIER_1
+            query Annotated { id }
+
+            query Bare { id }
+        "};
+
+        let dropped = parsed_inputs_from_files_with_comments(&[("ops.graphql", source)], false)
+            .generate_operations()
+            .unwrap();
+        let preserved = parsed_inputs_from_files_with_comments(&[("ops.graphql", source)], true)
+            .generate_operations()
+            .unwrap();
+
+        let id_of = |ops: &[super::PersistedQueryOperation], name: &str| {
+            ops.iter()
+                .find(|op| op.name == name)
+                .expect("operation present")
+                .id
+                .clone()
+        };
+
+        // The annotated operation hashes differently, because its body changed.
+        assert_that!(id_of(&preserved, "Annotated") != id_of(&dropped, "Annotated")).is_true();
+        // An operation with no preceding comment is untouched either way.
+        assert_that!(id_of(&preserved, "Bare").as_str())
+            .is_equal_to(id_of(&dropped, "Bare").as_str());
+    }
+
+    #[test]
+    fn preserved_comment_bodies_are_still_valid_graphql() {
+        let inputs = parsed_inputs_from_files_with_comments(
+            &[(
+                "ops.graphql",
+                indoc::indoc! {"
+                    # @meta fci_tier: TIER_1
+                    # @meta owner: consumer-payments
+                    query GetHomeFeed($userId: ID!) {
+                      homeFeed(userId: $userId) { ...FeedFields }
+                    }
+
+                    fragment FeedFields on Feed { id title }
+                "},
+            )],
+            true,
+        );
+
+        let operations = inputs.generate_operations().unwrap();
+        let body = operations[0].body.as_str();
+
+        assert_that!(body).contains("# @meta fci_tier: TIER_1");
+        // A body carrying comments must still parse, since the router executes
+        // the stored body verbatim.
+        let parsed = apollo_compiler::parser::Parser::new().parse_ast(body, "body.graphql");
+        assert_that!(parsed.is_ok()).is_true();
+    }
+
+    #[test]
+    fn comments_above_fragments_are_not_preserved() {
+        let inputs = parsed_inputs_from_files_with_comments(
+            &[(
+                "ops.graphql",
+                indoc::indoc! {"
+                    # @meta fci_tier: TIER_1
+                    query GetProduct { product { ...ProductFields } }
+
+                    # @meta this comment is on a fragment
+                    fragment ProductFields on Product { id }
+                "},
+            )],
+            true,
+        );
+
+        let operations = inputs.generate_operations().unwrap();
+        let body = operations[0].body.as_str();
+
+        assert_that!(body).contains("# @meta fci_tier: TIER_1");
+        assert_that!(body).does_not_contain("this comment is on a fragment");
     }
 
     #[test]

--- a/src/command/persisted_queries/generate/manifest/operation/parsed_inputs.rs
+++ b/src/command/persisted_queries/generate/manifest/operation/parsed_inputs.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use rover_std::{Fs, sha256_hex};
 
 use super::{
-    parsed_fragment::ParsedFragment, parsed_operation::ParsedOperation,
-    persisted_query_operation::PersistedQueryOperation,
+    comments::extract_leading_comments, parsed_fragment::ParsedFragment,
+    parsed_operation::ParsedOperation, persisted_query_operation::PersistedQueryOperation,
 };
 use crate::command::persisted_queries::generate::manifest::{
     ast_ext::SelectionSetExt,
@@ -21,13 +21,16 @@ pub(crate) struct ParsedInputs {
 }
 
 impl ParsedInputs {
-    pub(super) fn from_file(file: &Utf8Path) -> Result<Self, ParseFailure> {
+    pub(super) fn from_file(
+        file: &Utf8Path,
+        preserve_comments: bool,
+    ) -> Result<Self, ParseFailure> {
         let contents = Fs::read_file(file).map_err(|err| ParseFailure {
             file: file.to_path_buf(),
             message: err.to_string(),
         })?;
         let document = ApolloParser::new()
-            .parse_ast(contents, file.as_std_path())
+            .parse_ast(contents.as_str(), file.as_std_path())
             .map_err(|err| ParseFailure {
                 file: file.to_path_buf(),
                 message: err.to_string(),
@@ -59,12 +62,20 @@ impl ParsedInputs {
                             .to_string(),
                         });
                     }
+                    let leading_comments = if preserve_comments {
+                        operation.location().and_then(|location| {
+                            extract_leading_comments(&contents, location.offset())
+                        })
+                    } else {
+                        None
+                    };
                     parsed.operations.insert(
                         name,
                         ParsedOperation {
                             file: file.to_path_buf(),
                             direct_fragment_spreads: operation.selection_set.collect_spreads(),
                             operation,
+                            leading_comments,
                         },
                     );
                 }
@@ -95,10 +106,13 @@ impl ParsedInputs {
         Ok(parsed)
     }
 
-    pub(crate) fn from_files(files: Vec<Utf8PathBuf>) -> Result<Self, GenerateError> {
+    pub(crate) fn from_files(
+        files: Vec<Utf8PathBuf>,
+        preserve_comments: bool,
+    ) -> Result<Self, GenerateError> {
         let (parsed, failures): (Vec<_>, Vec<_>) = files
             .into_iter()
-            .map(|file| Self::from_file(&file))
+            .map(|file| Self::from_file(&file, preserve_comments))
             .partition_result();
 
         if !failures.is_empty() {
@@ -189,7 +203,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let file = Utf8PathBuf::from_path_buf(temp.path().join("ops.graphql")).unwrap();
         std::fs::write(&file, "query { field }").unwrap();
-        let result = ParsedInputs::from_file(&file).map_err(|e| e.to_string());
+        let result = ParsedInputs::from_file(&file, false).map_err(|e| e.to_string());
 
         assert_that!(result).is_err().is_equal_to(format!(
             "{file}: Anonymous GraphQL operations are not supported. Please name your query."
@@ -201,7 +215,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let file = Utf8PathBuf::from_path_buf(temp.path().join("ops.graphql")).unwrap();
         std::fs::write(&file, "query GetUser { id }\nquery GetUser { name }").unwrap();
-        let result = ParsedInputs::from_file(&file).map_err(|e| e.to_string());
+        let result = ParsedInputs::from_file(&file, false).map_err(|e| e.to_string());
 
         assert_that!(result).is_err().is_equal_to(format!(
             "{file}: Operation named \"GetUser\" is already defined in {file}. Duplicate found in {file}."
@@ -218,10 +232,10 @@ mod tests {
 
         let mut combined = ParsedInputs::default();
         combined
-            .merge(ParsedInputs::from_file(&a).unwrap())
+            .merge(ParsedInputs::from_file(&a, false).unwrap())
             .unwrap();
         let result = combined
-            .merge(ParsedInputs::from_file(&b).unwrap())
+            .merge(ParsedInputs::from_file(&b, false).unwrap())
             .map_err(|e| e.to_string());
 
         assert_that!(result).is_err().is_equal_to(format!(
@@ -237,7 +251,7 @@ mod tests {
         std::fs::write(&a, "query { field }").unwrap();
         std::fs::write(&b, "query { other }").unwrap();
 
-        let result = ParsedInputs::from_files(vec![a.clone(), b.clone()]);
+        let result = ParsedInputs::from_files(vec![a.clone(), b.clone()], false);
 
         assert_that!(result).is_err();
         let msg = result.unwrap_err().to_string();
@@ -255,10 +269,10 @@ mod tests {
 
         let mut combined = ParsedInputs::default();
         combined
-            .merge(ParsedInputs::from_file(&a).unwrap())
+            .merge(ParsedInputs::from_file(&a, false).unwrap())
             .unwrap();
         let result = combined
-            .merge(ParsedInputs::from_file(&b).unwrap())
+            .merge(ParsedInputs::from_file(&b, false).unwrap())
             .map_err(|e| e.to_string());
 
         assert_that!(result).is_err().is_equal_to(format!(

--- a/src/command/persisted_queries/generate/manifest/operation/parsed_operation.rs
+++ b/src/command/persisted_queries/generate/manifest/operation/parsed_operation.rs
@@ -15,6 +15,10 @@ pub(super) struct ParsedOperation {
     pub(super) file: Utf8PathBuf,
     pub(super) operation: Node<ast::OperationDefinition>,
     pub(super) direct_fragment_spreads: BTreeSet<String>,
+    /// Comment block immediately preceding the operation in its source file,
+    /// captured only when comment preservation is enabled. Prepended to the
+    /// printed body, which means it participates in the operation's ID.
+    pub(super) leading_comments: Option<String>,
 }
 
 impl ParsedOperation {
@@ -97,7 +101,12 @@ impl ParsedOperation {
             )
             .collect::<Vec<_>>();
 
-        Ok(print_document(&definitions))
+        let document = print_document(&definitions);
+
+        Ok(match &self.leading_comments {
+            Some(comments) => format!("{comments}\n{document}"),
+            None => document,
+        })
     }
 }
 
@@ -134,6 +143,7 @@ mod tests {
                             file: Utf8PathBuf::from("test.graphql"),
                             direct_fragment_spreads: spreads,
                             operation: op,
+                            leading_comments: None,
                         },
                     );
                 }

--- a/src/command/persisted_queries/generate/mod.rs
+++ b/src/command/persisted_queries/generate/mod.rs
@@ -20,12 +20,23 @@ pub struct Generate {
     /// Path to write the generated manifest to. If omitted, the manifest is printed to stdout.
     #[arg(long = "manifest-path", short = 'm', value_name = "FILE")]
     manifest_path: Option<Utf8PathBuf>,
+
+    /// Keep the comment block that precedes each operation in the generated
+    /// operation body, instead of dropping it during normalization.
+    ///
+    /// Only the contiguous comments directly above an operation are kept;
+    /// comments elsewhere in a document are still dropped. Because operation
+    /// IDs are a hash of the body, enabling this changes the ID of every
+    /// operation that has a preceding comment, so clients must generate their
+    /// manifests the same way.
+    #[arg(long = "preserve-comments")]
+    preserve_comments: bool,
 }
 
 impl Generate {
     pub async fn run<P: rover_print::print::Print>(&self, stderr: &P) -> RoverResult<RoverOutput> {
         let files = self.file_discovery.find(&["graphql"])?;
-        let manifest = PersistedQueryManifest::from_files(files)?;
+        let manifest = PersistedQueryManifest::from_files(files, self.preserve_comments)?;
         let operation_count = manifest.operation_count();
 
         if operation_count == 0 {


### PR DESCRIPTION
## What

Adds an opt-in `--preserve-comments` flag to `rover persisted-queries generate` that keeps the contiguous comment block directly above each operation in the generated manifest body. Default output is byte-for-byte identical to today.

## Why

Platform teams annotate operations with structured comments (`# @meta ...`) and need those annotations to survive into the persisted-query manifest, so router customizations (Rhai scripts, coprocessors) can read them at request time from the stored body. Today `generate` reprints each operation from the AST, and comments are deleted by construction: `apollo-compiler` does not retain them.

One-Pager (internal Confluence): https://apollographql.atlassian.net/wiki/x/BIDrrQ

Process note: this PR accompanies the One-Pager rather than following the full staged submission process. The near-term/long-term split (retain comments now, an operation-metadata directive as the long-term path) was directed by PM Matt Ratzke on 2026-08-20, who approved starting this work; the branch exists as the reference implementation for that decision. Happy to hold review until the One-Pager has been discussed, and to resequence however the team prefers.

## Behavior

- Off by default. Without the flag, output is unchanged, byte for byte.
- With the flag, only operations with a contiguous leading comment block change; each ID is the SHA-256 of the new (comment-inclusive) body. Operations without a leading comment keep their exact current ID, so adoption is per-operation.
- Comments above fragments and inside selection sets are still dropped (rationale in the One-Pager's Risks section: AST transforms applied before printing can delete the nodes interior comments anchor to).
- The flag's help text documents the ID consequence, since a manifest with rehashed IDs requires clients to take their IDs from this manifest.

## Testing

- 9 unit tests on the comment scanner (blank-line separation, preceding definition, indentation, CRLF, first line of file, trailing comment of a previous operation).
- 5 integration tests (comments appear with the flag; dropped without; only annotated operations' IDs change; comment-bearing bodies still parse as valid GraphQL; fragment comments are not captured).
- All 61 persisted-queries tests pass; `cargo +nightly fmt --check` and `cargo clippy --locked --workspace --all-targets` clean.
- Verified independently on generated output: `sha256(body) == id` holds in both modes; default mode emits no comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
