### PR TITLE
Avoid tag-name collisions and same-tag rate limiting in graph-artifact e2e tests

### DIFF
--- a/tests/e2e/graph_artifact/list_tags.rs
+++ b/tests/e2e/graph_artifact/list_tags.rs
@@ -129,10 +129,7 @@ async fn e2e_test_rover_graph_artifact_list_tags_by_digest_happy_path(
     remote_supergraph_graph_id: String,
 ) {
     let tag = random_tag(E2E_TEST_TAG);
-    let _cleanup = TagCleanup {
-        graph_id: remote_supergraph_graph_id.clone(),
-        tag: tag.clone(),
-    };
+    let _cleanup = TagCleanup::new(remote_supergraph_graph_id.clone(), tag.clone());
     info!("Creating tag '{tag}' then listing tags for artifact {E2E_TEST_ARTIFACT_DIGEST}");
     create_tag(&remote_supergraph_graph_id, &tag);
 

--- a/tests/e2e/graph_artifact/mod.rs
+++ b/tests/e2e/graph_artifact/mod.rs
@@ -1,4 +1,4 @@
-use std::{process::Command, str::from_utf8};
+use std::{process::Command, str::from_utf8, thread, time::Duration};
 
 use assert_cmd::cargo;
 use rand::RngExt;
@@ -12,16 +12,27 @@ mod list_tags;
 mod tag;
 mod untag;
 
-/// Generates a tag string with a random numeric suffix so concurrent CI jobs
-/// (which all share the `rover-e2e-tests` graph) don't collide on the same tag
-/// name.
+/// Generates a tag string with a random 64-bit hex suffix so concurrent CI jobs
+/// (which all share the `rover-e2e-tests` graph, across every runner in the
+/// matrix) don't collide on the same tag name.
 pub(super) fn random_tag(prefix: &str) -> String {
-    let n: u16 = rand::rng().random_range(0..500);
-    format!("{prefix}-{n:03}")
+    let n: u64 = rand::rng().random();
+    format!("{prefix}-{n:016x}")
+}
+
+/// The registry enforces a minimum interval of about a second between
+/// successive operations on the same tag, measured from when the previous one
+/// started. `tag` only returns once the tag is applied, so the previous
+/// operation is already complete by the time a test untags; the limit is purely
+/// on how soon the same tag can be touched again, which leaves waiting as the
+/// only way to avoid a rejected-then-retried untag.
+pub(super) fn wait_for_tag_reuse_window() {
+    thread::sleep(Duration::from_secs(2));
 }
 
 /// Removes a tag, logging (but not failing) if the removal does not succeed.
 pub(super) fn delete_tag(graph_id: &str, tag: &str) {
+    wait_for_tag_reuse_window();
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.args([
         "graph-artifact",
@@ -44,14 +55,33 @@ pub(super) fn delete_tag(graph_id: &str, tag: &str) {
 }
 
 /// RAII guard that deletes a tag when dropped, ensuring cleanup even if a test
-/// panics before reaching the explicit cleanup call.
+/// panics before reaching the explicit cleanup call. A test that removes the
+/// tag itself should call [`TagCleanup::disarm`] so the guard doesn't issue a
+/// redundant untag.
 pub(super) struct TagCleanup {
-    pub graph_id: String,
-    pub tag: String,
+    graph_id: String,
+    tag: String,
+    armed: bool,
+}
+
+impl TagCleanup {
+    pub(super) const fn new(graph_id: String, tag: String) -> Self {
+        Self {
+            graph_id,
+            tag,
+            armed: true,
+        }
+    }
+
+    pub(super) const fn disarm(&mut self) {
+        self.armed = false;
+    }
 }
 
 impl Drop for TagCleanup {
     fn drop(&mut self) {
-        delete_tag(&self.graph_id, &self.tag);
+        if self.armed {
+            delete_tag(&self.graph_id, &self.tag);
+        }
     }
 }

--- a/tests/e2e/graph_artifact/tag.rs
+++ b/tests/e2e/graph_artifact/tag.rs
@@ -138,10 +138,7 @@ async fn e2e_test_rover_graph_artifact_tag_nonexistent_digest(remote_supergraph_
 #[traced_test]
 async fn e2e_test_rover_graph_artifact_tag_happy_path(remote_supergraph_graph_id: String) {
     let tag = random_tag(E2E_TEST_TAG);
-    let _cleanup = TagCleanup {
-        graph_id: remote_supergraph_graph_id.clone(),
-        tag: tag.clone(),
-    };
+    let _cleanup = TagCleanup::new(remote_supergraph_graph_id.clone(), tag.clone());
     info!("Tagging artifact {E2E_TEST_ARTIFACT_DIGEST} with tag {tag}");
 
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));

--- a/tests/e2e/graph_artifact/untag.rs
+++ b/tests/e2e/graph_artifact/untag.rs
@@ -7,7 +7,7 @@ use speculoos::{assert_that, boolean::BooleanAssertions, string::StrAssertions};
 use tracing::{error, info};
 use tracing_test::traced_test;
 
-use super::{E2E_TEST_ARTIFACT_DIGEST, TagCleanup, random_tag};
+use super::{E2E_TEST_ARTIFACT_DIGEST, TagCleanup, random_tag, wait_for_tag_reuse_window};
 use crate::e2e::remote_supergraph_graph_id;
 
 const E2E_TEST_TAG: &str = "e2e-test-artifact-untag";
@@ -59,10 +59,7 @@ async fn e2e_test_rover_graph_artifact_untag_nonexistent_graph_id() {
 #[traced_test]
 async fn e2e_test_rover_graph_artifact_untag_happy_path(remote_supergraph_graph_id: String) {
     let tag = random_tag(E2E_TEST_TAG);
-    let _cleanup = TagCleanup {
-        graph_id: remote_supergraph_graph_id.clone(),
-        tag: tag.clone(),
-    };
+    let mut cleanup = TagCleanup::new(remote_supergraph_graph_id.clone(), tag.clone());
 
     // First assign the tag so there's something to remove.
     info!("Tagging artifact {E2E_TEST_ARTIFACT_DIGEST} with tag {tag}");
@@ -86,6 +83,7 @@ async fn e2e_test_rover_graph_artifact_untag_happy_path(remote_supergraph_graph_
     }
 
     // Now remove it.
+    wait_for_tag_reuse_window();
     info!("Removing tag {tag} from graph {remote_supergraph_graph_id}");
     let mut cmd = Command::new(cargo::cargo_bin!("rover"));
     cmd.args([
@@ -106,6 +104,7 @@ async fn e2e_test_rover_graph_artifact_untag_happy_path(remote_supergraph_graph_
         error!("stderr: {}", String::from_utf8_lossy(&output.stderr));
         panic!("Command did not complete successfully");
     }
+    cleanup.disarm();
 
     let json: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
         panic!(


### PR DESCRIPTION
The `graph-artifact` e2e tests all run against the shared `rover-e2e-tests` graph, and every leg of the smoke-test matrix runs them concurrently. Two things made that noisy.

**Tag-name collisions between legs.** `random_tag` drew its suffix from only 500 values, so parallel legs regularly picked the same tag name and then raced each other's `tag`/`untag` calls on it. The suffix is now a random 64-bit hex value (still well within the OCI tag character and length rules).

**Untagging a tag immediately after creating it.** The registry serializes mutations of a given tag, and it enforces a minimum interval of about one second between successive operations on the same tag, measured from when the previous one started. `rover graph-artifact tag` only returns once the tag is fully applied, so by the time these tests run `untag` the previous operation is already complete; what trips the limit is simply that the untag starts within a second of the tag. The registry's client retries the rejected call after roughly a second, so the tests passed anyway, but every run was generating a batch of rejected-then-retried requests on the registry side and quietly depending on that retry to succeed. There is no signal Rover could poll for instead: the previous operation is already done, and the limit is on how soon the same tag can be touched again, so a wait is the only client-side way to avoid it.

This change adds `wait_for_tag_reuse_window()` (a 2s sleep) and calls it before any untag of a tag the test just created — including inside `delete_tag`, so the `TagCleanup` drop guard is covered. It also gives `TagCleanup` a `new()` constructor and a `disarm()` method, and disarms it in the `untag` happy path once the test has removed the tag itself, so the guard does not issue a redundant untag.

Cost: three 2s waits per leg (the `tag` and `list-tags` cleanups and the `untag` happy path), and since the e2e binary runs tests on parallel threads that is at most a couple of seconds of wall-clock time against a step that takes 10–12 minutes.

Test-only change; no user-facing behavior is affected.

- [x] A CHANGELOG.md entry is not needed for this PR
