### PR TITLE
fix(auth): register the device-code grant type for rover auth login -…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+- **Register the device-code grant type for `rover auth login --no-browser`'s OAuth client - @dotdat**
+
+  Every OAuth client provisioned via `cargo xtask register-oauth-client` (for both staging and prod) was registered with only the `authorization_code` grant type, never `urn:ietf:params:oauth:grant-type:device_code` - so `rover auth login --no-browser` always failed at the very first step, with the server rejecting the device-authorization request as `unsupported_grant_type`
+
 - **Surface the underlying GraphQL errors when a response has no `data` field - @sirdodger**
 
   Requests that returned GraphQL errors alongside a null/missing `data` field previously showed a generic message instead of the actual error text. `GraphQLServiceError::NoData` now maps to the underlying errors (joined by newline) when there are any, falling back to the generic "No data field provided" message only when the response truly carried no errors either.

--- a/crates/rover-auth/src/oauth2/mod.rs
+++ b/crates/rover-auth/src/oauth2/mod.rs
@@ -53,6 +53,10 @@ pub enum GrantType {
     AuthorizationCode,
     /// Client credentials grant.
     ClientCredentials,
+    /// Device authorization grant (RFC 8628). Not a `snake_case` word, so it
+    /// isn't covered by this enum's `rename_all` and needs its own `rename`.
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:device_code")]
+    DeviceCode,
 }
 
 /// Client authentication method for the token endpoint.

--- a/crates/rover-auth/src/oauth2/register.rs
+++ b/crates/rover-auth/src/oauth2/register.rs
@@ -35,7 +35,11 @@ impl RegisterRequest {
                 Scope::new("email".to_string()),
             ],
             redirect_uris: vec![redirect_url],
-            grant_types: vec![GrantType::AuthorizationCode],
+            // `rover auth login` uses this client for both the PKCE browser flow
+            // (authorization_code) and `--no-browser` (device_code) - both grant
+            // types need to be registered, or the device-code flow is rejected
+            // with `unsupported_grant_type` at the device-authorization endpoint.
+            grant_types: vec![GrantType::AuthorizationCode, GrantType::DeviceCode],
             token_endpoint_auth_method: TokenEndpointAuthMethod::None,
         }
     }

--- a/crates/rover-auth/tests/registration.rs
+++ b/crates/rover-auth/tests/registration.rs
@@ -73,6 +73,42 @@ async fn test_client_registration_sends_expected_scopes() {
     mock.assert();
 }
 
+// Without this, the device-authorization endpoint rejects `rover auth login
+// --no-browser` with `unsupported_grant_type`, since the registered client
+// never claimed the device-code grant in the first place.
+#[rstest]
+#[tokio::test]
+#[timeout(Duration::from_secs(5))]
+async fn test_client_registration_sends_the_device_code_grant_type() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/register")
+            .body_includes("authorization_code")
+            .body_includes("urn:ietf:params:oauth:grant-type:device_code");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"client_id":"device-code-client"}"#);
+    });
+
+    let register_url = Url::parse(&format!("http://{}/register", server.address())).unwrap();
+    let redirect_url = Url::parse("http://127.0.0.1:8080/callback").unwrap();
+
+    let req = RegisterRequest::builder()
+        .register_url(register_url)
+        .redirect_url(redirect_url)
+        .build();
+
+    let http_service = ReqwestService::builder()
+        .client(reqwest::Client::default())
+        .build()
+        .unwrap();
+
+    let result = Register::new(http_service).oneshot(req).await;
+    assert_that!(result).is_ok();
+    mock.assert();
+}
+
 #[rstest]
 #[tokio::test]
 #[timeout(Duration::from_secs(5))]


### PR DESCRIPTION
GrantType only had `AuthorizationCode` and `ClientCredentials` variants, so every OAuth client provisioned via `cargo xtask register-oauth-client` (staging and prod alike) never claimed `urn:ietf:params:oauth:grant-type:device_code`. The device-authorization endpoint then rejects rover auth login --no-browser's very first request with `unsupported_grant_type`

Add a DeviceCode variant (serialized to the RFC 8628 grant-type URN) and register it alongside AuthorizationCode. Existing client IDs need to be re-registered to pick this up.

- [ ] A CHANGELOG.md entry is not needed for this PR
