### PR TITLE
Fix subgraph check's blocking-downstream exit-code gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+- **`rover subgraph check` now fails on an actually-failed blocking downstream contract check, even when the overall workflow status hasn't caught up - @dotdat**
+
+  `subgraph check`'s exit code only ever looked at the overall check-workflow status, never at the downstream task's per-variant data, so a blocking downstream contract check that had genuinely failed could be missed entirely if Studio's aggregate status hadn't caught up yet — the command would report success and exit zero. It now escalates to a failure whenever any downstream variant is an actual blocking failure, the same `DownstreamCheckResponse::has_blocking_failure` gate `graph check` already uses, bringing `subgraph check`'s exit code and JSON `downstream.task_status` in line with `graph check`'s existing behavior. Supersedes the stale, unmerged #3377.
+
 - **Register the device-code grant type for `rover auth login --no-browser`'s OAuth client - @dotdat**
 
   Every OAuth client provisioned via `cargo xtask register-oauth-client` (for both staging and prod) was registered with only the `authorization_code` grant type, never `urn:ietf:params:oauth:grant-type:device_code` - so `rover auth login --no-browser` always failed at the very first step, with the server rejecting the device-authorization request as `unsupported_grant_type`

--- a/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
+++ b/crates/rover-client/src/operations/subgraph/check_workflow/runner.rs
@@ -225,6 +225,16 @@ fn get_check_response_from_data(
         graph_ref.variant()
     );
 
+    let maybe_downstream_response = get_downstream_response_from_result(
+        downstream_status,
+        downstream_target_url,
+        downstream_result,
+    );
+    let downstream_failed = maybe_downstream_response
+        .as_ref()
+        .map(DownstreamCheckResponse::has_blocking_failure)
+        .unwrap_or(false);
+
     let check_response = CheckWorkflowResponse {
         default_target_url,
         maybe_core_schema_modified: Some(core_schema_modified),
@@ -250,19 +260,17 @@ fn get_check_response_from_data(
             custom_target_url,
             custom_result,
         ),
-        maybe_downstream_response: get_downstream_response_from_result(
-            downstream_status,
-            downstream_target_url,
-            downstream_result,
-        ),
+        maybe_downstream_response,
     };
 
     match check_workflow.status {
-        CheckWorkflowStatus::PASSED => Ok(check_response),
-        CheckWorkflowStatus::FAILED => Err(RoverClientError::CheckWorkflowFailure {
-            graph_ref,
-            check_response: Box::new(check_response),
-        }),
+        CheckWorkflowStatus::PASSED if !downstream_failed => Ok(check_response),
+        CheckWorkflowStatus::PASSED | CheckWorkflowStatus::FAILED => {
+            Err(RoverClientError::CheckWorkflowFailure {
+                graph_ref,
+                check_response: Box::new(check_response),
+            })
+        }
         _ => Err(RoverClientError::UnknownCheckWorkflowStatus),
     }
 }
@@ -461,11 +469,11 @@ fn get_downstream_response_from_result(
         Some(results) => {
             let variants: Vec<DownstreamVariantCheckResult> =
                 results.into_iter().map(Into::into).collect();
-            Some(DownstreamCheckResponse {
-                task_status: task_status.into(),
-                target_url,
+            Some(DownstreamCheckResponse::new(
                 variants,
-            })
+                task_status.into(),
+                target_url,
+            ))
         }
         None => None,
     }
@@ -725,6 +733,12 @@ mod tests {
         assert!(response.maybe_lint_response.is_none());
     }
 
+    /// A blocking downstream contract workflow that has actually failed makes the
+    /// check fail even though the overall workflow status (and the downstream
+    /// task's own aggregate status) both still report PASSED -- Studio's aggregate
+    /// status can lag behind the per-variant data in the same response. Mirrors
+    /// `blocking_downstream_workflow_failure_fails_the_check` in
+    /// `crates/rover-client/src/operations/graph/check_workflow/runner.rs`.
     #[rstest]
     fn downstream_result_maps_into_shared_variant_shape(graph_ref: GraphRef) {
         let data = create_check_workflow_data(
@@ -750,18 +764,134 @@ mod tests {
         );
         let subgraph = "test-subgraph".to_string();
 
+        let result = get_check_response_from_data(data, graph_ref.clone(), subgraph);
+
+        assert_that!(&result).is_err();
+        match result.unwrap_err() {
+            RoverClientError::CheckWorkflowFailure {
+                graph_ref: returned_graph_ref,
+                check_response,
+            } => {
+                assert_that!(&returned_graph_ref).is_equal_to(&graph_ref);
+                let expected = DownstreamCheckResponse {
+                    task_status: CheckTaskStatus::FAILED,
+                    target_url: Some(
+                        "https://studio.apollographql.com/graph/test-graph/checks/downstream"
+                            .to_string(),
+                    ),
+                    variants: vec![DownstreamVariantCheckResult {
+                        graph_id: "test-graph".to_string(),
+                        variant_name: "mobile".to_string(),
+                        blocking: true,
+                        fails_upstream_workflow: Some(true),
+                        status: CheckTaskStatus::FAILED,
+                    }],
+                };
+                assert_that!(&check_response.maybe_downstream_response).is_equal_to(Some(expected));
+            }
+            other => panic!("Expected CheckWorkflowFailure error, got {other:?}"),
+        }
+    }
+
+    /// Mirrors `downstream_result_maps_into_shared_variant_shape`, but isolates the
+    /// *other* half of `has_blocking_failure`'s OR: `blocking: false` and
+    /// `status: PASSED` mean the `blocking && FAILED` predicate can't be what fails
+    /// the check here -- only `fails_upstream_workflow` can.
+    #[rstest]
+    fn fails_upstream_workflow_alone_fails_the_check(graph_ref: GraphRef) {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "PASSED",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": false,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "PASSED" },
+                            "failsUpstreamWorkflow": true
+                        }
+                    ]
+                }
+            ]),
+        );
+        let subgraph = "test-subgraph".to_string();
+
+        let result = get_check_response_from_data(data, graph_ref.clone(), subgraph);
+
+        assert_that!(&result).is_err();
+        match result.unwrap_err() {
+            RoverClientError::CheckWorkflowFailure {
+                graph_ref: returned_graph_ref,
+                check_response,
+            } => {
+                assert_that!(&returned_graph_ref).is_equal_to(&graph_ref);
+                let expected = DownstreamCheckResponse {
+                    task_status: CheckTaskStatus::FAILED,
+                    target_url: Some(
+                        "https://studio.apollographql.com/graph/test-graph/checks/downstream"
+                            .to_string(),
+                    ),
+                    variants: vec![DownstreamVariantCheckResult {
+                        graph_id: "test-graph".to_string(),
+                        variant_name: "mobile".to_string(),
+                        blocking: false,
+                        fails_upstream_workflow: Some(true),
+                        status: CheckTaskStatus::PASSED,
+                    }],
+                };
+                assert_that!(&check_response.maybe_downstream_response).is_equal_to(Some(expected));
+            }
+            other => panic!("Expected CheckWorkflowFailure error, got {other:?}"),
+        }
+    }
+
+    /// The server can report the `DownstreamCheckTask` itself as `FAILED` for
+    /// reasons that don't make any individual variant a blocking failure (e.g. a
+    /// non-blocking contract variant failing). That alone shouldn't fail the check
+    /// -- only `has_blocking_failure` should.
+    #[rstest]
+    fn non_blocking_task_failure_does_not_fail_the_check(graph_ref: GraphRef) {
+        let data = create_check_workflow_data(
+            CheckWorkflowStatus::PASSED,
+            json!([
+                {
+                    "__typename": "DownstreamCheckTask",
+                    "id": "downstream-task",
+                    "status": "FAILED",
+                    "targetURL": "https://studio.apollographql.com/graph/test-graph/checks/downstream",
+                    "results": [
+                        {
+                            "__typename": "DownstreamCheckResult",
+                            "blocking": false,
+                            "downstreamGraphID": "test-graph",
+                            "downstreamVariantName": "mobile",
+                            "downstreamWorkflow": { "status": "FAILED" },
+                            "failsUpstreamWorkflow": false
+                        }
+                    ]
+                }
+            ]),
+        );
+        let subgraph = "test-subgraph".to_string();
+
         let response = get_check_response_from_data(data, graph_ref, subgraph).unwrap();
 
         let expected = DownstreamCheckResponse {
-            task_status: CheckTaskStatus::PASSED,
+            task_status: CheckTaskStatus::FAILED,
             target_url: Some(
                 "https://studio.apollographql.com/graph/test-graph/checks/downstream".to_string(),
             ),
             variants: vec![DownstreamVariantCheckResult {
                 graph_id: "test-graph".to_string(),
                 variant_name: "mobile".to_string(),
-                blocking: true,
-                fails_upstream_workflow: Some(true),
+                blocking: false,
+                fails_upstream_workflow: Some(false),
                 status: CheckTaskStatus::FAILED,
             }],
         };

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -8,4 +8,5 @@ mod info;
 mod installers;
 mod output;
 mod schema;
+mod subgraph;
 mod supergraph;

--- a/tests/integration/subgraph/check.rs
+++ b/tests/integration/subgraph/check.rs
@@ -1,0 +1,157 @@
+use std::fs;
+
+use assert_cmd::Command;
+use httpmock::{Method::POST, MockServer};
+use insta::assert_json_snapshot;
+use serde_json::Value;
+use serial_test::serial;
+
+const IS_FEDERATED_RESPONSE: &str =
+    r#"{"data":{"graph":{"variant":{"subgraphs":[{"name":"my-subgraph"}]}}}}"#;
+
+const CHECK_SUBMISSION_RESPONSE: &str = r#"{"data":{"graph":{"variant":{"submitSubgraphCheckAsync":{
+    "__typename":"CheckRequestSuccess",
+    "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/1",
+    "workflowID":"workflow-1"
+}}}}}"#;
+
+const STATUS_POLL_RESPONSE: &str = r#"{"data":{"graph":{"checkWorkflow":{
+    "status":"PASSED",
+    "tasks":[{
+        "__typename":"DownstreamCheckTask",
+        "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream"
+    }]
+}}}}"#;
+
+/// Starts a mock Studio server for `rover subgraph check`, wiring up the
+/// check-submission and status-poll responses common to every case, stubs the full
+/// workflow-fetch response with `workflow_fetch_response`, and runs the real
+/// `rover subgraph check` binary against it. Returns whether the command succeeded
+/// and its parsed JSON output.
+fn run_subgraph_check(workflow_fetch_response: &str) -> (bool, Value) {
+    let server = MockServer::start();
+
+    let is_federated_mock = server.mock(|when, then| {
+        when.method(POST).body_includes("IsFederatedGraph");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(IS_FEDERATED_RESPONSE);
+    });
+    let submission_mock = server.mock(|when, then| {
+        when.method(POST).body_includes("SubgraphCheckMutation");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(CHECK_SUBMISSION_RESPONSE);
+    });
+    let status_mock = server.mock(|when, then| {
+        when.method(POST)
+            .body_includes("SubgraphCheckWorkflowStatusQuery");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(STATUS_POLL_RESPONSE);
+    });
+    let fetch_mock = server.mock(|when, then| {
+        when.method(POST)
+            .body_includes("SubgraphCheckWorkflowQuery");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(workflow_fetch_response);
+    });
+
+    let temp = tempfile::tempdir().unwrap();
+    let schema = temp.path().join("schema.graphql");
+    fs::write(&schema, "type Query { hello: String }").unwrap();
+
+    let output = Command::cargo_bin("rover")
+        .unwrap()
+        .env("APOLLO_KEY", "testkey")
+        .env("APOLLO_REGISTRY_URL", server.base_url())
+        .arg("subgraph")
+        .arg("check")
+        .arg("my-graph@current")
+        .arg("--name")
+        .arg("my-subgraph")
+        .arg("--schema")
+        .arg(&schema)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    is_federated_mock.assert();
+    submission_mock.assert();
+    status_mock.assert();
+    fetch_mock.assert();
+
+    let json = serde_json::from_slice(&output.stdout).unwrap();
+    (output.status.success(), json)
+}
+
+/// Verifies that `rover subgraph check` fails the command, and correctly attributes
+/// the failure to the downstream task, when a blocking downstream contract check has
+/// actually failed -- even though the overall workflow status and the downstream
+/// task's own aggregate status both still report PASSED (Studio's aggregate status
+/// can lag behind the per-variant data in the same response). This is the subgraph
+/// counterpart to `graph_check_fails_on_blocking_downstream_contract_failure` in
+/// `tests/integration/graph/check.rs`, exercising the same
+/// `DownstreamCheckResponse::new` escalation and closing the gap where
+/// `rover subgraph check` previously never checked downstream blocking failures at
+/// all when the overall workflow was reported PASSED.
+#[test]
+#[serial]
+fn subgraph_check_fails_on_blocking_downstream_contract_failure() {
+    let (success, json) = run_subgraph_check(
+        r#"{"data":{"graph":{"checkWorkflow":{
+            "status":"PASSED",
+            "tasks":[{
+                "__typename":"DownstreamCheckTask",
+                "status":"PASSED",
+                "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                "results":[{
+                    "__typename":"DownstreamCheckResult",
+                    "blocking":true,
+                    "downstreamGraphID":"my-graph",
+                    "downstreamVariantName":"mobile",
+                    "downstreamWorkflow":{"status":"FAILED"},
+                    "failsUpstreamWorkflow":null
+                }]
+            }]
+        }}}}"#,
+    );
+
+    assert!(!success, "expected a nonzero exit code; json: {json}");
+    assert_json_snapshot!(json);
+}
+
+/// Verifies that `rover subgraph check` succeeds when the downstream task's own
+/// aggregate status is FAILED but no individual variant is actually a blocking
+/// failure -- pinning the exit-code gate to `has_blocking_failure`, not the raw (and
+/// here misleading) `task_status`. Mirrors
+/// `non_blocking_task_failure_does_not_fail_the_check` in
+/// `crates/rover-client/src/operations/subgraph/check_workflow/runner.rs`, but
+/// exercised through the real CLI end to end.
+#[test]
+#[serial]
+fn subgraph_check_succeeds_despite_non_blocking_task_status_failure() {
+    let (success, json) = run_subgraph_check(
+        r#"{"data":{"graph":{"checkWorkflow":{
+            "status":"PASSED",
+            "tasks":[{
+                "__typename":"DownstreamCheckTask",
+                "status":"FAILED",
+                "targetURL":"https://studio.apollographql.com/graph/my-graph/checks/downstream",
+                "results":[{
+                    "__typename":"DownstreamCheckResult",
+                    "blocking":false,
+                    "downstreamGraphID":"my-graph",
+                    "downstreamVariantName":"mobile",
+                    "downstreamWorkflow":{"status":"FAILED"},
+                    "failsUpstreamWorkflow":false
+                }]
+            }]
+        }}}}"#,
+    );
+
+    assert!(success, "expected a zero exit code; json: {json}");
+    assert_json_snapshot!(json);
+}

--- a/tests/integration/subgraph/mod.rs
+++ b/tests/integration/subgraph/mod.rs
@@ -1,0 +1,1 @@
+mod check;

--- a/tests/integration/subgraph/snapshots/main__integration__subgraph__check__subgraph_check_fails_on_blocking_downstream_contract_failure.snap
+++ b/tests/integration/subgraph/snapshots/main__integration__subgraph__check__subgraph_check_fails_on_blocking_downstream_contract_failure.snap
@@ -1,0 +1,30 @@
+---
+source: tests/integration/subgraph/check.rs
+expression: json
+---
+{
+  "json_version": "3",
+  "data": {
+    "core_schema_modified": false,
+    "tasks": {
+      "downstream": {
+        "task_status": "FAILED",
+        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+        "variants": [
+          {
+            "graph_id": "my-graph",
+            "variant_name": "mobile",
+            "blocking": true,
+            "fails_upstream_workflow": null,
+            "status": "FAILED"
+          }
+        ]
+      }
+    },
+    "success": false
+  },
+  "error": {
+    "message": "The changes in the schema you proposed caused downstream checks to fail.",
+    "code": "E043"
+  }
+}

--- a/tests/integration/subgraph/snapshots/main__integration__subgraph__check__subgraph_check_succeeds_despite_non_blocking_task_status_failure.snap
+++ b/tests/integration/subgraph/snapshots/main__integration__subgraph__check__subgraph_check_succeeds_despite_non_blocking_task_status_failure.snap
@@ -1,0 +1,27 @@
+---
+source: tests/integration/subgraph/check.rs
+expression: json
+---
+{
+  "json_version": "3",
+  "data": {
+    "core_schema_modified": false,
+    "tasks": {
+      "downstream": {
+        "task_status": "FAILED",
+        "target_url": "https://studio.apollographql.com/graph/my-graph/checks/downstream",
+        "variants": [
+          {
+            "graph_id": "my-graph",
+            "variant_name": "mobile",
+            "blocking": false,
+            "fails_upstream_workflow": false,
+            "status": "FAILED"
+          }
+        ]
+      }
+    },
+    "success": true
+  },
+  "error": null
+}


### PR DESCRIPTION
## Summary

`rover subgraph check`'s exit code only ever consulted the overall check-workflow status (`match check_workflow.status { PASSED => Ok, FAILED => Err, ... }`), never the downstream task's own per-variant data. A blocking downstream contract check that had genuinely failed could be missed entirely if Studio's aggregate workflow status hadn't caught up yet — the command would report success and exit zero.

`rover graph check` closed this exact gap for itself in #3681, via `DownstreamCheckResponse::has_blocking_failure`/`::new` on the shared type. This PR mirrors that fix for `subgraph check`:

- `get_downstream_response_from_result` now builds its response through `DownstreamCheckResponse::new`, which escalates `task_status` to `FAILED` when any variant is an actual blocking failure — the same escalation `graph check` already gets, so `subgraph check`'s exit code and JSON `downstream.task_status` now agree with `graph check`'s.
- The terminal match gates on `has_blocking_failure` computed from that response, collapsing the `PASSED`/`FAILED` arms the same way `graph check`'s does.
- Updated `downstream_result_maps_into_shared_variant_shape` (its fixture is a blocking failure, and previously asserted the old, buggy `Ok` outcome for it), and added the two other unit tests mirroring `graph check`'s coverage of `has_blocking_failure`'s two OR branches and the negative case.
- Added `tests/integration/subgraph/check.rs`, the CLI-level counterpart to `tests/integration/graph/check.rs` (added in #3681), exercising the same two scenarios through the real binary end to end.

Verified both the unit-level and CLI-level new/updated tests actually catch the bug: temporarily reverting the gate made the expected tests fail before reverting back.

## Context

Supersedes #3377 ("Report downstream contract failures"), which attempted this same fix but against the pre-widening `blocking_variants: Vec<String>` shape, before #3680's widening (`variants: Vec<DownstreamVariantCheckResult>`) landed — it was never rebased onto that shape and is stale. ROVER-460 (the ticket behind #3680) explicitly assumed #3377 would land first ("existing blocking-failure behavior, already correct after #3377, is unchanged"), but #3680 merged without it.